### PR TITLE
Playback feature flag

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManager.kt
@@ -8,6 +8,6 @@ interface EndOfYearManager {
     suspend fun getPlayedEpisodeCount(year: Year = YEAR_TO_SYNC): Int
 
     companion object {
-        val YEAR_TO_SYNC = Year.of(2024)
+        val YEAR_TO_SYNC = Year.of(2025)
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManagerImpl.kt
@@ -23,7 +23,7 @@ class EndOfYearManagerImpl @Inject constructor(
     override suspend fun isEligibleForEndOfYear(year: Year): Boolean {
         val epochStart = year.toEpochMillis(clock.zone)
         val epochEnd = year.plusYears(1).toEpochMillis(clock.zone)
-        return FeatureFlag.isEnabled(Feature.END_OF_YEAR_2024) && getTotalPlaybackTime(epochStart, epochEnd) > 5.minutes
+        return FeatureFlag.isEnabled(Feature.END_OF_YEAR_2025) && getTotalPlaybackTime(epochStart, epochEnd) > 5.minutes
     }
 
     override suspend fun getStats(year: Year): EndOfYearStats = coroutineScope {

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -20,12 +20,12 @@ enum class Feature(
         hasFirebaseRemoteFlag = true,
         hasDevToggle = false,
     ),
-    END_OF_YEAR_2024(
-        key = "end_of_year_2024",
-        title = "End of Year 2024",
-        defaultValue = false,
+    END_OF_YEAR_2025(
+        key = "end_of_year_2025",
+        title = "End of Year 2025",
+        defaultValue = isDebugOrPrototypeBuild,
         tier = FeatureTier.Free,
-        hasFirebaseRemoteFlag = true,
+        hasFirebaseRemoteFlag = false,
         hasDevToggle = false,
     ),
     INTRO_PLUS_OFFER_ENABLED(


### PR DESCRIPTION
## Description

This change creates a new feature flag for Playback 2025. 

Fixes PCDROID-235

## Testing Instructions

1. Sign into an account with playback data
2. Restart the app
3. ✅ Verify the playback banner is visible

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
