### PR TITLE
Add Up Next Sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 7.100
 -----
+*   New Features
+    *   Add an option to sort Up Next by date
+        ([#4405](https://github.com/Automattic/pocket-casts-android/pull/4405))
 *   Bug Fixes
     *   Fix restoring large Up Next queues
         ([#4562](https://github.com/Automattic/pocket-casts-android/pull/4562))

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
@@ -73,6 +73,7 @@ class UpNextAdapter(
     private val settings: Settings,
     private val playbackManager: PlaybackManager,
     private val swipeRowActionsFactory: SwipeRowActions.Factory,
+    private val onSortClick: () -> Unit,
     private val onSwipeAction: (BaseEpisode, SwipeAction) -> Unit,
 ) : ListAdapter<Any, RecyclerView.ViewHolder>(UPNEXT_ADAPTER_DIFF) {
     private val dateFormatter = RelativeDateFormatter(context)
@@ -132,7 +133,11 @@ class UpNextAdapter(
                 )
             }
 
-            R.layout.adapter_up_next_footer -> HeaderViewHolder(AdapterUpNextFooterBinding.inflate(inflater, parent, false))
+            R.layout.adapter_up_next_footer -> HeaderViewHolder(
+                binding = AdapterUpNextFooterBinding.inflate(inflater, parent, false),
+                onSortClick = onSortClick,
+            )
+
             R.layout.adapter_up_next_playing -> PlayingViewHolder(AdapterUpNextPlayingBinding.inflate(inflater, parent, false))
             else -> throw IllegalStateException("Unknown view type in up next")
         }
@@ -195,7 +200,14 @@ class UpNextAdapter(
         this.isUpNextNotEmpty = isUpNextNotEmpty
     }
 
-    inner class HeaderViewHolder(val binding: AdapterUpNextFooterBinding) : RecyclerView.ViewHolder(binding.root) {
+    inner class HeaderViewHolder(
+        val binding: AdapterUpNextFooterBinding,
+        val onSortClick: () -> Unit,
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        init {
+            binding.sort.setOnClickListener { onSortClick() }
+        }
 
         fun bind(header: PlayerViewModel.UpNextSummary) {
             with(binding) {
@@ -218,6 +230,7 @@ class UpNextAdapter(
                     root.resources.getQuantityString(LR.plurals.player_up_next_header_title, header.episodeCount, header.episodeCount, time)
                 }
 
+                sort.isVisible = isUpNextNotEmpty
                 shuffle.isVisible = isUpNextNotEmpty
                 shuffle.updateShuffleButton()
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
@@ -271,6 +271,7 @@ class UpNextFragment :
                     swipeActionViewModel.handleAction(swipeAction, episode.uuid, childFragmentManager)
                 }
             },
+            onSortClick = ::showSortDialog,
         )
         adapter.theme = overrideTheme
     }
@@ -541,5 +542,12 @@ class UpNextFragment :
         val canScroll = binding.recyclerView.canScrollVertically(-1)
         binding.recyclerView.quickScrollToTop()
         return canScroll
+    }
+
+    private fun showSortDialog() {
+        if (childFragmentManager.findFragmentByTag("up-next-sort") != null) {
+            return
+        }
+        UpNextSortFragment().show(childFragmentManager, "up-next-sort")
     }
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextSortFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextSortFragment.kt
@@ -1,0 +1,44 @@
+package au.com.shiftyjelly.pocketcasts.player.view
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
+import androidx.compose.ui.res.stringResource
+import androidx.fragment.app.viewModels
+import androidx.fragment.compose.content
+import au.com.shiftyjelly.pocketcasts.compose.components.SelectedOptionColumn
+import au.com.shiftyjelly.pocketcasts.models.type.UpNextSortType
+import au.com.shiftyjelly.pocketcasts.player.viewmodel.UpNextViewModel
+import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+internal class UpNextSortFragment : BaseDialogFragment() {
+    private val viewModel by viewModels<UpNextViewModel>({ requireParentFragment() })
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ) = content {
+        DialogBox(
+            fillMaxHeight = false,
+            modifier = Modifier.nestedScroll(rememberNestedScrollInteropConnection()),
+        ) {
+            SelectedOptionColumn(
+                title = getString(LR.string.player_up_next_sort),
+                options = UpNextSortType.entries,
+                selectedOption = null,
+                optionLabel = { option -> stringResource(option.descriptionId) },
+                onClickOption = { option ->
+                    viewModel.sortUpNext(option)
+                    dismiss()
+                },
+                modifier = Modifier.navigationBarsPadding(),
+            )
+        }
+    }
+}

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/UpNextViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/UpNextViewModel.kt
@@ -2,11 +2,14 @@ package au.com.shiftyjelly.pocketcasts.player.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import au.com.shiftyjelly.pocketcasts.repositories.di.IoDispatcher
+import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
+import au.com.shiftyjelly.pocketcasts.models.db.dao.UpNextDao
+import au.com.shiftyjelly.pocketcasts.models.type.UpNextSortType
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -14,18 +17,21 @@ import kotlinx.coroutines.reactive.asFlow
 
 @HiltViewModel
 class UpNextViewModel @Inject constructor(
-    val userManager: UserManager,
-    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+    private val userManager: UserManager,
+    private val upNextQueue: UpNextQueue,
 ) : ViewModel() {
-
     private val _isSignedInAsPaidUser = MutableStateFlow(false)
     val isSignedInAsPaidUser: StateFlow<Boolean> get() = _isSignedInAsPaidUser
 
     init {
-        viewModelScope.launch(ioDispatcher) {
+        viewModelScope.launch {
             userManager.getSignInState().asFlow().collect { signInState ->
                 _isSignedInAsPaidUser.value = signInState.isSignedInAsPlusOrPatron
             }
         }
+    }
+
+    fun sortUpNext(sortType: UpNextSortType) {
+        upNextQueue.sortUpNext(sortType)
     }
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/UpNextViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/UpNextViewModel.kt
@@ -2,6 +2,8 @@ package au.com.shiftyjelly.pocketcasts.player.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
 import au.com.shiftyjelly.pocketcasts.models.db.dao.UpNextDao
 import au.com.shiftyjelly.pocketcasts.models.type.UpNextSortType
@@ -19,6 +21,7 @@ import kotlinx.coroutines.reactive.asFlow
 class UpNextViewModel @Inject constructor(
     private val userManager: UserManager,
     private val upNextQueue: UpNextQueue,
+    private val tracker: AnalyticsTracker,
 ) : ViewModel() {
     private val _isSignedInAsPaidUser = MutableStateFlow(false)
     val isSignedInAsPaidUser: StateFlow<Boolean> get() = _isSignedInAsPaidUser
@@ -32,6 +35,10 @@ class UpNextViewModel @Inject constructor(
     }
 
     fun sortUpNext(sortType: UpNextSortType) {
+        tracker.track(
+            AnalyticsEvent.UP_NEXT_SORT,
+            mapOf("sort_type" to sortType.analyticsValue),
+        )
         upNextQueue.sortUpNext(sortType)
     }
 }

--- a/modules/features/player/src/main/res/layout/adapter_up_next_footer.xml
+++ b/modules/features/player/src/main/res/layout/adapter_up_next_footer.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/upNextFooter"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -10,19 +10,19 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:layout_margin="16dp">
+        android:layout_margin="16dp"
+        android:orientation="horizontal">
 
         <TextView
             android:id="@+id/lblUpNextTime"
             style="@style/P50"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:layout_marginEnd="4dp"
-            android:textColor="?attr/primary_text_02"
-            android:gravity="center_vertical"
             android:layout_gravity="center_vertical"
+            android:layout_marginEnd="4dp"
+            android:layout_weight="1"
+            android:gravity="center_vertical"
+            android:textColor="?attr/primary_text_02"
             tools:text="2 episodes - 23 min." />
 
         <ImageButton
@@ -30,12 +30,22 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center_vertical"
+            android:layout_marginEnd="16dp"
             android:background="?attr/actionBarItemBackground"
             android:contentDescription="@string/up_next_shuffle_button_content_description"
             android:gravity="center_vertical"
-            android:layout_marginEnd="6dp"
-            android:visibility="gone"
             app:srcCompat="@drawable/shuffle" />
+
+        <ImageButton
+            android:id="@+id/sort"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:background="?attr/actionBarItemBackground"
+            android:contentDescription="@string/player_up_next_sort"
+            android:gravity="center_vertical"
+            app:srcCompat="@drawable/ic_sort"
+            app:tint="?attr/primary_icon_02" />
     </LinearLayout>
 
     <androidx.compose.ui.platform.ComposeView

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/UpNextViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/UpNextViewModelTest.kt
@@ -10,7 +10,6 @@ import io.reactivex.Flowable
 import java.time.Instant
 import junit.framework.TestCase.assertEquals
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.mockito.kotlin.mock
@@ -58,6 +57,6 @@ class UpNextViewModelTest {
                     ),
                 ),
             )
-        return UpNextViewModel(userManager, UnconfinedTestDispatcher())
+        return UpNextViewModel(userManager, mock())
     }
 }

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/UpNextViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/UpNextViewModelTest.kt
@@ -7,16 +7,20 @@ import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPlatform
 import au.com.shiftyjelly.pocketcasts.payment.BillingCycle
 import au.com.shiftyjelly.pocketcasts.payment.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
+import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import io.reactivex.Flowable
 import java.time.Instant
 import junit.framework.TestCase.assertEquals
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
 class UpNextViewModelTest {
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
 
     @Test
     fun `initial state isSignedInAsPaidUser should be true for paid user`() = runTest {

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/UpNextViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/UpNextViewModelTest.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.player.viewmodel
 
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.models.type.SignInState
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPlatform
@@ -57,6 +58,6 @@ class UpNextViewModelTest {
                     ),
                 ),
             )
-        return UpNextViewModel(userManager, mock())
+        return UpNextViewModel(userManager, mock(), AnalyticsTracker.test())
     }
 }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -386,6 +386,7 @@ enum class AnalyticsEvent(val key: String) {
     UP_NEXT_DISMISSED("up_next_dismissed"),
     UP_NEXT_SHUFFLE_ENABLED("up_next_shuffle_enabled"),
     UP_NEXT_DISCOVER_BUTTON_TAPPED("up_next_discover_button_tapped"),
+    UP_NEXT_SORT("up_next_sort"),
 
     /* Player */
     PLAYER_SHOWN("player_shown"),

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -462,6 +462,7 @@
     <string name="player_played_up_to">Played up to %s</string>
     <string name="player_time_remaining">Time remaining %s</string>
     <string name="drag_down_to_dismiss_content_description">Drag down to dismiss</string>
+    <string name="player_up_next_sort">Sort Up Next</string>
 
     <!-- Chapters -->
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/UpNextChangeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/UpNextChangeDao.kt
@@ -4,6 +4,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Transaction
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.UpNextChange
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/UpNextChangeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/UpNextChangeDao.kt
@@ -4,7 +4,6 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
-import androidx.room.Transaction
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.UpNextChange
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/UpNextSortType.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/UpNextSortType.kt
@@ -1,0 +1,33 @@
+package au.com.shiftyjelly.pocketcasts.models.type
+
+import androidx.annotation.StringRes
+import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+enum class UpNextSortType(
+    val analyticsValue: String,
+    @StringRes val descriptionId: Int,
+) : Comparator<BaseEpisode> {
+    NewestToOldest(
+        analyticsValue = "newest_to_oldest",
+        descriptionId = LR.string.sort_newest_to_oldest,
+    ) {
+        private val comparatorDelegate = Comparator.comparing(BaseEpisode::publishedDate)
+            .thenComparing(BaseEpisode::addedDate)
+
+        override fun compare(o1: BaseEpisode, o2: BaseEpisode): Int {
+            return comparatorDelegate.compare(o2, o1)
+        }
+    },
+    OldestToNewest(
+        analyticsValue = "oldest_to_newest",
+        descriptionId = LR.string.sort_oldest_to_newest,
+    ) {
+        private val comparatorDelegate = Comparator.comparing(BaseEpisode::publishedDate)
+            .thenComparing(BaseEpisode::addedDate)
+
+        override fun compare(o1: BaseEpisode, o2: BaseEpisode): Int {
+            return comparatorDelegate.compare(o1, o2)
+        }
+    },
+}

--- a/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/type/UpNextSortTypeTest.kt
+++ b/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/type/UpNextSortTypeTest.kt
@@ -1,7 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.models.type
 
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
-import java.sql.Date
+import java.util.Date
 import org.junit.Assert.assertEquals
 import org.junit.Test
 

--- a/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/type/UpNextSortTypeTest.kt
+++ b/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/type/UpNextSortTypeTest.kt
@@ -1,0 +1,112 @@
+package au.com.shiftyjelly.pocketcasts.models.type
+
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import java.sql.Date
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class UpNextSortTypeTest {
+    @Test
+    fun `sort newest to oldest`() {
+        val episodes = listOf(
+            PodcastEpisode(
+                uuid = "0",
+                publishedDate = Date(0),
+                addedDate = Date(0),
+            ),
+            PodcastEpisode(
+                uuid = "1",
+                publishedDate = Date(1),
+                addedDate = Date(0),
+            ),
+            PodcastEpisode(
+                uuid = "2",
+                publishedDate = Date(2),
+                addedDate = Date(100),
+            ),
+            PodcastEpisode(
+                uuid = "3",
+                publishedDate = Date(2),
+                addedDate = Date(200),
+            ),
+        )
+
+        assertEquals(
+            listOf(
+                PodcastEpisode(
+                    uuid = "3",
+                    publishedDate = Date(2),
+                    addedDate = Date(200),
+                ),
+                PodcastEpisode(
+                    uuid = "2",
+                    publishedDate = Date(2),
+                    addedDate = Date(100),
+                ),
+                PodcastEpisode(
+                    uuid = "1",
+                    publishedDate = Date(1),
+                    addedDate = Date(0),
+                ),
+                PodcastEpisode(
+                    uuid = "0",
+                    publishedDate = Date(0),
+                    addedDate = Date(0),
+                ),
+            ),
+            episodes.sortedWith(UpNextSortType.NewestToOldest),
+        )
+    }
+
+    @Test
+    fun `sort oldest to newest`() {
+        val episodes = listOf(
+            PodcastEpisode(
+                uuid = "3",
+                publishedDate = Date(2),
+                addedDate = Date(200),
+            ),
+            PodcastEpisode(
+                uuid = "2",
+                publishedDate = Date(2),
+                addedDate = Date(100),
+            ),
+            PodcastEpisode(
+                uuid = "1",
+                publishedDate = Date(1),
+                addedDate = Date(0),
+            ),
+            PodcastEpisode(
+                uuid = "0",
+                publishedDate = Date(0),
+                addedDate = Date(0),
+            ),
+        )
+
+        assertEquals(
+            listOf(
+                PodcastEpisode(
+                    uuid = "0",
+                    publishedDate = Date(0),
+                    addedDate = Date(0),
+                ),
+                PodcastEpisode(
+                    uuid = "1",
+                    publishedDate = Date(1),
+                    addedDate = Date(0),
+                ),
+                PodcastEpisode(
+                    uuid = "2",
+                    publishedDate = Date(2),
+                    addedDate = Date(100),
+                ),
+                PodcastEpisode(
+                    uuid = "3",
+                    publishedDate = Date(2),
+                    addedDate = Date(200),
+                ),
+            ),
+            episodes.sortedWith(UpNextSortType.OldestToNewest),
+        )
+    }
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueue.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueue.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.repositories.playback
 
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.type.UpNextSortType
 import au.com.shiftyjelly.pocketcasts.preferences.model.AutoPlaySource
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
@@ -46,6 +47,7 @@ interface UpNextQueue {
     suspend fun importServerChangesBlocking(episodes: List<BaseEpisode>, playbackManager: PlaybackManager, downloadManager: DownloadManager)
     fun contains(uuid: String): Boolean
     fun updateCurrentEpisodeState(state: State)
+    fun sortUpNext(sortType: UpNextSortType)
 
     sealed class State {
         object Empty : State()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueueImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueueImpl.kt
@@ -28,7 +28,6 @@ import io.reactivex.schedulers.Schedulers
 import java.util.Collections
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
-import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 import kotlin.random.Random
 import kotlinx.coroutines.CoroutineScope
@@ -37,7 +36,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 
-@Singleton
 class UpNextQueueImpl @Inject constructor(
     appDatabase: AppDatabase,
     private val settings: Settings,


### PR DESCRIPTION
## Description

This adds parity with the Web Player and allows sorting Up Next episodes by date.

## Testing Instructions

1. Add episodes to Up Next.
2. Open Up Next.
3. Tap sort button.
4. Select sorting option.
5. The episodes should get sorted.

## Screenshots or Screencast 

https://github.com/user-attachments/assets/97be055c-b205-4673-b46d-ccc96e07b727

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack