### PR TITLE
Include missing list uuid to track curated lists events

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -300,7 +300,7 @@ class PodcastAdapter(
                 EpisodeViewHolder(
                     binding = binding,
                     showArtwork = settings.artworkConfiguration.value.useEpisodeArtwork(Element.Podcasts),
-                    fromListUuid = null,
+                    fromListUuid = fromListUuid,
                     imageRequestFactory = imageRequestFactory,
                     swipeRowActionsFactory = swipeRowActionsFactory,
                     rowDataProvider = rowDataProvider,


### PR DESCRIPTION
## Description

`fromListUuid` property wasn't being set in the `PodcastAdapter` which led to `discover_list_episode_play` event not being triggered. This fixes that.

## Testing Instructions

1. Go to the Discover page.
2. Open a podcast from a curated list like `Trending`.
3. Play any episode.
4. You should see `discover_list_episode_play` event being triggered in the logs.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.