### PR TITLE
[Playback] Extra padding for the share images

### DIFF
--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoryCaptureController.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoryCaptureController.kt
@@ -1,7 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.endofyear
 
 import android.graphics.Bitmap
-import android.graphics.Paint
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -9,13 +8,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.asAndroidBitmap
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.graphics.applyCanvas
 import androidx.core.graphics.createBitmap
 import androidx.core.graphics.drawable.toBitmap
-import androidx.core.graphics.scale
-import au.com.shiftyjelly.pocketcasts.endofyear.ui.backgroundColor
 import au.com.shiftyjelly.pocketcasts.models.to.Story
 import au.com.shiftyjelly.pocketcasts.utils.fitToAspectRatio
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
@@ -23,7 +19,6 @@ import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer.TAG_CRASH
 import dev.shreyaspatil.capturable.controller.CaptureController
 import dev.shreyaspatil.capturable.controller.rememberCaptureController
 import java.io.File
-import kotlin.math.roundToInt
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
@@ -48,7 +43,6 @@ internal fun rememberStoryCaptureController(): StoryCaptureController {
         object : StoryCaptureController {
             private var _isSharing by mutableStateOf(false)
             override val isSharing get() = _isSharing
-            override var topControlsHeightPx = 0
 
             override fun captureController(story: Story): CaptureController = when (story) {
                 is Story.PlaceholderWhileLoading -> cover
@@ -78,14 +72,14 @@ internal fun rememberStoryCaptureController(): StoryCaptureController {
                         val pcLogo = AppCompatResources.getDrawable(context, IR.drawable.pc_logo_pill)!!
                             .toBitmap()
 
-                        createBitmap(background.width, background.height - topControlsHeightPx).applyCanvas {
+                        createBitmap(background.width, background.height).applyCanvas {
                             // Draw captured bitmap
-                            drawBitmap(background, 0f, -topControlsHeightPx.toFloat(), null)
+                            drawBitmap(background, 0f, 0f, null)
                             // Draw PC logo
                             drawBitmap(
                                 pcLogo,
                                 (width - pcLogo.width).toFloat() / 2,
-                                height - (pcLogo.height * 1.5f), // Pad the logo from the bottom by half its height
+                                height - (pcLogo.height * 2f), // Pad the logo from the bottom by its height
                                 null,
                             )
                             // Draw at the correct ratio for Instagram sharing, this will include black bars in the image
@@ -109,7 +103,6 @@ internal fun rememberStoryCaptureController(): StoryCaptureController {
 
 internal interface StoryCaptureController {
     val isSharing: Boolean
-    var topControlsHeightPx: Int
 
     fun captureController(story: Story): CaptureController
     suspend fun capture(story: Story): File?
@@ -120,7 +113,6 @@ internal interface StoryCaptureController {
             private val controller = rememberCaptureController()
 
             override val isSharing = false
-            override var topControlsHeightPx = 0
 
             override fun captureController(story: Story) = controller
 

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/Common.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/Common.kt
@@ -144,7 +144,6 @@ internal fun PreviewBox(
             onClose = {},
             onPreviousStory = {},
             onNextStory = {},
-            controller = StoryCaptureController.preview(),
             isTalkbackOn = false,
             color = Color.White,
         )

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/StoriesPage.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/StoriesPage.kt
@@ -36,7 +36,6 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
@@ -116,7 +115,6 @@ internal fun StoriesPage(
             onClose = onClose,
             onPreviousStory = { onChangeStory(false) },
             onNextStory = { onChangeStory(true) },
-            controller = controller,
         )
     }
 }
@@ -252,20 +250,13 @@ internal fun BoxScope.TopControls(
     onClose: () -> Unit,
     onPreviousStory: () -> Unit,
     onNextStory: () -> Unit,
-    controller: StoryCaptureController,
 ) {
-    val density = LocalDensity.current
-    // Calculate the height so that we can remove it from the share images
-    val statusBarHeightPx = measurements.statusBarInsets.getTop(density)
-    val extraPaddingPx = with(density) { 24.dp.roundToPx() }
-
     Column(
         horizontalAlignment = Alignment.End,
         modifier = Modifier
             .align(Alignment.TopCenter)
             .fillMaxWidth()
-            .windowInsetsPadding(measurements.statusBarInsets)
-            .onGloballyPositioned { controller.topControlsHeightPx = it.size.height + statusBarHeightPx - extraPaddingPx },
+            .windowInsetsPadding(measurements.statusBarInsets),
     ) {
         PagerProgressingIndicator(
             state = pagerState,


### PR DESCRIPTION
## Description

This changes pushes the title down and the Pocket Casts logo up the page so it has less chance of clashing with Instagram UI.

Fixes https://linear.app/a8c/issue/PCDROID-356/adjust-heading-position-in-shareable-asset

## Testing Instructions

- Share each story on Instagram using the "Story" option
- ✅ Verify that the text is positioned away from the controls

## Screenshots

| | | | |
| --- | --- | --- | --- |
| <img width="1198" height="2531" alt="Screenshot_20251203_205229" src="https://github.com/user-attachments/assets/7698bf9a-1a81-4347-866a-5e663d38500b" /> | <img width="1198" height="2531" alt="Screenshot_20251203_205400" src="https://github.com/user-attachments/assets/29df979d-caef-42c9-aabb-6cf605c6533a" /> | <img width="1198" height="2531" alt="Screenshot_20251203_205414" src="https://github.com/user-attachments/assets/3f4bcb2b-548f-494e-89dd-80339c72a4ad" /> | <img width="1198" height="2531" alt="Screenshot_20251203_205427" src="https://github.com/user-attachments/assets/faeee435-a5b2-4582-8ccb-57e40d3686d0" /> |
| <img width="1198" height="2531" alt="Screenshot_20251203_205443" src="https://github.com/user-attachments/assets/be2da04f-a829-45af-9eb1-28fde70e4cf3" /> | <img width="1198" height="2531" alt="Screenshot_20251203_205501" src="https://github.com/user-attachments/assets/db0a020a-d4f8-4e6b-83b2-9415ce2a96ba" /> | <img width="1198" height="2531" alt="Screenshot_20251203_205517" src="https://github.com/user-attachments/assets/d2a7f419-56ef-4796-b3e9-537229ca13f0" /> | <img width="1198" height="2531" alt="Screenshot_20251203_205529" src="https://github.com/user-attachments/assets/1eb132c3-33e2-49e2-91b1-ecdb662a6e4c" /> |







 



## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
