### PR TITLE
Fix auto downloading archived episodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
         ([#4560](https://github.com/Automattic/pocket-casts-android/pull/4560))
     *   Fix transcript button incorrectly disabled
         ([#4555](https://github.com/Automattic/pocket-casts-android/pull/4555))
+    *   Fix archived episodes not being downloaded when added to queue
+        ([#4555](https://github.com/Automattic/pocket-casts-android/pull/4555))
 
 7.99
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
     *   Fix transcript button incorrectly disabled
         ([#4555](https://github.com/Automattic/pocket-casts-android/pull/4555))
     *   Fix archived episodes not being downloaded when added to queue
-        ([#4555](https://github.com/Automattic/pocket-casts-android/pull/4555))
+        ([#4570](https://github.com/Automattic/pocket-casts-android/pull/4570))
 
 7.99
 -----

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadHelper.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadHelper.kt
@@ -30,7 +30,7 @@ object DownloadHelper {
     }
 
     fun addAutoDownloadedEpisodeToQueue(episode: BaseEpisode, from: String, downloadManager: DownloadManager, episodeManager: EpisodeManager, source: SourceView) {
-        if (episode.isDownloaded || episode.isDownloading || episode.episodeStatus == EpisodeStatusEnum.DOWNLOAD_FAILED) {
+        if (episode.isQueued || episode.isDownloaded || episode.isDownloading || episode.episodeStatus == EpisodeStatusEnum.DOWNLOAD_FAILED) {
             if (episode.episodeStatus == EpisodeStatusEnum.DOWNLOAD_FAILED) {
                 LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Not autodownloading ${episode.title} from $from because it has already failed.")
             }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadHelper.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadHelper.kt
@@ -30,7 +30,7 @@ object DownloadHelper {
     }
 
     fun addAutoDownloadedEpisodeToQueue(episode: BaseEpisode, from: String, downloadManager: DownloadManager, episodeManager: EpisodeManager, source: SourceView) {
-        if (episode.isQueued || episode.isDownloaded || episode.isDownloading || episode.isExemptFromAutoDownload || episode.episodeStatus == EpisodeStatusEnum.DOWNLOAD_FAILED) {
+        if (episode.isDownloaded || episode.isDownloading || episode.episodeStatus == EpisodeStatusEnum.DOWNLOAD_FAILED) {
             if (episode.episodeStatus == EpisodeStatusEnum.DOWNLOAD_FAILED) {
                 LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Not autodownloading ${episode.title} from $from because it has already failed.")
             }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
@@ -113,6 +113,7 @@ class PlaylistManagerImpl(
                         playlistFlow.first()
                             ?.episodes
                             ?.toPodcastEpisodes()
+                            ?.filterNot { it.isExemptFromAutoDownload }
                             ?.take(playlist.autodownloadLimit)
                             .orEmpty()
                     }


### PR DESCRIPTION
## Description

#4477 introduced a bug when adding episodes to Up Next when auto-download feature was enabled. Such episodes got skipped because of the `isExemptFromAutoDownload` condition.

## Testing Instructions

1. Go to the settings.
2. Go to the auto download settings.
3. Disable the "On Follow" setting.
4. Enable the "Episodes added to Up Next" setting.
5. Follow any podcast.
6. Go to it.
7. Swipe left to archive an episode.
8. Show archived episodes.
9. Swipe right on the archived episode.
10. It should be added to the queue and auto-downloaded.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.