### PR TITLE
Disable Material Lint check

### DIFF
--- a/lint.xml
+++ b/lint.xml
@@ -21,4 +21,7 @@
     <!-- This issue causes nondeterministic results when generating baseline files -->
     <issue id="ConvertToWebp" severity="ignore"/>
 
+    <!-- We use only adaptive window info from Material3 which doesn't collide with Material -->
+    <issue id="UsingMaterialAndMaterial3Libraries" severity="ignore"/>
+
 </lint>


### PR DESCRIPTION
## Description

Context: p1759848936887519-slack-C028JAG44VD

## Testing Instructions

1. Run `./gradlew :app:lintRelease`
2. Open the report.
3. There should be no mention of `UsingMaterialAndMaterial3Libraries`.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.