### PR TITLE
Remove custom snackbar theming

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -390,7 +390,6 @@ class MainActivity :
                     }
                     Snackbar.make(view, getString(LR.string.end_of_year_failed_to_load_message), Snackbar.LENGTH_LONG)
                         .setAction(LR.string.retry, action)
-                        .setTextColor(ThemeColor.primaryText01(Theme.ThemeType.DARK))
                         .show()
                 }
             }
@@ -1901,9 +1900,6 @@ class MainActivity :
 
         Snackbar.make(view, snackbarMessage, Snackbar.LENGTH_LONG)
             .setAction(LR.string.settings_view, action)
-            .setActionTextColor(result.tintColor)
-            .setBackgroundTint(ThemeColor.primaryUi01(Theme.ThemeType.DARK))
-            .setTextColor(ThemeColor.primaryText01(Theme.ThemeType.DARK))
             .show()
     }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -517,18 +517,12 @@ class PlayerHeaderFragment :
 
         Snackbar.make(view, snackbarMessage, Snackbar.LENGTH_LONG)
             .setAction(LR.string.settings_view, viewBookmarksAction)
-            .setActionTextColor(result.tintColor)
-            .setBackgroundTint(ThemeColor.primaryUi01(Theme.ThemeType.DARK))
-            .setTextColor(ThemeColor.primaryText01(Theme.ThemeType.DARK))
             .show()
     }
 
     private fun showSnackBar(text: CharSequence) {
         parentFragment?.view?.let {
-            Snackbar.make(it, text, Snackbar.LENGTH_SHORT)
-                .setBackgroundTint(ThemeColor.primaryUi01(Theme.ThemeType.LIGHT))
-                .setTextColor(ThemeColor.primaryText01(Theme.ThemeType.LIGHT))
-                .show()
+            Snackbar.make(it, text, Snackbar.LENGTH_SHORT).show()
         }
     }
 


### PR DESCRIPTION
## Description

This PR removes custom theming when showing snackbars. It is rather unpredictable and can lead to legibility issues. I removed it even from the scenarios where it was generally ok. It's just simpler to not have to deal with those things as they don't offer meaningful improvements.

## Testing Instructions

Code review should be enough.

## Screenshots or Screencast 

| Before | After |
| - | - |
| <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/6e2b9eab-2442-4a13-826e-8efb5bee529a" /> | <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/9ceaccdd-801e-4074-bee7-5296e43175fb" /> |

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack