### PR TITLE
[Playback] Top Story fix scale issues

### DIFF
--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/LongestEpisodeStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/LongestEpisodeStory.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TopShowStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TopShowStory.kt
@@ -58,8 +58,8 @@ import kotlin.time.Duration.Companion.days
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
-val AnimationEndScale = 1.3f
-val AnimationStartScale = 1.8f
+private const val ANIMATION_START_SCALE = 1.8f
+private const val ANIMATION_END_SCALE = 1.3f
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
@@ -103,7 +103,7 @@ internal fun TopShowStory(
 
             val contentHeight = maxHeight - headerHeight - footerHeight
             // reduce the size to account for the growth during the animation
-            val contentHeightMinusGrowth = contentHeight - (contentHeight * (AnimationEndScale - 1f))
+            val contentHeightMinusGrowth = contentHeight / ANIMATION_END_SCALE
 
             CenterContent(
                 story = story,
@@ -145,7 +145,7 @@ private fun CenterContent(
     )
 
     val lottieScaleAnimation by animateFloatAsState(
-        targetValue = if (isPlaying) AnimationEndScale else AnimationStartScale,
+        targetValue = if (isPlaying) ANIMATION_END_SCALE else ANIMATION_START_SCALE,
         animationSpec = animationSpec,
     )
 


### PR DESCRIPTION
## Description

I've tried to improve the scaling issues on the top show story. This new approach figures out the height of the header and footer and then the area remaining for the animation content. I'm not sure if there is a better way in Compose, but this one does seem to work when changing the display size. 

[Linear](https://linear.app/a8c/issue/PCDROID-331/fix-scale-issues-with-the-asset)

## Testing Instructions

Try with different device sizes, such as a small and normal phone. 

1. Log in with a user that has playback data
2. Go to the top show story
3. ✅ Verify the animation looks correct.

## Screenshots 

Large display size:
<img width="850" height="888" alt="Screenshot 2025-11-25 at 4 55 12 pm" src="https://github.com/user-attachments/assets/f02ab823-b374-4318-87f0-e166d02cedae" />

Normal display size:
<img width="828" height="890" alt="Screenshot 2025-11-25 at 4 54 48 pm" src="https://github.com/user-attachments/assets/28fc2016-6323-4105-8d09-6361007f2f4a" />

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
