### PR TITLE
Update play progress while playing

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeRowData.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeRowData.kt
@@ -82,9 +82,9 @@ class EpisodeRowDataProvider @Inject constructor(
             .map { if (it.episodeUuid == episodeUuid) it else emptyState }
             .distinctUntilChanged { prev, curr ->
                 prev.state == curr.state &&
-                prev.episodeUuid == curr.episodeUuid &&
-                prev.positionMs == curr.positionMs &&
-                prev.isBuffering == curr.isBuffering
+                    prev.episodeUuid == curr.episodeUuid &&
+                    prev.positionMs == curr.positionMs &&
+                    prev.isBuffering == curr.isBuffering
             }
     }
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Related to #4708, after implementing the fix in #4709, the progress circle in the episode row is only updated when playing state is changed (play/pause). This changes to also update to show the accurate episode progress. Included isBuffering, to not introduced the original issue fixed in: https://github.com/Automattic/pocket-casts-android/pull/4552

This does introduce a flickering of the scrollbar every time the play progress is updated, I couldn't see how to fix this without doing a restructuring of how the views are handled. I think that's worthy of it's own issue.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Go to playlist view
2. Start any episode
3. Observe play progress is updated in row continously

## Screenshots or Screencast 
<!-- if applicable -->

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
