### PR TITLE
[Playback] Refine ending story animation

### DIFF
--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/EndingStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/EndingStory.kt
@@ -61,7 +61,7 @@ internal fun EndingStory(
             modifier = Modifier.weight(1f),
         )
         Image(
-            painter = painterResource(IR.drawable.navdrawer_logo),
+            painter = painterResource(IR.drawable.pocket_casts_logo),
             contentDescription = null,
             modifier = Modifier
                 .size(60.dp)

--- a/modules/services/images/src/main/res/drawable/pocket_casts_logo.xml
+++ b/modules/services/images/src/main/res/drawable/pocket_casts_logo.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="60dp"
+    android:height="60dp"
+    android:viewportWidth="60"
+    android:viewportHeight="60">
+  <path
+      android:pathData="M0,30C0,13.431 13.431,0 30,0C46.569,0 60,13.431 60,30H52.5C52.5,17.574 42.426,7.5 30,7.5C17.574,7.5 7.5,17.574 7.5,30C7.5,42.426 17.574,52.5 30,52.5V60C13.431,60 0,46.569 0,30ZM30,48C20.059,48 12,39.941 12,30C12,20.059 20.059,12 30,12C39.941,12 48,20.059 48,30H41.455C41.455,23.674 36.326,18.545 30,18.545C23.674,18.545 18.545,23.674 18.545,30C18.545,36.326 23.674,41.455 30,41.455V48Z"
+      android:fillColor="#ffffff"
+      android:fillType="evenOdd"/>
+</vector>


### PR DESCRIPTION
## Description
Small tweaks on the ending story animation. Using exact specs from slack.

Slack: p1762510640624219-slack-C09EXS7SWP6

Linked to PCDROID-232

## Testing Instructions
1. Log in with an account that has playback data
2. Open playback and step to the end
3. Observe

## Screenshots or Screencast 
| Specs | Actual |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/f72077a0-3ecd-4ff2-9804-066be08efd44" /> | <video src="https://github.com/user-attachments/assets/9175ac4e-e4cf-489c-bfc8-d79ea84bf241" /> |


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 