### PR TITLE
Playback Year vs Year text change

### DIFF
--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2110,9 +2110,9 @@
     <!--Title of the story when this year's listening time is bigger than previous year by more than 500%. -->
     <string name="end_of_year_stories_year_over_year_title_went_up_a_lot">From zero to hero!</string>
     <!-- Subtitle of the story that compares year listening time when this year's listening time is bigger than last's year. %1$s is the year -->
-    <string name="end_of_year_stories_year_over_year_subtitle_went_up">Hope you stretched first!</string>
+    <string name="end_of_year_stories_year_over_year_subtitle_went_up">More podcasts, more joy</string>
     <!-- Subtitle of the story when this year's listening time is bigger than previous year by more than 500%. -->
-    <string name="end_of_year_stories_year_over_year_subtitle_went_up_a_lot">You listened more than 500% this year — welcome to the club</string>
+    <string name="end_of_year_stories_year_over_year_subtitle_went_up_a_lot">You listened more than 500% this year — welcome&#160;to&#160;the&#160;club</string>
     <!-- Title of the story when this year's listening time is almost the same as the previous year. %1$s is the year -->
     <string name="end_of_year_stories_year_over_year_title_flat">Your %1$s listening held steady</string>
     <!-- Subtitle of the story that compares year listening time when this year's listening time is almost the same as last's year -->


### PR DESCRIPTION
## Description

This change updates the Playback story Year vs Year with the requested text from the designer. I also tweaked other text so it looks better.

Fixes https://linear.app/a8c/issue/PCDROID-325/adjust-copy-in-comparison-story

## Testing Instructions

Apply the following [test.patch](https://github.com/user-attachments/files/23666378/test.patch) so you can view the story with the correct data.

```
curl -L https://github.com/user-attachments/files/23666378/test.patch | git apply
```

Open Playback and verify the text is correct.

## Screenshots 

| Before | After |
| --- | --- |
| <img width="1198" height="2531" alt="Screenshot_20251121_121746" src="https://github.com/user-attachments/assets/fd38d750-491f-4963-9ff7-a38aedbde495" /> | <img width="1198" height="2531" alt="Screenshot_20251121_121649" src="https://github.com/user-attachments/assets/568e4638-c539-41c7-b895-affce7ec658c" /> | 
| <img width="1198" height="2531" alt="Screenshot_20251121_121756" src="https://github.com/user-attachments/assets/520812d7-9fd9-4e34-bbf0-978d40f30466" /> | <img width="1198" height="2531" alt="Screenshot_20251121_121655" src="https://github.com/user-attachments/assets/135cdd31-fe63-4bd5-afd1-968765e6c65e" /> | 

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
