### PR TITLE
[Playback] Let cover story finish when we have the stats

### DIFF
--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/EndOfYearViewModel.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/EndOfYearViewModel.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.endofyear
 
 import android.app.Activity
+import androidx.annotation.VisibleForTesting
 import androidx.compose.runtime.Immutable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -137,6 +138,11 @@ class EndOfYearViewModel @AssistedInject constructor(
                 statsLoaded.emit(true)
             }
         }
+    }
+
+    @VisibleForTesting
+    internal fun markGracePeriodExpired() {
+        coverStoryGracePeriodExpired.value = true
     }
 
     private suspend fun createUiModel(

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesActivity.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesActivity.kt
@@ -218,7 +218,7 @@ class StoriesActivity : ComponentActivity() {
             }
         }
 
-        var lastStory by remember { mutableStateOf<Story?>(null)}
+        var lastStory by remember { mutableStateOf<Story?>(null) }
         LaunchedEffect(state::class) {
             if (state is UiState.Synced || state is UiState.Syncing) {
                 // Track displayed page to not report it twice from different events.

--- a/modules/features/endofyear/src/test/kotlin/au/com/shiftyjelly/pocketcasts/endofyear/EndOfYearViewModelTest.kt
+++ b/modules/features/endofyear/src/test/kotlin/au/com/shiftyjelly/pocketcasts/endofyear/EndOfYearViewModelTest.kt
@@ -69,7 +69,6 @@ class EndOfYearViewModelTest {
         isAutoRenewing = true,
         giftDays = 0,
     )
-    private val patronSubscription = plusSubscription.copy(tier = SubscriptionTier.Patron)
     private val subscriptionFlow = MutableStateFlow<Subscription?>(plusSubscription)
 
     private val stats = EndOfYearStats(
@@ -148,6 +147,7 @@ class EndOfYearViewModelTest {
         endOfYearManager.stats.add(stats)
 
         viewModel.syncData()
+        viewModel.markGracePeriodExpired()
         viewModel.uiState.test {
             assertTrue(awaitItem() is UiState.Synced)
         }
@@ -160,6 +160,7 @@ class EndOfYearViewModelTest {
         subscriptionFlow.value = null
 
         viewModel.syncData()
+        viewModel.markGracePeriodExpired()
         viewModel.uiState.test {
             val stories = awaitStories()
 
@@ -184,6 +185,7 @@ class EndOfYearViewModelTest {
         endOfYearManager.stats.add(stats)
 
         viewModel.syncData()
+        viewModel.markGracePeriodExpired()
         viewModel.uiState.test {
             val story = awaitStory<NumberOfShows>()
 
@@ -201,6 +203,7 @@ class EndOfYearViewModelTest {
         endOfYearManager.stats.add(stats.copy(playedPodcastIds = listOf("id")))
 
         viewModel.syncData()
+        viewModel.markGracePeriodExpired()
         viewModel.uiState.test {
             val story = awaitStory<NumberOfShows>()
 
@@ -214,6 +217,7 @@ class EndOfYearViewModelTest {
         endOfYearManager.stats.add(stats.copy(playedPodcastIds = List(6) { "id-$it" }))
 
         viewModel.syncData()
+        viewModel.markGracePeriodExpired()
         viewModel.uiState.test {
             val story = awaitStory<NumberOfShows>()
 
@@ -228,6 +232,7 @@ class EndOfYearViewModelTest {
         endOfYearManager.stats.add(stats.copy(playedPodcastIds = emptyList()))
 
         viewModel.syncData()
+        viewModel.markGracePeriodExpired()
         viewModel.uiState.test {
             val stories = awaitStories()
 
@@ -241,6 +246,7 @@ class EndOfYearViewModelTest {
         endOfYearManager.stats.add(stats)
 
         viewModel.syncData()
+        viewModel.markGracePeriodExpired()
         viewModel.uiState.test {
             val story = awaitStory<TopShow>()
 
@@ -257,6 +263,7 @@ class EndOfYearViewModelTest {
         endOfYearManager.stats.add(stats.copy(topPodcasts = emptyList()))
 
         viewModel.syncData()
+        viewModel.markGracePeriodExpired()
         viewModel.uiState.test {
             val stories = awaitStories()
 
@@ -270,6 +277,7 @@ class EndOfYearViewModelTest {
         endOfYearManager.stats.add(stats)
 
         viewModel.syncData()
+        viewModel.markGracePeriodExpired()
         viewModel.uiState.test {
             val story = awaitStory<TopShows>()
 
@@ -286,6 +294,7 @@ class EndOfYearViewModelTest {
         endOfYearManager.stats.add(stats)
 
         viewModel.syncData()
+        viewModel.markGracePeriodExpired()
         viewModel.uiState.test {
             assertEquals(
                 TopShows(stats.topPodcasts, podcastListUrl = null),
@@ -306,6 +315,7 @@ class EndOfYearViewModelTest {
         endOfYearManager.stats.add(stats.copy(topPodcasts = emptyList()))
 
         viewModel.syncData()
+        viewModel.markGracePeriodExpired()
         viewModel.uiState.test {
             val stories = awaitStories()
 
@@ -319,6 +329,7 @@ class EndOfYearViewModelTest {
         endOfYearManager.stats.add(stats)
 
         viewModel.syncData()
+        viewModel.markGracePeriodExpired()
         viewModel.uiState.test {
             val story = awaitStory<Ratings>()
 
@@ -335,6 +346,7 @@ class EndOfYearViewModelTest {
         endOfYearManager.stats.add(stats)
 
         viewModel.syncData()
+        viewModel.markGracePeriodExpired()
         viewModel.uiState.test {
             val story = awaitStory<TotalTime>()
 
@@ -351,6 +363,7 @@ class EndOfYearViewModelTest {
         endOfYearManager.stats.add(stats)
 
         viewModel.syncData()
+        viewModel.markGracePeriodExpired()
         viewModel.uiState.test {
             val story = awaitStory<LongestEpisode>()
 
@@ -367,6 +380,7 @@ class EndOfYearViewModelTest {
         endOfYearManager.stats.add(stats.copy(longestEpisode = null))
 
         viewModel.syncData()
+        viewModel.markGracePeriodExpired()
         viewModel.uiState.test {
             val stories = awaitStories()
 
@@ -381,6 +395,7 @@ class EndOfYearViewModelTest {
         subscriptionFlow.value = null
 
         viewModel.syncData()
+        viewModel.markGracePeriodExpired()
         viewModel.uiState.test {
             val stories = awaitStories()
 
@@ -394,6 +409,7 @@ class EndOfYearViewModelTest {
         endOfYearManager.stats.add(stats)
 
         viewModel.syncData()
+        viewModel.markGracePeriodExpired()
         viewModel.uiState.test {
             val story = awaitStory<YearVsYear>()
 
@@ -414,6 +430,7 @@ class EndOfYearViewModelTest {
         endOfYearManager.stats.add(stats)
 
         viewModel.syncData()
+        viewModel.markGracePeriodExpired()
         viewModel.uiState.test {
             val story = awaitStory<CompletionRate>()
 
@@ -435,6 +452,7 @@ class EndOfYearViewModelTest {
         subscriptionFlow.value = null
 
         viewModel.syncData()
+        viewModel.markGracePeriodExpired()
         viewModel.resumeStoryAutoProgress(StoryProgressPauseReason.ScreenInBackground)
         val stories = (viewModel.uiState.first() as UiState.Synced).stories
 
@@ -483,6 +501,7 @@ class EndOfYearViewModelTest {
         subscriptionFlow.value = null
 
         viewModel.syncData()
+        viewModel.markGracePeriodExpired()
         val stories = (viewModel.uiState.first() as UiState.Synced).stories
 
         viewModel.switchStory.test {
@@ -510,6 +529,7 @@ class EndOfYearViewModelTest {
         subscriptionFlow.value = null
 
         viewModel.syncData()
+        viewModel.markGracePeriodExpired()
         val stories = (viewModel.uiState.first() as UiState.Synced).stories
 
         viewModel.switchStory.test {
@@ -538,6 +558,7 @@ class EndOfYearViewModelTest {
         endOfYearManager.stats.add(stats)
 
         viewModel.syncData()
+        viewModel.markGracePeriodExpired()
         val stories = (viewModel.uiState.first() as UiState.Synced).stories
 
         assertEquals(1, viewModel.getNextStoryIndex(stories.indexOf<Cover>()))
@@ -559,6 +580,7 @@ class EndOfYearViewModelTest {
         endOfYearManager.stats.add(stats)
 
         viewModel.syncData()
+        viewModel.markGracePeriodExpired()
         val stories = (viewModel.uiState.first() as UiState.Synced).stories
 
         assertEquals(null, viewModel.getPreviousStoryIndex(stories.indexOf<Cover>()))
@@ -581,6 +603,7 @@ class EndOfYearViewModelTest {
         subscriptionFlow.value = null
 
         viewModel.syncData()
+        viewModel.markGracePeriodExpired()
         val stories = (viewModel.uiState.first() as UiState.Synced).stories
 
         assertEquals(1, viewModel.getNextStoryIndex(stories.indexOf<Cover>()))
@@ -603,6 +626,7 @@ class EndOfYearViewModelTest {
         subscriptionFlow.value = null
 
         viewModel.syncData()
+        viewModel.markGracePeriodExpired()
         val stories = (viewModel.uiState.first() as UiState.Synced).stories
 
         assertEquals(null, viewModel.getPreviousStoryIndex(stories.indexOf<Cover>()))
@@ -625,6 +649,7 @@ class EndOfYearViewModelTest {
         subscriptionFlow.value = null
 
         viewModel.syncData()
+        viewModel.markGracePeriodExpired()
         viewModel.uiState.test {
             val stories = awaitStories()
 


### PR DESCRIPTION
## Description
A bug has been identified that affects the cover story progress. If the stats were fetched quickly, the story progress reset.
This PR fixes that. Now we don't trigger `viewModel.onStoryChanged` unintentionally from the activity's code. Plus we guarantee the cover story to finish its progress before pushing out a new state object.

Fixes PCDROID-319

## Testing Instructions
You should test this with various emulator settings to simulate different network conditions
<img width="822" height="271" alt="SCR-20251119-pjma" src="https://github.com/user-attachments/assets/4104ebcd-d41a-4d2b-a5d7-5e9522e05f04" />

1. Sign in with an account that has playback data
2. Open playback
3. Observe
- [x] cover story completes every time without being reset
- [x] if the network conditions are poor, you should see the loading spinner then change to the number of shows story when the data is available
4. Clear storage, change network settings and start over


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

