### PR TITLE
Analytics event if Playback screenshots

### DIFF
--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/EndOfYearViewModel.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/EndOfYearViewModel.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.endofyear
 
+import android.app.Activity
 import androidx.compose.runtime.Immutable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -368,6 +369,18 @@ class EndOfYearViewModel @AssistedInject constructor(
         } else {
             null
         }
+    }
+
+    fun screenshotDetected(story: Story, activity: Activity) {
+        analyticsTracker.track(
+            event = AnalyticsEvent.END_OF_YEAR_STORY_SHARED,
+            properties = mapOf(
+                "activity" to activity.javaClass.name,
+                "from" to "screenshot",
+                "story" to story.analyticsValue,
+                "year" to year.value,
+            ),
+        )
     }
 
     private data class RandomShowIds(

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesActivity.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesActivity.kt
@@ -256,6 +256,7 @@ class StoriesActivity : ComponentActivity() {
                 val currentStory = stories?.getOrNull(pagerState.currentPage)
                 if (currentStory?.isShareable == true) {
                     viewModel.pauseStoryAutoProgress(StoryProgressPauseReason.ScreenshotDialog)
+                    viewModel.screenshotDetected(story = currentStory, activity = this@StoriesActivity)
                     showScreenshotDialog = true
                 }
             }

--- a/modules/services/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/SharingClient.kt
+++ b/modules/services/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/SharingClient.kt
@@ -266,6 +266,7 @@ class SharingClient(
                     values = mapOf(
                         "story" to data.story.analyticsValue,
                         "year" to data.year.value,
+                        "from" to "button",
                     ),
                 )
                 Intent()


### PR DESCRIPTION
## Description

This change adds an analytic so we can consider if people are using the phone screenshot more than our own share button. 

Fixes https://linear.app/a8c/issue/PCDROID-306/consider-tracking-screenshots-as-sharing-events

## Testing Instructions

1. Log in with an account that has playback data
2. Open playback
3. Go to a story with the share button
4. Use the phone hardware buttons to take a screenshot
5. ✅ Verify the dialog in the app offers to share use our image 
6. ✅ Verify the analytic `end_of_year_story_shared` is in the logs with the properties `year`, `story`, `activity`, and `from=button`.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
