### PR TITLE
Remove the Playback 2025 mention from the changelog for version 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,6 @@
 *   New Features
     *   Add support for Manual Playlists and rebrand Filters as Smart Playlists
         ([#4711](https://github.com/Automattic/pocket-casts-android/pull/4670))
-    *   Add new intro story for playback
-        ([#4670](https://github.com/Automattic/pocket-casts-android/pull/4670))
 *   Bug Fixes
     *   Fix podcasts drag & drop swapping podcasts' positions
         ([#4699](https://github.com/Automattic/pocket-casts-android/pull/4699))


### PR DESCRIPTION
As we aren't adding the Playback 2025 feature until version 8.1, I have removed the entry from the changelog. 
