### PR TITLE
[Playback] Fix labels on top of rating pillars

### DIFF
--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/RatingsStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/RatingsStory.kt
@@ -257,6 +257,7 @@ private fun RowScope.AnimatedRatingBar(
         composition = numberComposition,
         progress = { numberAnimatable.progress },
         dynamicProperties = dynamicProperties,
+        contentScale = ContentScale.FillBounds,
         fontMap = remember {
             mapOf(
                 "Inter-Regular" to Typeface.create("sans-serif", Typeface.NORMAL),


### PR DESCRIPTION
## Description
I noticed that the labels are misaligned in some cases. This PR addesses that

Fixes PCDROID-339

## Testing Instructions
Just review the code pls.

## Screenshots or Screencast 
| Before | After | 
| --- | --- |
| <img width="1080" height="2400" alt="Screenshot_20251124_141724" src="https://github.com/user-attachments/assets/6eef0427-082a-49ac-ba5b-87f7bfe96542" /> | <img width="1080" height="2400" alt="Screenshot_20251124_143552" src="https://github.com/user-attachments/assets/52615a7f-e076-430a-a332-4c9740d2ca92" /> |


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 