### PR TITLE
Add Generated Transcripts to the Plus upsell.

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeFeatureItem.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeFeatureItem.kt
@@ -29,6 +29,11 @@ enum class PlusUpgradeFeatureItem(
         override val isMonthlyFeature get() = FeatureFlag.isEnabled(Feature.BANNER_ADS_PLAYER) || FeatureFlag.isEnabled(Feature.BANNER_ADS_PODCASTS)
         override fun title() = LR.string.onboarding_plus_feature_no_banner_ads
     },
+    Transcripts(
+        image = IR.drawable.ic_transcript_24,
+    ) {
+        override fun title() = LR.string.onboarding_upgrade_features_transcripts
+    },
     Folders(
         image = IR.drawable.ic_plus_feature_folder,
     ) {

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2619,6 +2619,7 @@
     <string name="onboarding_upgrade_schedule_notify">We\'ll notify you about your trial ending.</string>
     <string name="onboarding_upgrade_schedule_billing">You\'ll be charged on %1$s. Cancel anytime before.</string>
     <string name="onboarding_upgrade_schedule_see_features">See all Plus features</string>
+    <string name="onboarding_upgrade_features_transcripts">Generated Transcripts</string>
     <string name="onboarding_upgrade_features_folders">Tidy your collection with Folders</string>
     <string name="onboarding_upgrade_features_shuffle">Shuffle your queue</string>
     <string name="onboarding_upgrade_features_bookmarks">Keep timestamps with Bookmarks</string>


### PR DESCRIPTION
## Description

This change includes the Generated Transcripts feature on the Plus upsell page. 

Fixes PCDROID-188

## Testing Instructions

1. Be signed out
2. Tap on the Profile tab -> Pocket Casts Plus
3. ✅ Verify the feature is listed

## Screenshots 

<img width="400" src="https://github.com/user-attachments/assets/6f5d7a22-79be-4cf3-bfce-57b77ab57437" />

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
