### PR TITLE
Fix playlists crash

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
@@ -91,9 +91,9 @@ class PlaylistManagerImpl(
     override fun playlistPreviewsFlow(): Flow<List<PlaylistPreview>> {
         return playlistDao.allPlaylistsFlow().map { playlists ->
             withContext(computationContext) {
-                playlists.map { playlist ->
-                    playlist.toPlaylistPreview()
-                }
+                playlists
+                    .map { playlist -> playlist.toPlaylistPreview() }
+                    .distinctBy { it.uuid }
             }
         }
     }
@@ -355,7 +355,9 @@ class PlaylistManagerImpl(
     }
 
     override fun playlistPreviewsForEpisodeFlow(episodeUuid: String, searchTerm: String?): Flow<List<PlaylistPreviewForEpisode>> {
-        return playlistDao.playlistPreviewsForEpisodeFlow(episodeUuid, searchTerm.orEmpty())
+        return playlistDao
+            .playlistPreviewsForEpisodeFlow(episodeUuid, searchTerm.orEmpty())
+            .map { playlists -> playlists.distinctBy { it.uuid } }
     }
 
     override suspend fun getManualEpisodeSources(searchTerm: String?): List<ManualPlaylistEpisodeSource> {


### PR DESCRIPTION
## Description

This fixes 2 things:

- Crash due to old lingering playlists leading to a non-unique UUIDs. UUIDs uniqueness will be addressed in a non hot-fix branch as it requires database migration. See: p1763964433192079-slack-C05S3A24L4T
- An inconsistency in a smart rule. See: p1763992155914749-slack-C093RV9N8DR

Closes #4789

## Testing Instructions

1. Install the app from the `release/8.0.1` branch.
2. Open the app without creating any account.
3. Got to the playlists tab.
4. Execute this query:
```sql
INSERT INTO playlists (
  _id, uuid, title, iconId, sortPosition, 
  sortId, manual, draft, deleted, syncStatus, 
  autoDownload, autoDownloadLimit, 
  unplayed, partiallyPlayed, finished, 
  downloaded, notDownloaded, audioVideo, 
  filterHours, starred, allPodcasts, 
  podcastUuids, filterDuration, longerThan, 
  shorterThan, showArchivedEpisodes, 
  clean_title
) 
VALUES 
  (
    100, '2797DCF8-1C93-4999-B52A-D1849736FA2C', 
    'Some Title', 0, 1, 0, 0, 0, 0, 0, 0, 10, 
    1, 1, 1, 1, 1, 0, 0, 0, 1, '', 0, 20, 40, 0, 
    'some title'
  );
```
5. App will crash.
6. Update the app with the version from `mehow/task/hotfix` branch.
7. Open the app.
8. There should be no crash.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.