### PR TITLE
Display drag and drop tooltip

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerDsl.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerDsl.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.rules.TestWatcher
 import org.junit.runner.Description
@@ -280,6 +281,14 @@ class PlaylistManagerDsl : TestWatcher() {
         val playlistId = "playlist-id-$playlistIndex"
         val playlist = playlistDao.getAllPlaylistsIn(listOf(playlistId)).singleOrNull()
         assertEquals(PlaylistEntity.SYNC_STATUS_NOT_SYNCED, playlist?.syncStatus)
+    }
+
+    fun expectRearrangeTooltipSet() {
+        assertTrue(settings.showRearrangePlaylistsTooltip.value)
+    }
+
+    fun expectRearrangeTooltipNotSet() {
+        assertFalse(settings.showRearrangePlaylistsTooltip.value)
     }
 
     // Creators

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerManualTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerManualTest.kt
@@ -908,4 +908,13 @@ class PlaylistManagerManualTest {
             assertEquals(45.seconds, awaitItem()?.metadata?.playbackDurationLeft)
         }
     }
+
+    @Test
+    fun setReorderPlaylistsTooltip() = dsl.test {
+        expectRearrangeTooltipNotSet()
+
+        manager.createManualPlaylist("Playlist name")
+
+        expectRearrangeTooltipSet()
+    }
 }

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerSmartTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerSmartTest.kt
@@ -201,6 +201,7 @@ class PlaylistManagerSmartTest {
                 )
             },
         )
+        expectRearrangeTooltipNotSet()
     }
 
     @Test
@@ -222,6 +223,7 @@ class PlaylistManagerSmartTest {
                 )
             },
         )
+        expectRearrangeTooltipNotSet()
     }
 
     @Test
@@ -618,5 +620,14 @@ class PlaylistManagerSmartTest {
             }
             assertEquals(40.seconds, awaitItem()?.metadata?.playbackDurationLeft)
         }
+    }
+
+    @Test
+    fun setReorderPlaylistsTooltip() = dsl.test {
+        expectRearrangeTooltipNotSet()
+
+        manager.createSmartPlaylist(playlistDraft(index = 0))
+
+        expectRearrangeTooltipSet()
     }
 }

--- a/app/src/test/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragmentViewModelTest.kt
+++ b/app/src/test/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragmentViewModelTest.kt
@@ -92,7 +92,7 @@ class FiltersFragmentViewModelTest {
         whenever(settings.isFreeAccountFiltersBannerDismissed).thenReturn(bannerSetting)
         whenever(bannerSetting.flow).thenReturn(MutableStateFlow(false))
 
-        whenever(settings.showEmptyFiltersListTooltip).thenReturn(tooltipMock)
+        whenever(settings.showPremadePlaylistsTooltip).thenReturn(tooltipMock)
 
         val smartPlaylistManager = mock<SmartPlaylistManager>()
         whenever(smartPlaylistManager.findAllRxFlowable()).thenReturn(mock())

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragmentViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragmentViewModel.kt
@@ -116,7 +116,7 @@ class FiltersFragmentViewModel @Inject constructor(
     }
 
     suspend fun shouldShowTooltipSuspend(filters: List<PlaylistEntity>, onShowTooltip: () -> Unit) {
-        if (!settings.showEmptyFiltersListTooltip.value) return
+        if (!settings.showPremadePlaylistsTooltip.value) return
         if (filters.size > 2) return
 
         val requiredUuids = setOf(Playlist.NEW_RELEASES_UUID, Playlist.IN_PROGRESS_UUID)
@@ -138,7 +138,7 @@ class FiltersFragmentViewModel @Inject constructor(
     }
 
     fun onTooltipClosed() {
-        settings.showEmptyFiltersListTooltip.set(false, updateModifiedAt = false)
+        settings.showPremadePlaylistsTooltip.set(false, updateModifiedAt = false)
         analyticsTracker.track(AnalyticsEvent.FILTER_TOOLTIP_CLOSED)
     }
 

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsFragment.kt
@@ -73,7 +73,7 @@ class PlaylistsFragment :
                 },
                 onFreeAccountBannerDismiss = viewModel::dismissFreeAccountBanner,
                 onShowPremadePlaylistsTooltip = viewModel::trackTooltipShown,
-                onDismissPremadePlaylistsTooltip = viewModel::dismissPremadePlaylistsTooltip,
+                onDismissTooltip = viewModel::dismissTooltip,
             )
         }
 

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsViewModel.kt
@@ -4,11 +4,13 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.playlists.component.PlaylistTooltip
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.Playlist
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistPreview
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
+import au.com.shiftyjelly.pocketcasts.utils.extensions.combine
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.milliseconds
@@ -39,14 +41,22 @@ class PlaylistsViewModel @Inject constructor(
         playlistManager.playlistPreviewsFlow(),
         settings.showPlaylistsOnboarding.flow,
         showFreeAccountBanner,
-        settings.showEmptyFiltersListTooltip.flow,
+        settings.showPremadePlaylistsTooltip.flow,
+        settings.showRearrangePlaylistsTooltip.flow,
         settings.bottomInset,
-    ) { playlists, showOnboarding, showFreeAccountBanner, showTooltip, bottomInset ->
+    ) { playlists, showOnboarding, showFreeAccountBanner, showPremadeTooltip, showRearrangeTooltip, bottomInset ->
         UiState(
             playlists = PlaylistsState.Loaded(playlists),
             showOnboarding = showOnboarding,
             showFreeAccountBanner = showFreeAccountBanner,
-            showPremadePlaylistsTooltip = shouldShowPremadePlaylistsTooltip(showTooltip, playlists),
+            displayedTooltips = buildList {
+                if (shouldShowPremadePlaylistsTooltip(showPremadeTooltip, playlists)) {
+                    add(PlaylistTooltip.Premade)
+                }
+                if (shouldShowRearrangePlaylistsTooltip(showRearrangeTooltip, playlists)) {
+                    add(PlaylistTooltip.Rearrange)
+                }
+            },
             miniPlayerInset = bottomInset,
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(stopTimeout = 300.milliseconds), UiState.Empty)
@@ -77,7 +87,7 @@ class PlaylistsViewModel @Inject constructor(
     fun updatePlaylistsOrder(playlistUuids: List<String>) {
         viewModelScope.launch {
             playlistManager.sortPlaylists(playlistUuids)
-            trackPlaylistsReodered()
+            trackPlaylistsReordered()
         }
     }
 
@@ -86,16 +96,25 @@ class PlaylistsViewModel @Inject constructor(
         settings.isFreeAccountFiltersBannerDismissed.set(true, updateModifiedAt = true)
     }
 
-    fun dismissPremadePlaylistsTooltip() {
-        trackTooltipDismissed()
-        settings.showEmptyFiltersListTooltip.set(false, updateModifiedAt = false)
+    internal fun dismissTooltip(tooltip: PlaylistTooltip) {
+        when (tooltip) {
+            PlaylistTooltip.Premade -> {
+                // We track this only due to legacy reasons
+                trackTooltipDismissed()
+                settings.showPremadePlaylistsTooltip.set(false, updateModifiedAt = false)
+            }
+
+            PlaylistTooltip.Rearrange -> {
+                settings.showRearrangePlaylistsTooltip.set(false, updateModifiedAt = false)
+            }
+        }
     }
 
     fun trackPlaylistsShown(playlistCount: Int) {
         analyticsTracker.track(AnalyticsEvent.FILTER_LIST_SHOWN, mapOf("filter_count" to playlistCount))
     }
 
-    fun trackPlaylistsReodered() {
+    fun trackPlaylistsReordered() {
         analyticsTracker.track(AnalyticsEvent.FILTER_LIST_REORDERED)
     }
 
@@ -130,11 +149,16 @@ class PlaylistsViewModel @Inject constructor(
         playlists.size == PremadePlaylistUuids.size &&
         playlists.all { playlist -> playlist.uuid in PremadePlaylistUuids }
 
+    private fun shouldShowRearrangePlaylistsTooltip(
+        tooltipFlag: Boolean,
+        playlists: List<PlaylistPreview>,
+    ) = tooltipFlag && playlists.size > 1
+
     internal data class UiState(
         val playlists: PlaylistsState,
         val showOnboarding: Boolean,
         val showFreeAccountBanner: Boolean,
-        val showPremadePlaylistsTooltip: Boolean,
+        val displayedTooltips: List<PlaylistTooltip>,
         val miniPlayerInset: Int,
     ) {
         val showEmptyState
@@ -148,7 +172,7 @@ class PlaylistsViewModel @Inject constructor(
                 playlists = PlaylistsState.Loading,
                 showOnboarding = false,
                 showFreeAccountBanner = false,
-                showPremadePlaylistsTooltip = false,
+                displayedTooltips = emptyList(),
                 miniPlayerInset = 0,
             )
         }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/component/PlaylistPreviewRow.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/component/PlaylistPreviewRow.kt
@@ -82,11 +82,12 @@ internal fun PlaylistPreviewRow(
     getEpisodeCountFlow: (String) -> StateFlow<Int?>,
     refreshArtworkUuids: suspend (String) -> Unit,
     refreshEpisodeCount: suspend (String) -> Unit,
-    showTooltip: Boolean,
+    showPremadeTooltip: Boolean,
+    showRearrangeTooltip: Boolean,
+    onDismissTooltip: (PlaylistTooltip) -> Unit,
     showDivider: Boolean,
     onClick: () -> Unit,
     onDelete: () -> Unit,
-    onClickTooltip: () -> Unit,
     modifier: Modifier = Modifier,
     backgroundColor: Color = MaterialTheme.theme.colors.primaryUi01,
 ) {
@@ -219,7 +220,7 @@ internal fun PlaylistPreviewRow(
                         podcastUuids = artworkUuids.orEmpty(),
                         artworkSize = 56.dp,
                     )
-                    if (showTooltip) {
+                    if (showPremadeTooltip) {
                         TooltipPopup(
                             title = stringResource(LR.string.premade_playlists_tooltip_title),
                             body = stringResource(LR.string.premade_playlists_tooltip_body),
@@ -228,7 +229,7 @@ internal fun PlaylistPreviewRow(
                             maxWidth = 400.dp,
                             elevation = 8.dp,
                             anchorOffset = DpOffset(x = (-8).dp, y = 4.dp),
-                            onClick = onClickTooltip,
+                            onClick = { onDismissTooltip(PlaylistTooltip.Premade) },
                         )
                     }
                 }
@@ -255,20 +256,38 @@ internal fun PlaylistPreviewRow(
                     text = episodeCount?.toString().orEmpty(),
                     color = MaterialTheme.theme.colors.primaryText02,
                 )
-                Image(
-                    painter = painterResource(IR.drawable.ic_chevron_small_right),
-                    contentDescription = null,
-                    colorFilter = ColorFilter.tint(MaterialTheme.theme.colors.primaryText02),
-                    modifier = Modifier
-                        .padding(3.dp)
-                        .size(24.dp),
-                )
+                Box {
+                    Image(
+                        painter = painterResource(IR.drawable.ic_chevron_small_right),
+                        contentDescription = null,
+                        colorFilter = ColorFilter.tint(MaterialTheme.theme.colors.primaryText02),
+                        modifier = Modifier
+                            .padding(3.dp)
+                            .size(24.dp),
+                    )
+                    if (showRearrangeTooltip) {
+                        TooltipPopup(
+                            title = stringResource(LR.string.rearrange_playlists_tooltip_title),
+                            body = stringResource(LR.string.rearrange_playlists_tooltip_body),
+                            tipPosition = TipPosition.TopEnd,
+                            maxWidthFraction = 0.75f,
+                            maxWidth = 400.dp,
+                            elevation = 8.dp,
+                            onClick = { onDismissTooltip(PlaylistTooltip.Rearrange) },
+                        )
+                    }
+                }
             }
             if (showDivider) {
                 HorizontalDivider(startIndent = 16.dp)
             }
         }
     }
+}
+
+internal enum class PlaylistTooltip {
+    Premade,
+    Rearrange,
 }
 
 private enum class SwipeToDeleteAnchor {
@@ -306,11 +325,12 @@ private fun PlaylistPreviewRowPreview(
                 getEpisodeCountFlow = { MutableStateFlow(null) },
                 refreshArtworkUuids = {},
                 refreshEpisodeCount = {},
-                showTooltip = false,
+                showPremadeTooltip = false,
+                showRearrangeTooltip = false,
+                onDismissTooltip = {},
                 showDivider = true,
                 onClick = {},
                 onDelete = {},
-                onClickTooltip = {},
                 modifier = Modifier.fillMaxWidth(),
             )
             PlaylistPreviewRow(
@@ -324,11 +344,12 @@ private fun PlaylistPreviewRowPreview(
                 getEpisodeCountFlow = { MutableStateFlow(1) },
                 refreshArtworkUuids = {},
                 refreshEpisodeCount = {},
-                showTooltip = false,
+                showPremadeTooltip = false,
+                showRearrangeTooltip = false,
+                onDismissTooltip = {},
                 showDivider = true,
                 onClick = {},
                 onDelete = {},
-                onClickTooltip = {},
                 modifier = Modifier.fillMaxWidth(),
             )
             PlaylistPreviewRow(
@@ -343,11 +364,12 @@ private fun PlaylistPreviewRowPreview(
                 getEpisodeCountFlow = { MutableStateFlow(null) },
                 refreshArtworkUuids = {},
                 refreshEpisodeCount = {},
-                showTooltip = false,
+                showPremadeTooltip = false,
+                showRearrangeTooltip = false,
+                onDismissTooltip = {},
                 showDivider = false,
                 onClick = {},
                 onDelete = {},
-                onClickTooltip = {},
                 modifier = Modifier.fillMaxWidth(),
             )
         }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1024,6 +1024,8 @@
     <string name="podcast_not_in_playlists">Not included in any Smart Playlists</string>
     <string name="premade_playlists_tooltip_body">We made these to help you get started.\nThey auto-update based on your listening.</string>
     <string name="premade_playlists_tooltip_title">Smart Playlists, ready to go</string>
+    <string name="rearrange_playlists_tooltip_body">Press and hold a playlist to move it.</string>
+    <string name="rearrange_playlists_tooltip_title">Reorder your playlists</string>
     <!-- %1$s is playlist's title -->
     <string name="preview_playlist">Preview %1$s</string>
     <string name="save_smart_rule">Save Smart Rule</string>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -576,7 +576,8 @@ interface Settings {
 
     val showPodcastsRecentlyPlayedSortOrderTooltip: UserSetting<Boolean>
 
-    val showEmptyFiltersListTooltip: UserSetting<Boolean>
+    val showPremadePlaylistsTooltip: UserSetting<Boolean>
+    val showRearrangePlaylistsTooltip: UserSetting<Boolean>
 
     val suggestedFoldersDismissTimestamp: UserSetting<Instant?>
     val suggestedFoldersDismissCount: UserSetting<Int>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -1543,9 +1543,15 @@ class SettingsImpl @Inject constructor(
         sharedPrefs = sharedPreferences,
     )
 
-    override val showEmptyFiltersListTooltip: UserSetting<Boolean> = UserSetting.BoolPref(
+    override val showPremadePlaylistsTooltip: UserSetting<Boolean> = UserSetting.BoolPref(
         sharedPrefKey = "show_empty_filters_list_tooltip",
         defaultValue = true,
+        sharedPrefs = sharedPreferences,
+    )
+
+    override val showRearrangePlaylistsTooltip: UserSetting<Boolean> = UserSetting.BoolPref(
+        sharedPrefKey = "show_rearrange_playlists_tooltip",
+        defaultValue = false,
         sharedPrefs = sharedPreferences,
     )
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
@@ -429,7 +429,7 @@ class PlaylistManagerImpl(
         }
 
     private suspend fun createPlaylist(entity: PlaylistEntity, uuid: String? = null): String {
-        return appDatabase.withTransaction {
+        val uuid = appDatabase.withTransaction {
             val uuids = playlistDao.getAllPlaylistUuids()
             val finalUuid = uuid?.takeIf { it !in uuids } ?: generateUniqueUuid(uuids)
             val finalEntity = entity.copy(uuid = finalUuid, sortPosition = 0)
@@ -440,6 +440,10 @@ class PlaylistManagerImpl(
             }
             finalUuid
         }
+        if (uuid !in Playlist.PREDEFINED_UUIDS) {
+            settings.showRearrangePlaylistsTooltip.set(true, updateModifiedAt = false)
+        }
+        return uuid
     }
 }
 


### PR DESCRIPTION
## Description

This shows a drag and drop tooltip when a user creates a playlist.

Designs: 5sC4z4Mu42LvL4MAAIbQVi-fi-5705_20635

Closes PCDROID-212

## Testing Instructions

1. Create a playlist.
2. You should see a drag & drop tooltip.
3. Tap anywhere on the screen outside of the nav bar..
4. The tooltip should dismiss.

## Screenshots or Screencast 

<img width="540" alt="image" src="https://github.com/user-attachments/assets/be812313-14c2-402e-b899-d86f41ee796e" />

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack