### PR TITLE
Display archived episode status when building a playlist

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/AddEpisodesColumn.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/AddEpisodesColumn.kt
@@ -200,14 +200,9 @@ private fun Footer(
         verticalAlignment = Alignment.Bottom,
         modifier = modifier,
     ) {
-        val episodeIcon = if (episode.isArchived) {
-            IR.drawable.ic_archive
-        } else {
-            null
-        }
-        if (episodeIcon != null) {
+        if (episode.isArchived) {
             Image(
-                painter = painterResource(episodeIcon),
+                painter = painterResource(IR.drawable.ic_archive),
                 contentDescription = null,
                 colorFilter = ColorFilter.tint(MaterialTheme.theme.colors.primaryText02),
                 modifier = Modifier


### PR DESCRIPTION
## Description

Closes PCDROID-310

## Testing Instructions

1. Archive some episodes in a podcast.
2. Create a manual playlist.
3. Start build episode list.
4. Go to the podcast that you archived episodes for.
5. Episodes should display archived status.

## Screenshots or Screencast 

<img width="540" alt="image" src="https://github.com/user-attachments/assets/67a762b5-1aaa-4c94-961b-ecf9a2effc62" />

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack