### PR TITLE
Fix auto-play playing completed episodes

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/HistoryManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/HistoryManager.kt
@@ -63,8 +63,6 @@ class HistoryManager @Inject constructor(
             .toList()
             .await()
 
-        val skeletonEpisodes = mutableListOf<PodcastEpisode>()
-
         for (change in changes) {
             val interactionDate = change.modifiedAt.toLong()
 
@@ -89,8 +87,6 @@ class HistoryManager @Inject constructor(
                 }
             }
         }
-
-        episodeManager.insertBlocking(skeletonEpisodes)
 
         if (updateServerModified) {
             settings.setHistoryServerModified(response.serverModified)


### PR DESCRIPTION
## Description

When auto play is selecting the next episode to play it selects episodes with are played but not archived. This doesn't sound correct so this PR fixes this.

## Testing Instructions

1. Go to a podcast page
2. Mark episodes above and below an episode as played but not archived
3. Play the episode in the middle until completion
4. ✅ Verify neither of the two played episodes are played next

## Screencast 

https://github.com/user-attachments/assets/fbade792-ede9-47f9-9a24-dd52b7842ae0

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
