### PR TITLE
Add i18n headers

### DIFF
--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/di/InterceptorModule.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/di/InterceptorModule.kt
@@ -138,6 +138,7 @@ object InterceptorModule {
         settings: Settings,
     ): Interceptor {
         return InternationalizationInterceptor(
+            allowedHosts = listOf(BuildConfig.WEB_BASE_HOST, BuildConfig.SERVER_SHORT_HOST),
             provideLocale = { context.resources.configuration.locales[0] },
             provideRegion = { settings.discoverCountryCode.value },
         )

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/di/ServersModule.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/di/ServersModule.kt
@@ -349,6 +349,10 @@ annotation class TokenInterceptor
 
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
+annotation class I18nInterceptor
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
 annotation class Transcripts
 
 @Qualifier

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/interceptors/InternationalizationInterceptor.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/interceptors/InternationalizationInterceptor.kt
@@ -1,21 +1,32 @@
 package au.com.shiftyjelly.pocketcasts.servers.interceptors
 
 import java.util.Locale
+import okhttp3.HttpUrl
 import okhttp3.Interceptor
 import okhttp3.Request
 import okhttp3.Response
 
 internal class InternationalizationInterceptor(
+    private val allowedHosts: List<String>,
     private val provideLocale: () -> Locale,
     private val provideRegion: () -> String,
 ) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
         val request = chain.request()
-            .newBuilder()
-            .addHeaderIfNotEmpty(APP_LANGUAGE_HEADER, provideLocale().toIso6391())
-            .addHeaderIfNotEmpty(USER_REGION_HEADER, provideRegion())
-            .build()
-        return chain.proceed(request)
+        val newRequest = if (isHostAllowed(request.url)) {
+            request.newBuilder()
+                .addHeaderIfNotEmpty(APP_LANGUAGE_HEADER, provideLocale().toIso6391())
+                .addHeaderIfNotEmpty(USER_REGION_HEADER, provideRegion())
+                .build()
+        } else {
+            request
+        }
+
+        return chain.proceed(newRequest)
+    }
+
+    private fun isHostAllowed(url: HttpUrl): Boolean {
+        return allowedHosts.any { allowedHost -> url.host.endsWith(allowedHost, ignoreCase = true) }
     }
 
     private fun Locale.toIso6391() = buildString {

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/interceptors/InternationalizationInterceptor.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/interceptors/InternationalizationInterceptor.kt
@@ -1,0 +1,43 @@
+package au.com.shiftyjelly.pocketcasts.servers.interceptors
+
+import java.util.Locale
+import okhttp3.Interceptor
+import okhttp3.Request
+import okhttp3.Response
+
+internal class InternationalizationInterceptor(
+    private val provideLocale: () -> Locale,
+    private val provideRegion: () -> String,
+) : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+            .newBuilder()
+            .addHeaderIfNotEmpty(APP_LANGUAGE_HEADER, provideLocale().toIso6391())
+            .addHeaderIfNotEmpty(USER_REGION_HEADER, provideRegion())
+            .build()
+        return chain.proceed(request)
+    }
+
+    private fun Locale.toIso6391() = buildString {
+        if (language.isNotEmpty()) {
+            append(language)
+        }
+        if (isNotEmpty() && country.isNotEmpty()) {
+            append('-')
+            append(country)
+        }
+    }
+
+    private fun Request.Builder.addHeaderIfNotEmpty(header: String, value: String): Request.Builder {
+        return if (value.isNotEmpty()) {
+            header(header, value)
+        } else {
+            this
+        }
+    }
+
+    companion object {
+        const val APP_LANGUAGE_HEADER = "X-App-Language"
+        const val USER_REGION_HEADER = "X-User-Region"
+    }
+}

--- a/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/interceptors/InternationalizationInterceptorTest.kt
+++ b/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/interceptors/InternationalizationInterceptorTest.kt
@@ -1,0 +1,78 @@
+package au.com.shiftyjelly.pocketcasts.servers.interceptors
+
+import au.com.shiftyjelly.pocketcasts.servers.interceptors.InternationalizationInterceptor.Companion.APP_LANGUAGE_HEADER
+import au.com.shiftyjelly.pocketcasts.servers.interceptors.InternationalizationInterceptor.Companion.USER_REGION_HEADER
+import java.util.Locale
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+class InternationalizationInterceptorTest {
+    @get:Rule
+    val server = MockWebServer()
+
+    private var locale = Locale.US
+    private var region = "gb"
+
+    private val client = OkHttpClient.Builder()
+        .addInterceptor(
+            InternationalizationInterceptor(
+                provideLocale = { locale },
+                provideRegion = { region },
+            ),
+        )
+        .build()
+    private val url = server.url("/")
+
+    @Test
+    fun `add i18n headers`() {
+        val request = Request.Builder().url(url).build()
+
+        server.enqueue(MockResponse())
+        client.newCall(request).execute()
+
+        var serverRequest = server.takeRequest()
+        assertEquals("en-US", serverRequest.getHeader(APP_LANGUAGE_HEADER))
+        assertEquals("gb", serverRequest.getHeader(USER_REGION_HEADER))
+
+        locale = Locale.GERMANY
+        region = "us"
+
+        server.enqueue(MockResponse())
+        client.newCall(request).execute()
+
+        serverRequest = server.takeRequest()
+        assertEquals("de-DE", serverRequest.getHeader(APP_LANGUAGE_HEADER))
+        assertEquals("us", serverRequest.getHeader(USER_REGION_HEADER))
+    }
+
+    @Test
+    fun `add partial language header`() {
+        locale = Locale.of("pl")
+        val request = Request.Builder().url(url).build()
+
+        server.enqueue(MockResponse())
+        client.newCall(request).execute()
+
+        val serverRequest = server.takeRequest()
+        assertEquals("pl", serverRequest.getHeader(APP_LANGUAGE_HEADER))
+    }
+
+    @Test
+    fun `do not add empty headers`() {
+        locale = Locale.ROOT
+        region = ""
+        val request = Request.Builder().url(url).build()
+
+        server.enqueue(MockResponse())
+        client.newCall(request).execute()
+
+        val serverRequest = server.takeRequest()
+        assertEquals(null, serverRequest.getHeader(APP_LANGUAGE_HEADER))
+        assertEquals(null, serverRequest.getHeader(USER_REGION_HEADER))
+    }
+}


### PR DESCRIPTION
## Description

This adds`X-App-Language` and `X-User-Region` headers to our HTTP requests.

Closes PCDROID-179

## Testing Instructions

1. Start the app.
2. Check for the headers either in the Logcat or in the Network Inspection.
3. The headers should match your configuration.
4. Go to Discover and scroll to the bottom.
5. Change your region.
6. Value should be reflected in the `X-User-Region` header.
7. Change device's or app's language from the system settings.
8. Value should be reflected in the `X-App-Language` header.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.