### PR TITLE
Add unavailable episode icon

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/EditPlaylistPage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/EditPlaylistPage.kt
@@ -285,10 +285,17 @@ private fun Footer(
         verticalAlignment = Alignment.Bottom,
         modifier = modifier,
     ) {
-        val isArchived = episodeWrapper is PlaylistEpisode.Available && episodeWrapper.episode.isArchived
-        if (isArchived) {
+        val episodeIcon = when (episodeWrapper) {
+            is PlaylistEpisode.Available -> if (episodeWrapper.episode.isArchived) {
+                IR.drawable.ic_archive
+            } else {
+                null
+            }
+            is PlaylistEpisode.Unavailable -> IR.drawable.ic_episode_unavailable
+        }
+        if (episodeIcon != null) {
             Image(
-                painter = painterResource(IR.drawable.ic_archive),
+                painter = painterResource(episodeIcon),
                 contentDescription = null,
                 colorFilter = ColorFilter.tint(MaterialTheme.theme.colors.primaryText02),
                 modifier = Modifier
@@ -298,6 +305,7 @@ private fun Footer(
         }
         TextH60(
             text = buildString {
+                val isArchived = episodeWrapper is PlaylistEpisode.Available && episodeWrapper.episode.isArchived
                 if (isArchived) {
                     append(stringResource(LR.string.archived))
                     append(" • ")

--- a/modules/features/filters/src/main/res/layout/adapter_episode_unavailable.xml
+++ b/modules/features/filters/src/main/res/layout/adapter_episode_unavailable.xml
@@ -62,26 +62,45 @@
             android:alpha="0.4"
             android:ellipsize="end"
             android:maxLines="2"
-            app:layout_constraintBottom_toTopOf="@+id/unavailableLabel"
+            app:layout_constraintBottom_toTopOf="@+id/unavailableStatusContainer"
             app:layout_constraintEnd_toEndOf="@+id/dateLabel"
             app:layout_constraintStart_toStartOf="@id/dateLabel"
             app:layout_constraintTop_toBottomOf="@id/dateLabel"
             tools:text="Episode title" />
 
-        <TextView
-            android:id="@+id/unavailableLabel"
-            style="?attr/textCaption"
+        <LinearLayout
+            android:id="@+id/unavailableStatusContainer"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginBottom="12dp"
             android:alpha="0.4"
-            android:ellipsize="end"
-            android:maxLines="1"
-            android:text="@string/unavailable"
+            android:orientation="horizontal"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="@+id/dateLabel"
             app:layout_constraintStart_toStartOf="@id/dateLabel"
-            app:layout_constraintTop_toBottomOf="@id/titleLabel" />
+            app:layout_constraintTop_toBottomOf="@id/titleLabel"
+            tools:ignore="UseCompoundDrawables">
+
+            <ImageView
+                android:id="@+id/imgUnavailable"
+                android:layout_width="16dp"
+                android:layout_height="16dp"
+                android:layout_gravity="center"
+                android:layout_marginEnd="4dp"
+                android:importantForAccessibility="no"
+                android:src="@drawable/ic_episode_unavailable"
+                app:tint="?attr/primary_icon_02" />
+
+            <TextView
+                android:id="@+id/unavailableLabel"
+                style="?attr/textCaption"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:layout_weight="1"
+                android:ellipsize="end"
+                android:maxLines="1"
+                android:text="@string/unavailable" />
+        </LinearLayout>
 
         <View
             android:layout_width="match_parent"

--- a/modules/services/images/src/main/res/drawable/ic_episode_unavailable.xml
+++ b/modules/services/images/src/main/res/drawable/ic_episode_unavailable.xml
@@ -1,0 +1,29 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="28dp"
+    android:height="28dp"
+    android:viewportWidth="28"
+    android:viewportHeight="28">
+
+    <group
+        android:pivotX="12"
+        android:pivotY="12"
+        android:rotation="45"
+        android:translateX="2"
+        android:translateY="2">
+        <path
+            android:fillColor="#ff00ff"
+            android:pathData="M12,7C11.448,7 11,7.448 11,8V11H8C7.448,11 7,11.448 7,12C7,12.552 7.448,13 8,13H11V16C11,16.552 11.448,17 12,17C12.552,17 13,16.552 13,16V13H16C16.552,13 17,12.552 17,12C17,11.448 16.552,11 16,11H13V8C13,7.448 12.552,7 12,7Z" />
+    </group>
+
+    <group
+        android:translateX="2"
+        android:translateY="2">
+
+        <path
+            android:fillColor="#ff00ff"
+            android:fillType="evenOdd"
+            android:pathData="M12,22C17.523,22 22,17.523 22,12C22,6.477 17.523,2 12,2C6.477,2 2,6.477 2,12C2,17.523 6.477,22 12,22ZM12,24C18.627,24 24,18.627 24,12C24,5.373 18.627,0 12,0C5.373,0 0,5.373 0,12C0,18.627 5.373,24 12,24Z" />
+
+    </group>
+
+</vector>


### PR DESCRIPTION
## Description

This adds unavailable episodes status icon.

Closes PCDROID-183

## Testing Instructions

1. Create a Manual Playlists.
2. Add an episode to it.
3. Execute this query.
```sql
DELETE FROM podcast_episodes WHERE uuid IS (SELECT episode_uuid FROM manual_playlist_episodes LIMIT 1)
```
4. Verify that the UI has an indicator icon.

## Screenshots or Screencast 

| Playlist | Edit Mode |
| - | - |
| <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/d44b0064-20c5-4044-8464-adaf307e424e" /> | <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/d7e7f28d-520a-4815-ad68-780261659219" /> |

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack