### PR TITLE
Decrease swipe action linger duration

### DIFF
--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/swipe/SwipeRowLayout.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/swipe/SwipeRowLayout.kt
@@ -243,7 +243,7 @@ class SwipeRowLayout<T : SwipeButton.UiState> @JvmOverloads constructor(
                 primaryButton.callOnSwipeActionListeners()
                 swipedAction?.cancel()
                 swipedAction = runDelayedAction(
-                    350.milliseconds,
+                    100.milliseconds,
                     action = {
                         primaryButton.elevation = 1f
                         swipeableView.translationX = 0f


### PR DESCRIPTION
## Description

We got some beta feedback that the linger duration feels too long. When implementing it I wasn't sure about it as well. It makes sense to make it shorter since this isn't a transition so it should feel snappier.

## Testing Instructions

Smoke test swiping animation.

## Screenshots or Screencast 

| Before | After |
| - | - |
| <video src="https://github.com/user-attachments/assets/dfa1ec7e-9f11-4cd5-95f4-fb9161a9347d" /> | <video src="https://github.com/user-attachments/assets/0169d030-6a8e-4f3a-9abb-bc047131a22c" /> |

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.