### PR TITLE
Use proper contentDescription for play/pause button

### DIFF
--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/AnimatedPlayPauseButton.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/AnimatedPlayPauseButton.kt
@@ -63,7 +63,7 @@ fun AnimatedPlayPauseButton(
         ),
     )
 
-    val contentDescription = stringResource(LR.string.playback_command)
+    val contentDescription = stringResource(LR.string.play)
     Box(
         modifier = modifier
             .size(circleSize)


### PR DESCRIPTION
## Description
This PR addresses a small accessibility around the play/pause button on our player.

Fixes PCDROID-297

## Testing Instructions
1. Enable Talkback
2. Launch the app, open fullscreen player
3. Focus the play/pause button
Verify that Talkback reads out 'Playback control button'

Small caveat: my first approach was to use the same value that we're passing to `clickActionLabel` to properly represent the actual state of the button, but that will fall into a crazy loop in playing state: talkback reads out Pause button that steals audio focus from the app so the playback pauses. That is reflected on the UI as the button becomes Play button again. That triggers another Talkback readout. When the app gets back audio focus from Talkback, the playback resumes that changes the button's state again and Talkback kicks in again... you see the loop, right?


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 