### PR TITLE
Animate alpha of the last cover in the number of shows story

### DIFF
--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/NumberOfShowsStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/NumberOfShowsStory.kt
@@ -1,7 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.endofyear.ui
 
 import androidx.compose.animation.core.CubicBezierEasing
-import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -195,11 +194,10 @@ private fun PodcastCoverCarousel(
             if (pageOffset <= peekingItems) {
                 val scale = 1f - (pageOffset * peekFraction).coerceAtMost(peekFraction * peekingItems)
                 val maxOffset = peekingItems.toFloat()
-                val imageAlpha = if (pageOffset <= (maxOffset - 1f)) {
-                    1f
+                val imageAlpha = if (pageOffset > (maxOffset - 1f)) {
+                    (-pageOffset + maxOffset).coerceIn(0f, 1f)
                 } else {
-                    val normalizedOffset = (-pageOffset + maxOffset).coerceIn(0f, 1f)
-                    LinearEasing.transform(normalizedOffset)
+                    1f
                 }
 
                 PodcastImage(


### PR DESCRIPTION
## Description

I find the instant appearing and disappearing of artworks quite jarring. This adds fade in and fade out effects to the cover similar to what we have on iOS. See: p1763116183035909/1763041665.342689-slack-C09EXS7SWP6

I changed max page count from 100 to `Int.MAX_VALUE`. [This suggestions](https://github.com/Automattic/pocket-casts-android/pull/4752#discussion_r2541197129) from Copilot was wrong. There is no difference for the memory between 10, 100, and infinite count of lazy loaded pages that go over the same list of objects using the modulo operator. But `INT_MAX` has an advantage of letting the animation run for virtually forever, which can be needed in case someone holds a finger on their screen.

## Testing Instructions

1. Start playback.
2. Notice fade in and fade out animations on the covers in the Number of Shows story.

## Screenshots or Screencast 

| Before | After |
| - | - |
| <video src="https://github.com/user-attachments/assets/30790e1c-2dde-4151-a589-a21c81fa79ad" /> | <video src="https://github.com/user-attachments/assets/f469087b-469f-48e4-95c2-a87c6d60a853" /> |

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack