### PR TITLE
Add setting to optionally hide generated transcripts

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AppearanceSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AppearanceSettingsFragment.kt
@@ -231,6 +231,14 @@ class AppearanceSettingsFragment : BaseFragment() {
             refreshArtwork()
         }
 
+        binding.swtShowGeneratedTranscripts.isChecked = viewModel.showGeneratedTranscripts.value
+        binding.swtShowGeneratedTranscripts.setOnCheckedChangeListener { _, isChecked ->
+            viewModel.updateShowGeneratedTranscripts(isChecked)
+        }
+        binding.btnShowGeneratedTranscripts.setOnClickListener {
+            binding.swtShowGeneratedTranscripts.isChecked = !binding.swtShowGeneratedTranscripts.isChecked
+        }
+
         binding.upgradeBannerBackground.setOnClickListener {
             openOnboardingFlow()
         }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/SettingsAppearanceViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/SettingsAppearanceViewModel.kt
@@ -36,6 +36,7 @@ class SettingsAppearanceViewModel @Inject constructor(
     val createAccountState = MutableLiveData<SettingsAppearanceState>().apply { value = SettingsAppearanceState.Empty }
     val showArtworkOnLockScreen = settings.showArtworkOnLockScreen.flow
     val artworkConfiguration = settings.artworkConfiguration.flow
+    val showGeneratedTranscripts = settings.showGeneratedTranscripts.flow
 
     var changeThemeType: Pair<Theme.ThemeType?, Theme.ThemeType?> = Pair(null, null)
     var changeAppIconType: Pair<AppIcon.AppIconType?, AppIcon.AppIconType?> = Pair(null, null)
@@ -145,6 +146,14 @@ class SettingsAppearanceViewModel @Inject constructor(
         settings.artworkConfiguration.set(currentConfiguration.copy(useEpisodeArtwork = value), updateModifiedAt = true)
         analyticsTracker.track(
             AnalyticsEvent.SETTINGS_APPEARANCE_USE_EPISODE_ARTWORK_TOGGLED,
+            mapOf("enabled" to value),
+        )
+    }
+
+    fun updateShowGeneratedTranscripts(value: Boolean) {
+        settings.showGeneratedTranscripts.set(value, updateModifiedAt = true)
+        analyticsTracker.track(
+            AnalyticsEvent.SETTINGS_APPEARANCE_SHOW_GENERATED_TRANSCRIPTS_TOGGLED,
             mapOf("enabled" to value),
         )
     }

--- a/modules/features/settings/src/main/res/layout/fragment_settings_appearance.xml
+++ b/modules/features/settings/src/main/res/layout/fragment_settings_appearance.xml
@@ -287,7 +287,7 @@
                 app:layout_constraintTop_toBottomOf="@+id/lblEpisodeArtworkConfiguration" />
 
             <View
-                android:id="@+id/dividerViewUpNext"
+                android:id="@+id/dividerViewEpisodeDescription"
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/divider_height"
                 android:background="?attr/primary_ui_05"
@@ -296,6 +296,80 @@
                 app:layout_constraintHorizontal_bias="0.0"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/lblRefreshAllPodcastArtwork" />
+
+            <TextView
+                android:id="@+id/lblEpisodeDescription"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="72dp"
+                android:layout_marginTop="16dp"
+                android:paddingBottom="8dp"
+                android:text="@string/settings_episode_description"
+                android:textAppearance="@style/H40"
+                android:textColor="?attr/primary_interactive_01"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/dividerViewEpisodeDescription" />
+
+            <View
+                android:id="@+id/btnShowGeneratedTranscripts"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:background="?android:attr/selectableItemBackground"
+                android:importantForAccessibility="no"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/lblShowGeneratedTranscripts"
+                app:layout_constraintBottom_toBottomOf="@+id/lblShowGeneratedTranscriptsDetails"/>
+
+            <TextView
+                android:id="@+id/lblShowGeneratedTranscripts"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="16dp"
+                android:paddingTop="8dp"
+                android:text="@string/settings_show_generated_transcripts"
+                android:textAppearance="@style/H40"
+                android:textColor="?attr/primary_text_01"
+                android:importantForAccessibility="no"
+                app:layout_constraintEnd_toStartOf="@+id/swtShowGeneratedTranscripts"
+                app:layout_constraintStart_toStartOf="@+id/lblEpisodeDescription"
+                app:layout_constraintTop_toBottomOf="@+id/lblEpisodeDescription" />
+
+            <Switch
+                android:id="@+id/swtShowGeneratedTranscripts"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:layout_marginEnd="24dp"
+                android:contentDescription="@string/settings_show_generated_transcripts"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/lblShowGeneratedTranscripts" />
+
+            <TextView
+                android:id="@+id/lblShowGeneratedTranscriptsDetails"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:layout_marginEnd="16dp"
+                android:paddingBottom="8dp"
+                android:text="@string/settings_show_generated_transcripts_details"
+                android:textAppearance="@style/H40"
+                android:textColor="?attr/primary_text_02"
+                app:layout_constraintEnd_toStartOf="@+id/swtShowGeneratedTranscripts"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toStartOf="@+id/lblShowGeneratedTranscripts"
+                app:layout_constraintTop_toBottomOf="@+id/lblShowGeneratedTranscripts" />
+
+            <View
+                android:id="@+id/dividerViewUpNext"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/divider_height"
+                android:background="?attr/primary_ui_05"
+                android:layout_marginTop="16dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/lblShowGeneratedTranscriptsDetails" />
 
             <TextView
                 android:id="@+id/lblUpNext"

--- a/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/SettingsAppearanceViewModelTest.kt
+++ b/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/SettingsAppearanceViewModelTest.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.settings.viewmodel
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.models.type.SignInState
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -82,6 +83,10 @@ class SettingsAppearanceViewModelTest {
         whenever(artworkConfiguration.flow).thenReturn(MutableStateFlow(ArtworkConfiguration(false)))
         whenever(settings.artworkConfiguration).thenReturn(artworkConfiguration)
 
+        val showGeneratedTranscripts: UserSetting<Boolean> = mock()
+        whenever(showGeneratedTranscripts.flow).thenReturn(MutableStateFlow(true))
+        whenever(settings.showGeneratedTranscripts).thenReturn(showGeneratedTranscripts)
+
         viewModel = SettingsAppearanceViewModel(
             userManager = userManager,
             settings = settings,
@@ -98,5 +103,16 @@ class SettingsAppearanceViewModelTest {
         viewModel.onThemeChanged(ThemeType.DARK)
 
         verify(notificationManager).updateUserFeatureInteraction(OnboardingNotificationType.Themes)
+    }
+
+    @Test
+    fun `when show generated transcripts is updated, should update setting and track analytics`() = runTest {
+        viewModel.updateShowGeneratedTranscripts(false)
+
+        verify(settings.showGeneratedTranscripts).set(false, updateModifiedAt = true)
+        verify(analyticsTracker).track(
+            AnalyticsEvent.SETTINGS_APPEARANCE_SHOW_GENERATED_TRANSCRIPTS_TOGGLED,
+            mapOf("enabled" to false),
+        )
     }
 }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -568,6 +568,7 @@ enum class AnalyticsEvent(val key: String) {
     SETTINGS_APPEARANCE_SHOW_ARTWORK_ON_LOCK_SCREEN_TOGGLED("settings_appearance_show_artwork_on_lock_screen_toggled"),
     SETTINGS_APPEARANCE_USE_DARK_UP_NEXT_TOGGLED("settings_appearance_use_dark_up_next_toggled"),
     SETTINGS_APPEARANCE_USE_DYNAMIC_COLORS_WIDGET_TOGGLED("settings_appearance_use_dynamic_colors_widget_toggled"),
+    SETTINGS_APPEARANCE_SHOW_GENERATED_TRANSCRIPTS_TOGGLED("settings_appearance_show_generated_transcripts_toggled"),
 
     /* Settings - Advanced Episode Artwork */
     SETTINGS_ADVANCED_EPISODE_ARTWORK_SHOWN("settings_advanced_episode_artwork_shown"),

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1460,6 +1460,7 @@
     <string name="settings_export_send_email">Send email</string>
     <string name="settings_export_send_email_summary">Export your podcasts in the super geeky (but widely supported) OPML format.</string>
     <string name="settings_export_subscriptions">Export podcasts</string>
+    <string name="settings_episode_description">Episode Description</string>
     <string name="settings_general_defaults">Defaults</string>
     <string name="settings_general_player">Player</string>
     <string name="settings_general_sleep_timer">Sleep Timer</string>
@@ -1579,6 +1580,8 @@
     <string name="settings_show_archived_summary_show">New podcasts you follow will show archived episodes.</string>
     <string name="settings_show_artwork">Show artwork on lock screen</string>
     <string name="settings_show_artwork_details">This will also show artwork on connected Bluetooth devices, watches, etc.</string>
+    <string name="settings_show_generated_transcripts">Show Generated Transcripts</string>
+    <string name="settings_show_generated_transcripts_details">Display AI-generated transcripts when available</string>
     <string name="settings_skip_back_time">Skip back time</string>
     <string name="settings_skip_back_time_summary">10 seconds</string>
     <string name="settings_skip_forward_time">Skip forward time</string>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -409,6 +409,7 @@ interface Settings {
     fun showPlayedEpisodes(): Boolean
 
     val showArtworkOnLockScreen: UserSetting<Boolean>
+    val showGeneratedTranscripts: UserSetting<Boolean>
     val newEpisodeNotificationActions: UserSetting<List<NewEpisodeNotificationAction>>
 
     val autoArchiveIncludesStarred: UserSetting<Boolean>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -857,6 +857,12 @@ class SettingsImpl @Inject constructor(
         sharedPrefs = sharedPreferences,
     )
 
+    override val showGeneratedTranscripts = UserSetting.BoolPref(
+        sharedPrefKey = "showGeneratedTranscripts",
+        defaultValue = true,
+        sharedPrefs = sharedPreferences,
+    )
+
     override fun setSelectedTab(selected: Int?) {
         if (selected != null) {
             setInt("selected_tab", selected)


### PR DESCRIPTION
## Description
Add `Show Generated Transcripts` setting to `Appearance` settings screen to allow users to hide generated transcripts from episode detail view for users who don't want them to be displayed.

Fixes # <!-- issue number, if applicable -->

## Testing Instructions
1. Verify transcripts placeholder is showing as expected in episode description view.
2. Open `Appearance` settings menu.
3. Scroll down to new `Episode Description` section of the screen.
4. Toggle the `Show Generated Transcript` setting off.
5. Go back to previous episode description and verify no transcript placeholder is pushing the episode description down the screen.

## Screenshots or Screencast 
<img width="352" height="785" alt="Show Transcripts on" src="https://github.com/user-attachments/assets/92150def-4723-47fb-9e7e-7894696a5b50" />

<img width="353" height="789" alt="Show Transcripts off" src="https://github.com/user-attachments/assets/0bd45886-dc92-499a-b5e1-528b6ad78abf" />

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [X] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ X Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
