### PR TITLE
Change episode status separator

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/BaseEpisodeViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/BaseEpisodeViewHolder.kt
@@ -236,7 +236,7 @@ abstract class BaseEpisodeViewHolder<T : Any>(
             val archivedString = context.getString(LR.string.archived)
             val timeLeft = TimeHelper.getTimeLeft(episode.playedUpToMs, episode.durationMs.toLong(), episode.isInProgress, context)
             bindStatus(
-                text = "$archivedString. ${timeLeft.text}",
+                text = "$archivedString · ${timeLeft.text}",
                 description = "$archivedString. ${timeLeft.description}",
                 iconId = IR.drawable.ic_archive,
                 iconTint = primaryIcon02Tint,


### PR DESCRIPTION
## Description

Change archived status separator from `.` to `·`.

Context: p1759832359963469/1759806249.844679-slack-C093RV9N8DR

## Testing Instructions

Code review should be enough.

## Screenshots or Screencast 

| Before | After |
| - | - |
| <img width="740" height="164" alt="image" src="https://github.com/user-attachments/assets/64637b2a-3cbe-4d18-be68-243993736fb8" /> | <img width="738" height="159" alt="image" src="https://github.com/user-attachments/assets/654d1a62-f694-4b38-95f4-3f68899c0d7c" /> |

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.