### PR TITLE
Update smart playlist creation flow

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/smart/AppliedRulesPage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/smart/AppliedRulesPage.kt
@@ -93,6 +93,7 @@ internal fun AppliedRulesPage(
                         rules = activeRules,
                         starredEpisodeCount = starredEpisodeCount,
                         appliedRules = appliedRules,
+                        showHeader = onCreatePlaylist == null,
                         onClickRule = onClickRule,
                     )
                 }
@@ -183,18 +184,21 @@ private fun ActiveRulesContent(
     rules: List<RuleType>,
     appliedRules: AppliedRules,
     starredEpisodeCount: Int,
+    showHeader: Boolean,
     onClickRule: (RuleType) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
         modifier = modifier.padding(horizontal = 16.dp),
     ) {
-        TextH20(
-            text = stringResource(LR.string.enabled_rules),
-        )
-        Spacer(
-            modifier = Modifier.height(16.dp),
-        )
+        if (showHeader) {
+            TextH20(
+                text = stringResource(LR.string.enabled_rules),
+            )
+            Spacer(
+                modifier = Modifier.height(16.dp),
+            )
+        }
         AppliedRulesColumn(
             rules = rules,
             appliedRules = appliedRules,
@@ -227,7 +231,7 @@ private fun InactiveRulesContent(
                 .semantics(true) {},
         ) {
             TextH20(
-                text = stringResource(LR.string.other_options),
+                text = stringResource(LR.string.more_rules),
             )
             Spacer(
                 modifier = Modifier.weight(1f),

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -234,7 +234,6 @@
     <string name="ad_report_reason_other">Other</string>
     <string name="banner_ad_plus_prompt">Say goodbye to banner ads and more with Pocket Casts Plus</string>
     <string name="ad_report_confirmation">You reported this ad.</string>
-    <string name="other_options">Other options</string>
     <string name="add_episodes">Add episodes</string>
     <string name="your_podcasts">Your podcasts</string>
     <string name="unavailable">Unavailable</string>
@@ -954,6 +953,7 @@
     <string name="manual_playlist_search_no_podcast_title">No podcast found</string>
     <string name="manual_playlist_search_no_podcast_or_folder_body">We couldn’t find any podcast or folder for that search. Try another keyword.</string>
     <string name="manual_playlist_search_no_podcast_or_folder_title" translatable="false">@string/manual_playlist_search_no_podcast_title</string>
+    <string name="more_rules">More rules</string>
     <string name="new_playlist">New playlist</string>
     <string name="new_playlists_title_placeholder">Playlist’s name</string>
     <string name="new_smart_playlist_banner_body">Automatically add episodes based on rules</string>


### PR DESCRIPTION
## Description

This removes "Enabled rules"  header when creating a playlist and changes "Other options" copy to "More rules".

Designs: https://linear.app/a8c/issue/DSGPOC-54/smart-playlists-improve-messaging-for-enabled-rules-to-distinguish#comment-2ca6ee65

Closes PCDROID-358

## Testing Instructions

1. Start creating a smart playlist.
2. Save any rule.
3. You should not see "Enabled rules" header.
4. You should see "More rules" section.

## Screenshots or Screencast 

<img width="540" alt="image" src="https://github.com/user-attachments/assets/892c4362-00c0-44ce-8e71-d4ede3021782" />

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack