### PR TITLE
Add uuids to episode completion tracking

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1300,7 +1300,13 @@ open class PlaybackManager @Inject constructor(
                 LogBuffer.e(LogBuffer.TAG_PLAYBACK, "OnCompletion uuid does not match playback state current episode, ignoring onComplete event.")
                 return
             }
-            analyticsTracker.track(AnalyticsEvent.PLAYER_EPISODE_COMPLETED)
+            analyticsTracker.track(
+                AnalyticsEvent.PLAYER_EPISODE_COMPLETED,
+                mapOf(
+                    "podcast_uuid" to episode.podcastOrSubstituteUuid,
+                    "episode_uuid" to episode.uuid,
+                ),
+            )
 
             // remove from Up Next
             upNextQueue.removeEpisode(episode, shouldShuffleUpNext = settings.upNextShuffle.value)
@@ -2147,7 +2153,13 @@ open class PlaybackManager @Inject constructor(
                     sleepEndOfEpisode(episode)
                     episodeManager.markAsPlayedBlocking(episode, this, podcastManager)
                 } else {
-                    analyticsTracker.track(AnalyticsEvent.PLAYER_EPISODE_COMPLETED)
+                    analyticsTracker.track(
+                        AnalyticsEvent.PLAYER_EPISODE_COMPLETED,
+                        mapOf(
+                            "podcast_uuid" to episode.podcastOrSubstituteUuid,
+                            "episode_uuid" to episode.uuid,
+                        ),
+                    )
                     statsManager.addTimeSavedAutoSkipping(timeRemaining.toLong() * 1000L)
                     episodeManager.markAsPlayedBlocking(episode, this, podcastManager)
                     LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Skipping remainder of ${episode.title} with skip last $skipLast")


### PR DESCRIPTION
## Description

See [this comment](https://linear.app/a8c/issue/PCWEB-250/add-player-episode-completed-event-for-analytics-across-all-clients#comment-7bdc3a0e).

## Testing Instructions

1. Play an episode to the end.
2. Verify that the `player_episode_completed` event contains both podcast uuid and episode uuid properties.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.