### PR TITLE
[Analysis] Update `Aligned16KB` Lint Check Severity to Error

### DIFF
--- a/lint.xml
+++ b/lint.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <lint>
+    <issue id="Aligned16KB" severity="error" />
     <issue id="ObsoleteSdkInt" severity="error" />
     <issue id="PrivateResource" severity="error" />
     <issue id="RequiredSize" severity="error" />


### PR DESCRIPTION
Closes: [AINFRA-1818](https://linear.app/a8c/issue/AINFRA-1818)
Reason: pdt0Fp-4dX-p2 + pdt0Fp-4dX-p2#comment-1740

---

## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

Add `Aligned16KB` lint check with error severity to ensure 16KB page alignment compliance is enforced at build time.

FYI: Starting with Android 15 (API 35), devices may use 16KB memory page sizes. Apps with native code or dependencies using native libraries must be 16KB aligned to run on these devices. By elevating this lint check to error severity, we catch alignment issues during the build process rather than at runtime.

---

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

1. Run lint on the app modules:
    ```
    ./gradlew :app:lintDebug :automotive:lintDebug :wear:lintDebug
    ```
2. Verify no `Aligned16KB` errors are reported.
3. (Optional) To verify the lint check catches non-aligned libraries:
    - Temporarily add the [MockK](https://github.com/mockk/mockk) library of version [1.14.2](https://github.com/mockk/mockk/releases/tag/1.14.2) (see patch).
        - FYI: This version includes native libraries compiled before 16KB page alignment was required.
    - Run lint again:
        ```
        ./gradlew :app:lintDebug
        ```
    - Verify lint fails with an `Aligned16KB` error for the [MockK](https://github.com/mockk/mockk) library.

<details>
    <summary>patch</summary>

```diff
Subject: [PATCH] Analysis: Update aligned16kb lint severity to error

Add Aligned16KB lint check with error severity to the root lint.xml file
to ensure 16KB page alignment compliance is enforced at build time.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
---
Index: gradle/libs.versions.toml
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/gradle/libs.versions.toml b/gradle/libs.versions.toml
--- a/gradle/libs.versions.toml	(revision 7940fdf8720bdf7e93f89687ed4b77d5e658b8b8)
+++ b/gradle/libs.versions.toml	(date 1769512432682)
@@ -42,6 +42,7 @@
 media3 = "1.9.0"
 mockito = "5.21.0"
 mockito-kotlin = "6.2.2"
+mockk = "1.14.2"
 moshi = "1.15.2"
 navigation = "2.9.6"
 okhttp = "5.3.2"
@@ -179,6 +180,9 @@
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "mockito-kotlin" }
 
+# MockK
+mockk-android = { module = "io.mockk:mockk-android", version.ref = "mockk" }
+
 # Moshi
 moshi = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
 moshi-adapters = { module = "com.squareup.moshi:moshi-adapters", version.ref = "moshi" }
Index: app/build.gradle.kts
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/app/build.gradle.kts b/app/build.gradle.kts
--- a/app/build.gradle.kts	(revision 7940fdf8720bdf7e93f89687ed4b77d5e658b8b8)
+++ b/app/build.gradle.kts	(date 1769512432681)
@@ -144,6 +144,7 @@
     testImplementation(libs.junit)
     testImplementation(libs.mockito.core)
     testImplementation(libs.mockito.kotlin)
+    testImplementation(libs.mockk.android)
     testImplementation(libs.turbine)
 
     testImplementation(projects.modules.services.sharedtest)
```

</details>

---

## Checklist (`N/A`)