### PR TITLE
Fix crash message dialog state

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperPage.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperPage.kt
@@ -114,19 +114,17 @@ fun DeveloperPage(
         item {
             ResetPlaylistsOnboarding(onClick = onResetPlaylistsOnboarding)
         }
+    }
 
-        if (openCrashMessageDialog) {
-            item {
-                CrashMessageDialog(
-                    initialMessage = crashMessage,
-                    onDismiss = { openCrashMessageDialog = false },
-                    onConfirm = { message ->
-                        openCrashMessageDialog = false
-                        crashMessage = message
-                    },
-                )
-            }
-        }
+    if (openCrashMessageDialog) {
+        CrashMessageDialog(
+            initialMessage = crashMessage,
+            onDismiss = { openCrashMessageDialog = false },
+            onConfirm = { message ->
+                openCrashMessageDialog = false
+                crashMessage = message
+            },
+        )
     }
 }
 


### PR DESCRIPTION
## Description

Crash message dialog was wrong wrapped in a lazy column causing it to not appear until the column's state change.

## Testing Instructions

1. Go to developer's settings.
2. Long press "Report a crash".
3. Dialog should appear.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.