### PR TITLE
[Playback] Unify bottom paragprah texts

### DIFF
--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/LongestEpisodeStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/LongestEpisodeStory.kt
@@ -36,7 +36,6 @@ import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
@@ -64,7 +63,7 @@ import java.io.File
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
-private const val SMALL_SCREEN_SIZE_FACTOR = .6f
+private const val SMALL_SCREEN_SIZE_FACTOR = .7f
 private const val ANIMATION_SCALE_FACTOR_FULL_WIDTH = 1.2f
 
 @OptIn(ExperimentalComposeUiApi::class)
@@ -109,13 +108,14 @@ internal fun LongestEpisodeStory(
                     ANIMATION_SCALE_FACTOR_FULL_WIDTH
                 },
                 modifier = Modifier
-                    .size(animationContainerSize)
+                    .padding(top = 32.dp)
+                    .size(animationContainerSize + 32.dp)
                     .align(Alignment.Center),
             )
             Footer(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height((maxHeight - animationContainerSize) / 2)
+                    .height(((maxHeight - animationContainerSize) / 2) - 32.dp)
                     .align(Alignment.BottomCenter),
                 story = story,
                 measurements = measurements,
@@ -271,7 +271,7 @@ private fun Footer(
             fontScale = measurements.smallDeviceFactor,
             color = colorResource(UR.color.white),
             modifier = Modifier
-                .padding(24.dp)
+                .padding(horizontal = 24.dp)
                 .padding(bottom = 24.dp),
         )
     }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TopShowStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TopShowStory.kt
@@ -259,7 +259,7 @@ private fun Footer(
         color = colorResource(UR.color.white),
         modifier = Modifier
             .fillMaxWidth()
-            .padding(24.dp)
+            .padding(horizontal = 24.dp)
             .padding(bottom = 24.dp),
         textAlign = TextAlign.Center,
     )


### PR DESCRIPTION
## Description
This PR aims to make the bottom texts consistent across stories.
It also increases the animation size of the longest episode story by a bit on small devices.

Fixes PCDROID-332

## Testing Instructions
Test on small and regular-screen devices.
1. Log in with a device that has playback
2. Open playback and scroll though stories
3. Verify bottom paragprah looks

## Screenshots or Screencast 
| TopShow Normal | LongestEP Normal | TopShow Small | LongestEP Small |
| --- | --- | --- | --- |
| <img width="1080" height="2400" alt="Screenshot_20251124_160200" src="https://github.com/user-attachments/assets/41d85b7a-968e-44fc-ad78-510e63cac559" /> | <img width="1080" height="2400" alt="Screenshot_20251124_160153" src="https://github.com/user-attachments/assets/aa6fc8e7-430d-447c-942b-1c3d7b0503c0" /> | <img width="720" height="1280" alt="Screenshot_20251124_161654" src="https://github.com/user-attachments/assets/6dd4230b-1c59-4f8a-ab1a-255e1a8fee2d" /> | <img width="720" height="1280" alt="Screenshot_20251124_161648" src="https://github.com/user-attachments/assets/2cf23945-d94c-4bce-ba7a-9ac122ff4902" /> |


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 