### PR TITLE
Sync playlist show archived setting

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerBaseTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerBaseTest.kt
@@ -447,9 +447,11 @@ class PlaylistManagerBaseTest {
         insertSmartPlaylist(index = 0)
 
         expectNotShowArchived(playlistIndex = 0)
+        expectSynced(playlistIndex = 0)
 
         manager.toggleShowArchived("playlist-id-0")
         expectShowArchived(playlistIndex = 0)
+        expectNotSynced(playlistIndex = 0)
 
         manager.toggleShowArchived("playlist-id-0")
         expectNotShowArchived(playlistIndex = 0)

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerDsl.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerDsl.kt
@@ -267,6 +267,18 @@ class PlaylistManagerDsl : TestWatcher() {
         assertEquals(count, actual.size)
     }
 
+    suspend fun expectSynced(playlistIndex: Int) {
+        val playlistId = "playlist-id-$playlistIndex"
+        val playlist = playlistDao.getAllPlaylistsIn(listOf(playlistId)).singleOrNull()
+        assertEquals(PlaylistEntity.SYNC_STATUS_SYNCED, playlist?.syncStatus)
+    }
+
+    suspend fun expectNotSynced(playlistIndex: Int) {
+        val playlistId = "playlist-id-$playlistIndex"
+        val playlist = playlistDao.getAllPlaylistsIn(listOf(playlistId)).singleOrNull()
+        assertEquals(PlaylistEntity.SYNC_STATUS_NOT_SYNCED, playlist?.syncStatus)
+    }
+
     // Creators
     fun smartPlaylistEntity(index: Int, builder: (PlaylistEntity) -> PlaylistEntity = { it }): PlaylistEntity {
         val id = "playlist-id-$index"

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
@@ -162,10 +162,12 @@ abstract class PlaylistDao {
     @Query(
         """
         UPDATE playlists
-        SET showArchivedEpisodes = (CASE 
+        SET 
+          showArchivedEpisodes = (CASE 
             WHEN showArchivedEpisodes IS 0 THEN 1 
             ELSE 0
-        END)
+          END),
+          syncStatus = $SYNC_STATUS_NOT_SYNCED
         WHERE uuid = :uuid    
     """,
     )

--- a/modules/services/protobuf/src/main/proto/sync_api.proto
+++ b/modules/services/protobuf/src/main/proto/sync_api.proto
@@ -99,6 +99,7 @@ message SyncUserPlaylist {
   google.protobuf.Int32Value shorter_than = 23;
   repeated string episode_order = 24;
   repeated SyncPlaylistEpisode episodes = 25;
+  google.protobuf.BoolValue show_archived = 26;
 }
 
 message SyncPlaylistEpisode {
@@ -232,6 +233,7 @@ message PlaylistSyncResponse {
   google.protobuf.Int32Value shorter_than = 23;
   repeated string episode_order = 24;
   repeated SyncPlaylistEpisode episodes = 25;
+  google.protobuf.BoolValue show_archived = 26;
 }
 
 message PodcastRatingResponse {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/data/PlaylistSync.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/data/PlaylistSync.kt
@@ -14,6 +14,7 @@ import com.google.protobuf.boolValue
 import com.google.protobuf.int32Value
 import com.google.protobuf.int64Value
 import com.google.protobuf.stringValue
+import com.google.protobuf.value
 import com.pocketcasts.service.api.PlaylistSyncResponse
 import com.pocketcasts.service.api.Record
 import com.pocketcasts.service.api.SyncUserPlaylist
@@ -201,6 +202,9 @@ internal class PlaylistSync(
                         shorterThan = int32Value {
                             value = localPlaylist.shorterThan
                         }
+                        showArchived = boolValue {
+                            value = localPlaylist.showArchivedEpisodes
+                        }
                         if (localPlaylist.manual) {
                             val localEpisodes = playlistDao.getManualPlaylistEpisodesForSync(localPlaylist.uuid)
                             episodeOrder.addAll(localEpisodes.map(ManualPlaylistEpisode::episodeUuid))
@@ -266,6 +270,9 @@ private fun PlaylistEntity.applyServerPlaylist(serverPlaylist: PlaylistSyncRespo
     serverPlaylist.shorterThanOrNull?.value?.let { value ->
         shorterThan = value
     }
+    serverPlaylist.showArchived?.value?.let { value ->
+        showArchivedEpisodes = value
+    }
 }
 
 private fun PlaylistEntity.applyServerPlaylist(serverPlaylist: SyncUserPlaylist) = apply {
@@ -322,6 +329,9 @@ private fun PlaylistEntity.applyServerPlaylist(serverPlaylist: SyncUserPlaylist)
     }
     serverPlaylist.shorterThanOrNull?.value?.let { value ->
         shorterThan = value
+    }
+    serverPlaylist.showArchived?.value?.let { value ->
+        showArchivedEpisodes = value
     }
 }
 


### PR DESCRIPTION
## Description

As the title says.

Closes PCDROID-184

## Testing Instructions

1. Install `debug` variant as the change is available right now only in staging.
2. Sign in.
3. Create a Manual Playlist.
4. Add episodes to it.
5. Archive an episode.
6. Toggle archived state to "show archived".
7. Go to profile and sync your account.
8. Close the app and clear the storage.
9. Open the app.
10. Wait until the app syncs.
11. Go to playlists.
12. Open the Manual Playlist.
13. It should show archived episodes.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.