### PR TITLE
Fix manual progress interactions

### DIFF
--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesActivity.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesActivity.kt
@@ -148,7 +148,7 @@ class StoriesActivity : ComponentActivity() {
         }
         val scope = rememberCoroutineScope()
         val state by viewModel.uiState.collectAsState()
-        val pagerState = rememberPagerState(pageCount = { state.storyCount })
+        val pagerState = rememberPagerState(pageCount = { state.stories.size })
         val storyChanger = remember(pagerState, scope) {
             StoryChanger(pagerState, viewModel, scope)
         }
@@ -174,10 +174,6 @@ class StoriesActivity : ComponentActivity() {
                 onRestartPlayback = storyChanger::reset,
                 onClose = {
                     viewModel.trackStoriesClosed("close_button")
-                    finish()
-                },
-                onFailedToLoad = {
-                    setResult(0, StoriesActivityContract.setResult(source))
                     finish()
                 },
             )
@@ -270,6 +266,12 @@ class StoriesActivity : ComponentActivity() {
                     viewModel.resumeStoryAutoProgress(StoryProgressPauseReason.TakingScreenshot)
                 }
             }
+        }
+
+        LaunchedEffect(Unit) {
+            viewModel.syncFailedSignal.await()
+            setResult(0, StoriesActivityContract.setResult(source))
+            finish()
         }
     }
 

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/Common.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/Common.kt
@@ -65,17 +65,18 @@ internal val Story.backgroundColor
     }
 internal val Story.controlsColor
     get() = when (this) {
-        is Story.Cover,
-        is Story.NumberOfShows,
-        is Story.TopShow,
-        is Story.Ratings,
-        is Story.TotalTime,
-        is Story.LongestEpisode,
-        is Story.YearVsYear,
-        is Story.CompletionRate,
-        is Story.Ending,
-        -> Color.White
-        else -> Color.Black
+        is Story.Cover -> Color.White
+        is Story.NumberOfShows -> Color.White
+        is Story.TopShow -> Color.White
+        is Story.TopShows -> Color.Black
+        is Story.Ratings -> Color.White
+        is Story.TotalTime -> Color.White
+        is Story.LongestEpisode -> Color.White
+        is Story.PlusInterstitial -> Color.Black
+        is Story.YearVsYear -> Color.White
+        is Story.CompletionRate -> Color.White
+        is Story.Ending -> Color.White
+        is Story.PlaceholderWhileLoading -> Color.White
     }
 
 internal data class EndOfYearMeasurements(

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/StoriesPage.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/StoriesPage.kt
@@ -66,7 +66,6 @@ internal fun StoriesPage(
     onClickUpsell: () -> Unit,
     onRestartPlayback: () -> Unit,
     onClose: () -> Unit,
-    onFailedToLoad: () -> Unit,
 ) {
     val size = LocalContext.current.sizeLimit?.let(Modifier::size) ?: Modifier.fillMaxSize()
     BoxWithConstraints(
@@ -87,43 +86,24 @@ internal fun StoriesPage(
             )
         }
 
-        if (state is UiState.Failure) {
-            onFailedToLoad()
-        } else if (state is UiState.Syncing) {
-            Stories(
-                stories = state.stories,
-                measurements = measurements,
-                controller = controller,
-                pagerState = pagerState,
-                onChangeStory = onChangeStory,
-                onShareStory = onShareStory,
-                onHoldStory = onHoldStory,
-                onReleaseStory = onReleaseStory,
-                onLearnAboutRatings = onLearnAboutRatings,
-                onClickUpsell = onClickUpsell,
-                onRestartPlayback = onRestartPlayback,
-                blockGestures = true,
-            )
-        } else if (state is UiState.Synced) {
-            Stories(
-                stories = state.stories,
-                measurements = measurements,
-                controller = controller,
-                pagerState = pagerState,
-                onChangeStory = onChangeStory,
-                onShareStory = onShareStory,
-                onHoldStory = onHoldStory,
-                onReleaseStory = onReleaseStory,
-                onLearnAboutRatings = onLearnAboutRatings,
-                onClickUpsell = onClickUpsell,
-                onRestartPlayback = onRestartPlayback,
-            )
-        }
+        Stories(
+            stories = state.stories,
+            measurements = measurements,
+            controller = controller,
+            pagerState = pagerState,
+            onChangeStory = onChangeStory,
+            onShareStory = onShareStory,
+            onHoldStory = onHoldStory,
+            onReleaseStory = onReleaseStory,
+            onLearnAboutRatings = onLearnAboutRatings,
+            onClickUpsell = onClickUpsell,
+            onRestartPlayback = onRestartPlayback,
+        )
 
         TopControls(
             pagerState = pagerState,
             progress = state.storyProgress,
-            color = (state as? UiState.Synced)?.stories?.get(pagerState.currentPage)?.controlsColor ?: Color.White,
+            color = state.stories.getOrNull(pagerState.currentPage)?.controlsColor ?: Color.White,
             measurements = measurements,
             onClose = onClose,
             controller = controller,
@@ -144,28 +124,23 @@ private fun Stories(
     onLearnAboutRatings: () -> Unit,
     onClickUpsell: () -> Unit,
     onRestartPlayback: () -> Unit,
-    blockGestures: Boolean = false,
 ) {
     val widthPx = LocalDensity.current.run { measurements.width.toPx() }
 
     HorizontalPager(
         state = pagerState,
         userScrollEnabled = false,
-        modifier = if (blockGestures) {
-            Modifier
-        } else {
-            Modifier.pointerInput(Unit) {
-                awaitEachGesture {
-                    awaitFirstDown().consume()
-                    val timeMark = TimeSource.Monotonic.markNow()
-                    onHoldStory()
-                    val up = waitForUpOrCancellation()?.also { it.consume() }
-                    if (up != null && timeMark.elapsedNow() < 250.milliseconds) {
-                        val moveForward = up.position.x > widthPx / 2
-                        onChangeStory(moveForward)
-                    }
-                    onReleaseStory()
+        modifier = Modifier.pointerInput(Unit) {
+            awaitEachGesture {
+                awaitFirstDown().consume()
+                val timeMark = TimeSource.Monotonic.markNow()
+                onHoldStory()
+                val up = waitForUpOrCancellation()?.also { it.consume() }
+                if (up != null && timeMark.elapsedNow() < 250.milliseconds) {
+                    val moveForward = up.position.x > widthPx / 2
+                    onChangeStory(moveForward)
                 }
+                onReleaseStory()
             }
         },
     ) { index ->

--- a/modules/features/endofyear/src/test/kotlin/au/com/shiftyjelly/pocketcasts/endofyear/EndOfYearViewModelTest.kt
+++ b/modules/features/endofyear/src/test/kotlin/au/com/shiftyjelly/pocketcasts/endofyear/EndOfYearViewModelTest.kt
@@ -136,9 +136,7 @@ class EndOfYearViewModelTest {
         endOfYearSync.isSynced.add(false)
 
         viewModel.syncData()
-        viewModel.uiState.test {
-            assertEquals(UiState.Failure, awaitItem())
-        }
+        assertTrue(viewModel.syncFailedSignal.isCompleted)
     }
 
     @Test
@@ -147,7 +145,6 @@ class EndOfYearViewModelTest {
         endOfYearManager.stats.add(stats)
 
         viewModel.syncData()
-        viewModel.markGracePeriodExpired()
         viewModel.uiState.test {
             assertTrue(awaitItem() is UiState.Synced)
         }
@@ -160,7 +157,6 @@ class EndOfYearViewModelTest {
         subscriptionFlow.value = null
 
         viewModel.syncData()
-        viewModel.markGracePeriodExpired()
         viewModel.uiState.test {
             val stories = awaitStories()
 
@@ -185,7 +181,6 @@ class EndOfYearViewModelTest {
         endOfYearManager.stats.add(stats)
 
         viewModel.syncData()
-        viewModel.markGracePeriodExpired()
         viewModel.uiState.test {
             val story = awaitStory<NumberOfShows>()
 
@@ -203,7 +198,6 @@ class EndOfYearViewModelTest {
         endOfYearManager.stats.add(stats.copy(playedPodcastIds = listOf("id")))
 
         viewModel.syncData()
-        viewModel.markGracePeriodExpired()
         viewModel.uiState.test {
             val story = awaitStory<NumberOfShows>()
 
@@ -217,7 +211,6 @@ class EndOfYearViewModelTest {
         endOfYearManager.stats.add(stats.copy(playedPodcastIds = List(6) { "id-$it" }))
 
         viewModel.syncData()
-        viewModel.markGracePeriodExpired()
         viewModel.uiState.test {
             val story = awaitStory<NumberOfShows>()
 
@@ -232,7 +225,6 @@ class EndOfYearViewModelTest {
         endOfYearManager.stats.add(stats.copy(playedPodcastIds = emptyList()))
 
         viewModel.syncData()
-        viewModel.markGracePeriodExpired()
         viewModel.uiState.test {
             val stories = awaitStories()
 
@@ -246,7 +238,6 @@ class EndOfYearViewModelTest {
         endOfYearManager.stats.add(stats)
 
         viewModel.syncData()
-        viewModel.markGracePeriodExpired()
         viewModel.uiState.test {
             val story = awaitStory<TopShow>()
 
@@ -263,7 +254,6 @@ class EndOfYearViewModelTest {
         endOfYearManager.stats.add(stats.copy(topPodcasts = emptyList()))
 
         viewModel.syncData()
-        viewModel.markGracePeriodExpired()
         viewModel.uiState.test {
             val stories = awaitStories()
 
@@ -277,7 +267,6 @@ class EndOfYearViewModelTest {
         endOfYearManager.stats.add(stats)
 
         viewModel.syncData()
-        viewModel.markGracePeriodExpired()
         viewModel.uiState.test {
             val story = awaitStory<TopShows>()
 
@@ -294,7 +283,6 @@ class EndOfYearViewModelTest {
         endOfYearManager.stats.add(stats)
 
         viewModel.syncData()
-        viewModel.markGracePeriodExpired()
         viewModel.uiState.test {
             assertEquals(
                 TopShows(stats.topPodcasts, podcastListUrl = null),
@@ -315,7 +303,6 @@ class EndOfYearViewModelTest {
         endOfYearManager.stats.add(stats.copy(topPodcasts = emptyList()))
 
         viewModel.syncData()
-        viewModel.markGracePeriodExpired()
         viewModel.uiState.test {
             val stories = awaitStories()
 
@@ -329,7 +316,6 @@ class EndOfYearViewModelTest {
         endOfYearManager.stats.add(stats)
 
         viewModel.syncData()
-        viewModel.markGracePeriodExpired()
         viewModel.uiState.test {
             val story = awaitStory<Ratings>()
 
@@ -346,7 +332,6 @@ class EndOfYearViewModelTest {
         endOfYearManager.stats.add(stats)
 
         viewModel.syncData()
-        viewModel.markGracePeriodExpired()
         viewModel.uiState.test {
             val story = awaitStory<TotalTime>()
 
@@ -363,7 +348,6 @@ class EndOfYearViewModelTest {
         endOfYearManager.stats.add(stats)
 
         viewModel.syncData()
-        viewModel.markGracePeriodExpired()
         viewModel.uiState.test {
             val story = awaitStory<LongestEpisode>()
 
@@ -380,7 +364,6 @@ class EndOfYearViewModelTest {
         endOfYearManager.stats.add(stats.copy(longestEpisode = null))
 
         viewModel.syncData()
-        viewModel.markGracePeriodExpired()
         viewModel.uiState.test {
             val stories = awaitStories()
 
@@ -395,7 +378,6 @@ class EndOfYearViewModelTest {
         subscriptionFlow.value = null
 
         viewModel.syncData()
-        viewModel.markGracePeriodExpired()
         viewModel.uiState.test {
             val stories = awaitStories()
 
@@ -409,7 +391,6 @@ class EndOfYearViewModelTest {
         endOfYearManager.stats.add(stats)
 
         viewModel.syncData()
-        viewModel.markGracePeriodExpired()
         viewModel.uiState.test {
             val story = awaitStory<YearVsYear>()
 
@@ -430,7 +411,6 @@ class EndOfYearViewModelTest {
         endOfYearManager.stats.add(stats)
 
         viewModel.syncData()
-        viewModel.markGracePeriodExpired()
         viewModel.uiState.test {
             val story = awaitStory<CompletionRate>()
 
@@ -452,7 +432,6 @@ class EndOfYearViewModelTest {
         subscriptionFlow.value = null
 
         viewModel.syncData()
-        viewModel.markGracePeriodExpired()
         viewModel.resumeStoryAutoProgress(StoryProgressPauseReason.ScreenInBackground)
         val stories = (viewModel.uiState.first() as UiState.Synced).stories
 
@@ -501,7 +480,6 @@ class EndOfYearViewModelTest {
         subscriptionFlow.value = null
 
         viewModel.syncData()
-        viewModel.markGracePeriodExpired()
         val stories = (viewModel.uiState.first() as UiState.Synced).stories
 
         viewModel.switchStory.test {
@@ -529,7 +507,6 @@ class EndOfYearViewModelTest {
         subscriptionFlow.value = null
 
         viewModel.syncData()
-        viewModel.markGracePeriodExpired()
         val stories = (viewModel.uiState.first() as UiState.Synced).stories
 
         viewModel.switchStory.test {
@@ -558,7 +535,6 @@ class EndOfYearViewModelTest {
         endOfYearManager.stats.add(stats)
 
         viewModel.syncData()
-        viewModel.markGracePeriodExpired()
         val stories = (viewModel.uiState.first() as UiState.Synced).stories
 
         assertEquals(1, viewModel.getNextStoryIndex(stories.indexOf<Cover>()))
@@ -580,7 +556,6 @@ class EndOfYearViewModelTest {
         endOfYearManager.stats.add(stats)
 
         viewModel.syncData()
-        viewModel.markGracePeriodExpired()
         val stories = (viewModel.uiState.first() as UiState.Synced).stories
 
         assertEquals(null, viewModel.getPreviousStoryIndex(stories.indexOf<Cover>()))
@@ -603,7 +578,6 @@ class EndOfYearViewModelTest {
         subscriptionFlow.value = null
 
         viewModel.syncData()
-        viewModel.markGracePeriodExpired()
         val stories = (viewModel.uiState.first() as UiState.Synced).stories
 
         assertEquals(1, viewModel.getNextStoryIndex(stories.indexOf<Cover>()))
@@ -626,7 +600,6 @@ class EndOfYearViewModelTest {
         subscriptionFlow.value = null
 
         viewModel.syncData()
-        viewModel.markGracePeriodExpired()
         val stories = (viewModel.uiState.first() as UiState.Synced).stories
 
         assertEquals(null, viewModel.getPreviousStoryIndex(stories.indexOf<Cover>()))
@@ -649,7 +622,6 @@ class EndOfYearViewModelTest {
         subscriptionFlow.value = null
 
         viewModel.syncData()
-        viewModel.markGracePeriodExpired()
         viewModel.uiState.test {
             val stories = awaitStories()
 


### PR DESCRIPTION
## Description

This change fixes an issue with not being able to manually progress the state from the Cover Story when data is loaded.

Fixes PCDROID-320

## Testing Instructions

1. Go through Playback stories at least once to make sure that your data is loaded.
2. Open Playback.
3. Tap on the right side of the Cover Story.
4. UI should progress to the next story.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.