### PR TITLE
Exclude prototype builds from Sentry

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -431,7 +431,7 @@ fun Project.configureSentry() {
         }
         autoInstallation.enabled = false
         includeDependenciesReport = false
-        ignoredBuildTypes = setOf("debug", "debugProd")
+        ignoredBuildTypes = setOf("debug", "debugProd", "prototype")
     }
 }
 


### PR DESCRIPTION
## Description

I forgot to do this when integrating prototype builds.

## Testing Instructions

Coder review is enough.