### PR TITLE
[Tooling] Improve `new_hotfix_release` lanes to work when there's no release tag

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -292,6 +292,8 @@ platform :android do
     # Fetch the base ref to ensure it's available locally
     sh('git', 'fetch', 'origin', base_ref_for_hotfix)
 
+    ensure_branch_does_not_exist!(release_branch_name)
+
     # Create the hotfix branch
     UI.message("Creating hotfix branch from '#{base_ref_for_hotfix}'...")
     Fastlane::Helper::GitHelper.create_branch(release_branch_name, from: base_ref_for_hotfix)


### PR DESCRIPTION
Related to AINFRA-1518

## Description

This PR aims to add more robustness and require less manual intervention to the hotfix creation lane `new_hotfix_release`.

We have observed that sometimes it is possible that the release has been finalized but a release tag isn't present yet for some reason (likely due to the fact that the release hasn't been published yet), so release managers will get an error and require manual intervention.

This PR changes the code so that it, if not release tag is present, we start the hotfix branch based on the corresponding release branch.

## Testing instructions

These are some test scenarios that can be simulated:
1. There is a release tag that can be used to create the hotfix branch
2. There's no tag, but there's still a release branch that can be used to create the hotfix branch
3. There's no tag or branch (error)
4. The provided version doesn't have a patch component like `30.6` instead of `30.6.1` (error)

To test it, you can create test branches / tags (⚠️ delete them later or, even better, use [this technique](https://github.com/bloom/DayOne-Apple/pull/27670#issuecomment-3553138802) of pointing your working copy’s `origin` remote to a local bare repo instead ⚠️ ) and run `bundle exec fastlane new_hotfix_release skip_confirm:false version_name:$VERSION version_code:$CODE` and then answer `no` after the prompt so that the lane execution stops and check the printed values.

For example:
1. Create and push release branch `release/30.6` (which doesn't exist and has no corresponding tag for that version)
2. Run `bundle exec fastlane new_hotfix_release skip_confirm:false version_name:30.6.1 version_code:9999`
3. It should use the `release/30.6` branch instead of trying to use a tag. It should print:
```
ℹ️  Tag '30.6' not found on the remote. Using release branch 'release/30.6' as the base for hotfix instead.
New hotfix branch from release/30.6: release/30.6.1

New hotfix version: 30.6.1

Current build code: 9388
New build code: 9999


Do you want to continue? (y/n)
```
