### PR TITLE
Refactor network code wiring

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerDsl.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerDsl.kt
@@ -26,7 +26,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.SmartRules
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.SettingsImpl
-import au.com.shiftyjelly.pocketcasts.servers.di.ServersModule
+import au.com.shiftyjelly.pocketcasts.servers.di.NetworkModule
 import au.com.shiftyjelly.pocketcasts.sharedtest.MutableClock
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import java.util.Date
@@ -61,7 +61,7 @@ class PlaylistManagerDsl : TestWatcher() {
 
     override fun starting(description: Description) {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
-        val moshi = ServersModule().provideMoshi()
+        val moshi = NetworkModule().provideMoshi()
 
         database = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
             .addTypeConverters(ModelModule.provideRoomConverters(moshi))

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/servers/account/SyncAccountTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/servers/account/SyncAccountTest.kt
@@ -11,11 +11,11 @@ import au.com.shiftyjelly.pocketcasts.repositories.sync.SignInSource
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncAccountManagerImpl
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManagerImpl
-import au.com.shiftyjelly.pocketcasts.servers.di.ServersModule
+import au.com.shiftyjelly.pocketcasts.servers.di.NetworkModule
 import au.com.shiftyjelly.pocketcasts.servers.sync.SyncServiceManager
 import java.net.HttpURLConnection
 import kotlinx.coroutines.runBlocking
-import okhttp3.Cache
+import okhttp3.Dispatcher
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
@@ -24,14 +24,11 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.mock
-import retrofit2.Retrofit
+import retrofit2.create
 
 internal class SyncAccountTest {
-
     private lateinit var context: Context
     private lateinit var mockWebServer: MockWebServer
-    private lateinit var retrofit: Retrofit
-    private lateinit var okhttpCache: Cache
     private lateinit var syncManager: SyncManager
 
     @Before
@@ -40,13 +37,17 @@ internal class SyncAccountTest {
         mockWebServer = MockWebServer()
         mockWebServer.start()
 
-        val moshi = ServersModule().provideMoshi()
+        val module = NetworkModule()
+        val moshi = module.provideMoshi()
         val okHttpClient = OkHttpClient.Builder().build()
-        retrofit = ServersModule.provideRetrofit(baseUrl = mockWebServer.url("/").toString(), okHttpClient = okHttpClient, moshi = moshi)
-        okhttpCache = ServersModule.createCache(folder = "TestCache", context = context, cacheSizeInMB = 10)
+        val retrofit = module.provideRetrofitBuilder(moshi, Dispatcher())
+            .baseUrl(mockWebServer.url("/").toString())
+            .client(okHttpClient)
+            .build()
+        val okhttpCache = NetworkModule.createCache(folder = "TestCache", context = context, cacheSizeInMB = 10)
 
         val accountManager = AccountManager.get(context)
-        val syncServiceManager = SyncServiceManager(retrofit, mock(), okhttpCache)
+        val syncServiceManager = SyncServiceManager(retrofit.create(), mock(), okhttpCache)
         val syncAccountManager = SyncAccountManagerImpl(mock(), accountManager)
 
         syncManager = SyncManagerImpl(

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/settings/SettingsImplTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/settings/SettingsImplTest.kt
@@ -5,7 +5,7 @@ import android.content.SharedPreferences
 import androidx.test.platform.app.InstrumentationRegistry
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.SettingsImpl
-import au.com.shiftyjelly.pocketcasts.servers.di.ServersModule
+import au.com.shiftyjelly.pocketcasts.servers.di.NetworkModule
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import kotlin.time.Duration.Companion.days
 import org.junit.Assert.assertFalse
@@ -24,7 +24,7 @@ class SettingsImplTest {
         sharedPreferences = context.getSharedPreferences("test_prefs", Context.MODE_PRIVATE)
         sharedPreferences.edit().clear().commit()
 
-        val moshi = ServersModule().provideMoshi()
+        val moshi = NetworkModule().provideMoshi()
         val firebaseRemoteConfig = FirebaseRemoteConfig.getInstance()
 
         settings = SettingsImpl(

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/settings/advanced/AdvancedSettingsTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/settings/advanced/AdvancedSettingsTest.kt
@@ -8,7 +8,7 @@ import au.com.shiftyjelly.pocketcasts.preferences.SettingsImpl
 import au.com.shiftyjelly.pocketcasts.preferences.model.ArtworkConfiguration
 import au.com.shiftyjelly.pocketcasts.preferences.model.ArtworkConfiguration.Element
 import au.com.shiftyjelly.pocketcasts.preferences.model.ShelfItem
-import au.com.shiftyjelly.pocketcasts.servers.di.ServersModule
+import au.com.shiftyjelly.pocketcasts.servers.di.NetworkModule
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -26,7 +26,7 @@ class AdvancedSettingsTest {
 
         val sharedPreferences = context.getSharedPreferences(fileName, Context.MODE_PRIVATE)
         sharedPreferences.edit().clear().commit()
-        val moshi = ServersModule().provideMoshi()
+        val moshi = NetworkModule().provideMoshi()
         val firebaseRemoteConfig = FirebaseRemoteConfig.getInstance()
         settings = SettingsImpl(
             sharedPreferences = sharedPreferences,

--- a/modules/features/discover/src/test/kotlin/au/com/shiftyjelly/pocketcasts/discover/worker/CuratedPodcastsCrawlerTest.kt
+++ b/modules/features/discover/src/test/kotlin/au/com/shiftyjelly/pocketcasts/discover/worker/CuratedPodcastsCrawlerTest.kt
@@ -2,7 +2,7 @@ package au.com.shiftyjelly.pocketcasts.discover.worker
 
 import au.com.shiftyjelly.pocketcasts.models.entity.CuratedPodcast
 import au.com.shiftyjelly.pocketcasts.repositories.lists.ListRepository
-import au.com.shiftyjelly.pocketcasts.servers.di.ServersModule
+import au.com.shiftyjelly.pocketcasts.servers.di.NetworkModule
 import au.com.shiftyjelly.pocketcasts.servers.server.ListWebService
 import kotlinx.coroutines.test.runTest
 import okhttp3.mockwebserver.MockResponse
@@ -25,7 +25,7 @@ class CuratedPodcastsCrawlerTest {
 
     @Before
     fun setup() {
-        val moshi = ServersModule().provideMoshi()
+        val moshi = NetworkModule().provideMoshi()
         val service = Retrofit.Builder()
             .baseUrl(server.url("/"))
             .addConverterFactory(MoshiConverterFactory.create(moshi))

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/RepositoryProviderModule.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/RepositoryProviderModule.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.repositories.di
 
+import android.accounts.AccountManager
 import android.content.Context
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
@@ -83,5 +84,11 @@ class RepositoryProviderModule {
             syncManager,
             platform,
         )
+    }
+
+    @Provides
+    @Singleton
+    fun provideAccountManager(@ApplicationContext context: Context): AccountManager {
+        return AccountManager.get(context)
     }
 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/bumpstats/WpComServiceManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/bumpstats/WpComServiceManager.kt
@@ -1,16 +1,12 @@
 package au.com.shiftyjelly.pocketcasts.servers.bumpstats
 
 import au.com.shiftyjelly.pocketcasts.models.entity.AnonymousBumpStat
-import au.com.shiftyjelly.pocketcasts.servers.di.WpComServiceRetrofit
 import javax.inject.Inject
 import retrofit2.Response
-import retrofit2.Retrofit
 
 class WpComServiceManager @Inject constructor(
-    @WpComServiceRetrofit retrofit: Retrofit,
+    private val service: WpComService,
 ) {
-    private val service: WpComService = retrofit.create(WpComService::class.java)
-
     suspend fun bumpStatAnonymously(bumpStats: List<AnonymousBumpStat>): Response<String> {
         val request = AnonymousBumpStatsRequest(bumpStats)
         return service.bumpStatAnonymously(request)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/cdn/StaticServiceManagerImpl.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/cdn/StaticServiceManagerImpl.kt
@@ -1,18 +1,15 @@
 package au.com.shiftyjelly.pocketcasts.servers.cdn
 
 import au.com.shiftyjelly.pocketcasts.models.entity.BlazeAd
-import au.com.shiftyjelly.pocketcasts.servers.di.StaticServiceRetrofit
 import au.com.shiftyjelly.pocketcasts.utils.Optional
 import io.reactivex.Single
 import javax.inject.Inject
-import retrofit2.Retrofit
 
-class StaticServiceManagerImpl @Inject constructor(@StaticServiceRetrofit retrofit: Retrofit) : StaticServiceManager {
-
-    val server: StaticService = retrofit.create(StaticService::class.java)
-
+class StaticServiceManagerImpl @Inject constructor(
+    private val service: StaticService,
+) : StaticServiceManager {
     override fun getColorsSingle(podcastUuid: String): Single<Optional<ArtworkColors>> {
-        return server.getColorsMaybe(podcastUuid)
+        return service.getColorsMaybe(podcastUuid)
             // convert response to artwork colors
             .map(ColorsResponse::toArtworkColors)
             // convert to optional so we can handle if the value is missing
@@ -22,10 +19,10 @@ class StaticServiceManagerImpl @Inject constructor(@StaticServiceRetrofit retrof
     }
 
     override suspend fun getColors(podcastUuid: String): ArtworkColors? {
-        return server.getColors(podcastUuid)?.toArtworkColors()
+        return service.getColors(podcastUuid)?.toArtworkColors()
     }
 
     override suspend fun getBlazeAds(): List<BlazeAd> {
-        return server.getBlazePromotions().toBlazeAds()
+        return service.getBlazePromotions().toBlazeAds()
     }
 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/di/NetworkModule.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/di/NetworkModule.kt
@@ -1,6 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.servers.di
 
-import android.accounts.AccountManager
 import android.content.Context
 import au.com.shiftyjelly.pocketcasts.models.entity.AnonymousBumpStat
 import au.com.shiftyjelly.pocketcasts.models.type.BlazeAdLocation
@@ -16,16 +15,22 @@ import au.com.shiftyjelly.pocketcasts.servers.OkHttpInterceptor
 import au.com.shiftyjelly.pocketcasts.servers.adapters.ExecutorEnqueueAdapterFactory
 import au.com.shiftyjelly.pocketcasts.servers.adapters.InstantAdapter
 import au.com.shiftyjelly.pocketcasts.servers.addInterceptors
+import au.com.shiftyjelly.pocketcasts.servers.bumpstats.WpComService
+import au.com.shiftyjelly.pocketcasts.servers.cdn.StaticService
+import au.com.shiftyjelly.pocketcasts.servers.list.ListDownloadService
+import au.com.shiftyjelly.pocketcasts.servers.list.ListUploadService
 import au.com.shiftyjelly.pocketcasts.servers.model.DisplayStyleMoshiAdapter
 import au.com.shiftyjelly.pocketcasts.servers.model.ExpandedStyleMoshiAdapter
 import au.com.shiftyjelly.pocketcasts.servers.model.ListTypeMoshiAdapter
 import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheService
 import au.com.shiftyjelly.pocketcasts.servers.podcast.TranscriptService
+import au.com.shiftyjelly.pocketcasts.servers.refresh.RefreshService
 import au.com.shiftyjelly.pocketcasts.servers.search.AutoCompleteResult
 import au.com.shiftyjelly.pocketcasts.servers.search.AutoCompleteSearchService
 import au.com.shiftyjelly.pocketcasts.servers.search.CombinedResult
 import au.com.shiftyjelly.pocketcasts.servers.server.ListWebService
 import au.com.shiftyjelly.pocketcasts.servers.sync.LoginIdentity
+import au.com.shiftyjelly.pocketcasts.servers.sync.SyncService
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.adapters.Rfc3339DateJsonAdapter
 import dagger.Module
@@ -50,26 +55,29 @@ import retrofit2.create
 
 @Module
 @InstallIn(SingletonComponent::class)
-class ServersModule {
+class NetworkModule {
     companion object {
-        private val okHttpDispatcher = Dispatcher()
-
         fun createCache(folder: String, context: Context, cacheSizeInMB: Int): Cache {
             val cacheSize = cacheSizeInMB * 1024 * 1024
             val cacheDirectory = File(context.cacheDir.absolutePath, folder)
             return Cache(cacheDirectory, cacheSize.toLong())
         }
+    }
 
-        fun provideRetrofit(baseUrl: String, okHttpClient: OkHttpClient, moshi: Moshi): Retrofit {
-            return Retrofit.Builder()
-                .addConverterFactory(ProtoConverterFactory.create())
-                .addConverterFactory(MoshiConverterFactory.create(moshi))
-                .addCallAdapterFactory(ExecutorEnqueueAdapterFactory(okHttpDispatcher.executorService))
-                .addCallAdapterFactory(RxJava2CallAdapterFactory.createWithScheduler(Schedulers.from(okHttpDispatcher.executorService)))
-                .baseUrl(baseUrl)
-                .client(okHttpClient)
-                .build()
-        }
+    @Provides
+    @Singleton
+    fun provideDispatcher(): Dispatcher = Dispatcher()
+
+    @Provides
+    @Cached
+    fun provideCachedCache(@ApplicationContext context: Context): Cache {
+        return createCache(folder = "HttpCache", context = context, cacheSizeInMB = 10)
+    }
+
+    @Provides
+    @Transcripts
+    fun provideTranscriptCache(@ApplicationContext context: Context): Cache {
+        return createCache(folder = "TranscriptCache", context = context, cacheSizeInMB = 50)
     }
 
     @Provides
@@ -94,18 +102,21 @@ class ServersModule {
     }
 
     @Provides
-    @Singleton
-    @Raw
-    fun provideRawClient(): OkHttpClient {
-        return OkHttpClient.Builder()
-            .dispatcher(okHttpDispatcher)
-            .build()
+    fun provideRetrofitBuilder(moshi: Moshi, dispatcher: Dispatcher): Retrofit.Builder {
+        return Retrofit.Builder()
+            .addConverterFactory(ProtoConverterFactory.create())
+            .addConverterFactory(MoshiConverterFactory.create(moshi))
+            .addCallAdapterFactory(ExecutorEnqueueAdapterFactory(dispatcher.executorService))
+            .addCallAdapterFactory(RxJava2CallAdapterFactory.createWithScheduler(Schedulers.from(dispatcher.executorService)))
     }
 
     @Provides
-    @Cached
-    fun provideCachedCache(@ApplicationContext context: Context): Cache {
-        return createCache(folder = "HttpCache", context = context, cacheSizeInMB = 10)
+    @Singleton
+    @Raw
+    fun provideRawClient(dispatcher: Dispatcher): OkHttpClient {
+        return OkHttpClient.Builder()
+            .dispatcher(dispatcher)
+            .build()
     }
 
     @Provides
@@ -171,15 +182,9 @@ class ServersModule {
     }
 
     @Provides
-    @Transcripts
-    fun provideTranscriptCache(@ApplicationContext context: Context): Cache {
-        return createCache(folder = "TranscriptCache", context = context, cacheSizeInMB = 50)
-    }
-
-    @Provides
     @Singleton
     @Transcripts
-    internal fun provideTranscriptsClient(
+    fun provideTranscriptsClient(
         @Raw client: OkHttpClient,
         @Transcripts cache: Cache,
         @Transcripts interceptors: List<@JvmSuppressWildcards OkHttpInterceptor>,
@@ -197,7 +202,7 @@ class ServersModule {
     @Provides
     @Singleton
     @Player
-    fun providePlayerClinet(
+    fun providePlayerClient(
         @Raw client: OkHttpClient,
         @Player interceptors: List<@JvmSuppressWildcards OkHttpInterceptor>,
     ): OkHttpClient {
@@ -224,16 +229,24 @@ class ServersModule {
     @Provides
     @SyncServiceRetrofit
     @Singleton
-    internal fun provideApiRetrofit(@Cached okHttpClient: OkHttpClient, moshi: Moshi): Retrofit {
-        return provideRetrofit(baseUrl = Settings.SERVER_API_URL, okHttpClient = okHttpClient, moshi = moshi)
+    fun provideApiRetrofit(
+        builder: Retrofit.Builder,
+        @Cached okHttpClient: OkHttpClient,
+    ): Retrofit {
+        return builder
+            .baseUrl(Settings.SERVER_API_URL)
+            .client(okHttpClient)
+            .build()
     }
 
     @Provides
     @WpComServiceRetrofit
     @Singleton
-    internal fun provideWpComApiRetrofit(@Cached okHttpClient: OkHttpClient, moshi: Moshi): Retrofit {
-        return Retrofit.Builder()
-            .addConverterFactory(MoshiConverterFactory.create(moshi))
+    fun provideWpComApiRetrofit(
+        builder: Retrofit.Builder,
+        @Cached okHttpClient: OkHttpClient,
+    ): Retrofit {
+        return builder
             .baseUrl(Settings.WP_COM_API_URL)
             .client(okHttpClient)
             .build()
@@ -242,89 +255,146 @@ class ServersModule {
     @Provides
     @RefreshServiceRetrofit
     @Singleton
-    internal fun provideRefreshRetrofit(@NoCacheTokened okHttpClient: OkHttpClient, moshi: Moshi): Retrofit {
-        return provideRetrofit(baseUrl = Settings.SERVER_MAIN_URL, okHttpClient = okHttpClient, moshi = moshi)
+    fun provideRefreshRetrofit(
+        builder: Retrofit.Builder,
+        @NoCacheTokened okHttpClient: OkHttpClient,
+    ): Retrofit {
+        return builder
+            .baseUrl(Settings.SERVER_MAIN_URL)
+            .client(okHttpClient)
+            .build()
     }
 
     @Provides
     @PodcastCacheServiceRetrofit
     @Singleton
-    internal fun providePodcastRetrofit(@Cached okHttpClient: OkHttpClient, moshi: Moshi): Retrofit {
-        return provideRetrofit(baseUrl = Settings.SERVER_CACHE_URL, okHttpClient = okHttpClient, moshi = moshi)
+    fun providePodcastRetrofit(
+        builder: Retrofit.Builder,
+        @Cached okHttpClient: OkHttpClient,
+    ): Retrofit {
+        return builder
+            .baseUrl(Settings.SERVER_CACHE_URL)
+            .client(okHttpClient)
+            .build()
     }
 
     @Provides
     @StaticServiceRetrofit
     @Singleton
-    internal fun provideStaticRetrofit(@Cached okHttpClient: OkHttpClient, moshi: Moshi): Retrofit {
-        return provideRetrofit(baseUrl = Settings.SERVER_STATIC_URL, okHttpClient = okHttpClient, moshi = moshi)
+    fun provideStaticRetrofit(
+        builder: Retrofit.Builder,
+        @Cached okHttpClient: OkHttpClient,
+    ): Retrofit {
+        return builder
+            .baseUrl(Settings.SERVER_STATIC_URL)
+            .client(okHttpClient)
+            .build()
     }
 
     @Provides
     @ListDownloadServiceRetrofit
     @Singleton
-    internal fun provideListDownloadRetrofit(@NoCache okHttpClient: OkHttpClient, moshi: Moshi): Retrofit {
-        return provideRetrofit(baseUrl = Settings.SERVER_LIST_URL, okHttpClient = okHttpClient, moshi = moshi)
+    fun provideListDownloadRetrofit(
+        builder: Retrofit.Builder,
+        @NoCache okHttpClient: OkHttpClient,
+    ): Retrofit {
+        return builder
+            .baseUrl(Settings.SERVER_LIST_URL)
+            .client(okHttpClient)
+            .build()
     }
 
     @Provides
     @ListUploadServiceRetrofit
     @Singleton
-    internal fun provideListUploadRetrofit(@NoCache okHttpClient: OkHttpClient, moshi: Moshi): Retrofit {
-        return provideRetrofit(baseUrl = Settings.SERVER_SHARING_URL, okHttpClient = okHttpClient, moshi = moshi)
+    fun provideListUploadRetrofit(
+        builder: Retrofit.Builder,
+        @NoCache okHttpClient: OkHttpClient,
+    ): Retrofit {
+        return builder
+            .baseUrl(Settings.SERVER_SHARING_URL)
+            .client(okHttpClient)
+            .build()
     }
 
     @Provides
     @DiscoverServiceRetrofit
     @Singleton
-    internal fun provideDiscoverRetrofit(@Cached okHttpClient: OkHttpClient, moshi: Moshi): Retrofit {
-        return provideRetrofit(baseUrl = Settings.SERVER_STATIC_URL, okHttpClient = okHttpClient, moshi = moshi)
-    }
-
-    @Provides
-    @Singleton
-    internal fun provideListWebService(@DiscoverServiceRetrofit retrofit: Retrofit): ListWebService {
-        return retrofit.create(ListWebService::class.java)
+    fun provideDiscoverRetrofit(
+        builder: Retrofit.Builder,
+        @Cached okHttpClient: OkHttpClient,
+    ): Retrofit {
+        return builder
+            .baseUrl(Settings.SERVER_STATIC_URL)
+            .client(okHttpClient)
+            .build()
     }
 
     @Provides
     @TranscriptRetrofit
     @Singleton
-    internal fun provideTranscriptRetrofit(@Transcripts okHttpClient: OkHttpClient): Retrofit {
-        return Retrofit.Builder()
-            .client(okHttpClient)
+    fun provideTranscriptRetrofit(
+        builder: Retrofit.Builder,
+        @Transcripts okHttpClient: OkHttpClient,
+    ): Retrofit {
+        return builder
             .baseUrl("http://localhost/") // Base URL is required but will be set using the annotation @Url
+            .client(okHttpClient)
             .build()
     }
 
     @Provides
     @Singleton
     @SearchRetrofit
-    internal fun provideSearchApiRetrofit(@Cached okHttpClient: OkHttpClient, moshi: Moshi): Retrofit {
-        return Retrofit.Builder()
-            .addConverterFactory(MoshiConverterFactory.create(moshi))
+    fun provideSearchApiRetrofit(
+        builder: Retrofit.Builder,
+        @Cached okHttpClient: OkHttpClient,
+    ): Retrofit {
+        return builder
             .baseUrl(Settings.SEARCH_API_URL)
             .client(okHttpClient)
             .build()
     }
 
+    @Provides
+    @Singleton
+    fun provideListWebService(@DiscoverServiceRetrofit retrofit: Retrofit): ListWebService = retrofit.create()
+
     @Singleton
     @Provides
-    internal fun provideAutoCompleteSearchService(@SearchRetrofit retrofit: Retrofit): AutoCompleteSearchService = retrofit.create(AutoCompleteSearchService::class.java)
+    fun provideAutoCompleteSearchService(@SearchRetrofit retrofit: Retrofit): AutoCompleteSearchService = retrofit.create()
 
     @Provides
     @Singleton
-    internal fun provideAccountManager(@ApplicationContext context: Context): AccountManager {
-        return AccountManager.get(context)
-    }
+    fun provideCacheService(@PodcastCacheServiceRetrofit retrofit: Retrofit): PodcastCacheService = retrofit.create()
 
     @Provides
     @Singleton
-    fun provideCacheServer(@PodcastCacheServiceRetrofit retrofit: Retrofit): PodcastCacheService = retrofit.create()
+    fun provideTranscriptCacheService(@TranscriptRetrofit retrofit: Retrofit): TranscriptService = retrofit.create()
 
     @Provides
     @Singleton
-    fun provideTranscriptCacheServer(@TranscriptRetrofit retrofit: Retrofit): TranscriptService = retrofit.create()
+    fun provideStaticService(@StaticServiceRetrofit retrofit: Retrofit): StaticService = retrofit.create()
+
+    @Provides
+    @Singleton
+    fun provideListUploadService(@ListUploadServiceRetrofit retrofit: Retrofit): ListUploadService = retrofit.create()
+
+    @Provides
+    @Singleton
+    fun provideListDownloadService(@ListDownloadServiceRetrofit retrofit: Retrofit): ListDownloadService = retrofit.create()
+
+    @Provides
+    @Singleton
+    fun provideRefreshService(@RefreshServiceRetrofit retrofit: Retrofit): RefreshService = retrofit.create()
+
+    @Provides
+    @Singleton
+    fun provideWpComService(@WpComServiceRetrofit retrofit: Retrofit): WpComService = retrofit.create()
+
+    @Provides
+    @Singleton
+    fun provideSyncService(@SyncServiceRetrofit retrofit: Retrofit): SyncService = retrofit.create()
 }
 
 @Qualifier

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/list/ListServiceManagerImpl.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/list/ListServiceManagerImpl.kt
@@ -2,23 +2,16 @@ package au.com.shiftyjelly.pocketcasts.servers.list
 
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.servers.di.ListDownloadServiceRetrofit
-import au.com.shiftyjelly.pocketcasts.servers.di.ListUploadServiceRetrofit
 import au.com.shiftyjelly.pocketcasts.utils.extensions.sha1
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 import javax.inject.Inject
-import retrofit2.Retrofit
 
 class ListServiceManagerImpl @Inject constructor(
-    @ListUploadServiceRetrofit uploadRetrofit: Retrofit,
-    @ListDownloadServiceRetrofit downloadRetrofit: Retrofit,
+    private val uploadService: ListUploadService,
+    private val downloadService: ListDownloadService,
 ) : ListServiceManager {
-
-    private val uploadService: ListUploadService = uploadRetrofit.create(ListUploadService::class.java)
-    private val downloadService: ListDownloadService = downloadRetrofit.create(ListDownloadService::class.java)
-
     companion object {
         private val DATE_FORMAT = SimpleDateFormat("yyyyMMddHHmmss", Locale.US)
 

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/refresh/RefreshServiceManagerImpl.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/refresh/RefreshServiceManagerImpl.kt
@@ -2,20 +2,16 @@ package au.com.shiftyjelly.pocketcasts.servers.refresh
 
 import android.os.Build
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.servers.di.RefreshServiceRetrofit
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import java.io.IOException
 import java.util.Locale
 import javax.inject.Inject
 import retrofit2.Response
-import retrofit2.Retrofit
 
 class RefreshServiceManagerImpl @Inject constructor(
-    @RefreshServiceRetrofit retrofit: Retrofit,
+    private val service: RefreshService,
     private val settings: Settings,
 ) : RefreshServiceManager {
-    private val service: RefreshService = retrofit.create(RefreshService::class.java)
-
     override suspend fun importOpml(urls: List<String>): Response<StatusResponse<ImportOpmlResponse>> {
         val request = ImportOpmlRequest(urls = urls)
         addDeviceParameters(request)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServiceManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServiceManager.kt
@@ -10,7 +10,6 @@ import au.com.shiftyjelly.pocketcasts.preferences.AccessToken
 import au.com.shiftyjelly.pocketcasts.preferences.RefreshToken
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.servers.di.Cached
-import au.com.shiftyjelly.pocketcasts.servers.di.SyncServiceRetrofit
 import au.com.shiftyjelly.pocketcasts.servers.sync.forgotpassword.ForgotPasswordRequest
 import au.com.shiftyjelly.pocketcasts.servers.sync.forgotpassword.ForgotPasswordResponse
 import au.com.shiftyjelly.pocketcasts.servers.sync.history.HistoryYearResponse
@@ -56,7 +55,6 @@ import okhttp3.Cache
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.RequestBody.Companion.asRequestBody
 import retrofit2.Response
-import retrofit2.Retrofit
 
 /**
  * The only class outside of the server module that should use this class is the
@@ -64,7 +62,7 @@ import retrofit2.Retrofit
  */
 @Singleton
 open class SyncServiceManager @Inject constructor(
-    @SyncServiceRetrofit retrofit: Retrofit,
+    private val service: SyncService,
     val settings: Settings,
     @Cached val cache: Cache,
 ) {
@@ -82,8 +80,6 @@ open class SyncServiceManager @Inject constructor(
             m = Settings.SYNC_API_MODEL
         }
     }
-
-    private val service: SyncService = retrofit.create(SyncService::class.java)
 
     suspend fun register(email: String, password: String): LoginTokenResponse {
         val request = RegisterRequest(email = email, password = password, scope = SCOPE_MOBILE)


### PR DESCRIPTION
## Description

This PR primarily contains structural changes:

- Renamed `ServersModule` to `NetworkModule`.
- Moved `AccountManager` out of `NetworkModule`.
- Inject `Retrofit.Builder` instead of using a top-level `provideRetrofit` function to ensure shared dispatcher and configuration. Previously, some providers used `provideRetrofit`, while others created their own configurations.
- Inject services directly into consumer classes instead of injecting `Retrofit` and having consumers create the services themselves. This should slightly improve performance, as services will now be cached as singletons rather than being created repeatedly.

Relates to PCDROID-403

## Testing Instructions

Smoke test the app. Verify that search and transcripts still work.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack