### PR TITLE
Optimize playlists performance

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerManualTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerManualTest.kt
@@ -780,21 +780,6 @@ class PlaylistManagerManualTest {
                 ),
                 awaitItem(),
             )
-
-            insertPodcast(index = 1)
-            insertPodcastEpisode(index = 2, podcastIndex = 1)
-            assertEquals(
-                listOf(
-                    playlistPreviewForEpisode(index = 0) {
-                        it.copy(episodeCount = 0, hasEpisode = false)
-                    },
-                    playlistPreviewForEpisode(index = 1) {
-                        it.copy(episodeCount = 3, hasEpisode = true, artworkPodcastUuids = listOf("podcast-id-1"))
-                    },
-                    playlistPreviewForEpisode(index = 2),
-                ),
-                awaitItem(),
-            )
         }
     }
 

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/ui/PlaybackServiceTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/ui/PlaybackServiceTest.kt
@@ -83,8 +83,6 @@ class PlaybackServiceTest {
         val playlistPreview = ManualPlaylistPreview(
             uuid = UUID.randomUUID().toString(),
             title = "Playlist title",
-            episodeCount = 0,
-            artworkPodcastUuids = emptyList(),
             settings = Playlist.Settings.ForPreview,
             icon = PlaylistIcon(0),
         )

--- a/automotive/src/androidTest/java/au/com/shiftyjelly/pocketcasts/AutoPlaybackServiceTest.kt
+++ b/automotive/src/androidTest/java/au/com/shiftyjelly/pocketcasts/AutoPlaybackServiceTest.kt
@@ -78,8 +78,6 @@ class AutoPlaybackServiceTest {
             val playlist = ManualPlaylistPreview(
                 uuid = "uuid",
                 title = "Playlist title",
-                episodeCount = 0,
-                artworkPodcastUuids = emptyList(),
                 settings = Playlist.Settings.ForPreview,
                 icon = PlaylistIcon(0),
             )

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsFragment.kt
@@ -46,6 +46,8 @@ class PlaylistsFragment :
             PlaylistsPage(
                 uiState = uiState,
                 listState = listState,
+                getPreviewMetadataFlow = viewModel::getPreviewMetadataFlow,
+                refreshPreviewMetadata = viewModel::refreshPreviewMetadata,
                 onCreatePlaylist = {
                     viewModel.trackCreatePlaylistClicked()
                     val fragment = childFragmentManager.findFragmentByTag("create_playlist")

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsPage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsPage.kt
@@ -61,10 +61,11 @@ import au.com.shiftyjelly.pocketcasts.playlists.PlaylistsViewModel.UiState
 import au.com.shiftyjelly.pocketcasts.playlists.component.PlaylistPreviewRow
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.ManualPlaylistPreview
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.Playlist
-import au.com.shiftyjelly.pocketcasts.repositories.playlist.Playlist.Type
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistPreview
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.SmartPlaylistPreview
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import sh.calvin.reorderable.ReorderableItem
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -72,6 +73,8 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 @Composable
 internal fun PlaylistsPage(
     uiState: UiState,
+    getPreviewMetadataFlow: (String) -> StateFlow<PlaylistPreview.Metadata?>,
+    refreshPreviewMetadata: (String) -> Unit,
     onCreatePlaylist: () -> Unit,
     onDeletePlaylist: (PlaylistPreview) -> Unit,
     onOpenPlaylist: (PlaylistPreview) -> Unit,
@@ -106,6 +109,8 @@ internal fun PlaylistsPage(
 
             PlaylistsContent(
                 playlistsState = uiState.playlists,
+                getPreviewMetadataFlow = getPreviewMetadataFlow,
+                refreshPreviewMetadata = refreshPreviewMetadata,
                 showPremadePlaylistsTooltip = showTooltip,
                 listState = listState,
                 contentPadding = PaddingValues(
@@ -140,8 +145,10 @@ internal fun PlaylistsPage(
 }
 
 @Composable
-private fun ColumnScope.PlaylistsContent(
+private fun PlaylistsContent(
     playlistsState: PlaylistsState,
+    getPreviewMetadataFlow: (String) -> StateFlow<PlaylistPreview.Metadata?>,
+    refreshPreviewMetadata: (String) -> Unit,
     showPremadePlaylistsTooltip: Boolean,
     listState: LazyListState,
     contentPadding: PaddingValues,
@@ -170,6 +177,8 @@ private fun ColumnScope.PlaylistsContent(
                 if (playlists.isNotEmpty()) {
                     PlaylistsColumn(
                         playlists = playlists,
+                        getPreviewMetadataFlow = getPreviewMetadataFlow,
+                        refreshPreviewMetadata = refreshPreviewMetadata,
                         showPremadePlaylistsTooltip = showPremadePlaylistsTooltip,
                         listState = listState,
                         contentPadding = contentPadding,
@@ -200,6 +209,8 @@ private fun ColumnScope.PlaylistsContent(
 @Composable
 private fun PlaylistsColumn(
     playlists: List<PlaylistPreview>,
+    getPreviewMetadataFlow: (String) -> StateFlow<PlaylistPreview.Metadata?>,
+    refreshPreviewMetadata: (String) -> Unit,
     showPremadePlaylistsTooltip: Boolean,
     listState: LazyListState,
     contentPadding: PaddingValues,
@@ -242,6 +253,8 @@ private fun PlaylistsColumn(
 
                 PlaylistPreviewRow(
                     playlist = playlist,
+                    getPreviewMetadataFlow = getPreviewMetadataFlow,
+                    refreshPreviewMetadata = refreshPreviewMetadata,
                     showTooltip = showPremadePlaylistsTooltip && index == displayItems.lastIndex,
                     showDivider = index != displayItems.lastIndex,
                     backgroundColor = backgroundColor,
@@ -369,6 +382,8 @@ private fun PlaylistsPageEmptyStatePreview() {
                 showPremadePlaylistsTooltip = false,
                 miniPlayerInset = 0,
             ),
+            getPreviewMetadataFlow = { MutableStateFlow(null) },
+            refreshPreviewMetadata = {},
             onCreatePlaylist = {},
             onDeletePlaylist = {},
             onOpenPlaylist = {},
@@ -394,6 +409,8 @@ private fun PlaylistsPageEmptyStateNoBannerPreview() {
                 showPremadePlaylistsTooltip = false,
                 miniPlayerInset = 0,
             ),
+            getPreviewMetadataFlow = { MutableStateFlow(null) },
+            refreshPreviewMetadata = {},
             onCreatePlaylist = {},
             onDeletePlaylist = {},
             onOpenPlaylist = {},
@@ -420,16 +437,12 @@ private fun PlaylistPagePreview(
                         ManualPlaylistPreview(
                             uuid = "uuid-0",
                             title = "Playlist 0",
-                            episodeCount = 0,
-                            artworkPodcastUuids = emptyList(),
                             settings = Playlist.Settings.ForPreview,
                             icon = PlaylistIcon(0),
                         ),
                         SmartPlaylistPreview(
                             uuid = "uuid-1",
                             title = "Playlist 1",
-                            episodeCount = 253,
-                            artworkPodcastUuids = emptyList(),
                             settings = Playlist.Settings.ForPreview,
                             smartRules = SmartRules.Default,
                             icon = PlaylistIcon(0),
@@ -441,6 +454,8 @@ private fun PlaylistPagePreview(
                 showPremadePlaylistsTooltip = false,
                 miniPlayerInset = 0,
             ),
+            getPreviewMetadataFlow = { MutableStateFlow(null) },
+            refreshPreviewMetadata = {},
             onCreatePlaylist = {},
             onDeletePlaylist = {},
             onOpenPlaylist = {},

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsViewModel.kt
@@ -13,7 +13,10 @@ import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.WhileSubscribed
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
@@ -49,7 +52,17 @@ class PlaylistsViewModel @Inject constructor(
             showPremadePlaylistsTooltip = shouldShowPremadePlaylistsTooltip(showTooltip, playlists),
             miniPlayerInset = bottomInset,
         )
-    }.stateIn(viewModelScope, SharingStarted.Eagerly, UiState.Empty)
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(stopTimeout = 300.milliseconds), UiState.Empty)
+
+    fun getPreviewMetadataFlow(playlistUuid: String): StateFlow<PlaylistPreview.Metadata?> {
+        return playlistManager.getPreviewMetadataFlow(playlistUuid)
+    }
+
+    fun refreshPreviewMetadata(playlistUuid: String) {
+        viewModelScope.launch {
+            playlistManager.refreshPreviewMetadata(playlistUuid)
+        }
+    }
 
     fun deletePlaylist(uuid: String) {
         viewModelScope.launch {
@@ -121,10 +134,11 @@ class PlaylistsViewModel @Inject constructor(
         val showPremadePlaylistsTooltip: Boolean,
         val miniPlayerInset: Int,
     ) {
-        val showEmptyState get() = when (playlists) {
-            is PlaylistsState.Loading -> false
-            is PlaylistsState.Loaded -> playlists.value.isEmpty()
-        }
+        val showEmptyState
+            get() = when (playlists) {
+                is PlaylistsState.Loading -> false
+                is PlaylistsState.Loaded -> playlists.value.isEmpty()
+            }
 
         companion object {
             val Empty = UiState(

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/AddToPlaylistFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/AddToPlaylistFragment.kt
@@ -82,15 +82,18 @@ internal class AddToPlaylistFragment : BaseDialogFragment() {
                 AddToPlaylistPage(
                     playlistPreviews = uiState.playlistPreviews,
                     unfilteredPlaylistsCount = uiState.unfilteredPlaylistsCount,
+                    episodeLimit = uiState.episodeLimit,
                     navController = navController,
                     searchFieldState = viewModel.searchFieldState.textState,
                     newPlaylistNameState = viewModel.newPlaylistNameState,
+                    getPreviewMetadataFlow = viewModel::getPreviewMetadataFlow,
+                    refreshPreviewMetadata = viewModel::refreshPreviewMetadata,
                     onClickCreatePlaylist = {
                         viewModel.trackCreateNewPlaylistTapped()
                         viewModel.createPlaylist()
                     },
                     onChangeEpisodeInPlaylist = { playlist ->
-                        if (playlist.canAddOrRemoveEpisode) {
+                        if (playlist.canAddOrRemoveEpisode(uiState.episodeLimit)) {
                             if (playlist.hasEpisode) {
                                 viewModel.trackEpisodeRemoveTapped()
                                 viewModel.removeFromPlaylist(playlist.uuid)

--- a/modules/features/filters/src/test/kotlin/au/com/shiftyjelly/pocketcasts/playlists/create/FakePlaylistManager.kt
+++ b/modules/features/filters/src/test/kotlin/au/com/shiftyjelly/pocketcasts/playlists/create/FakePlaylistManager.kt
@@ -6,17 +6,18 @@ import au.com.shiftyjelly.pocketcasts.models.entity.ManualPlaylistPodcastSource
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.PlaylistEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.PlaylistEpisodeMetadata
+import au.com.shiftyjelly.pocketcasts.models.to.PlaylistPreviewForEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.PlaylistEpisodeSortType
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.ManualPlaylist
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistPreview
-import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistPreviewForEpisode
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.SmartPlaylist
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.SmartPlaylistDraft
 import java.util.UUID
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.flowOf
 
@@ -25,6 +26,12 @@ class FakePlaylistManager : PlaylistManager {
     override fun playlistPreviewsFlow(): Flow<List<PlaylistPreview>> {
         return playlistPreviews.asStateFlow()
     }
+
+    override fun getPreviewMetadataFlow(playlistUuid: String): StateFlow<PlaylistPreview.Metadata?> {
+        return MutableStateFlow(null)
+    }
+
+    override suspend fun refreshPreviewMetadata(playlistUuid: String) = Unit
 
     override suspend fun getAutoDownloadEpisodes(): List<PodcastEpisode> {
         return emptyList()

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastSettingsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastSettingsFragment.kt
@@ -76,6 +76,8 @@ class PodcastSettingsFragment :
                 uiState = uiState,
                 toolbarColors = toolbarColors,
                 navController = navController,
+                getPreviewMetadataFlow = viewModel::getPreviewMetadataFlow,
+                refreshPreviewMetadata = viewModel::refreshPreviewMetadata,
                 onChangeNotifications = viewModel::changeNotifications,
                 onChangeAutoDownload = viewModel::changeAutoDownload,
                 onChangeAddToUpNext = viewModel::changeAddToUpNext,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastSettingsHomePage.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastSettingsHomePage.kt
@@ -352,8 +352,6 @@ private fun PodcastSettingsHomePagePreview(
                     SmartPlaylistPreview(
                         uuid = "playlist-uuid-$index",
                         title = "Playlist $index",
-                        episodeCount = 0,
-                        artworkPodcastUuids = emptyList(),
                         settings = Playlist.Settings.ForPreview,
                         smartRules = SmartRules.Default.copy(
                             podcasts = PodcastsRule.Selected(uuids = setOf("podcast-uuid")),

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastSettingsPage.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastSettingsPage.kt
@@ -30,9 +30,11 @@ import au.com.shiftyjelly.pocketcasts.models.to.AutoArchiveAfterPlaying
 import au.com.shiftyjelly.pocketcasts.models.to.AutoArchiveInactive
 import au.com.shiftyjelly.pocketcasts.models.to.AutoArchiveLimit
 import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.PodcastSettingsViewModel
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistPreview
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.helper.ToolbarColors
+import kotlinx.coroutines.flow.StateFlow
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
@@ -40,6 +42,8 @@ internal fun PodcastSettingsPage(
     podcastTitle: String,
     toolbarColors: ToolbarColors,
     uiState: PodcastSettingsViewModel.UiState?,
+    getPreviewMetadataFlow: (String) -> StateFlow<PlaylistPreview.Metadata?>,
+    refreshPreviewMetadata: (String) -> Unit,
     onChangeNotifications: (Boolean) -> Unit,
     onChangeAutoDownload: (Boolean) -> Unit,
     onChangeAddToUpNext: (Boolean) -> Unit,
@@ -181,6 +185,8 @@ internal fun PodcastSettingsPage(
                 }
                 PodcastSettingsPlaylistsPage(
                     uiState = uiState,
+                    getPreviewMetadataFlow = getPreviewMetadataFlow,
+                    refreshPreviewMetadata = refreshPreviewMetadata,
                     onAddPodcastToPlaylists = onAddPodcastToPlaylists,
                     onRemovePodcastFromPlaylists = onRemovePodcastFromPlaylists,
                 )

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
@@ -75,6 +75,8 @@ class AutoDownloadSettingsFragment :
                 AutoDownloadSettingsPage(
                     uiState = uiState,
                     navController = navController,
+                    getPreviewMetadataFlow = viewModel::getPreviewMetadataFlow,
+                    refreshPreviewMetadata = viewModel::refreshPreviewMetadata,
                     onChangeUpNextDownload = viewModel::changeUpNextDownload,
                     onChangeNewEpisodesDownload = viewModel::changeNewEpisodesDownload,
                     onChangeOnFollowDownload = viewModel::changeOnFollowDownload,

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsPage.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsPage.kt
@@ -1,7 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.settings
 
-import androidx.compose.animation.core.Spring
-import androidx.compose.animation.core.spring
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Column
@@ -26,14 +24,18 @@ import au.com.shiftyjelly.pocketcasts.compose.navigation.slideInToEnd
 import au.com.shiftyjelly.pocketcasts.compose.navigation.slideInToStart
 import au.com.shiftyjelly.pocketcasts.compose.navigation.slideOutToEnd
 import au.com.shiftyjelly.pocketcasts.compose.navigation.slideOutToStart
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistPreview
 import au.com.shiftyjelly.pocketcasts.settings.viewmodel.AutoDownloadSettingsViewModel.UiState
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
+import kotlinx.coroutines.flow.StateFlow
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 internal fun AutoDownloadSettingsPage(
     uiState: UiState?,
+    getPreviewMetadataFlow: (String) -> StateFlow<PlaylistPreview.Metadata?>,
+    refreshPreviewMetadata: (String) -> Unit,
     onChangeUpNextDownload: (Boolean) -> Unit,
     onChangeNewEpisodesDownload: (Boolean) -> Unit,
     onChangeOnFollowDownload: (Boolean) -> Unit,
@@ -127,6 +129,8 @@ internal fun AutoDownloadSettingsPage(
                 composable(AutoDownloadSettingsRoute.Playlists.value) {
                     AutoDownloadSettingsPlaylistsPage(
                         playlists = state.playlists,
+                        getPreviewMetadataFlow = getPreviewMetadataFlow,
+                        refreshPreviewMetadata = refreshPreviewMetadata,
                         onChangePlaylist = onChangePlaylist,
                         onChangeAllPlaylists = onChangeAllPlaylists,
                     )

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
@@ -18,7 +18,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.PlaylistEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.PlaylistEpisodeMetadata
-import au.com.shiftyjelly.pocketcasts.models.to.PlaylistPreviewForEpisodeEntity
+import au.com.shiftyjelly.pocketcasts.models.to.PlaylistPreviewForEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.PlaylistShortcut
 import au.com.shiftyjelly.pocketcasts.models.to.RawManualEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.PlaylistEpisodeSortType
@@ -102,9 +102,9 @@ abstract class PlaylistDao {
           sortPosition ASC
     """,
     )
-    protected abstract fun playlistPreviewsForEpisodeFlowUnsafe(episodeUuid: String, searchTerm: String): Flow<List<PlaylistPreviewForEpisodeEntity>>
+    protected abstract fun playlistPreviewsForEpisodeFlowUnsafe(episodeUuid: String, searchTerm: String): Flow<List<PlaylistPreviewForEpisode>>
 
-    fun playlistPreviewsForEpisodeFlow(episodeUuid: String, searchTerm: String): Flow<List<PlaylistPreviewForEpisodeEntity>> {
+    fun playlistPreviewsForEpisodeFlow(episodeUuid: String, searchTerm: String): Flow<List<PlaylistPreviewForEpisode>> {
         val escapedTerm = searchTerm.escapeLike('\\')
         return playlistPreviewsForEpisodeFlowUnsafe(episodeUuid, escapedTerm)
     }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/PlaylistPreviewForEpisode.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/PlaylistPreviewForEpisode.kt
@@ -2,9 +2,13 @@ package au.com.shiftyjelly.pocketcasts.models.to
 
 import androidx.room.ColumnInfo
 
-data class PlaylistPreviewForEpisodeEntity(
+data class PlaylistPreviewForEpisode(
     @ColumnInfo(name = "uuid") val uuid: String,
     @ColumnInfo(name = "title") val title: String,
     @ColumnInfo(name = "episode_count") val episodeCount: Int,
     @ColumnInfo(name = "has_episode") val hasEpisode: Boolean,
-)
+) {
+    fun canAddOrRemoveEpisode(episodeLimit: Int): Boolean {
+        return hasEpisode || episodeCount < episodeLimit
+    }
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManager.kt
@@ -7,11 +7,17 @@ import au.com.shiftyjelly.pocketcasts.models.to.PlaylistEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.PlaylistEpisodeMetadata
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import au.com.shiftyjelly.pocketcasts.models.type.PlaylistEpisodeSortType as SortType
 
 interface PlaylistManager {
     // <editor-fold desc="Generic playlists">
     fun playlistPreviewsFlow(): Flow<List<PlaylistPreview>>
+
+    fun getPreviewMetadataFlow(playlistUuid: String): StateFlow<PlaylistPreview.Metadata?>
+
+    suspend fun refreshPreviewMetadata(playlistUuid: String)
 
     suspend fun getAutoDownloadEpisodes(): List<PodcastEpisode>
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManager.kt
@@ -5,6 +5,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.ManualPlaylistPodcastSource
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.PlaylistEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.PlaylistEpisodeMetadata
+import au.com.shiftyjelly.pocketcasts.models.to.PlaylistPreviewForEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
@@ -119,7 +119,7 @@ class PlaylistManagerImpl(
 
     override suspend fun refreshPreviewMetadata(playlistUuid: String) {
         val cachedValue = getCachedMetadata(playlistUuid)
-        if (Duration.between(cachedValue.lastRefreshTime, clock.instant()).seconds > 30) {
+        if (Duration.between(cachedValue.lastRefreshTime, clock.instant()).seconds > CACHE_EVICTION_TIMEOUT.inWholeSeconds) {
             val preview = playlistDao.getAllPlaylistsIn(listOf(playlistUuid)).firstOrNull()?.toPlaylistPreview() ?: return
 
             val episodeCount: Int
@@ -637,3 +637,5 @@ private class CachedMetadata(
     val lastRefreshTime: Instant,
     val flow: MutableStateFlow<PlaylistPreview.Metadata?>,
 )
+
+private val CACHE_EVICTION_TIMEOUT = 30.seconds

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistPreview.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistPreview.kt
@@ -6,18 +6,19 @@ import au.com.shiftyjelly.pocketcasts.models.type.SmartRules
 sealed interface PlaylistPreview {
     val uuid: String
     val title: String
-    val episodeCount: Int
-    val artworkPodcastUuids: List<String>
     val settings: Playlist.Settings
     val icon: PlaylistIcon
     val type: Playlist.Type
+
+    data class Metadata(
+        val episodeCount: Int,
+        val artworkPodcastUuids: List<String>,
+    )
 }
 
 data class SmartPlaylistPreview(
     override val uuid: String,
     override val title: String,
-    override val episodeCount: Int,
-    override val artworkPodcastUuids: List<String>,
     override val settings: Playlist.Settings,
     override val icon: PlaylistIcon,
     val smartRules: SmartRules,
@@ -28,8 +29,6 @@ data class SmartPlaylistPreview(
 data class ManualPlaylistPreview(
     override val uuid: String,
     override val title: String,
-    override val episodeCount: Int,
-    override val artworkPodcastUuids: List<String>,
     override val settings: Playlist.Settings,
     override val icon: PlaylistIcon,
 ) : PlaylistPreview {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistPreview.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistPreview.kt
@@ -34,14 +34,3 @@ data class ManualPlaylistPreview(
 ) : PlaylistPreview {
     override val type get() = Playlist.Type.Manual
 }
-
-data class PlaylistPreviewForEpisode(
-    val uuid: String,
-    val title: String,
-    val episodeCount: Int,
-    val artworkPodcastUuids: List<String>,
-    val hasEpisode: Boolean,
-    val episodeLimit: Int,
-) {
-    val canAddOrRemoveEpisode get() = hasEpisode || episodeCount < episodeLimit
-}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -567,22 +567,18 @@ class PodcastManagerImpl @Inject constructor(
     }
 
     override fun updateOverrideGlobalEffectsBlocking(podcast: Podcast, override: Boolean) {
-        podcast.overrideGlobalEffects = override
         podcastDao.updateOverrideGlobalEffectsBlocking(override, podcast.uuid)
     }
 
     override suspend fun updateTrimModeBlocking(podcast: Podcast, trimMode: TrimMode) {
-        podcast.trimMode = trimMode
         podcastDao.updateTrimSilenceModeBlocking(trimMode, podcast.uuid)
     }
 
     override fun updateVolumeBoostedBlocking(podcast: Podcast, override: Boolean) {
-        podcast.isVolumeBoosted = override
         podcastDao.updateVolumeBoostedBlocking(override, podcast.uuid)
     }
 
     override fun updatePlaybackSpeedBlocking(podcast: Podcast, speed: Double) {
-        podcast.playbackSpeed = speed
         podcastDao.updatePlaybackSpeedBlocking(speed, podcast.uuid)
     }
 

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/extensions/Flow.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/extensions/Flow.kt
@@ -73,6 +73,32 @@ inline fun <T1, T2, T3, T4, T5, T6, T7, T8, R> combine(
     )
 }
 
+inline fun <T1, T2, T3, T4, T5, T6, T7, T8, T9, R> combine(
+    flow1: Flow<T1>,
+    flow2: Flow<T2>,
+    flow3: Flow<T3>,
+    flow4: Flow<T4>,
+    flow5: Flow<T5>,
+    flow6: Flow<T6>,
+    flow7: Flow<T7>,
+    flow8: Flow<T8>,
+    flow9: Flow<T9>,
+    crossinline transform: suspend (T1, T2, T3, T4, T5, T6, T7, T8, T9) -> R,
+): Flow<R> = kotlinCombine(flow1, flow2, flow3, flow4, flow5, flow6, flow7, flow8, flow9) { array ->
+    @Suppress("UNCHECKED_CAST")
+    transform(
+        array[0] as T1,
+        array[1] as T2,
+        array[2] as T3,
+        array[3] as T4,
+        array[4] as T5,
+        array[5] as T6,
+        array[6] as T7,
+        array[7] as T8,
+        array[8] as T9,
+    )
+}
+
 fun <T> Flow<T>.windowed(size: Int) = flow {
     check(size > 0) { "Window size must be positive: $size" }
     val queue = ArrayDeque<T>(size)

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/playlists/PlaylistsViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/playlists/PlaylistsViewModel.kt
@@ -7,12 +7,14 @@ import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistPreview
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 
 @HiltViewModel
 class PlaylistsViewModel @Inject constructor(
-    playlistManager: PlaylistManager,
+    private val playlistManager: PlaylistManager,
 ) : ViewModel() {
 
     sealed class UiState {
@@ -23,4 +25,14 @@ class PlaylistsViewModel @Inject constructor(
     val uiState = playlistManager.playlistPreviewsFlow()
         .map { UiState.Loaded(playlists = it) }
         .stateIn(viewModelScope, SharingStarted.Lazily, UiState.Loading)
+
+    fun getPreviewMetadataFlow(playlistUuid: String): StateFlow<PlaylistPreview.Metadata?> {
+        return playlistManager.getPreviewMetadataFlow(playlistUuid)
+    }
+
+    fun refreshPreviewMetadata(playlistUuid: String) {
+        viewModelScope.launch {
+            playlistManager.refreshPreviewMetadata(playlistUuid)
+        }
+    }
 }


### PR DESCRIPTION
## Description

This PR addresses performance issues when users are subscribed to many podcasts. Displaying playlist artwork and episode counts requires loading data from the episodes table, which can contain hundreds of thousands of episodes. With multiple playlists, this becomes prohibitively slow.

### Optimizations
- Decouple playlist preview from playlist metadata. The preview (containing only uuid, title, and configuration) can now be fetched quickly. Metadata, on the other hand, is cached with a 30-second eviction timeout.  
- In-memory operations for configuration changes. When interacting with playlists to update configurations, all operations are performed in memory first and then dispatched to the database. This improves the responsiveness of controls.  

### Trade-offs
While these optimizations greatly improve performance, they introduce some drawbacks for previews (not full playlist view):  
- Metadata staleness: Since metadata is cached, users may occasionally see outdated covers or inaccurate episode counts.  
- Temporary UI inconsistencies: Because changes are applied in memory before persisting, users who quickly toggle settings and re-enter the screen may see a momentarily inconsistent state.  

Both of these drawbacks are in my opinion acceptable, as the app achieves eventual consistency.

## Testing Instructions

1. Install the prototype build: `gw :app:assemblePrototype && adb install ./app/build/outputs/apk/prototype/app-prototype.apk`.
2. Sign in with an account that has many podcasts. You can use p1759424300783619-slack-C028JAG44VD.
3. Wait for data to sync. This may take a couple of minutes.
4. Once synced, go to the Playlists tab.
5. The tab should load relatively quickly.
6. Open a Manual Playlist. Preview it, edit it, etc. It might take a bit to load it initially depending on the amount of metadata that is currently being fetched.
7. Open a Smart Playlist. Preview it, edit it, etc. It might take a bit to load it initially depending on the amount of metadata that is currently being fetched.
8. Go to any podcast.
9. Open its settings.
10. Settings should load quickly.
11. Edit settings, including skip first and skip last.
12. Changes should be responsive.
13. Open Smart Playlist podcast settings.
14. Including and excluding podcasts should be responsive.
15. Go to the Profile tab.
16. Open auto-download settings.
17. Settings should be responsive.
18. Go to any podcast.
19. Swipe left and tap the Add to Playlist button.
20. The flow should be responsive.
21. Sign out and clear the data.
22. Sign in with a regular account that follows tens of podcasts and has a couple of playlists.
23. Smoke test the app. It should feel rather normal.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.