### PR TITLE
Connect firebase flag

### DIFF
--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -185,7 +185,7 @@ enum class Feature(
         title = "Predictive search suggestions",
         defaultValue = isDebugOrPrototypeBuild,
         tier = FeatureTier.Free,
-        hasFirebaseRemoteFlag = false,
+        hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
     ),
     IMPROVED_SEARCH_RESULTS(


### PR DESCRIPTION
## Description
As title says.

Fixes https://linear.app/a8c/issue/PCDROID-210/enable-autocompelte-suggestions-ff

## Testing Instructions
1. Apply patch: 
[disable_improvements.patch](https://github.com/user-attachments/files/23054337/disable_improvements.patch)
2. Build and clean install the app
3. Log in with a Plus account that has some folders and some followed podcasts


Now we're going to test the Discover search
1. Tap the search bar on Discover
2. Start typing something, e.g. 'test'
- [ ] verify that loading spinner appears
- [ ] verify that loading spinner disappears and the suggestions pop in
3. Keep adding more letters to the search query. e.g. 'testam'
- [ ] suggestions update 
4. Tap a suggested keyword e.g. 'testament'
- [ ] verify that results are displayed as expected
5. Delete some letters from the keyword. e.g. 'tes'
- [ ] verify that suggestions are displayed again
6. Press enter on your keyboard or hit the magnifier icon on the soft keyboard
- [ ] verify that real search kicks in and shows results
7. Clear the search query
- [ ] verify that Recent searches appear with your real searches
8. Select one of your recent searches
- [ ] verify that search results are displayed

Now we're focusing on local search aka podcast search
1. Tap the Podcasts tab
2. Tap the search icon in the toolbar
- [ ] recent searches appear
3. Start typing something that would yield local results (name of a folder or podcast that you follow)
- [ ] verify that your local hits are displayed under the search term suggestions
4. Make sure tap events are handled correctly on your local hits as well
5. Tap enter to see the results
- [ ] local hits are also present in the results

You can also try following podcasts from the suggestions

## Screenshots or screencast

https://github.com/user-attachments/assets/5b6b3810-00b5-4fc4-8f89-b78254da32ae



## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
