### PR TITLE
Use a correct playlists copy

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/EpisodeArtworkConfigurationFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/EpisodeArtworkConfigurationFragment.kt
@@ -152,7 +152,7 @@ class EpisodeArtworkConfigurationFragment : BaseFragment() {
 
     private val ArtworkConfiguration.Element.titleId
         get() = when (this) {
-            ArtworkConfiguration.Element.Filters -> LR.string.filters
+            ArtworkConfiguration.Element.Filters -> LR.string.playlists
             ArtworkConfiguration.Element.UpNext -> LR.string.up_next
             ArtworkConfiguration.Element.Downloads -> LR.string.profile_navigation_downloads
             ArtworkConfiguration.Element.Files -> LR.string.profile_navigation_files


### PR DESCRIPTION
## Description

The copy for episodes artwork didn't use a correct label. I'm not hiding it behind a feature flag because there is no point to it now really.

Closes PCDROID-348

## Testing Instructions

1. Go to the settings.
2. Go to the appearance settings.
3. Go to the advanced episode artwork settings.
4. Verify that you see "Playlists" instead of "Filters".

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.