### PR TITLE
[Installments] Update plan id to `p1y-installments`

### DIFF
--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/Data.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/Data.kt
@@ -357,7 +357,7 @@ sealed interface SubscriptionPlan {
                 }
 
                 BillingCycle.Yearly -> if (isInstallment) {
-                    "p1-installment"
+                    "p1y-installments"
                 } else {
                     "p1y"
                 }

--- a/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/SubscriptionPlansTest.kt
+++ b/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/SubscriptionPlansTest.kt
@@ -411,7 +411,7 @@ class SubscriptionPlansTest {
         assertEquals(BillingCycle.Yearly, plan.billingCycle)
         assertTrue(plan.isInstallment)
         assertEquals(SubscriptionPlan.PLUS_YEARLY_INSTALLMENT_PRODUCT_ID, plan.productId)
-        assertEquals("p1-installment", plan.basePlanId)
+        assertEquals("p1y-installments", plan.basePlanId)
         assertEquals(infinitePricingPhase.price, plan.recurringPrice)
         assertNotNull(plan.installmentPlanDetails)
         assertEquals(12, plan.installmentPlanDetails!!.commitmentPaymentsCount)

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/extensions/PaymentExtensionsTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/extensions/PaymentExtensionsTest.kt
@@ -61,7 +61,7 @@ class PaymentExtensionsTest {
         name = "Plus Yearly Installment",
         pricingPlans = PricingPlans(
             basePlan = PricingPlan.Base(
-                planId = "p1-installment",
+                planId = "p1y-installments",
                 pricingPhases = listOf(installmentPricingPhase),
                 tags = emptyList(),
                 installmentPlanDetails = InstallmentPlanDetails(


### PR DESCRIPTION
## Description
Changed plan id. See discussion for details: p1770050420764929-slack-C0A0PJSLGBT

Fixes PCDROID-422

## Testing Instructions
1. Apply patch [debug-as-prod.patch](https://github.com/user-attachments/files/25044966/debug-as-prod.patch)
2. Build debug version and install it
3. Make sure Google Play Billing Lab is installed ([link](https://play.google.com/store/apps/details?id=com.google.android.apps.play.billingtestcompanion&hl=en))
4. Set country to Brazil or Spain or France or Italy in Play Lab
5. Launch PC app, get to the upgrade screen
6. Verify you're seeing the installment plan


## Screenshots or Screencast 
<img width="1080" height="2400" alt="Screenshot_20260203_130229" src="https://github.com/user-attachments/assets/028a7f31-8a6b-4188-8620-443741631a42" />


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 