### PR TITLE
Account for children dialogs when asking for a review

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -34,6 +34,7 @@ import androidx.core.view.updatePadding
 import androidx.dynamicanimation.animation.DynamicAnimation.TRANSLATION_Y
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.commitNow
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.Observer
@@ -1914,15 +1915,43 @@ class MainActivity :
     private fun canDisplayAppRatingsPrompt(reason: AppReviewReason): Boolean {
         return reason == AppReviewReason.DevelopmentTrigger || (
             FeatureFlag.isEnabled(Feature.IMPROVE_APP_RATINGS) &&
-                navigator.isAtRootOfStack() &&
-                !navigator.isShowingModal() &&
-                childrenWithBackStack.all { it.getBackstackCount() == 0 } &&
-                supportFragmentManager.backStackEntryCount == 0 &&
-                supportFragmentManager.fragments.none { it is DialogFragment } &&
+                !binding.root.wasTouchedInLast(2.seconds) &&
                 frameBottomSheetBehavior.state == BottomSheetBehavior.STATE_COLLAPSED &&
                 !viewModel.shouldShowStoriesModal.value &&
                 !binding.playerBottomSheet.isPlayerOpen &&
-                !binding.root.wasTouchedInLast(2.seconds)
+                isAtRootOfStack() &&
+                isNoDialogShown() &&
+                areChildrenAtRootOfStack() &&
+                isNoChildDialogShown()
             )
+    }
+
+    private fun isAtRootOfStack(): Boolean {
+        return navigator.isAtRootOfStack() && supportFragmentManager.isAtRootOfStack()
+    }
+
+    private fun isNoDialogShown(): Boolean {
+        return !navigator.isShowingModal() && supportFragmentManager.isNoDialogShown()
+    }
+
+    private fun areChildrenAtRootOfStack(): Boolean {
+        return childrenWithBackStack.all { it.getBackstackCount() == 0 } &&
+            supportFragmentManager.fragments
+                .filter { fragment -> fragment.host != null }
+                .all { fragment -> fragment.childFragmentManager.isAtRootOfStack() }
+    }
+
+    private fun isNoChildDialogShown(): Boolean {
+        return supportFragmentManager.fragments
+            .filter { fragment -> fragment.host != null }
+            .all { fragment -> fragment.childFragmentManager.isNoDialogShown() }
+    }
+
+    private fun FragmentManager.isAtRootOfStack(): Boolean {
+        return backStackEntryCount == 0
+    }
+
+    private fun FragmentManager.isNoDialogShown(): Boolean {
+        return fragments.none { it is DialogFragment }
     }
 }


### PR DESCRIPTION
## Description

The current logic doesn't account for child dialogs. I also moved faster review prevention checks to be used first.

Closes PCDROID-299

## Testing Instructions

1. Start with a clean app.
2. Create a playlist.
3. Go back to the playlists page and quickly tap "+" button to start creating a new playlist.
4. Wait ~10 seconds.
5. The review prompt should not appear.
6. Close the playlist creation dialog.
7. Wait ~10 seconds.
8. The review prompt should appear.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.