### PR TITLE
Show only positive playlist duration

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerManualTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerManualTest.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.repositories.playlist
 import app.cash.turbine.test
 import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.SYNC_STATUS_NOT_SYNCED
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.models.type.PlaylistEpisodeSortType
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -694,7 +695,7 @@ class PlaylistManagerManualTest {
     fun computeTotalPlaybackDurationLeft() = dsl.test {
         insertManualPlaylist(index = 0)
         insertPodcast(index = 0)
-        repeat(6) { index ->
+        repeat(7) { index ->
             insertManualEpisode(index = index, podcastIndex = 0, playlistIndex = 0)
         }
 
@@ -729,6 +730,11 @@ class PlaylistManagerManualTest {
 
             insertPodcastEpisode(index = 5, podcastIndex = 0) {
                 it.copy(duration = 5.0, isArchived = true)
+            }
+            assertEquals(40.seconds, awaitItem()?.metadata?.playbackDurationLeft)
+
+            insertPodcastEpisode(index = 6, podcastIndex = 0) {
+                it.copy(duration = 20.0, playingStatus = EpisodePlayingStatus.COMPLETED)
             }
             assertEquals(40.seconds, awaitItem()?.metadata?.playbackDurationLeft)
 

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerSmartTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerSmartTest.kt
@@ -553,6 +553,11 @@ class PlaylistManagerSmartTest {
                 it.copy(duration = 0.0, playedUpTo = 10.0)
             }
             assertEquals(40.seconds, awaitItem()?.metadata?.playbackDurationLeft)
+
+            insertPodcastEpisode(index = 5, podcastIndex = 0) {
+                it.copy(duration = 20.0, playingStatus = EpisodePlayingStatus.COMPLETED)
+            }
+            assertEquals(40.seconds, awaitItem()?.metadata?.playbackDurationLeft)
         }
     }
 

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/component/PlaylistHeader.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/component/PlaylistHeader.kt
@@ -400,7 +400,7 @@ private fun PlaylistInfoText(
     }
     val durationLeftText = remember(resources, playbackDurationLeft, episodeCount) {
         playbackDurationLeft
-            ?.takeIf { episodeCount != null && episodeCount > 0 }
+            ?.takeIf { episodeCount != null && episodeCount > 0 && it > Duration.ZERO }
             ?.toFriendlyString(resources, pluralResourceId = { unit -> unit.shortResourceId })
     }
     val playlistInfoText = remember(episodeCountText, durationLeftText) {

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/converter/EpisodePlayingStatusConverter.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/converter/EpisodePlayingStatusConverter.kt
@@ -7,7 +7,7 @@ class EpisodePlayingStatusConverter {
 
     @TypeConverter
     fun toEpisodePlayingStatus(value: Int?): EpisodePlayingStatus? {
-        return if (value == null) null else EpisodePlayingStatus.values()[value]
+        return if (value == null) null else EpisodePlayingStatus.entries[value]
     }
 
     @TypeConverter

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
@@ -220,7 +220,7 @@ abstract class PlaylistDao {
           SUM(IFNULL(podcastEpisode.archived, 0)) AS archived_episode_count,
           SUM(
             CASE
-              WHEN playlist.showArchivedEpisodes != 0 OR podcastEpisode.archived = 0
+              WHEN (playlist.showArchivedEpisodes != 0 OR podcastEpisode.archived = 0) AND podcastEpisode.playing_status != 2
               THEN MAX(0, IFNULL(podcastEpisode.duration, 0) - IFNULL(podcastEpisode.played_up_to, 0))
               ELSE 0
             END
@@ -467,7 +467,13 @@ abstract class PlaylistDao {
             selectClause = """
                 COUNT(*) AS episode_count, 
                 0 AS archived_episode_count,
-                SUM(MAX(episode.duration - episode.played_up_to, 0)) AS time_left
+                SUM(
+                  CASE
+                    WHEN episode.playing_status != 2
+                    THEN MAX(0, IFNULL(episode.duration, 0) - IFNULL(episode.played_up_to, 0))
+                    ELSE 0
+                  END
+                ) AS time_left
             """.trimIndent(),
             whereClause = smartRules.toSqlWhereClause(clock),
             orderByClause = null,


### PR DESCRIPTION
## Description

Context: p1761326646269319-slack-C093RV9N8DR

## Testing Instructions

1. Create a Manual Playlist.
2. Add an episode to it.
3. Mark it as played.
4. Unarchive it.
5. You shouldn't see any time left duration in the playlist header.

## Screenshots or Screencast 

<img width="540" alt="Screenshot_20251027-202111" src="https://github.com/user-attachments/assets/20c23fb3-8fc4-4c9c-9bcf-e997862fe88c" />

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.