### PR TITLE
[Improved Search] Send `term` param for `search_predictive_failed` event

### DIFF
--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchViewModel.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchViewModel.kt
@@ -49,14 +49,16 @@ class SearchViewModel @Inject constructor(
                         showSearchHistory = false
                         _state.update { uiState ->
                             when (operation) {
-                                is SearchUiState.SearchOperation.Error -> {
-                                    analyticsTracker.track(
-                                        AnalyticsEvent.IMPROVED_SEARCH_SUGGESTIONS_FAILED,
-                                        mapOf(
-                                            "source" to source.analyticsValue,
-                                            "term" to operation.searchTerm,
-                                        ),
-                                    )
+                                is SearchUiState.SearchOperation.Success -> {
+                                    if (operation.results.isEmpty()) {
+                                        analyticsTracker.track(
+                                            AnalyticsEvent.IMPROVED_SEARCH_SUGGESTIONS_FAILED,
+                                            mapOf(
+                                                "source" to source.analyticsValue,
+                                                "term" to operation.searchTerm,
+                                            ),
+                                        )
+                                    }
                                 }
 
                                 else -> Unit


### PR DESCRIPTION
## Description
We have decided to include the new `term` param for `search_predictive_failed` events. We also changed when to report the event: when the API call succeeds but returns no suggestions.
I also noticed that the `source` param were wong so I fixed that as well.

ctxt: p1761671329898829/1761240693.823919-slack-C09ENPJ5D2R

## Testing Instructions
1. Open Discover
2. Start typing something nonsensical
3. Notice that the event is tracked and the term is sent along

## Screenshots or Screencast 
<img width="2038" height="117" alt="SCR-20251029-jdhs" src="https://github.com/user-attachments/assets/816bc740-0db6-461e-99bf-c5ee728bf15a" />


## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
