### PR TITLE
Animate back button in smart rules flow

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/CreatePlaylistFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/CreatePlaylistFragment.kt
@@ -98,7 +98,6 @@ internal class CreatePlaylistFragment : BaseDialogFragment() {
                                 }
                             }
                         },
-                        onClickClose = ::dismiss,
                     )
                 }
             }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/CreatePlaylistPage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/CreatePlaylistPage.kt
@@ -61,7 +61,6 @@ internal fun CreatePlaylistPage(
     titleState: TextFieldState,
     onCreateManualPlaylist: () -> Unit,
     onContinueToSmartPlaylist: () -> Unit,
-    onClickClose: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val focusRequester = remember { FocusRequester() }
@@ -73,47 +72,37 @@ internal fun CreatePlaylistPage(
             .fillMaxSize()
             .verticalScroll(rememberScrollState())
             .navigationBarsPadding()
-            .imePadding(),
+            .imePadding()
+            .padding(horizontal = 16.dp),
     ) {
-        ThemedTopAppBar(
-            navigationButton = NavigationButton.Close,
-            style = ThemedTopAppBar.Style.Immersive,
-            iconColor = MaterialTheme.theme.colors.primaryIcon03,
-            windowInsets = WindowInsets(0),
-            onNavigationClick = onClickClose,
+        TextH20(
+            text = stringResource(LR.string.new_playlist),
         )
-        Column(
-            modifier = Modifier.padding(horizontal = 16.dp),
-        ) {
-            TextH20(
-                text = stringResource(LR.string.new_playlist),
-            )
-            Spacer(
-                modifier = Modifier.height(16.dp),
-            )
-            PlaylistNameInputField(
-                state = titleState,
-                onClickImeAction = onCreateManualPlaylist,
-                modifier = Modifier.focusRequester(focusRequester),
-            )
-            Spacer(
-                modifier = Modifier.height(16.dp),
-            )
-            SmartPlaylistButton(
-                enabled = titleState.text.isNotBlank(),
-                onClick = onContinueToSmartPlaylist,
-                modifier = Modifier.fillMaxWidth(),
-            )
-            Spacer(
-                modifier = Modifier.height(24.dp),
-            )
-            RowButton(
-                text = stringResource(LR.string.create_playlist),
-                enabled = titleState.text.isNotBlank(),
-                onClick = onCreateManualPlaylist,
-                includePadding = false,
-            )
-        }
+        Spacer(
+            modifier = Modifier.height(16.dp),
+        )
+        PlaylistNameInputField(
+            state = titleState,
+            onClickImeAction = onCreateManualPlaylist,
+            modifier = Modifier.focusRequester(focusRequester),
+        )
+        Spacer(
+            modifier = Modifier.height(16.dp),
+        )
+        SmartPlaylistButton(
+            enabled = titleState.text.isNotBlank(),
+            onClick = onContinueToSmartPlaylist,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        Spacer(
+            modifier = Modifier.height(24.dp),
+        )
+        RowButton(
+            text = stringResource(LR.string.create_playlist),
+            enabled = titleState.text.isNotBlank(),
+            onClick = onCreateManualPlaylist,
+            includePadding = false,
+        )
     }
 }
 
@@ -179,7 +168,6 @@ private fun CreatePlaylistPagePreview(
             titleState = titleState,
             onCreateManualPlaylist = {},
             onContinueToSmartPlaylist = {},
-            onClickClose = {},
             modifier = Modifier.fillMaxSize(),
         )
     }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/smart/DownloadStatusRulePage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/smart/DownloadStatusRulePage.kt
@@ -26,13 +26,11 @@ internal fun DownloadStatusRulePage(
     selectedRule: DownloadStatusRule,
     onSelectDownloadStatus: (DownloadStatusRule) -> Unit,
     onSaveRule: () -> Unit,
-    onClickBack: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     RulePage(
         title = stringResource(LR.string.filters_chip_download_status),
         onSaveRule = onSaveRule,
-        onClickBack = onClickBack,
         modifier = modifier,
     ) { bottomPadding ->
         Column(
@@ -51,11 +49,12 @@ internal fun DownloadStatusRulePage(
     }
 }
 
-private val DownloadStatusRule.displayLabelId get() = when (this) {
-    DownloadStatusRule.Any -> LR.string.all
-    DownloadStatusRule.Downloaded -> LR.string.downloaded
-    DownloadStatusRule.NotDownloaded -> LR.string.not_downloaded
-}
+private val DownloadStatusRule.displayLabelId
+    get() = when (this) {
+        DownloadStatusRule.Any -> LR.string.all
+        DownloadStatusRule.Downloaded -> LR.string.downloaded
+        DownloadStatusRule.NotDownloaded -> LR.string.not_downloaded
+    }
 
 @Composable
 @PreviewRegularDevice
@@ -69,7 +68,6 @@ private fun DownloadStatusRulePreview(
             selectedRule = rule,
             onSelectDownloadStatus = { rule = it },
             onSaveRule = {},
-            onClickBack = {},
         )
     }
 }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/smart/EpisodeDurationRulePage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/smart/EpisodeDurationRulePage.kt
@@ -51,14 +51,12 @@ internal fun EpisodeDurationRulePage(
     onDecrementMaxDuration: () -> Unit,
     onIncrementMaxDuration: () -> Unit,
     onSaveRule: () -> Unit,
-    onClickBack: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     RulePage(
         title = stringResource(LR.string.filters_episode_duration),
         isSaveEnabled = maxDuration > minDuration,
         onSaveRule = onSaveRule,
-        onClickBack = onClickBack,
         modifier = modifier,
     ) { bottomPadding ->
         Column(
@@ -182,7 +180,6 @@ private fun EpisodeDurationRulePreview(
             onDecrementMaxDuration = { maxDuration -= 5.minutes },
             onIncrementMaxDuration = { maxDuration += 5.minutes },
             onSaveRule = {},
-            onClickBack = {},
         )
     }
 }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/smart/EpisodeStatusRulePage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/smart/EpisodeStatusRulePage.kt
@@ -28,14 +28,12 @@ internal fun EpisodeStatusRulePage(
     onChangeInProgressStatus: (Boolean) -> Unit,
     onChangeCompletedStatus: (Boolean) -> Unit,
     onSaveRule: () -> Unit,
-    onClickBack: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     RulePage(
         title = stringResource(LR.string.filters_chip_episode_status),
         onSaveRule = onSaveRule,
         isSaveEnabled = rule.unplayed || rule.inProgress || rule.completed,
-        onClickBack = onClickBack,
         modifier = modifier,
     ) { bottomPadding ->
         Column(
@@ -76,7 +74,6 @@ private fun EpisodeStatusRulePreview(
             onChangeInProgressStatus = { rule.copy(inProgress = it) },
             onChangeCompletedStatus = { rule.copy(completed = it) },
             onSaveRule = {},
-            onClickBack = {},
         )
     }
 }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/smart/MediaTypeRulePage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/smart/MediaTypeRulePage.kt
@@ -26,13 +26,11 @@ internal fun MediaTypeRulePage(
     selectedRule: MediaTypeRule,
     onSelectMediaType: (MediaTypeRule) -> Unit,
     onSaveRule: () -> Unit,
-    onClickBack: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     RulePage(
         title = stringResource(LR.string.filters_chip_media_type),
         onSaveRule = onSaveRule,
-        onClickBack = onClickBack,
         modifier = modifier,
     ) { bottomPadding ->
         Column(
@@ -69,7 +67,6 @@ private fun MediaTypeRulePreview(
             selectedRule = rule,
             onSelectMediaType = { rule = it },
             onSaveRule = {},
-            onClickBack = {},
         )
     }
 }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/smart/PodcastsRulePage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/smart/PodcastsRulePage.kt
@@ -60,53 +60,13 @@ internal fun PodcastsRulePage(
     onChangeUseAllPodcasts: (Boolean) -> Unit,
     onSelectPodcast: (String) -> Unit,
     onDeselectPodcast: (String) -> Unit,
-    onSelectAllPodcasts: () -> Unit,
-    onDeselectAllPodcasts: () -> Unit,
     onSaveRule: () -> Unit,
-    onClickBack: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     RulePage(
         title = stringResource(LR.string.smart_rule_podcasts_title),
         onSaveRule = onSaveRule,
         isSaveEnabled = useAllPodcasts || selectedPodcastUuids.isNotEmpty(),
-        onClickBack = onClickBack,
-        toolbarActions = {
-            AnimatedVisibility(
-                enter = fadeIn,
-                exit = fadeOut,
-                visible = !useAllPodcasts,
-            ) {
-                Box(
-                    contentAlignment = Alignment.Center,
-                    modifier = Modifier
-                        .heightIn(min = 48.dp)
-                        .clickable(
-                            role = Role.Button,
-                            onClick = {
-                                if (podcasts.size == selectedPodcastUuids.size) {
-                                    onDeselectAllPodcasts()
-                                } else {
-                                    onSelectAllPodcasts()
-                                }
-                            },
-                        )
-                        .padding(horizontal = 16.dp)
-                        .semantics(mergeDescendants = true) {},
-                ) {
-                    Text(
-                        text = if (podcasts.size == selectedPodcastUuids.size) {
-                            stringResource(LR.string.smart_rule_podcasts_deselect_all)
-                        } else {
-                            stringResource(LR.string.smart_rule_podcasts_select_all)
-                        },
-                        color = MaterialTheme.theme.colors.primaryText02,
-                        fontSize = 17.sp,
-                        lineHeight = 22.sp,
-                    )
-                }
-            }
-        },
         modifier = modifier,
     ) { bottomPadding ->
         Column(
@@ -127,6 +87,52 @@ internal fun PodcastsRulePage(
                 onDeselectPodcast = onDeselectPodcast,
                 bottomPadding = bottomPadding,
                 modifier = Modifier.weight(1f),
+            )
+        }
+    }
+}
+
+@Composable
+internal fun PodcastRulesActions(
+    useAllPodcasts: Boolean,
+    selectedPodcastUuids: Set<String>,
+    podcasts: List<Podcast>,
+    onSelectAllPodcasts: () -> Unit,
+    onDeselectAllPodcasts: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    AnimatedVisibility(
+        enter = fadeIn,
+        exit = fadeOut,
+        visible = !useAllPodcasts,
+        modifier = modifier,
+    ) {
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier
+                .heightIn(min = 48.dp)
+                .clickable(
+                    role = Role.Button,
+                    onClick = {
+                        if (podcasts.size == selectedPodcastUuids.size) {
+                            onDeselectAllPodcasts()
+                        } else {
+                            onSelectAllPodcasts()
+                        }
+                    },
+                )
+                .padding(horizontal = 16.dp)
+                .semantics(mergeDescendants = true) {},
+        ) {
+            Text(
+                text = if (podcasts.size == selectedPodcastUuids.size) {
+                    stringResource(LR.string.smart_rule_podcasts_deselect_all)
+                } else {
+                    stringResource(LR.string.smart_rule_podcasts_select_all)
+                },
+                color = MaterialTheme.theme.colors.primaryText02,
+                fontSize = 17.sp,
+                lineHeight = 22.sp,
             )
         }
     }
@@ -296,10 +302,7 @@ private fun PodcastsRulePreview(
             onChangeUseAllPodcasts = { useAllPodcasts = it },
             onSelectPodcast = { podcastUuids += it },
             onDeselectPodcast = { podcastUuids -= it },
-            onSelectAllPodcasts = {},
-            onDeselectAllPodcasts = {},
             onSaveRule = {},
-            onClickBack = {},
         )
     }
 }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/smart/ReleaseDateRulePage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/smart/ReleaseDateRulePage.kt
@@ -26,13 +26,11 @@ internal fun ReleaseDateRulePage(
     selectedRule: ReleaseDateRule,
     onSelectReleaseDate: (ReleaseDateRule) -> Unit,
     onSaveRule: () -> Unit,
-    onClickBack: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     RulePage(
         title = stringResource(LR.string.filters_release_date),
         onSaveRule = onSaveRule,
-        onClickBack = onClickBack,
         modifier = modifier,
     ) { bottomPadding ->
         Column(
@@ -72,7 +70,6 @@ private fun ReleaseDateRulePreview(
             selectedRule = rule,
             onSelectReleaseDate = { rule = it },
             onSaveRule = {},
-            onClickBack = {},
         )
     }
 }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/smart/RulePage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/smart/RulePage.kt
@@ -4,8 +4,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.RowScope
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
@@ -17,15 +15,12 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.PreviewRegularDevice
-import au.com.shiftyjelly.pocketcasts.compose.bars.NavigationButton
-import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH20
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
@@ -37,10 +32,8 @@ import au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType
 internal fun RulePage(
     title: String,
     onSaveRule: () -> Unit,
-    onClickBack: () -> Unit,
     modifier: Modifier = Modifier,
     isSaveEnabled: Boolean = true,
-    toolbarActions: (@Composable RowScope.(Color) -> Unit) = {},
     content: @Composable BoxScope.(bottomPadding: Dp) -> Unit,
 ) {
     Column(
@@ -48,43 +41,30 @@ internal fun RulePage(
             .fillMaxSize()
             .verticalScroll(rememberScrollState()),
     ) {
-        ThemedTopAppBar(
-            navigationButton = NavigationButton.Back,
-            style = ThemedTopAppBar.Style.Immersive,
-            iconColor = MaterialTheme.theme.colors.primaryIcon03,
-            windowInsets = ZeroWindowInsets,
-            onNavigationClick = onClickBack,
-            actions = toolbarActions,
+        TextH20(
+            text = title,
+            modifier = Modifier.padding(horizontal = 16.dp),
         )
-        Column(
-            modifier = Modifier.weight(1f),
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth(),
         ) {
-            TextH20(
-                text = title,
-                modifier = Modifier.padding(horizontal = 16.dp),
-            )
-            Box(
-                modifier = Modifier
-                    .weight(1f)
-                    .fillMaxWidth(),
-            ) {
-                content(ButtonPadding)
-            }
-            RowButton(
-                text = stringResource(R.string.save_smart_rule),
-                enabled = isSaveEnabled,
-                onClick = onSaveRule,
-                includePadding = false,
-                modifier = Modifier
-                    .padding(horizontal = 16.dp)
-                    .navigationBarsPadding(),
-            )
+            content(ButtonPadding)
         }
+        RowButton(
+            text = stringResource(R.string.save_smart_rule),
+            enabled = isSaveEnabled,
+            onClick = onSaveRule,
+            includePadding = false,
+            modifier = Modifier
+                .padding(horizontal = 16.dp)
+                .navigationBarsPadding(),
+        )
     }
 }
 
 private val ButtonPadding = 24.dp
-private val ZeroWindowInsets = WindowInsets(0)
 
 @Composable
 @PreviewRegularDevice
@@ -95,7 +75,6 @@ private fun RulePagePreview(
         RulePage(
             title = "Title",
             onSaveRule = {},
-            onClickBack = {},
         ) { bottomPadding ->
             Box(
                 modifier = Modifier

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/smart/StarredRulePage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/smart/StarredRulePage.kt
@@ -50,7 +50,6 @@ internal fun StarredRulePage(
     useEpisodeArtwork: Boolean,
     onChangeUseStarredEpisodes: (Boolean) -> Unit,
     onSaveRule: () -> Unit,
-    onClickBack: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val useStarredEpisodes = when (selectedRule) {
@@ -61,7 +60,6 @@ internal fun StarredRulePage(
     RulePage(
         title = stringResource(LR.string.filters_title_starred),
         onSaveRule = onSaveRule,
-        onClickBack = onClickBack,
         modifier = modifier,
     ) { bottomPadding ->
         Column(
@@ -190,7 +188,6 @@ private fun StarredRulePreview(
                 rule = if (useStarred) StarredRule.Starred else StarredRule.Any
             },
             onSaveRule = {},
-            onClickBack = {},
         )
     }
 }


### PR DESCRIPTION
## Description

This animates back button from `X` to `<-` and back when creating or editing Smart Rules.

Close PCDROID-195

## Testing Instructions

Create and edit Smart Playlist. The top button should animate.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
