### PR TITLE
Remove podcast category underline style

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastHeader.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastHeader.kt
@@ -83,9 +83,12 @@ import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.LinkInteractionListener
 import androidx.compose.ui.text.Placeholder
 import androidx.compose.ui.text.PlaceholderVerticalAlign
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.Constraints
@@ -100,7 +103,6 @@ import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.Devices
 import au.com.shiftyjelly.pocketcasts.compose.components.ExpandableText
 import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
-import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImageDeprecated
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH20
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP60
@@ -328,9 +330,13 @@ private fun PodcastCategoriesLabel(
                     LinkAnnotation.Clickable(
                         tag = "category",
                         linkInteractionListener = LinkInteractionListener { onClickCategory() },
+                        styles = TextLinkStyles(
+                            style = SpanStyle(textDecoration = TextDecoration.None),
+                            focusedStyle = SpanStyle(textDecoration = TextDecoration.Underline),
+                        ),
                     ),
                     start = 0,
-                    end = category.length + if (author.isNotBlank()) 2 else 0,
+                    end = category.length,
                 )
             }
         }


### PR DESCRIPTION
## Description

I believe a library upgrade has pulled in a new version of `androidx.compose.ui:ui` and caused the category link on the podcast page to have an underline.

## Testing Instructions
1. Open a podcast page
2. ✅ Verify the podcast category isn't underlined or a different colour

## Screenshots 

| Before | After |
| --- | --- |
| <img width="1198" height="2531" alt="Screenshot_20251028_143003" src="https://github.com/user-attachments/assets/a5b56fca-e8c6-4f47-9866-ba2f621ff918" /> | <img width="1198" height="2531" alt="Screenshot_20251028_141934" src="https://github.com/user-attachments/assets/02f53732-ab99-4a33-9da2-a8ed5e7ac088" /> | 

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
