### PR TITLE
Remove changelog entries related to improved search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@
 *   New Features
     *   Add an option to sort Up Next by date
         ([#4586](https://github.com/Automattic/pocket-casts-android/pull/4586))
-    *   Implement search suggestions
-        ([#4571](https://github.com/Automattic/pocket-casts-android/pull/4571))
-    *   Update search results screen
-        ([#4583](https://github.com/Automattic/pocket-casts-android/pull/4583))
 *   Updates
     *   Improve sleep timer terminology and chapter option visibility
         ([#4564](https://github.com/Automattic/pocket-casts-android/pull/4564))


### PR DESCRIPTION
## Description
Removes entries from the changelog that are related to improved search. Reason is that we're not going to release the feature in 7.100.
Will re-add them once we do.

## Testing Instructions
Just check if the pipe turns green
