### PR TITLE
Align Playback buttons positions

### DIFF
--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/EndingStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/EndingStory.kt
@@ -118,6 +118,7 @@ internal fun EndingStory(
             backgroundColor = colorResource(UR.color.white),
             textColor = colorResource(UR.color.black),
         )
+        Spacer(Modifier.height(16.dp))
     }
 }
 

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/RatingsStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/RatingsStory.kt
@@ -354,7 +354,7 @@ private fun AbsentRatings(
             textColor = colorResource(UR.color.black),
         )
         Spacer(
-            modifier = Modifier.height(18.dp),
+            modifier = Modifier.height(16.dp),
         )
     }
 }


### PR DESCRIPTION
## Description

As the title says.

## Testing Instructions

1. Start Playback as a free user.
2. Navigate to Plus Story.
3. Tap the right edge to continue.
4. Notice that bottom button doesn't change its position.

## Screenshots or Screencast 

| Before | After |
| - | - |
| <img width="2270" height="2481" alt="image" src="https://github.com/user-attachments/assets/f5340f5b-7928-43dd-af05-426b3c6a09fa" /> | <img width="2259" height="2480" alt="image" src="https://github.com/user-attachments/assets/526336ad-c7cf-414a-80ac-62d01d99c05c" /> |

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
