### PR TITLE
More developer flags to speed up setting up the first install of the app

### DIFF
--- a/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserver.kt
+++ b/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserver.kt
@@ -139,7 +139,7 @@ class AppLifecycleObserver(
                     settings.autoPlayNextEpisodeOnEmpty.set(true, updateModifiedAt = false)
 
                     // For new users we want to auto download on follow podcast by default
-                    settings.autoDownloadOnFollowPodcast.set(true, updateModifiedAt = false)
+                    settings.autoDownloadOnFollowPodcast.set(Settings.AUTO_DOWNLOAD_ON_FOLLOW_DEFAULT_VALUE, updateModifiedAt = false)
 
                     // For new users we want to enable all notifications by default
                     settings.notifyRefreshPodcast.set(true, updateModifiedAt = false)

--- a/modules/services/preferences/build.gradle.kts
+++ b/modules/services/preferences/build.gradle.kts
@@ -15,15 +15,24 @@ android {
 
     defaultConfig {
         val localPropertiesFile = rootProject.file("local.properties")
-        val dataCollectionValue = if (localPropertiesFile.exists() && localPropertiesFile.isFile) {
+        var dataCollection: Boolean? = null
+        var sendCrashReports: Boolean? = null
+        var doneInitialOnboarding: Boolean? = null
+        var autoDownloadOnFollow: Boolean? = null
+        if (localPropertiesFile.exists() && localPropertiesFile.isFile) {
             val properties = Properties().apply {
                 load(localPropertiesFile.inputStream())
             }
-            properties.getProperty("au.com.shiftyjelly.pocketcasts.data.collection")?.toBooleanStrictOrNull()
-        } else {
-            null
+            dataCollection = properties.getProperty("au.com.shiftyjelly.pocketcasts.data.collection")?.toBooleanStrictOrNull()
+            sendCrashReports = properties.getProperty("au.com.shiftyjelly.pocketcasts.send.crash.reports")?.toBooleanStrictOrNull()
+            doneInitialOnboarding = properties.getProperty("au.com.shiftyjelly.pocketcasts.done.initial.onboarding")?.toBooleanStrictOrNull()
+            autoDownloadOnFollow = properties.getProperty("au.com.shiftyjelly.pocketcasts.auto.download.on.follow")?.toBooleanStrictOrNull()
         }
-        buildConfigField("Boolean", "DATA_COLLECTION_DEFAULT_VALUE", dataCollectionValue.toString())
+        buildConfigField("Boolean", "DATA_COLLECTION_DEFAULT_VALUE", dataCollection.toString())
+        buildConfigField("Boolean", "SEND_CRASH_REPORTS_DEFAULT_VALUE", sendCrashReports.toString())
+        buildConfigField("Boolean", "DONE_INITIAL_ONBOARDING_DEFAULT_VALUE", doneInitialOnboarding.toString())
+        buildConfigField("Boolean", "AUTO_DOWNLOAD_ON_FOLLOW_DEFAULT_VALUE", autoDownloadOnFollow.toString())
+
     }
 }
 

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -120,6 +120,8 @@ interface Settings {
         const val AUTOMOTIVE_CONNECTED_TO_MEDIA_SESSION = "automotive_connected_to_media_session"
 
         const val SHOW_REFERRALS_TOOLTIP = "show_referrals_tooltip"
+
+        val AUTO_DOWNLOAD_ON_FOLLOW_DEFAULT_VALUE = BuildConfig.AUTO_DOWNLOAD_ON_FOLLOW_DEFAULT_VALUE ?: true
     }
 
     enum class NotificationChannel(val id: String) {

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -1340,7 +1340,7 @@ class SettingsImpl @Inject constructor(
 
     override val sendCrashReports = UserSetting.BoolPref(
         sharedPrefKey = "SendCrashReportsKey",
-        defaultValue = BuildConfig.DATA_COLLECTION_DEFAULT_VALUE ?: true,
+        defaultValue = BuildConfig.SEND_CRASH_REPORTS_DEFAULT_VALUE ?: true,
         sharedPrefs = sharedPreferences,
     )
 
@@ -1362,7 +1362,7 @@ class SettingsImpl @Inject constructor(
 
     override fun getEndOfYearShowModal(): Boolean = getBoolean(END_OF_YEAR_SHOW_MODAL_2025_KEY, true)
 
-    override fun hasCompletedOnboarding() = getBoolean(DONE_INITIAL_ONBOARDING_KEY, false)
+    override fun hasCompletedOnboarding() = getBoolean(DONE_INITIAL_ONBOARDING_KEY, BuildConfig.DONE_INITIAL_ONBOARDING_DEFAULT_VALUE ?: false)
 
     override fun setHasDoneInitialOnboarding() {
         setBoolean(DONE_INITIAL_ONBOARDING_KEY, true)


### PR DESCRIPTION
## Description

This changes adds support for more developer flags to help speed up installing a clean version of the app.

- au.com.shiftyjelly.pocketcasts.send.crash.reports: default value for if errors are sent to Sentry
- au.com.shiftyjelly.pocketcasts.done.initial.onboarding: default value if the onboarding flow should be shown
- au.com.shiftyjelly.pocketcasts.auto.download.on.follow: default value of the auto download new podcasts you follow setting

local.properties
```
au.com.shiftyjelly.pocketcasts.send.crash.reports=false
au.com.shiftyjelly.pocketcasts.done.initial.onboarding=true
au.com.shiftyjelly.pocketcasts.auto.download.on.follow=false
```

## Testing Instructions

Try setting these properties to true or false, and with them removed.
1. Installing a clean version of the app
2. Check if the onboarding flow appears
3. If the Settings -> Auto download -> On Follow is toggled on/off
4. If the Settings -> Privacy -> Crash reports is toggled on/off

## Screencast 

https://github.com/user-attachments/assets/536f73b4-3479-4a2b-afc3-b71b1da97f66

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
