### PR TITLE
[Playback] Fix Longest episode analytics scaling

### DIFF
--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/LongestEpisodeStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/LongestEpisodeStory.kt
@@ -61,7 +61,6 @@ import java.io.File
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
-private const val SMALL_SCREEN_SIZE_FACTOR = .7f
 private const val ANIMATION_SCALE_FACTOR_FULL_WIDTH = 1.2f
 
 @OptIn(ExperimentalComposeUiApi::class)
@@ -252,22 +251,20 @@ private fun Footer(
     story: Story.LongestEpisode,
     measurements: EndOfYearMeasurements,
     modifier: Modifier = Modifier,
-) = Column(modifier = modifier, horizontalAlignment = Alignment.CenterHorizontally) {
-    Box(
-        modifier = modifier,
-        contentAlignment = Alignment.BottomCenter,
-    ) {
-        TextP40(
-            text = stringResource(LR.string.end_of_year_story_longest_episode_stats, story.episode.episodeTitle, story.episode.podcastTitle),
-            textAlign = TextAlign.Center,
-            disableAutoScale = true,
-            fontScale = measurements.smallDeviceFactor,
-            color = colorResource(UR.color.white),
-            modifier = Modifier
-                .padding(horizontal = 24.dp)
-                .padding(bottom = 24.dp),
-        )
-    }
+) = Box(
+    modifier = modifier,
+    contentAlignment = Alignment.BottomCenter,
+) {
+    TextP40(
+        text = stringResource(LR.string.end_of_year_story_longest_episode_stats, story.episode.episodeTitle, story.episode.podcastTitle),
+        textAlign = TextAlign.Center,
+        disableAutoScale = true,
+        fontScale = measurements.smallDeviceFactor,
+        color = colorResource(UR.color.white),
+        modifier = Modifier
+            .padding(horizontal = 24.dp)
+            .padding(bottom = 24.dp),
+    )
 }
 
 @Preview(device = Devices.PORTRAIT_REGULAR)


### PR DESCRIPTION
## Description
Based on Phil's solution for asset scaling, this PR aims to provide a consistent look for the Longest episode story assets across all screen sizes and display size presets.

Fixes PCDROID-331

## Testing Instructions
Test on small and regular screen size

1. Log in with an account that has playback data
2. Open playback and scroll until you see the longest episode story

## Screenshots or Screencast 
| Small - small | Small - norm | Small - high | Regular - small | Regular - norm | Regular - high |
| --- | --- | --- | --- | --- | --- |
| <img width="812" height="744" alt="SCR-20251125-mdlo" src="https://github.com/user-attachments/assets/00b42012-0313-4cb1-a23f-f227110c663c" /> | <img width="810" height="744" alt="SCR-20251125-mdpf" src="https://github.com/user-attachments/assets/579352bc-7f4c-4f27-b61d-3fc69e87e300" /> | <img width="806" height="739" alt="SCR-20251125-mdso" src="https://github.com/user-attachments/assets/b64801c5-a797-4989-aa12-c98bbe4d0f8d" /> | <img width="750" height="763" alt="SCR-20251125-mfdu" src="https://github.com/user-attachments/assets/4d2dfcef-232e-4b27-af52-4fa372e9b462" /> | <img width="752" height="764" alt="SCR-20251125-mfhq" src="https://github.com/user-attachments/assets/4e2fd0b0-14ab-4476-9f04-774a379667eb" /> | <img width="756" height="761" alt="SCR-20251125-mfmr" src="https://github.com/user-attachments/assets/8816d187-ff3c-4b32-8bea-ef719698da8c" /> |


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
