### PR TITLE
Fix full screen player navigation bar colour in buttons mode

### DIFF
--- a/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/theme/Theme.kt
+++ b/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/theme/Theme.kt
@@ -376,7 +376,7 @@ class Theme @Inject constructor(private val settings: Settings) {
         else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
             Color.BLACK
         } else {
-            return context.getThemeColor(R.attr.primary_ui_03)
+            context.getThemeColor(R.attr.primary_ui_03)
         }
     }
 


### PR DESCRIPTION
## Description

The Compose upgrade caused an issue in the beta with the navigation bar. Instead of it being transparent it changed to a solid colour. This was caused by the edge to edge library code adding a extra view if a colour was passed to the `enableEdgeToEdge` method.

Fixes https://linear.app/a8c/issue/PCDROID-371/full-screen-player-navigation-bar-colour-issue-when-navigation-mode

## Testing Instructions

1. Use the light theme
2. Open the full screen player
3. ✅ Verify the navigation bar is transparent

## Screenshots

| Before | After |
| --- | --- |
| <img width="1198" height="2531" alt="Player Buttons API 35 issue Light" src="https://github.com/user-attachments/assets/1c4bfa3d-5800-4224-ad88-a907ddf2ffa5" /> | <img width="1198" height="2531" alt="Screenshot_20251218_105031" src="https://github.com/user-attachments/assets/853f6439-aae3-4e5c-be8a-34c6b1d791ba" /> | 

The default gesture mode looks like the following.

<img width="400" src="https://github.com/user-attachments/assets/ea9cab05-4541-4f46-b489-257c685576b6" />

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
