### PR TITLE
Fix missing spaces around hyphen in referral share text

### DIFF
--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2476,7 +2476,7 @@
     <!-- Referrals share subject, `%1$s' is a placeholder for the offer duration on the Plus subscription -->
     <string name="referrals_share_subject">%1$s Guest Pass for Pocket&#160;Casts&#160;Plus!</string>
     <!-- Referrals share text, `%1$s' is a placeholder for the offer duration on the Plus subscription -->
-    <string name="referrals_share_text">Hi there!\n\nHere\'s a %1$s guest pass for Pocket&#160;Casts&#160;Plus–my favorite podcast player. It\'s packed with unique features like bookmarks, folders and more that you won\'t find anywhere else. I think you\'ll love it too!</string>
+    <string name="referrals_share_text">Hi there!\n\nHere\'s a %1$s guest pass for Pocket&#160;Casts&#160;Plus - my favorite podcast player. It\'s packed with unique features like bookmarks, folders and more that you won\'t find anywhere else. I think you\'ll love it too!</string>
     <!-- Referrals tooltip message, `%1$s' is a placeholder for the offer duration on the Plus subscription -->
     <string name="referrals_tooltip_message">Gift %1$s of Pocket&#160;Casts&#160;Plus!</string>
     <string name="referrals_create_subscription_failed">Could not create subscription. Please try again later.</string>


### PR DESCRIPTION
The referral share message displayed "Pocket Casts Plus–my favorite" with an en-dash and no spaces. This fixes it to use a hyphen with proper spacing: "Pocket Casts Plus - my favorite"

## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

Fixes PCDROID-418

## Testing Instructions

1. Log in with a Plus account
2. Go to Profile - Referral icon on the top left
3. Tap on "Share Guest Pass" CTA
4. Share on WhatsApp / Email / Messages, etc.
5. Check that the copy is changed

## Screenshots or Screencast 

<img width="260" alt="IMG_8149" src="https://github.com/user-attachments/assets/a43ee627-03b3-4a96-ab1c-6c2a637bf6aa" />

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
