### PR TITLE
Show snackbar when there are no episodes

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistFragment.kt
@@ -436,19 +436,26 @@ class PlaylistFragment :
         if (parentFragmentManager.findFragmentByTag("confirm_and_play") != null) {
             return
         }
-        if (viewModel.shouldShowPlayAllWarning()) {
-            val episodeCount = viewModel.uiState.value.playlist?.episodes.orEmpty().size
-            val buttonString = getString(LR.string.filters_play_episodes, episodeCount)
+        val episodeCount = viewModel.uiState.value.playlist?.metadata?.displayedAvailableEpisodeCount ?: 0
+        when {
+            episodeCount <= 0 -> {
+                val snackbarView = (requireActivity() as FragmentHostListener).snackBarView()
+                Snackbar.make(snackbarView, getString(LR.string.play_all_no_episodes_message), Snackbar.LENGTH_LONG).show()
+            }
+            viewModel.shouldShowPlayAllWarning() -> {
+                val buttonString = getString(LR.string.filters_play_episodes, episodeCount)
 
-            val dialog = ConfirmationDialog()
-                .setTitle(getString(LR.string.filters_play_all))
-                .setSummary(getString(LR.string.filters_play_all_summary))
-                .setIconId(IR.drawable.ic_play_all)
-                .setButtonType(ConfirmationDialog.ButtonType.Danger(buttonString))
-                .setOnConfirm { viewModel.playAll() }
-            dialog.show(parentFragmentManager, "confirm_play_all")
-        } else {
-            viewModel.playAll()
+                val dialog = ConfirmationDialog()
+                    .setTitle(getString(LR.string.filters_play_all))
+                    .setSummary(getString(LR.string.filters_play_all_summary))
+                    .setIconId(IR.drawable.ic_play_all)
+                    .setButtonType(ConfirmationDialog.ButtonType.Danger(buttonString))
+                    .setOnConfirm { viewModel.playAll() }
+                dialog.show(parentFragmentManager, "confirm_play_all")
+            }
+            else -> {
+                viewModel.playAll()
+            }
         }
     }
 

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -985,6 +985,7 @@
     <string name="new_playlists_title_placeholder">Playlist’s name</string>
     <string name="new_smart_playlist_banner_body">Automatically add episodes based on rules</string>
     <string name="new_smart_playlist_banner_title">Make into Smart Playlist</string>
+    <string name="play_all_no_episodes_message">All episodes archived. Add or unarchive to play.</string>
     <string name="playlist_archive_all">Archive All</string>
     <string name="playlist_artwork_description">Playlist’s artwork</string>
     <string name="playlist_download_all">Download All</string>


### PR DESCRIPTION
## Description

This shows a snackbar message when users try to play all episodes from an empty playlist.

Closes PCDROID-192

## Testing Instructions

1. Create a Manual Playlist.
2. Add some episodes to it.
3. Archive all episodes.
4. Make sure that the playlist doesn't show the archived episodes.
5. Tap "Play All".
6. You should see a feedback message.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack