### PR TITLE
Allow to add episodes to a playlist in bulk

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerManualTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerManualTest.kt
@@ -365,7 +365,7 @@ class PlaylistManagerManualTest {
     }
 
     @Test
-    fun addEpisodes() = dsl.test {
+    fun addSingleEpisode() = dsl.test {
         insertManualPlaylist(index = 0)
         insertPodcast(index = 0)
         insertPodcastEpisode(index = 0, podcastIndex = 0)
@@ -403,6 +403,72 @@ class PlaylistManagerManualTest {
                 )
             },
         )
+    }
+
+    @Test
+    fun addMultipleEpisodes() = dsl.test {
+        insertManualPlaylist(index = 0)
+        insertPodcast(index = 0)
+        insertPodcastEpisode(index = 0, podcastIndex = 0)
+        insertPodcastEpisode(index = 1, podcastIndex = 1)
+
+        val isAdded = manager.addManualEpisodes("playlist-id-0", listOf("episode-id-0", "episode-id-1"))
+        assertTrue(isAdded)
+
+        expectManualEpisodes(
+            playlistIndex = 0,
+            manualPlaylistEpisode(index = 0, podcastIndex = 0, playlistIndex = 0) {
+                it.copy(
+                    episodeSlug = "episode-slug-0",
+                    podcastSlug = "podcast-slug-0",
+                    isSynced = false,
+                )
+            },
+            manualPlaylistEpisode(index = 1, podcastIndex = 1, playlistIndex = 0) {
+                it.copy(
+                    episodeSlug = "episode-slug-1",
+                    podcastSlug = "",
+                    isSynced = false,
+                )
+            },
+        )
+    }
+
+    @Test
+    fun ignoreMissingEpisodesWhenAddingThem() = dsl.test {
+        insertManualPlaylist(index = 0)
+        insertPodcast(index = 0)
+        insertPodcastEpisode(index = 0, podcastIndex = 0)
+        insertPodcastEpisode(index = 1, podcastIndex = 1)
+
+        val isAdded = manager.addManualEpisodes("playlist-id-0", listOf("episode-id-0", "episode-id-1", "episode-id-3"))
+        assertTrue(isAdded)
+
+        expectManualEpisodes(
+            playlistIndex = 0,
+            manualPlaylistEpisode(index = 0, podcastIndex = 0, playlistIndex = 0) {
+                it.copy(
+                    episodeSlug = "episode-slug-0",
+                    podcastSlug = "podcast-slug-0",
+                    isSynced = false,
+                )
+            },
+            manualPlaylistEpisode(index = 1, podcastIndex = 1, playlistIndex = 0) {
+                it.copy(
+                    episodeSlug = "episode-slug-1",
+                    podcastSlug = "",
+                    isSynced = false,
+                )
+            },
+        )
+    }
+
+    @Test
+    fun failToAddEpisodesWhenNoneAreFound() = dsl.test {
+        insertManualPlaylist(index = 0)
+
+        val isAdded = manager.addManualEpisodes("playlist-id-0", listOf("episode-id-0", "episode-id-1"))
+        assertFalse(isAdded)
     }
 
     @Test

--- a/modules/features/filters/src/test/kotlin/au/com/shiftyjelly/pocketcasts/playlists/create/FakePlaylistManager.kt
+++ b/modules/features/filters/src/test/kotlin/au/com/shiftyjelly/pocketcasts/playlists/create/FakePlaylistManager.kt
@@ -120,8 +120,10 @@ class FakePlaylistManager : PlaylistManager {
     }
 
     val addManualEpisodeTurbine = Turbine<Pair<String, String>>(name = "addManualEpisodeTurbine")
-    override suspend fun addManualEpisode(playlistUuid: String, episodeUuid: String): Boolean {
-        addManualEpisodeTurbine.add(playlistUuid to episodeUuid)
+    override suspend fun addManualEpisodes(playlistUuid: String, episodeUuids: List<String>): Boolean {
+        for (episodeUuid in episodeUuids) {
+            addManualEpisodeTurbine.add(playlistUuid to episodeUuid)
+        }
         return true
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManager.kt
@@ -78,7 +78,9 @@ interface PlaylistManager {
 
     fun notAddedManualEpisodesFlow(playlistUuid: String, podcastUuid: String, searchTerm: String? = null): Flow<List<PodcastEpisode>>
 
-    suspend fun addManualEpisode(playlistUuid: String, episodeUuid: String): Boolean
+    suspend fun addManualEpisodes(playlistUuid: String, episodeUuids: List<String>): Boolean
+
+    suspend fun addManualEpisode(playlistUuid: String, episodeUuid: String): Boolean = addManualEpisodes(playlistUuid, listOf(episodeUuid))
 
     suspend fun sortManualEpisodes(playlistUuid: String, episodeUuids: List<String>)
 


### PR DESCRIPTION
## Description

This adds a bulk function to the manager to insert multiple episodes at once to a playlist.

Relates to PCDROID-413

## Testing Instructions

1. Create a manual playlist.
2. Adding episodes should still work as before.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
