### PR TITLE
[Playback] Unify header texts

### DIFF
--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/CompletionRateStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/CompletionRateStory.kt
@@ -92,6 +92,7 @@ internal fun CompletionRateStory(
                     story.listenedCount,
                 ),
                 subscriptionTier = story.subscriptionTier,
+                measurements = measurements,
             )
             Box(
                 modifier = Modifier

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/EndingStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/EndingStory.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.IntOffset
@@ -117,6 +118,7 @@ internal fun EndingStory(
                         alpha = animations.subTitle.alpha
                     },
                 textAlign = TextAlign.Center,
+                fontWeight = FontWeight.W500,
             )
         }
         Spacer(modifier = Modifier.weight(1f))

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/LongestEpisodeStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/LongestEpisodeStory.kt
@@ -245,6 +245,7 @@ private fun Header(
             ),
             disableAutoScale = true,
             color = colorResource(UR.color.white),
+            fontWeight = FontWeight.W500,
             modifier = Modifier.padding(horizontal = 24.dp),
         )
     }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/RatingsStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/RatingsStory.kt
@@ -69,7 +69,7 @@ internal fun RatingsStory(
     val modifier = Modifier
         .fillMaxSize()
         .background(story.backgroundColor)
-        .padding(top = measurements.closeButtonBottomEdge + 24.dp)
+        .padding(top = measurements.closeButtonBottomEdge + 16.dp)
     if (maxRatingCount != 0) {
         Box {
             PresentRatings(
@@ -119,9 +119,9 @@ private fun PresentRatings(
         HeaderText(
             title = title,
             subtitle = subtitle,
-            titleMaxLines = 2,
             modifier = Modifier
                 .fillMaxWidth(),
+            measurements = measurements,
         )
         RatingBars(
             stats = story.stats,

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TopShowStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TopShowStory.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -229,6 +230,7 @@ private fun Header(
             .fillMaxWidth()
             .padding(horizontal = 24.dp),
         textAlign = TextAlign.Center,
+        fontWeight = FontWeight.W500,
     )
 }
 

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TopShowsStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TopShowsStory.kt
@@ -85,6 +85,7 @@ internal fun TopShowsStory(
                 title = stringResource(LR.string.eoy_story_top_podcasts_title),
                 subtitle = stringResource(LR.string.eoy_story_top_podcasts_subtitle),
                 textColor = Color.Black,
+                measurements = measurements,
             )
             Spacer(modifier = Modifier.height(32.dp))
             val scrollState = rememberScrollState()

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/YearVsYearStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/YearVsYearStory.kt
@@ -180,7 +180,7 @@ private fun TextInfo(
         title = title,
         subtitle = subtitle,
         subscriptionTier = story.subscriptionTier,
-        titleMaxLines = 2,
+        measurements = measurements,
     )
 }
 

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/components/HeaderText.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/components/HeaderText.kt
@@ -7,19 +7,17 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.text.BasicText
-import androidx.compose.foundation.text.TextAutoSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadgeDisplayMode
 import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadgeForTier
@@ -30,10 +28,11 @@ import au.com.shiftyjelly.pocketcasts.payment.SubscriptionTier
 internal fun HeaderText(
     title: String,
     subtitle: String,
+    measurements: EndOfYearMeasurements,
     modifier: Modifier = Modifier,
     textColor: Color = Color.White,
     subscriptionTier: SubscriptionTier? = null,
-    titleMaxLines: Int = 1,
+    titleMaxLines: Int = 2,
 ) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -50,17 +49,15 @@ internal fun HeaderText(
                 modifier = Modifier.height(16.dp),
             )
         }
-        BasicText(
+        TextH10(
             text = title,
-            style = TextStyle(
-                fontSize = 25.sp,
-                fontWeight = FontWeight.W700,
-                textAlign = TextAlign.Center,
-                lineHeight = 30.sp,
-            ),
-            color = { textColor },
-            autoSize = TextAutoSize.StepBased(maxFontSize = 25.sp),
+            color = textColor,
+            fontSize = 25.sp,
+            lineHeight = 30.sp,
+            disableAutoScale = true,
+            fontScale = measurements.smallDeviceFactor,
             maxLines = titleMaxLines,
+            textAlign = TextAlign.Center,
         )
         Spacer(
             modifier = Modifier.height(8.dp),
@@ -90,8 +87,8 @@ private fun CompletionRatePreview() {
         HeaderText(
             title = "Compared to 2024, your listening time skyrocketed 20%",
             subtitle = "Hope you stretched first!",
+            measurements = measurements,
             subscriptionTier = SubscriptionTier.Plus,
-            titleMaxLines = 2,
             modifier = Modifier
                 .background(Color(0xFF27486A))
                 .padding(16.dp),


### PR DESCRIPTION
## Description
This PR makes the header texts consistent across Playback screen, including their position and style.

Fixes PCDROID-330

## Testing Instructions
Test on small and regular-screen devices as well.

1. Log in with an account that has playback data (Plus is preferred to see the paid stories)
2. Step trough the stories
3. Verify that their top position is consistent
4. Verify that their look is consistent

## Screenshots or Screencast 
| Small | Regular |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/e6356f0a-5bec-4814-b424-91f50759e65a" /> | <video src="https://github.com/user-attachments/assets/7e3e272d-eb8d-4647-a5c2-47916f99e5da" /> |

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
