### PR TITLE
Minor Playlists list speed up

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsViewModel.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.WhileSubscribed
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.reactive.asFlow
@@ -40,7 +41,7 @@ class PlaylistsViewModel @Inject constructor(
     internal val uiState = combine(
         playlistManager.playlistPreviewsFlow(),
         settings.showPlaylistsOnboarding.flow,
-        showFreeAccountBanner,
+        showFreeAccountBanner.onStart { emit(false) },
         settings.showPremadePlaylistsTooltip.flow,
         settings.showRearrangePlaylistsTooltip.flow,
         settings.bottomInset,


### PR DESCRIPTION
## Description

I spent a bit of time looking at the loading of the Playlists list page as I have noticed a few of the pages in the app seem to take long enough to load a white page is visible. I played around with shortening the fade in animation but it was hard to tell the difference. I have made a very minor change of giving the method that gets the sign in state a default value. It's most likely to be cached but there is a chance it would have to do a network request. 

<img width="300" src="https://github.com/user-attachments/assets/d51834c1-effe-4250-8c86-254c249364c7" />

## Testing Instructions

Check the Playlists list page still loads and will a fresh install it shows the "Create a free account" panel.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
