### PR TITLE
[Playback] TopShow: Update footer and header spacing to support small screens

### DIFF
--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TopShowStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TopShowStory.kt
@@ -57,7 +57,7 @@ import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
-private const val mediumHeightFactor = .6f
+private const val MEDIUM_HEIGHT_FACTOR = .6f
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
@@ -76,7 +76,7 @@ internal fun TopShowStory(
     ) {
         val windowSize = currentWindowAdaptiveInfo().windowSizeClass
         val sizeFactor = if (windowSize.isAtMostMediumHeight()) {
-            mediumHeightFactor
+            MEDIUM_HEIGHT_FACTOR
         } else {
             1f
         }


### PR DESCRIPTION
## Description
This PR addresses an issue with the TopShow story on small devices: the share button was squezzed.

Context: https://github.com/Automattic/pocket-casts-android/pull/4705#pullrequestreview-3442284459
Slack: p1762865730964529-slack-C09EXS7SWP6

Update: decided to scale back the animation on small screens.

Related to PCDROID-224

## Testing Instructions
1. Set up an emulator with small screen
2. Log in with an account that has playback data
3. Scroll until you see the TopShow story
4. Observe
5. Do the same on a regular device

## Screenshots or Screencast 
| Small | Normal |
| --- | --- | 
| <img width="720" height="1280" alt="Screenshot_20251112_100251" src="https://github.com/user-attachments/assets/98ab07e2-4e4f-4061-978b-bcc4fb8fcf7f" /> | <img width="1080" height="2400" alt="Screenshot_20251112_100240" src="https://github.com/user-attachments/assets/664e4fe2-b5d0-4381-9dc8-877d2f806ea3" /> |



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack