### PR TITLE
Minimize fetch subscription status call count

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
@@ -4,17 +4,49 @@ import au.com.shiftyjelly.pocketcasts.models.type.Membership
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPlatform
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.servers.sync.toMembership
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 @Singleton
 class SubscriptionManagerImpl @Inject constructor(
+    @ApplicationScope private val scope: CoroutineScope,
     private val syncManager: SyncManager,
     private val settings: Settings,
 ) : SubscriptionManager {
+    private val fetchMutex = Mutex()
+    private var fetchCallsCount = 0
+    private var inFlightSubscription: Deferred<Subscription?>? = null
+
     override suspend fun fetchFreshSubscription(): Subscription? {
+        val deferred = fetchMutex.withLock {
+            val inFlight = inFlightSubscription ?: scope.async(start = CoroutineStart.LAZY) { fetchSubscription() }
+            inFlightSubscription = inFlight
+            fetchCallsCount++
+            inFlight
+        }
+
+        return try {
+            deferred.await()
+        } finally {
+            fetchMutex.withLock {
+                fetchCallsCount--
+                if (fetchCallsCount == 0) {
+                    inFlightSubscription = null
+                }
+            }
+        }
+    }
+
+    private suspend fun fetchSubscription(): Subscription? {
         return runCatching { syncManager.subscriptionStatus().toMembership() }
             .onSuccess { membership ->
                 val subscription = membership.subscription

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
@@ -7,14 +7,11 @@ import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.servers.sync.toMembership
+import au.com.shiftyjelly.pocketcasts.utils.coroutines.SyncedAction
+import au.com.shiftyjelly.pocketcasts.utils.coroutines.run
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.CoroutineStart
-import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.async
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 
 @Singleton
 class SubscriptionManagerImpl @Inject constructor(
@@ -22,32 +19,8 @@ class SubscriptionManagerImpl @Inject constructor(
     private val syncManager: SyncManager,
     private val settings: Settings,
 ) : SubscriptionManager {
-    private val fetchMutex = Mutex()
-    private var fetchCallsCount = 0
-    private var inFlightSubscription: Deferred<Subscription?>? = null
-
-    override suspend fun fetchFreshSubscription(): Subscription? {
-        val deferred = fetchMutex.withLock {
-            val inFlight = inFlightSubscription ?: scope.async(start = CoroutineStart.LAZY) { fetchSubscription() }
-            inFlightSubscription = inFlight
-            fetchCallsCount++
-            inFlight
-        }
-
-        return try {
-            deferred.await()
-        } finally {
-            fetchMutex.withLock {
-                fetchCallsCount--
-                if (fetchCallsCount == 0) {
-                    inFlightSubscription = null
-                }
-            }
-        }
-    }
-
-    private suspend fun fetchSubscription(): Subscription? {
-        return runCatching { syncManager.subscriptionStatus().toMembership() }
+    private val fetchMembershipAction = SyncedAction<Unit, Membership?> {
+        runCatching { syncManager.subscriptionStatus().toMembership() }
             .onSuccess { membership ->
                 val subscription = membership.subscription
                 settings.cachedMembership.set(membership, updateModifiedAt = false)
@@ -55,8 +28,11 @@ class SubscriptionManagerImpl @Inject constructor(
                     settings.setTrialFinishedSeen(false)
                 }
             }
-            .map { membership -> membership.subscription }
             .getOrNull()
+    }
+
+    override suspend fun fetchFreshSubscription(): Subscription? {
+        return fetchMembershipAction.run(scope)?.subscription
     }
 
     override fun clearCachedMembership() {

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/coroutines/SyncedAction.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/coroutines/SyncedAction.kt
@@ -1,0 +1,38 @@
+package au.com.shiftyjelly.pocketcasts.utils.coroutines
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+class SyncedAction<InputT, OutputT>(
+    private val action: suspend (InputT) -> OutputT,
+) {
+    private val executeMutex = Mutex()
+    private var executeCount = 0
+    private var inFlightResult: Deferred<OutputT>? = null
+
+    suspend fun run(input: InputT, scope: CoroutineScope): OutputT {
+        val deferred = executeMutex.withLock {
+            val inFlight = inFlightResult ?: scope.async(start = CoroutineStart.LAZY) { action(input) }
+            inFlightResult = inFlight
+            executeCount++
+            inFlight
+        }
+
+        return try {
+            deferred.await()
+        } finally {
+            executeMutex.withLock {
+                executeCount--
+                if (executeCount == 0) {
+                    inFlightResult = null
+                }
+            }
+        }
+    }
+}
+
+suspend fun <T> SyncedAction<Unit, T>.run(scope: CoroutineScope) = run(input = Unit, scope)

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/coroutines/SyncedAction.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/coroutines/SyncedAction.kt
@@ -7,14 +7,14 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
-class SyncedAction<InputT, OutputT>(
-    private val action: suspend (InputT) -> OutputT,
+class SyncedAction<InputType, OutputType>(
+    private val action: suspend (InputType) -> OutputType,
 ) {
     private val executeMutex = Mutex()
     private var executeCount = 0
-    private var inFlightResult: Deferred<OutputT>? = null
+    private var inFlightResult: Deferred<OutputType>? = null
 
-    suspend fun run(input: InputT, scope: CoroutineScope): OutputT {
+    suspend fun run(input: InputType, scope: CoroutineScope): OutputType {
         val deferred = executeMutex.withLock {
             val inFlight = inFlightResult ?: scope.async(start = CoroutineStart.LAZY) { action(input) }
             inFlightResult = inFlight

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/coroutines/SyncedActionTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/coroutines/SyncedActionTest.kt
@@ -28,7 +28,7 @@ class SyncedActionTest {
         advanceUntilIdle()
 
         assertEquals(List(10) { 0 }, results.awaitAll())
-        assertEquals(counter, 1)
+        assertEquals(1, counter)
     }
 
     @Test

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/coroutines/SyncedActionTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/coroutines/SyncedActionTest.kt
@@ -1,0 +1,45 @@
+package au.com.shiftyjelly.pocketcasts.utils.coroutines
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SyncedActionTest {
+    @Test
+    fun `return the result`() = runTest {
+        val action = SyncedAction<Unit, Int> { 100 }
+
+        val result = action.run(scope = this)
+
+        assertEquals(100, result)
+    }
+
+    @Test
+    fun `run a single job`() = runTest {
+        var counter = 0
+        val action = SyncedAction<Unit, Int> { counter++ }
+
+        val results = List(10) { async { action.run(scope = this) } }
+        advanceUntilIdle()
+
+        assertEquals(List(10) { 0 }, results.awaitAll())
+        assertEquals(counter, 1)
+    }
+
+    @Test
+    fun `allow to run again`() = runTest {
+        var counter = 0
+        val action = SyncedAction<Unit, Int> { counter++ }
+
+        val result1 = action.run(scope = this)
+        assertEquals(0, result1)
+
+        val result2 = action.run(scope = this)
+        assertEquals(1, result2)
+    }
+}


### PR DESCRIPTION
## Description

Context : p1759227747944919-slack-C028JAG44VD

## Testing Instructions

Smoke test if your subscription status works.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.