### PR TITLE
Update playlist edit translations

### DIFF
--- a/modules/services/localization/src/main/res/values-ar/strings.xml
+++ b/modules/services/localization/src/main/res/values-ar/strings.xml
@@ -56,7 +56,6 @@ Language: ar
     <string name="add_to_up_next_top">إضافة في بداية قائمة التشغيل التالية</string>
     <string name="playlist_episodes_archived_title">لا توجد حلقات</string>
     <string name="playlist_episodes_archived_count">⁦%1$d⁩ مؤرشف</string>
-    <string name="playlist_edit_episodes_title">تحرير قائمة تشغيل</string>
     <string name="playlist_edit_episodes">إعادة ترتيب الحلقات</string>
     <string name="playlist_episode_unavailable_cta">إزالة من قائمة التشغيل</string>
     <string name="playlist_episode_unavailable_description">حذف منشئ podcast هذه الحلقة. ستبقى في قائمة تشغيلك حتى تزيلها.</string>

--- a/modules/services/localization/src/main/res/values-ca/strings.xml
+++ b/modules/services/localization/src/main/res/values-ca/strings.xml
@@ -40,7 +40,6 @@ Language: ca
     <string name="add_to_up_next_top">Afegir al principi de la cua</string>
     <string name="playlist_episodes_archived_title">No hi ha episodis</string>
     <string name="playlist_episodes_archived_count">%1$d arxivats</string>
-    <string name="playlist_edit_episodes_title">Editar la llista</string>
     <string name="playlist_edit_episodes">Reorganitzar els episodis</string>
     <string name="playlist_episode_unavailable_cta">Esborrar de la llista de reproducció</string>
     <string name="playlist_episode_unavailable_description">L\'autor del pòdcast ha eliminat aquest episodi. Es quedarà a la teva llista de reproducció fins que l\'esborris.</string>

--- a/modules/services/localization/src/main/res/values-de/strings.xml
+++ b/modules/services/localization/src/main/res/values-de/strings.xml
@@ -57,7 +57,6 @@ Language: de
     <string name="playlist_episodes_archived_title">Keine Folgen</string>
     <string name="playlist_episodes_archived_count">%1$d archiviert</string>
     <string name="playlist_edit_episodes">Folgen neu anordnen</string>
-    <string name="playlist_edit_episodes_title">Playlist bearbeiten</string>
     <string name="playlist_episode_unavailable_title">Folge nicht verfügbar</string>
     <string name="episode_sort_custom_order">Individuelle Reihenfolge</string>
     <string name="playlist_episode_unavailable_cta">Aus Playlist entfernen</string>

--- a/modules/services/localization/src/main/res/values-es-rMX/strings.xml
+++ b/modules/services/localization/src/main/res/values-es-rMX/strings.xml
@@ -57,7 +57,6 @@ Language: es
     <string name="playlist_episodes_archived_title">No hay episodios</string>
     <string name="playlist_episodes_archived_count">%1$d archivado(s)</string>
     <string name="playlist_edit_episodes">Reorganizar episodios</string>
-    <string name="playlist_edit_episodes_title">Editar la playlist</string>
     <string name="playlist_episode_unavailable_title">Episodio no disponible</string>
     <string name="episode_sort_custom_order">Orden personalizado</string>
     <string name="playlist_episode_unavailable_cta">Eliminar de la playlist</string>

--- a/modules/services/localization/src/main/res/values-es/strings.xml
+++ b/modules/services/localization/src/main/res/values-es/strings.xml
@@ -57,7 +57,6 @@ Language: es
     <string name="playlist_episodes_archived_title">No hay episodios</string>
     <string name="playlist_episodes_archived_count">%1$d archivado(s)</string>
     <string name="playlist_edit_episodes">Reorganizar episodios</string>
-    <string name="playlist_edit_episodes_title">Editar la playlist</string>
     <string name="playlist_episode_unavailable_title">Episodio no disponible</string>
     <string name="episode_sort_custom_order">Orden personalizado</string>
     <string name="playlist_episode_unavailable_cta">Eliminar de la playlist</string>

--- a/modules/services/localization/src/main/res/values-fr-rCA/strings.xml
+++ b/modules/services/localization/src/main/res/values-fr-rCA/strings.xml
@@ -57,7 +57,6 @@ Language: fr
     <string name="playlist_episodes_archived_title">Aucun épisode</string>
     <string name="playlist_episodes_archived_count">%1$d archivé(s)</string>
     <string name="playlist_edit_episodes">Réorganiser les épisodes</string>
-    <string name="playlist_edit_episodes_title">Modifier la playlist</string>
     <string name="playlist_episode_unavailable_title">Épisode non disponible</string>
     <string name="episode_sort_custom_order">Ordre personnalisé</string>
     <string name="playlist_episode_unavailable_cta">Retirer de la playlist</string>

--- a/modules/services/localization/src/main/res/values-fr/strings.xml
+++ b/modules/services/localization/src/main/res/values-fr/strings.xml
@@ -57,7 +57,6 @@ Language: fr
     <string name="playlist_episodes_archived_title">Aucun épisode</string>
     <string name="playlist_episodes_archived_count">%1$d archivé(s)</string>
     <string name="playlist_edit_episodes">Réorganiser les épisodes</string>
-    <string name="playlist_edit_episodes_title">Modifier la playlist</string>
     <string name="playlist_episode_unavailable_title">Épisode non disponible</string>
     <string name="episode_sort_custom_order">Ordre personnalisé</string>
     <string name="playlist_episode_unavailable_cta">Retirer de la playlist</string>

--- a/modules/services/localization/src/main/res/values-it/strings.xml
+++ b/modules/services/localization/src/main/res/values-it/strings.xml
@@ -56,7 +56,6 @@ Language: it
     <string name="add_to_up_next_top">Aggiungi a Successivo dall\'inizio </string>
     <string name="playlist_episodes_archived_title">Nessun episodio</string>
     <string name="playlist_episodes_archived_count">%1$d archiviato/i</string>
-    <string name="playlist_edit_episodes_title">Modifica playlist</string>
     <string name="playlist_edit_episodes">Riorganizza episodi</string>
     <string name="playlist_episode_unavailable_cta">Rimuovi dalla playlist</string>
     <string name="playlist_episode_unavailable_description">Il creatore del podcast ha eliminato questo episodio. Rimarrà nella playlist finché non la rimuovi.</string>

--- a/modules/services/localization/src/main/res/values-ja/strings.xml
+++ b/modules/services/localization/src/main/res/values-ja/strings.xml
@@ -56,7 +56,6 @@ Language: ja_JP
     <string name="add_to_up_next_top">「次のエピソード待機リスト」の上部に追加</string>
     <string name="playlist_episodes_archived_title">エピソードなし</string>
     <string name="playlist_episodes_archived_count">%1$d件をアーカイブ済み</string>
-    <string name="playlist_edit_episodes_title">プレイリストを編集</string>
     <string name="playlist_edit_episodes">エピソードを並べ替え</string>
     <string name="playlist_episode_unavailable_cta">プレイリストから削除</string>
     <string name="playlist_episode_unavailable_description">ポッドキャスト作成者がこのエピソードを削除しました。 あなたが削除するまでは、ご自身のプレイリストに残ります。</string>

--- a/modules/services/localization/src/main/res/values-ko/strings.xml
+++ b/modules/services/localization/src/main/res/values-ko/strings.xml
@@ -56,7 +56,6 @@ Language: ko_KR
     <string name="add_to_up_next_top">다음 차례에 추가(맨 처음)</string>
     <string name="playlist_episodes_archived_title">에피소드 없음</string>
     <string name="playlist_episodes_archived_count">%1$d개 보관됨</string>
-    <string name="playlist_edit_episodes_title">재생목록 편집</string>
     <string name="playlist_edit_episodes">에피소드 재정렬</string>
     <string name="playlist_episode_unavailable_cta">재생목록에서 제거</string>
     <string name="playlist_episode_unavailable_description">팟캐스트 크리에이터가 이 에피소드를 삭제했습니다. 회원님이 제거할 때까지 회원님 재생목록에는 남아 있습니다.</string>

--- a/modules/services/localization/src/main/res/values-nl/strings.xml
+++ b/modules/services/localization/src/main/res/values-nl/strings.xml
@@ -57,7 +57,6 @@ Language: nl
     <string name="playlist_episodes_archived_title">Geen afleveringen</string>
     <string name="playlist_episodes_archived_count">%1$d gearchiveerd</string>
     <string name="playlist_edit_episodes">Afleveringen herschikken</string>
-    <string name="playlist_edit_episodes_title">Playlist bewerken</string>
     <string name="playlist_episode_unavailable_title">Aflevering niet beschikbaar</string>
     <string name="episode_sort_custom_order">Aangepaste volgorde</string>
     <string name="playlist_episode_unavailable_cta">Verwijderen uit playlist</string>

--- a/modules/services/localization/src/main/res/values-pt-rBR/strings.xml
+++ b/modules/services/localization/src/main/res/values-pt-rBR/strings.xml
@@ -57,7 +57,6 @@ Language: pt_BR
     <string name="playlist_episodes_archived_title">Sem episódios</string>
     <string name="playlist_episodes_archived_count">%1$d arquivado(s)</string>
     <string name="playlist_edit_episodes">Reorganizar episódios</string>
-    <string name="playlist_edit_episodes_title">Editar playlist</string>
     <string name="playlist_episode_unavailable_title">Episódio indisponível</string>
     <string name="episode_sort_custom_order">Ordenação personalizada</string>
     <string name="playlist_episode_unavailable_cta">Remover da playlist</string>

--- a/modules/services/localization/src/main/res/values-ru/strings.xml
+++ b/modules/services/localization/src/main/res/values-ru/strings.xml
@@ -56,7 +56,6 @@ Language: ru
     <string name="add_to_up_next_top">Добавить в начало списка «Следующие»</string>
     <string name="playlist_episodes_archived_title">Нет выпусков</string>
     <string name="playlist_episodes_archived_count">Архивировано: %1$d</string>
-    <string name="playlist_edit_episodes_title">Редактировать плейлист</string>
     <string name="playlist_edit_episodes">Изменить очерёдность выпусков</string>
     <string name="playlist_episode_unavailable_cta">Удалить из плейлиста</string>
     <string name="playlist_episode_unavailable_description">Автор подкаста удалил этот выпуск. Он останется в вашем плейлисте, пока вы его не удалите.</string>

--- a/modules/services/localization/src/main/res/values-sv/strings.xml
+++ b/modules/services/localization/src/main/res/values-sv/strings.xml
@@ -56,7 +56,6 @@ Language: sv_SE
     <string name="add_to_up_next_top">Lägg till högst upp i Nästa</string>
     <string name="playlist_episodes_archived_title">Inga avsnitt</string>
     <string name="playlist_episodes_archived_count">%1$d arkiverade</string>
-    <string name="playlist_edit_episodes_title">Redigera spellista</string>
     <string name="playlist_edit_episodes">Ordna om avsnitt</string>
     <string name="playlist_episode_unavailable_cta">Ta bort från spellista</string>
     <string name="playlist_episode_unavailable_description">Podcastens skapare har tagit bort detta avsnitt. Det kommer att finnas kvar i din spellista tills du tar bort det.</string>

--- a/modules/services/localization/src/main/res/values-zh-rTW/strings.xml
+++ b/modules/services/localization/src/main/res/values-zh-rTW/strings.xml
@@ -56,7 +56,6 @@ Language: zh_TW
     <string name="add_to_up_next_top">新增至「接下來播放」開頭</string>
     <string name="playlist_episodes_archived_title">沒有單集</string>
     <string name="playlist_episodes_archived_count">已封存 %1$d 集</string>
-    <string name="playlist_edit_episodes_title">編輯播放清單</string>
     <string name="playlist_edit_episodes">重新排列單集</string>
     <string name="playlist_episode_unavailable_cta">從播放清單移除</string>
     <string name="playlist_episode_unavailable_description">Podcast 創作者已將本集刪除。 除非移除，否則該單集將持續保留在播放清單中。</string>

--- a/modules/services/localization/src/main/res/values-zh/strings.xml
+++ b/modules/services/localization/src/main/res/values-zh/strings.xml
@@ -56,7 +56,6 @@ Language: zh_CN
     <string name="add_to_up_next_top">添加到“接下来播放”顶部</string>
     <string name="playlist_episodes_archived_title">无剧集</string>
     <string name="playlist_episodes_archived_count">%1$d 已存档</string>
-    <string name="playlist_edit_episodes_title">编辑播放列表</string>
     <string name="playlist_edit_episodes">重新排列剧集</string>
     <string name="playlist_episode_unavailable_cta">从播放列表中移除</string>
     <string name="playlist_episode_unavailable_description">播客创作者删除了此剧集。 在您移除之前，它将保留在您的播放列表中。</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -998,8 +998,8 @@
     <string name="playlist_archive_all" translatable="false">@string/podcast_archive_all</string>
     <string name="playlist_artwork_description">Playlist’s artwork</string>
     <string name="playlist_download_all" translatable="false">@string/podcast_download_all</string>
-    <string name="playlist_edit_episodes">Rearrange episodes</string>
-    <string name="playlist_edit_episodes_title">Edit playlist</string>
+    <string name="playlist_edit_episodes">Reorder episodes</string>
+    <string name="playlist_edit_episodes_title" translatable="false">@string/playlist_edit_episodes</string>
     <string name="playlist_episode_unavailable_title">Episode unavailable</string>
     <string name="playlist_episode_unavailable_description">The podcast creator deleted this episode. It will stay in your playlist until you remove it.</string>
     <string name="playlist_episode_unavailable_cta">Remove from playlist</string>


### PR DESCRIPTION
## Description

Changes copies from "Rearrange episodes" and "Edit episodes" to "Reorder episodes".

Closes PCDROID-311

## Testing Instructions

1. Open a manual playlist.
2. Tap overflow button.
3. Notice "Reorder episodes" label.
4. Tap it.
5. Notice "Reorder episodes" toolbar title.

## Screenshots or Screencast 

| A | B |
| - | - |
| <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/8e1b7bb9-919e-4205-9c78-f11a01d6fcc0" /> | <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/b3f469be-ca60-4e9a-b571-bc6a8e442c28" /> |


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.