### PR TITLE
[Tooling] Migrate release pipelines to mac-metal queue

### DIFF
--- a/.buildkite/release-pipelines/code-freeze.yml
+++ b/.buildkite/release-pipelines/code-freeze.yml
@@ -19,7 +19,7 @@ steps:
       bundle exec fastlane code_freeze version:"${RELEASE_VERSION}" skip_confirm:true
     plugins: [$CI_TOOLKIT]
     agents:
-      queue: "tumblr-metal"
+      queue: "mac-metal"
     retry:
       manual:
         reason: If release jobs fail, you should always re-trigger the task from Releases V2 rather than retrying the individual job from Buildkite

--- a/.buildkite/release-pipelines/download-translations.yml
+++ b/.buildkite/release-pipelines/download-translations.yml
@@ -19,7 +19,7 @@ steps:
       bundle exec fastlane download_translations
     plugins: [$CI_TOOLKIT]
     agents:
-      queue: "tumblr-metal"
+      queue: "mac-metal"
     retry:
       manual:
         reason: If release jobs fail, you should always re-trigger the task from Releases V2 rather than retrying the individual job from Buildkite

--- a/.buildkite/release-pipelines/finalize-hotfix-release.yml
+++ b/.buildkite/release-pipelines/finalize-hotfix-release.yml
@@ -21,7 +21,7 @@ steps:
       bundle exec fastlane finalize_hotfix_release skip_confirm:true
     plugins: [$CI_TOOLKIT]
     agents:
-      queue: "tumblr-metal"
+      queue: "mac-metal"
     retry:
       manual:
         reason: If release jobs fail, you should always re-trigger the task from Releases V2 rather than retrying the individual job from Buildkite

--- a/.buildkite/release-pipelines/finalize-release.yml
+++ b/.buildkite/release-pipelines/finalize-release.yml
@@ -21,7 +21,7 @@ steps:
       bundle exec fastlane finalize_release skip_confirm:true skip_translations_download:true
     plugins: [$CI_TOOLKIT]
     agents:
-      queue: "tumblr-metal"
+      queue: "mac-metal"
     retry:
       manual:
         reason: If release jobs fail, you should always re-trigger the task from Releases V2 rather than retrying the individual job from Buildkite

--- a/.buildkite/release-pipelines/new-beta-release.yml
+++ b/.buildkite/release-pipelines/new-beta-release.yml
@@ -21,7 +21,7 @@ steps:
       bundle exec fastlane new_beta_release skip_confirm:true
     plugins: [$CI_TOOLKIT]
     agents:
-      queue: "tumblr-metal"
+      queue: "mac-metal"
     retry:
       manual:
         reason: If release jobs fail, you should always re-trigger the task from Releases V2 rather than retrying the individual job from Buildkite

--- a/.buildkite/release-pipelines/new-hotfix-release.yml
+++ b/.buildkite/release-pipelines/new-hotfix-release.yml
@@ -19,7 +19,7 @@ steps:
       bundle exec fastlane new_hotfix_release version_name:"$RELEASE_VERSION" version_code:"$VERSION_CODE" skip_confirm:true
     plugins: [$CI_TOOLKIT]
     agents:
-      queue: "tumblr-metal"
+      queue: "mac-metal"
     retry:
       manual:
         reason: If release jobs fail, you should always re-trigger the task from Releases V2 rather than retrying the individual job from Buildkite

--- a/.buildkite/release-pipelines/update-rollouts.yml
+++ b/.buildkite/release-pipelines/update-rollouts.yml
@@ -18,7 +18,7 @@ steps:
       bundle exec fastlane update_rollouts track:"$TRACK" percent:"$ROLLOUT_PERCENT"
     plugins: [$CI_TOOLKIT]
     agents:
-      queue: "tumblr-metal"
+      queue: "mac-metal"
     retry:
       manual:
         reason: If release jobs fail, you should always re-trigger the task from Releases V2 rather than retrying the individual job from Buildkite
@@ -38,7 +38,7 @@ steps:
       bundle exec fastlane publish_gh_release skip_confirm:true track:"$TRACK"
     plugins: [$CI_TOOLKIT]
     agents:
-      queue: "tumblr-metal"
+      queue: "mac-metal"
     retry:
       manual:
         reason: If release jobs fail, you should always re-trigger the task from Releases V2 rather than retrying the individual job from Buildkite


### PR DESCRIPTION
Fixes AINFRA-1664

Migrate release pipeline jobs from `tumblr-metal` to `mac-metal` queue.