### PR TITLE
Do not display rearrange tooltip multiple times

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
@@ -469,8 +469,9 @@ class PlaylistManagerImpl(
             }
             finalUuid
         }
-        if (uuid !in Playlist.PREDEFINED_UUIDS) {
-            settings.showRearrangePlaylistsTooltip.set(true, updateModifiedAt = false)
+        val setting = settings.showRearrangePlaylistsTooltip
+        if (uuid !in Playlist.PREDEFINED_UUIDS && setting.modifiedAt == null) {
+            setting.set(true, updateModifiedAt = true)
         }
         return uuid
     }


### PR DESCRIPTION
## Description

This fixes an issue where the rearrange tooltip would reset to be showed again after creating a playlists.

## Testing Instructions

1. Create a playlist.
2. Go to the playlists page.
3. Verify that you see the rearrange tooltip.
4. Dismiss it.
5. Create another playlist.
6. Go to the playlists page.
7. There should be no rearrange tooltip displayed.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.