### PR TITLE
Fix playlists not being interactive

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistFragment.kt
@@ -334,11 +334,15 @@ class PlaylistFragment :
         AppTheme(theme.activeTheme) {
             Box(
                 // Clickable to intercept events below the overlay
-                modifier = Modifier.clickable(
-                    onClick = {},
-                    interactionSource = null,
-                    indication = null,
-                ),
+                modifier = when (transition.currentState) {
+                    ContentState.Uninitialized, ContentState.HasNoEpisodes -> Modifier.clickable(
+                        onClick = {},
+                        interactionSource = null,
+                        indication = null,
+                    )
+
+                    ContentState.HasEpisode -> Modifier
+                },
             ) {
                 if (transition.currentState == ContentState.Uninitialized) {
                     Box(


### PR DESCRIPTION
## Description

Setting a clickable modifier on the no content overlay prevented the app from being interactive even when the playlist had content. This fixes that.

## Testing Instructions

1. Create a playlist.
2. Add an episode to it.
3. Go back to the playlist.
4. Make sure you can tap "Add episodes" button when a playlist has episodes in it.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.