### PR TITLE
Remove account creation feature flag

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -587,25 +587,23 @@ class MainActivity :
     }
 
     private fun encourageAccountCreation() {
-        if (FeatureFlag.isEnabled(Feature.ENCOURAGE_ACCOUNT_CREATION)) {
-            lifecycleScope.launch {
-                repeatOnLifecycle(Lifecycle.State.STARTED) {
-                    val encourageAccountCreation = settings.showFreeAccountEncouragement.value
-                    if (!encourageAccountCreation) {
-                        return@repeatOnLifecycle
-                    }
-                    settings.showFreeAccountEncouragement.set(false, updateModifiedAt = true)
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                val encourageAccountCreation = settings.showFreeAccountEncouragement.value
+                if (!encourageAccountCreation) {
+                    return@repeatOnLifecycle
+                }
+                settings.showFreeAccountEncouragement.set(false, updateModifiedAt = true)
 
-                    val isSignedIn = viewModel.signInState.asFlow().first().isSignedIn
-                    if (isSignedIn) {
-                        return@repeatOnLifecycle
-                    }
+                val isSignedIn = viewModel.signInState.asFlow().first().isSignedIn
+                if (isSignedIn) {
+                    return@repeatOnLifecycle
+                }
 
-                    if (Util.isTablet(this@MainActivity)) {
-                        AccountBenefitsFragment().show(supportFragmentManager, "account_benefits_fragment")
-                    } else {
-                        openOnboardingFlow(OnboardingFlow.AccountEncouragement)
-                    }
+                if (Util.isTablet(this@MainActivity)) {
+                    AccountBenefitsFragment().show(supportFragmentManager, "account_benefits_fragment")
+                } else {
+                    openOnboardingFlow(OnboardingFlow.AccountEncouragement)
                 }
             }
         }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragmentViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragmentViewModel.kt
@@ -13,8 +13,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.playlist.Playlist
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.SmartPlaylistManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import dagger.hilt.android.lifecycle.HiltViewModel
 import java.util.Collections
 import javax.inject.Inject
@@ -148,7 +146,7 @@ class FiltersFragmentViewModel @Inject constructor(
         userManager.getSignInState().asFlow().map { it.isSignedIn },
         settings.isFreeAccountFiltersBannerDismissed.flow,
     ) { isSignedIn, isBannerDismissed ->
-        !isSignedIn && !isBannerDismissed && FeatureFlag.isEnabled(Feature.ENCOURAGE_ACCOUNT_CREATION)
+        !isSignedIn && !isBannerDismissed
     }.stateIn(
         scope = viewModelScope,
         started = SharingStarted.Eagerly,

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsViewModel.kt
@@ -9,8 +9,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.playlist.Playlist
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistPreview
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.SharingStarted
@@ -30,9 +28,8 @@ class PlaylistsViewModel @Inject constructor(
     private val showFreeAccountBanner = combine(
         settings.isFreeAccountFiltersBannerDismissed.flow,
         userManager.getSignInState().asFlow().map { it.isSignedOut },
-        FeatureFlag.isEnabledFlow(Feature.ENCOURAGE_ACCOUNT_CREATION),
-    ) { isBannerDismissed, isSignedOut, isFeatureEnabled ->
-        isSignedOut && !isBannerDismissed && isFeatureEnabled
+    ) { isBannerDismissed, isSignedOut ->
+        isSignedOut && !isBannerDismissed
     }
 
     internal val uiState = combine(

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListViewModel.kt
@@ -12,8 +12,6 @@ import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
@@ -119,7 +117,7 @@ class ProfileEpisodeListViewModel @Inject constructor(
         userManager.getSignInState().asFlow().map { it.isSignedIn },
         settings.isFreeAccountHistoryBannerDismissed.flow,
     ) { isSignedIn, isBannerDismissed ->
-        !isSignedIn && !isBannerDismissed && FeatureFlag.isEnabled(Feature.ENCOURAGE_ACCOUNT_CREATION)
+        !isSignedIn && !isBannerDismissed
     }.stateIn(
         scope = viewModelScope,
         started = SharingStarted.Eagerly,

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileViewModel.kt
@@ -13,8 +13,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.StatsManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.utils.Gravatar
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.toDurationFromNow
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -110,7 +108,7 @@ class ProfileViewModel @Inject constructor(
         signInState.map { it.isSignedIn },
         settings.isFreeAccountProfileBannerDismissed.flow,
     ) { isSignedIn, isBannerDismissed ->
-        !isSignedIn && !isBannerDismissed && FeatureFlag.isEnabled(Feature.ENCOURAGE_ACCOUNT_CREATION)
+        !isSignedIn && !isBannerDismissed
     }.stateIn(
         scope = viewModelScope,
         started = SharingStarted.Eagerly,

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -84,14 +84,6 @@ enum class Feature(
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
     ),
-    ENCOURAGE_ACCOUNT_CREATION(
-        key = "encourage_account_creation",
-        title = "Account creation encouragement",
-        defaultValue = isDebugOrPrototypeBuild,
-        tier = FeatureTier.Free,
-        hasFirebaseRemoteFlag = true,
-        hasDevToggle = true,
-    ),
     RECOMMENDATIONS(
         key = "recommendations",
         title = "Recommendations",


### PR DESCRIPTION
## Description

As the title says.

## Testing Instructions

1. Clean install the app.
2. Go to the profile tab.
3. You should see the "create free account" banner.
4. Go to playlists.
5. You should see the banner.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.