### PR TITLE
Extract coroutine extensions to a separate project

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -123,6 +123,7 @@ dependencies {
     implementation(projects.modules.features.widgets)
     implementation(projects.modules.services.analytics)
     implementation(projects.modules.services.compose)
+    implementation(projects.modules.services.coroutines)
     implementation(projects.modules.services.crashlogging)
     implementation(projects.modules.services.deeplink)
     implementation(projects.modules.services.localization)

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
@@ -7,6 +7,7 @@ import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.experiments.ExperimentProvider
+import au.com.shiftyjelly.pocketcasts.coroutines.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.crashlogging.InitializeRemoteLogging
 import au.com.shiftyjelly.pocketcasts.discover.worker.CuratedPodcastsSyncWorker
 import au.com.shiftyjelly.pocketcasts.engage.EngageSdkBridge
@@ -15,7 +16,6 @@ import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.appreview.AppReviewExceptionHandler
 import au.com.shiftyjelly.pocketcasts.repositories.appreview.AppReviewManager
-import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.EndOfYearSync
 import au.com.shiftyjelly.pocketcasts.repositories.file.FileStorage

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -60,6 +60,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.appreview.AppReviewDialogFragment
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.coroutines.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.databinding.ActivityMainBinding
 import au.com.shiftyjelly.pocketcasts.deeplink.AddBookmarkDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.AppOpenDeepLink
@@ -144,7 +145,6 @@ import au.com.shiftyjelly.pocketcasts.profile.sonos.SonosAppLinkActivity
 import au.com.shiftyjelly.pocketcasts.referrals.ReferralsGuestPassFragment
 import au.com.shiftyjelly.pocketcasts.repositories.appreview.AppReviewManager
 import au.com.shiftyjelly.pocketcasts.repositories.bumpstats.BumpStatsTask
-import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.di.NotificationPermissionChecker
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.EndOfYearManager
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationHelper

--- a/automotive/build.gradle.kts
+++ b/automotive/build.gradle.kts
@@ -109,6 +109,7 @@ dependencies {
     implementation(projects.modules.features.shared)
     implementation(projects.modules.services.analytics)
     implementation(projects.modules.services.compose)
+    implementation(projects.modules.services.coroutines)
     implementation(projects.modules.services.crashlogging)
     implementation(projects.modules.services.localization)
     implementation(projects.modules.services.mediaNoop)

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutoPlaybackService.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutoPlaybackService.kt
@@ -12,9 +12,9 @@ import androidx.core.os.bundleOf
 import androidx.media.utils.MediaConstants.DESCRIPTION_EXTRAS_KEY_CONTENT_STYLE_BROWSABLE
 import androidx.media.utils.MediaConstants.DESCRIPTION_EXTRAS_VALUE_CONTENT_STYLE_LIST_ITEM
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.coroutines.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.localization.helper.tryToLocalise
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImage
 import au.com.shiftyjelly.pocketcasts.repositories.lists.ListRepository
 import au.com.shiftyjelly.pocketcasts.repositories.playback.EXTRA_CONTENT_STYLE_GROUP_TITLE_HINT

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveApplication.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveApplication.kt
@@ -9,9 +9,9 @@ import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.experiments.ExperimentProvider
+import au.com.shiftyjelly.pocketcasts.coroutines.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.crashlogging.InitializeRemoteLogging
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.jobs.VersionMigrationsWorker
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsFragment.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsFragment.kt
@@ -20,6 +20,7 @@ import au.com.shiftyjelly.pocketcasts.account.AccountActivity
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.components.UserAvatarConfig
 import au.com.shiftyjelly.pocketcasts.compose.extensions.setContentWithViewCompositionStrategy
+import au.com.shiftyjelly.pocketcasts.coroutines.flow.windowed
 import au.com.shiftyjelly.pocketcasts.databinding.FragmentAutomotiveSettingsBinding
 import au.com.shiftyjelly.pocketcasts.models.type.SignInState
 import au.com.shiftyjelly.pocketcasts.profile.AccountDetailsFragment
@@ -35,7 +36,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.searchhistory.SearchHistoryMa
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.utils.Gravatar
-import au.com.shiftyjelly.pocketcasts.utils.extensions.windowed
 import au.com.shiftyjelly.pocketcasts.utils.toDurationFromNow
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint

--- a/modules/features/account/build.gradle.kts
+++ b/modules/features/account/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
     api(libs.moshi)
     api(libs.navigation.runtime)
 
+    api(projects.modules.services.coroutines)
     api(projects.modules.features.search)
     api(projects.modules.features.settings)
     api(projects.modules.services.analytics)

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/di/AuthModule.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/di/AuthModule.kt
@@ -1,7 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.account.di
 
 import android.content.Context
-import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
+import au.com.shiftyjelly.pocketcasts.coroutines.di.ApplicationScope
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.data.WearDataLayerRegistry
 import dagger.Module

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/di/AuthPhoneModule.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/di/AuthPhoneModule.kt
@@ -2,7 +2,7 @@ package au.com.shiftyjelly.pocketcasts.account.di
 
 import au.com.shiftyjelly.pocketcasts.account.watchsync.WatchSyncAuthData
 import au.com.shiftyjelly.pocketcasts.account.watchsync.WatchSyncAuthDataSerializer
-import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
+import au.com.shiftyjelly.pocketcasts.coroutines.di.ApplicationScope
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.auth.data.phone.tokenshare.TokenBundleRepository
 import com.google.android.horologist.auth.data.phone.tokenshare.impl.TokenBundleRepositoryImpl

--- a/modules/features/endofyear/build.gradle.kts
+++ b/modules/features/endofyear/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     api(libs.dagger.hilt.android)
 
     api(projects.modules.services.analytics)
+    api(projects.modules.services.coroutines)
     api(projects.modules.services.model)
     api(projects.modules.services.preferences)
     api(projects.modules.services.repositories)

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/EndOfYearViewModel.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/EndOfYearViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.coroutines.CachedAction
 import au.com.shiftyjelly.pocketcasts.endofyear.StoriesActivity.StoriesSource
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.Story
@@ -18,7 +19,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.endofyear.EndOfYearSync
 import au.com.shiftyjelly.pocketcasts.servers.list.ListServiceManager
 import au.com.shiftyjelly.pocketcasts.sharing.SharingRequest
 import au.com.shiftyjelly.pocketcasts.utils.accessibility.AccessibilityManager
-import au.com.shiftyjelly.pocketcasts.utils.coroutines.CachedAction
 import au.com.shiftyjelly.pocketcasts.utils.extensions.padEnd
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory

--- a/modules/features/engage/build.gradle.kts
+++ b/modules/features/engage/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     api(libs.dagger.hilt.android)
     api(libs.hilt.work)
 
+    api(projects.modules.services.coroutines)
     api(projects.modules.services.repositories)
 
     implementation(libs.coroutines.play.services)

--- a/modules/features/engage/src/main/kotlin/au/com/shiftyjelly/pocketcasts/engage/EngageSdkBridge.kt
+++ b/modules/features/engage/src/main/kotlin/au/com/shiftyjelly/pocketcasts/engage/EngageSdkBridge.kt
@@ -1,7 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.engage
 
 import android.content.Context
-import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
+import au.com.shiftyjelly.pocketcasts.coroutines.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.external.ExternalDataManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature

--- a/modules/features/filters/build.gradle.kts
+++ b/modules/features/filters/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
 
     api(projects.modules.features.podcasts)
     api(projects.modules.services.analytics)
+    api(projects.modules.services.coroutines)
     api(projects.modules.services.model)
     api(projects.modules.services.preferences)
     api(projects.modules.services.repositories)

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/CreatePlaylistViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/CreatePlaylistViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.compose.text.SearchFieldState
+import au.com.shiftyjelly.pocketcasts.coroutines.flow.combine
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.PlaylistEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.PlaylistEpisodeSortType
@@ -23,7 +24,6 @@ import au.com.shiftyjelly.pocketcasts.preferences.model.ArtworkConfiguration.Ele
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.Playlist.Type
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.SmartPlaylistDraft
-import au.com.shiftyjelly.pocketcasts.utils.extensions.combine
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsViewModel.kt
@@ -4,13 +4,13 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.coroutines.flow.combine
 import au.com.shiftyjelly.pocketcasts.playlists.component.PlaylistTooltip
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.Playlist
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistPreview
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
-import au.com.shiftyjelly.pocketcasts.utils.extensions.combine
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.milliseconds

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/smart/EditRulesViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/smart/EditRulesViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.compose.text.SearchFieldState
+import au.com.shiftyjelly.pocketcasts.coroutines.flow.combine
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.PlaylistEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.DownloadStatusRule
@@ -13,7 +14,6 @@ import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.ReleaseDateRule
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.model.ArtworkConfiguration.Element
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
-import au.com.shiftyjelly.pocketcasts.utils.extensions.combine
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject

--- a/modules/features/player/build.gradle.kts
+++ b/modules/features/player/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     api(projects.modules.features.transcripts)
     api(projects.modules.services.analytics)
     api(projects.modules.services.compose)
+    api(projects.modules.services.coroutines)
     api(projects.modules.services.localization)
     api(projects.modules.services.model)
     api(projects.modules.services.preferences)

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
@@ -11,6 +11,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.compose.PodcastColors
 import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.coroutines.flow.combine
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
@@ -29,7 +30,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
-import au.com.shiftyjelly.pocketcasts.utils.extensions.combine
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectBookmarksHelper
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectHelper

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ShelfSharedViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ShelfSharedViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.coroutines.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
@@ -12,7 +13,6 @@ import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.model.ShelfItem
 import au.com.shiftyjelly.pocketcasts.repositories.chromecast.ChromeCastAnalytics
-import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.ChapterManager

--- a/modules/features/podcasts/build.gradle.kts
+++ b/modules/features/podcasts/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
     api(projects.modules.features.transcripts)
     api(projects.modules.services.analytics)
     api(projects.modules.services.compose)
+    api(projects.modules.services.coroutines)
     api(projects.modules.services.localization)
     api(projects.modules.services.model)
     api(projects.modules.services.preferences)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
@@ -13,6 +13,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.compose.PodcastColors
+import au.com.shiftyjelly.pocketcasts.coroutines.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
 import au.com.shiftyjelly.pocketcasts.models.entity.Folder
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
@@ -30,7 +31,6 @@ import au.com.shiftyjelly.pocketcasts.preferences.model.BookmarksSortType
 import au.com.shiftyjelly.pocketcasts.preferences.model.BookmarksSortTypeForPodcast
 import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
 import au.com.shiftyjelly.pocketcasts.repositories.chromecast.CastManager
-import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationHelper
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager

--- a/modules/features/profile/build.gradle.kts
+++ b/modules/features/profile/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
     api(projects.modules.features.podcasts)
     api(projects.modules.features.settings)
     api(projects.modules.services.analytics)
+    api(projects.modules.services.coroutines)
     api(projects.modules.services.model)
     api(projects.modules.services.preferences)
     api(projects.modules.services.repositories)

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudBottomSheetViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudBottomSheetViewModel.kt
@@ -8,8 +8,8 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.coroutines.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
-import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadHelper
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager

--- a/modules/features/reimagine/build.gradle.kts
+++ b/modules/features/reimagine/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     api(libs.dagger.hilt.android)
 
     api(projects.modules.services.analytics)
+    api(projects.modules.services.coroutines)
     api(projects.modules.services.model)
     api(projects.modules.services.preferences)
     api(projects.modules.services.repositories)

--- a/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/clip/ShareClipViewModel.kt
+++ b/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/clip/ShareClipViewModel.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.reimagine.clip
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.coroutines.flow.combine
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -14,7 +15,6 @@ import au.com.shiftyjelly.pocketcasts.sharing.Clip
 import au.com.shiftyjelly.pocketcasts.sharing.SharingRequest
 import au.com.shiftyjelly.pocketcasts.sharing.SocialPlatform
 import au.com.shiftyjelly.pocketcasts.sharing.VisualCardType
-import au.com.shiftyjelly.pocketcasts.utils.extensions.combine
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject

--- a/modules/features/settings/build.gradle.kts
+++ b/modules/features/settings/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
 
     api(projects.modules.services.analytics)
     api(projects.modules.services.compose)
+    api(projects.modules.services.coroutines)
     api(projects.modules.services.model)
     api(projects.modules.services.preferences)
     api(projects.modules.services.repositories)

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/ExportSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/ExportSettingsFragment.kt
@@ -13,8 +13,8 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.preference.EditTextPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
+import au.com.shiftyjelly.pocketcasts.coroutines.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.opml.OpmlImportTask
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
@@ -41,10 +41,10 @@ import au.com.shiftyjelly.pocketcasts.compose.components.SettingSectionHeader
 import au.com.shiftyjelly.pocketcasts.compose.components.SettingsSection
 import au.com.shiftyjelly.pocketcasts.compose.extensions.contentWithoutConsumedInsets
 import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.coroutines.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.images.R
 import au.com.shiftyjelly.pocketcasts.models.to.PodcastGrouping
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.settings.notification.MediaActionsFragment
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoDownloadSettingsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoDownloadSettingsViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.coroutines.flow.combine
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.type.AutoDownloadLimitSetting
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -14,7 +15,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistPreview
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.SmartPlaylistPreview
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.settings.AutoDownloadSettingsRoute
-import au.com.shiftyjelly.pocketcasts.utils.extensions.combine
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers

--- a/modules/features/shared/build.gradle.kts
+++ b/modules/features/shared/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     api(libs.dagger.hilt.android)
 
     api(projects.modules.services.analytics)
+    api(projects.modules.services.coroutines)
     api(projects.modules.services.crashlogging)
     api(projects.modules.services.model)
     api(projects.modules.services.preferences)

--- a/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserver.kt
+++ b/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserver.kt
@@ -6,9 +6,9 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
 import au.com.shiftyjelly.pocketcasts.analytics.AppLifecycleAnalytics
+import au.com.shiftyjelly.pocketcasts.coroutines.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.ads.BlazeAdsManager
-import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationScheduler
 import au.com.shiftyjelly.pocketcasts.utils.AppPlatform
 import au.com.shiftyjelly.pocketcasts.utils.Util

--- a/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/DownloadStatisticsReporter.kt
+++ b/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/DownloadStatisticsReporter.kt
@@ -3,8 +3,8 @@ package au.com.shiftyjelly.pocketcasts.shared
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
+import au.com.shiftyjelly.pocketcasts.coroutines.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.models.db.dao.EpisodeDao
-import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.di.ProcessLifecycle
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject

--- a/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/NetworkConnectionWatcherImpl.kt
+++ b/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/NetworkConnectionWatcherImpl.kt
@@ -6,7 +6,7 @@ import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
 import androidx.annotation.VisibleForTesting
-import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
+import au.com.shiftyjelly.pocketcasts.coroutines.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.playback.NetworkConnectionWatcher
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject

--- a/modules/features/widgets/build.gradle.kts
+++ b/modules/features/widgets/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     api(libs.moshi)
 
     api(projects.modules.services.analytics)
+    api(projects.modules.services.coroutines)
     api(projects.modules.services.model)
     api(projects.modules.services.preferences)
     api(projects.modules.services.repositories)

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/PlayerWidgetManager.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/PlayerWidgetManager.kt
@@ -4,8 +4,8 @@ import android.content.Context
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.GlanceAppWidgetManager
 import androidx.glance.appwidget.updateAll
+import au.com.shiftyjelly.pocketcasts.coroutines.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
-import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.widget.data.ClassicPlayerWidgetState
 import au.com.shiftyjelly.pocketcasts.widget.data.LargePlayerWidgetState
 import au.com.shiftyjelly.pocketcasts.widget.data.MediumPlayerWidgetState

--- a/modules/services/coroutines/build.gradle.kts
+++ b/modules/services/coroutines/build.gradle.kts
@@ -1,0 +1,25 @@
+plugins {
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.hilt)
+}
+
+android {
+    namespace = "au.com.shiftyjelly.pocketcasts.coroutines"
+    buildFeatures {
+        buildConfig = true
+    }
+}
+
+dependencies {
+    ksp(libs.dagger.hilt.compiler)
+    ksp(libs.hilt.compiler)
+
+    api(libs.dagger.hilt.android)
+    api(libs.coroutines.core)
+
+    testImplementation(libs.coroutines.test)
+    testImplementation(libs.junit)
+    testImplementation(libs.turbine)
+}

--- a/modules/services/coroutines/src/main/kotlin/au/com/shiftyjelly/pocketcasts/coroutines/CachedAction.kt
+++ b/modules/services/coroutines/src/main/kotlin/au/com/shiftyjelly/pocketcasts/coroutines/CachedAction.kt
@@ -1,4 +1,4 @@
-package au.com.shiftyjelly.pocketcasts.utils.coroutines
+package au.com.shiftyjelly.pocketcasts.coroutines
 
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope

--- a/modules/services/coroutines/src/main/kotlin/au/com/shiftyjelly/pocketcasts/coroutines/SyncedAction.kt
+++ b/modules/services/coroutines/src/main/kotlin/au/com/shiftyjelly/pocketcasts/coroutines/SyncedAction.kt
@@ -1,4 +1,4 @@
-package au.com.shiftyjelly.pocketcasts.utils.coroutines
+package au.com.shiftyjelly.pocketcasts.coroutines
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart

--- a/modules/services/coroutines/src/main/kotlin/au/com/shiftyjelly/pocketcasts/coroutines/di/ApplicationScope.kt
+++ b/modules/services/coroutines/src/main/kotlin/au/com/shiftyjelly/pocketcasts/coroutines/di/ApplicationScope.kt
@@ -1,0 +1,11 @@
+package au.com.shiftyjelly.pocketcasts.coroutines.di
+
+import javax.inject.Qualifier
+
+/**
+ * Annotation for providing coroutine scope that lasts the entire time the application
+ * is running.
+ */
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class ApplicationScope

--- a/modules/services/coroutines/src/main/kotlin/au/com/shiftyjelly/pocketcasts/coroutines/di/CoroutinesModule.kt
+++ b/modules/services/coroutines/src/main/kotlin/au/com/shiftyjelly/pocketcasts/coroutines/di/CoroutinesModule.kt
@@ -1,0 +1,19 @@
+package au.com.shiftyjelly.pocketcasts.coroutines.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+
+@Module
+@InstallIn(SingletonComponent::class)
+class CoroutinesModule {
+    @Provides
+    @Singleton
+    @ApplicationScope
+    fun provideApplicationScope(): CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+}

--- a/modules/services/coroutines/src/main/kotlin/au/com/shiftyjelly/pocketcasts/coroutines/flow/MapState.kt
+++ b/modules/services/coroutines/src/main/kotlin/au/com/shiftyjelly/pocketcasts/coroutines/flow/MapState.kt
@@ -1,0 +1,40 @@
+package au.com.shiftyjelly.pocketcasts.coroutines.flow
+
+import kotlinx.coroutines.ExperimentalForInheritanceCoroutinesApi
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.StateFlow
+
+// Source: https://github.com/Kotlin/kotlinx.coroutines/issues/2631#issuecomment-2812699291
+@OptIn(ExperimentalForInheritanceCoroutinesApi::class)
+fun <T, R> StateFlow<T>.mapState(transform: (T) -> R): StateFlow<R> = object : StateFlow<R> {
+    override val replayCache: List<R> get() = listOf(value)
+
+    override suspend fun collect(collector: FlowCollector<R>): Nothing {
+        var lastEmittedValue: Any? = nullSurrogate
+        this@mapState.collect { newValue ->
+            val transformedValue = transform(newValue)
+            if (transformedValue != lastEmittedValue) {
+                lastEmittedValue = transformedValue
+                collector.emit(transformedValue)
+            }
+        }
+    }
+
+    private var lastUpstreamValue = this@mapState.value
+
+    override var value: R = transform(lastUpstreamValue)
+        private set
+        get() {
+            val currentUpstreamValue: T = this@mapState.value
+            if (currentUpstreamValue == lastUpstreamValue) {
+                return field
+            }
+
+            val newValue = transform(currentUpstreamValue)
+            field = newValue
+            lastUpstreamValue = currentUpstreamValue
+            return newValue
+        }
+}
+
+private val nullSurrogate = Any()

--- a/modules/services/coroutines/src/main/kotlin/au/com/shiftyjelly/pocketcasts/coroutines/flow/Windowed.kt
+++ b/modules/services/coroutines/src/main/kotlin/au/com/shiftyjelly/pocketcasts/coroutines/flow/Windowed.kt
@@ -1,0 +1,21 @@
+package au.com.shiftyjelly.pocketcasts.coroutines.flow
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+fun <T> Flow<T>.windowed(size: Int) = flow {
+    check(size > 0) { "Window size must be positive: $size" }
+    val queue = ArrayDeque<T>(size)
+    collect { item ->
+        if (queue.size < size) {
+            queue.addLast(item)
+            if (queue.size == size) {
+                emit(queue.toList())
+            }
+        } else {
+            queue.removeFirst()
+            queue.addLast(item)
+            emit(queue.toList())
+        }
+    }
+}

--- a/modules/services/coroutines/src/test/kotlin/au/com/shiftyjelly/pocketcasts/coroutines/CachedActionTest.kt
+++ b/modules/services/coroutines/src/test/kotlin/au/com/shiftyjelly/pocketcasts/coroutines/CachedActionTest.kt
@@ -1,4 +1,4 @@
-package au.com.shiftyjelly.pocketcasts.utils.coroutines
+package au.com.shiftyjelly.pocketcasts.coroutines
 
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancelAndJoin

--- a/modules/services/coroutines/src/test/kotlin/au/com/shiftyjelly/pocketcasts/coroutines/SyncedActionTest.kt
+++ b/modules/services/coroutines/src/test/kotlin/au/com/shiftyjelly/pocketcasts/coroutines/SyncedActionTest.kt
@@ -1,4 +1,4 @@
-package au.com.shiftyjelly.pocketcasts.utils.coroutines
+package au.com.shiftyjelly.pocketcasts.coroutines
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async

--- a/modules/services/coroutines/src/test/kotlin/au/com/shiftyjelly/pocketcasts/coroutines/flow/FlowWindowedTest.kt
+++ b/modules/services/coroutines/src/test/kotlin/au/com/shiftyjelly/pocketcasts/coroutines/flow/FlowWindowedTest.kt
@@ -1,4 +1,4 @@
-package au.com.shiftyjelly.pocketcasts.utils.extensions
+package au.com.shiftyjelly.pocketcasts.coroutines.flow
 
 import app.cash.turbine.test
 import kotlinx.coroutines.flow.MutableSharedFlow

--- a/modules/services/crashlogging/build.gradle.kts
+++ b/modules/services/crashlogging/build.gradle.kts
@@ -21,6 +21,8 @@ dependencies {
     api(libs.dagger.hilt.android)
     api(libs.encryptedlogging)
 
+    api(projects.modules.services.coroutines)
+
     implementation(projects.modules.services.utils)
 
     testImplementation(libs.coroutines.test)

--- a/modules/services/crashlogging/src/main/java/au/com/shiftyjelly/pocketcasts/crashlogging/di/CrashLoggingModule.kt
+++ b/modules/services/crashlogging/src/main/java/au/com/shiftyjelly/pocketcasts/crashlogging/di/CrashLoggingModule.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.crashlogging.di
 
 import android.app.Application
 import android.content.Context
+import au.com.shiftyjelly.pocketcasts.coroutines.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.crashlogging.BuildConfig
 import au.com.shiftyjelly.pocketcasts.crashlogging.BuildDataProvider
 import au.com.shiftyjelly.pocketcasts.crashlogging.ContextBasedLocaleProvider
@@ -19,6 +20,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import java.io.File
 import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -53,14 +55,14 @@ abstract class CrashLoggingModule {
         @Singleton
         internal fun provideCrashLogging(
             @ApplicationContext application: Context,
+            @ApplicationScope scope: CoroutineScope,
             crashLoggingDataProvider: PocketCastsCrashLoggingDataProvider,
-            provideApplicationScope: ProvideApplicationScope,
         ): CrashLogging {
             return FilteringCrashLogging(
                 CrashLoggingProvider.createInstance(
                     application as Application,
                     crashLoggingDataProvider,
-                    provideApplicationScope(),
+                    scope,
                 ),
             )
         }

--- a/modules/services/crashlogging/src/main/java/au/com/shiftyjelly/pocketcasts/crashlogging/di/ProvideApplicationScope.kt
+++ b/modules/services/crashlogging/src/main/java/au/com/shiftyjelly/pocketcasts/crashlogging/di/ProvideApplicationScope.kt
@@ -1,7 +1,0 @@
-package au.com.shiftyjelly.pocketcasts.crashlogging.di
-
-import kotlinx.coroutines.CoroutineScope
-
-fun interface ProvideApplicationScope {
-    operator fun invoke(): CoroutineScope
-}

--- a/modules/services/preferences/build.gradle.kts
+++ b/modules/services/preferences/build.gradle.kts
@@ -1,5 +1,3 @@
-import java.util.Properties
-
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
@@ -37,6 +35,7 @@ dependencies {
     implementation(libs.play.cast)
     implementation(libs.timber)
 
+    implementation(projects.modules.services.coroutines)
     implementation(projects.modules.services.images)
     implementation(projects.modules.services.localization)
 

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/UserSetting.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/UserSetting.kt
@@ -2,7 +2,7 @@ package au.com.shiftyjelly.pocketcasts.preferences
 
 import android.annotation.SuppressLint
 import android.content.SharedPreferences
-import au.com.shiftyjelly.pocketcasts.utils.extensions.mapState
+import au.com.shiftyjelly.pocketcasts.coroutines.flow.mapState
 import java.time.Clock
 import java.time.Instant
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/modules/services/repositories/build.gradle.kts
+++ b/modules/services/repositories/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
     api(libs.work.rx2)
 
     api(projects.modules.services.analytics)
+    api(projects.modules.services.coroutines)
     api(projects.modules.services.crashlogging)
     api(projects.modules.services.localization)
     api(projects.modules.services.model)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/categories/CategoriesManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/categories/CategoriesManager.kt
@@ -1,7 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.repositories.categories
 
+import au.com.shiftyjelly.pocketcasts.coroutines.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.models.db.dao.UserCategoryVisitsDao
-import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.lists.ListRepository
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/chromecast/ChromeCastAnalytics.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/chromecast/ChromeCastAnalytics.kt
@@ -2,7 +2,7 @@ package au.com.shiftyjelly.pocketcasts.repositories.chromecast
 
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
-import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
+import au.com.shiftyjelly.pocketcasts.coroutines.di.ApplicationScope
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/ProcessLifecycle.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/ProcessLifecycle.kt
@@ -3,14 +3,6 @@ package au.com.shiftyjelly.pocketcasts.repositories.di
 import javax.inject.Qualifier
 
 /**
- * Annotation for providing coroutine scope that lasts the entire time the application
- * is running. Essentially, this is the better form of GlobalScope.
- */
-@Qualifier
-@Retention(AnnotationRetention.BINARY)
-annotation class ApplicationScope
-
-/**
  * Annotation for providing lifecycle owner that is associated with the app's process.
  */
 @Qualifier

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/RepositoryProviderModule.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/RepositoryProviderModule.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
-import au.com.shiftyjelly.pocketcasts.crashlogging.di.ProvideApplicationScope
 import au.com.shiftyjelly.pocketcasts.payment.PaymentClient
 import au.com.shiftyjelly.pocketcasts.payment.PaymentDataSource
 import au.com.shiftyjelly.pocketcasts.repositories.lists.ListRepository
@@ -23,9 +22,6 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import javax.inject.Singleton
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -34,16 +30,6 @@ class RepositoryProviderModule {
     @Provides
     @Singleton
     fun provideTokenHandler(syncAccountManager: SyncAccountManager): TokenHandler = syncAccountManager
-
-    @Provides
-    @Singleton
-    @ApplicationScope
-    fun coroutineScope(): CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
-
-    @Provides
-    fun provideApplicationScope(
-        @ApplicationScope appScope: CoroutineScope,
-    ): ProvideApplicationScope = ProvideApplicationScope { appScope }
 
     @Provides
     @Singleton

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearSyncImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearSyncImpl.kt
@@ -1,13 +1,13 @@
 package au.com.shiftyjelly.pocketcasts.repositories.endofyear
 
+import au.com.shiftyjelly.pocketcasts.coroutines.CachedAction
+import au.com.shiftyjelly.pocketcasts.coroutines.run
 import au.com.shiftyjelly.pocketcasts.models.entity.UserPodcastRating
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.HistoryManager
 import au.com.shiftyjelly.pocketcasts.repositories.ratings.RatingsManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.servers.extensions.toDate
-import au.com.shiftyjelly.pocketcasts.utils.coroutines.CachedAction
-import au.com.shiftyjelly.pocketcasts.utils.coroutines.run
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -18,6 +18,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.coroutines.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.localization.BuildConfig
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
@@ -37,7 +38,6 @@ import au.com.shiftyjelly.pocketcasts.preferences.model.PlayOverNotificationSett
 import au.com.shiftyjelly.pocketcasts.repositories.R
 import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
 import au.com.shiftyjelly.pocketcasts.repositories.chromecast.CastManager
-import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.di.NotificationPermissionChecker
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadHelper.removeEpisodeFromQueue
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/DefaultPlaylistsStartupInitializer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/DefaultPlaylistsStartupInitializer.kt
@@ -2,7 +2,7 @@ package au.com.shiftyjelly.pocketcasts.repositories.playlist
 
 import android.content.Context
 import androidx.startup.Initializer
-import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
+import au.com.shiftyjelly.pocketcasts.coroutines.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.di.initializerEntryPoint
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistInteractionNotifier.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistInteractionNotifier.kt
@@ -1,8 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.repositories.playlist
 
+import au.com.shiftyjelly.pocketcasts.coroutines.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.models.db.dao.PlaylistDao
 import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
-import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationManager
 import au.com.shiftyjelly.pocketcasts.repositories.notification.OnboardingNotificationType
 import java.util.concurrent.atomic.AtomicBoolean

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.repositories.podcast
 
 import android.content.Context
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.coroutines.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
 import au.com.shiftyjelly.pocketcasts.models.entity.CuratedPodcast
 import au.com.shiftyjelly.pocketcasts.models.entity.Folder
@@ -18,7 +19,6 @@ import au.com.shiftyjelly.pocketcasts.models.type.EpisodesSortType
 import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
 import au.com.shiftyjelly.pocketcasts.models.type.TrimMode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadHelper
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.getUrlForArtwork

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/shortcuts/DynamicShortcutsSynchronizer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/shortcuts/DynamicShortcutsSynchronizer.kt
@@ -8,10 +8,10 @@ import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.core.content.getSystemService
 import androidx.room.concurrent.AtomicBoolean
+import au.com.shiftyjelly.pocketcasts.coroutines.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.deeplink.ShowPlaylistDeepLink
 import au.com.shiftyjelly.pocketcasts.models.db.dao.PlaylistDao
 import au.com.shiftyjelly.pocketcasts.models.to.PlaylistShortcut
-import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.shortcutDrawableId
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.Playlist
 import dagger.hilt.android.qualifiers.ApplicationContext

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/shownotes/ShowNotesManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/shownotes/ShowNotesManager.kt
@@ -1,7 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.repositories.shownotes
 
+import au.com.shiftyjelly.pocketcasts.coroutines.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.models.db.dao.TranscriptDao
-import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.servers.ShowNotesServiceManager
 import au.com.shiftyjelly.pocketcasts.servers.podcast.TranscriptService
 import au.com.shiftyjelly.pocketcasts.servers.shownotes.ShowNotesState

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
@@ -1,14 +1,14 @@
 package au.com.shiftyjelly.pocketcasts.repositories.subscription
 
+import au.com.shiftyjelly.pocketcasts.coroutines.SyncedAction
+import au.com.shiftyjelly.pocketcasts.coroutines.di.ApplicationScope
+import au.com.shiftyjelly.pocketcasts.coroutines.run
 import au.com.shiftyjelly.pocketcasts.models.type.Membership
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPlatform
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.servers.sync.toMembership
-import au.com.shiftyjelly.pocketcasts.utils.coroutines.SyncedAction
-import au.com.shiftyjelly.pocketcasts.utils.coroutines.run
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineScope

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
@@ -8,10 +8,10 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.analytics.TracksAnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.experiments.ExperimentProvider
+import au.com.shiftyjelly.pocketcasts.coroutines.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.models.db.dao.PlaylistDao
 import au.com.shiftyjelly.pocketcasts.models.type.SignInState
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.EndOfYearSync
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationScheduler
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationSchedulerImpl.Companion.TAG_TRENDING_RECOMMENDATIONS

--- a/modules/services/utils/build.gradle.kts
+++ b/modules/services/utils/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     api(libs.rx2.java)
     api(libs.timber)
 
+    api(projects.modules.services.coroutines)
     api(projects.modules.services.payment)
 
     implementation(platform(libs.compose.bom))

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/providers/FirebaseRemoteFeatureProvider.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/providers/FirebaseRemoteFeatureProvider.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.utils.featureflag.providers
 
+import au.com.shiftyjelly.pocketcasts.coroutines.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.utils.config.FirebaseConfig
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
@@ -13,26 +14,15 @@ import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
 @Singleton
-class FirebaseRemoteFeatureProvider(
+class FirebaseRemoteFeatureProvider @Inject constructor(
     private val firebaseRemoteConfig: FirebaseRemoteConfig,
-    private val scope: CoroutineScope,
+    @ApplicationScope private val scope: CoroutineScope,
 ) : FeatureProvider {
     private val initialFetchComplete = CompletableDeferred<Boolean>()
-
-    @Inject
-    constructor(firebaseRemoteConfig: FirebaseRemoteConfig) : this(
-        firebaseRemoteConfig,
-        @Suppress("OPT_IN_USAGE")
-        // Using GlobalScope here is perfectly fine. This type is instantiated as a singleton.
-        // We have @ApplicationScope but it lives in a different module which cannot be included here.
-        // GlobalScope and @ApplicationScope are effectively the same as they have the same lifetime.
-        GlobalScope,
-    )
 
     override val priority: Int = MAX_PRIORITY
 

--- a/modules/services/views/build.gradle.kts
+++ b/modules/services/views/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
 
     api(projects.modules.services.analytics)
     api(projects.modules.services.compose)
+    api(projects.modules.services.coroutines)
     api(projects.modules.services.model)
     api(projects.modules.services.preferences)
     api(projects.modules.services.repositories)

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/WarningsHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/WarningsHelper.kt
@@ -7,11 +7,11 @@ import androidx.fragment.app.Fragment
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.coroutines.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
@@ -23,7 +23,7 @@ import au.com.shiftyjelly.pocketcasts.views.dialog.ConfirmationDialog
 import au.com.shiftyjelly.pocketcasts.views.fragments.BatteryRestrictionsSettingsFragment
 import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.qualifiers.ActivityContext
-import java.util.*
+import java.util.Locale
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodesHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodesHelper.kt
@@ -11,12 +11,12 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.coroutines.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.localization.extensions.getStringPlural
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/swipe/SwipeActionViewModel.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/swipe/SwipeActionViewModel.kt
@@ -8,9 +8,9 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.coroutines.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
-import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -70,6 +70,7 @@ include(":modules:features:widgets")
 // services
 include(":modules:services:analytics")
 include(":modules:services:compose")
+include(":modules:services:coroutines")
 include(":modules:services:crashlogging")
 include(":modules:services:deeplink")
 include(":modules:services:images")

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -146,6 +146,7 @@ dependencies {
     implementation(projects.modules.features.shared)
     implementation(projects.modules.services.analytics)
     implementation(projects.modules.services.compose)
+    implementation(projects.modules.services.coroutines)
     implementation(projects.modules.services.crashlogging)
     implementation(projects.modules.services.images)
     implementation(projects.modules.services.localization)

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/di/WearNetworkModule.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/di/WearNetworkModule.kt
@@ -2,7 +2,7 @@ package au.com.shiftyjelly.pocketcasts.wear.di
 
 import android.content.Context
 import android.net.ConnectivityManager
-import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
+import au.com.shiftyjelly.pocketcasts.coroutines.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.servers.di.Downloads
 import au.com.shiftyjelly.pocketcasts.wear.networking.PocketCastsNetworkingRules
 import com.google.android.horologist.networks.data.RequestType

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeViewModel.kt
@@ -12,6 +12,8 @@ import androidx.palette.graphics.Palette
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.coroutines.di.ApplicationScope
+import au.com.shiftyjelly.pocketcasts.coroutines.flow.combine
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
@@ -19,7 +21,6 @@ import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
 import au.com.shiftyjelly.pocketcasts.profile.cloud.AddFileActivity
-import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextPosition
@@ -31,7 +32,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.shownotes.ShowNotesManager
 import au.com.shiftyjelly.pocketcasts.servers.shownotes.ShowNotesState
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
-import au.com.shiftyjelly.pocketcasts.utils.extensions.combine
 import au.com.shiftyjelly.pocketcasts.views.helper.CloudDeleteHelper
 import au.com.shiftyjelly.pocketcasts.wear.ui.player.AudioOutputSelectorHelper
 import au.com.shiftyjelly.pocketcasts.wear.ui.player.StreamingConfirmationScreen

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/NowPlayingViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/NowPlayingViewModel.kt
@@ -3,8 +3,8 @@ package au.com.shiftyjelly.pocketcasts.wear.ui.player
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.coroutines.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import com.google.android.horologist.media.ui.components.controls.SeekButtonIncrement


### PR DESCRIPTION
## Description

This PR extracts all high-level coroutine APIs into a separate `:modules:services:coroutines` project. Previously, these APIs lived either in `:utils` or `:repositories`. This change is necessary because requiring, for example, `@ApplicationScope` pulled in the `:repositories` module along with all of its dependencies. It also made it impossible to avoid cyclic dependencies in the old setup, which required some workarounds like using `GlobalScope` or creating custom interface like `ProvideApplicationScope`.

Relates to PCDROID-420

## Testing Instructions

There are no real code changes. Only structural ones to the Gradle projects. Green CI should be enough.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.