### PR TITLE
[Playback] Make header lineHeight consistent across stories

### DIFF
--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/CoverStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/CoverStory.kt
@@ -54,7 +54,7 @@ internal fun CoverStory(
             TextH30(
                 fontScale = measurements.smallDeviceFactor,
                 fontSize = 25.sp,
-                lineHeight = 28.sp,
+                lineHeight = 30.sp,
                 text = stringResource(LR.string.eoy_playback_intro_title),
                 modifier = Modifier.padding(horizontal = 42.dp),
                 color = Color.White,

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/EndingStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/EndingStory.kt
@@ -81,6 +81,7 @@ internal fun EndingStory(
             fontScale = measurements.smallDeviceFactor,
             disableAutoScale = true,
             fontSize = 25.sp,
+            lineHeight = 30.sp,
             color = colorResource(UR.color.white),
             modifier = Modifier
                 .fillMaxWidth()

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TopShowStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TopShowStory.kt
@@ -200,6 +200,7 @@ private fun Header(
             2025,
         ),
         fontSize = 25.sp,
+        lineHeight = 30.sp,
         fontScale = measurements.smallDeviceFactor,
         disableAutoScale = true,
         color = colorResource(UR.color.white),

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TopShowsStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TopShowsStory.kt
@@ -84,6 +84,7 @@ internal fun TopShowsStory(
             text = stringResource(LR.string.eoy_story_top_podcasts_title),
             fontScale = measurements.smallDeviceFactor,
             fontSize = 25.sp,
+            lineHeight = 30.sp,
             disableAutoScale = true,
             modifier = Modifier.padding(horizontal = 24.dp),
             textAlign = TextAlign.Center,


### PR DESCRIPTION
## Description
This PR brings the headers on end of year stories consistent to each other, introducing 30.sp lineHeight.

Context: https://github.com/Automattic/pocket-casts-android/pull/4747#discussion_r2536253233
Figma: lH66LwxxgG8btQ8NrM0ldx-fi-4370_35065

## Testing Instructions
Just review the code pls.


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
