### PR TITLE
Use Main dispatcher for audio ducking job

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/FocusManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/FocusManager.kt
@@ -11,8 +11,8 @@ import androidx.media.AudioManagerCompat
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.model.PlayOverNotificationSetting
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
+import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -25,6 +25,7 @@ class FocusManager(
     private val settings: Settings,
     private val focusChangeListener: FocusChangeListener,
     private val coroutineScope: CoroutineScope,
+    private val mainThreadContext: CoroutineContext,
 ) : AudioManager.OnAudioFocusChangeListener {
 
     companion object {
@@ -174,7 +175,7 @@ class FocusManager(
                 if (focusChange == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK && previousAudioFocus == AUDIO_FOCUSED) {
                     LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Audio focus lost (can duck). Delaying notification by ${DUCK_LOSS_DELAY_MS}ms")
                     pendingDuckLossJob?.cancel()
-                    pendingDuckLossJob = coroutineScope.launch(Dispatchers.Main) {
+                    pendingDuckLossJob = coroutineScope.launch(mainThreadContext) {
                         delay(DUCK_LOSS_DELAY_MS)
                         val playOverNotification = canDuck()
                         LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Audio focus lost (can duck) after delay. Play over notification: $playOverNotification, is transient: $isLostTransient")

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -163,7 +163,13 @@ open class PlaybackManager @Inject constructor(
     override val coroutineContext: CoroutineContext
         get() = Dispatchers.Default
 
-    private val focusManager = FocusManager(application, settings, this, applicationScope)
+    private val focusManager = FocusManager(
+        context = application,
+        settings = settings,
+        focusChangeListener = this,
+        coroutineScope = applicationScope,
+        mainThreadContext = Dispatchers.Main,
+    )
 
     private var audioNoisyManager = AudioNoisyManager(application)
 

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/FocusManagerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/FocusManagerTest.kt
@@ -7,6 +7,7 @@ import android.media.AudioManager
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.PlayOverNotificationSetting
+import kotlin.coroutines.EmptyCoroutineContext
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -34,7 +35,7 @@ class FocusManagerTest {
     @Test
     fun `audio focus regained within 200ms should not pause playback`() = runTest {
         val listener = mock<FocusManager.FocusChangeListener>()
-        val focusManager = FocusManager(context, settings, listener, this)
+        val focusManager = FocusManager(context, settings, listener, this, EmptyCoroutineContext)
 
         focusManager.onAudioFocusChange(AudioManager.AUDIOFOCUS_GAIN)
         focusManager.onAudioFocusChange(AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK)
@@ -51,7 +52,7 @@ class FocusManagerTest {
     @Test
     fun `audio focus lost for more than 200ms should pause playback`() = runTest {
         val listener = mock<FocusManager.FocusChangeListener>()
-        val focusManager = FocusManager(context, settings, listener, this)
+        val focusManager = FocusManager(context, settings, listener, this, EmptyCoroutineContext)
 
         focusManager.onAudioFocusChange(AudioManager.AUDIOFOCUS_GAIN)
         focusManager.onAudioFocusChange(AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK)
@@ -65,7 +66,7 @@ class FocusManagerTest {
     @Test
     fun `audio focus lost for exactly 200ms should pause playback`() = runTest {
         val listener = mock<FocusManager.FocusChangeListener>()
-        val focusManager = FocusManager(context, settings, listener, this)
+        val focusManager = FocusManager(context, settings, listener, this, EmptyCoroutineContext)
 
         focusManager.onAudioFocusChange(AudioManager.AUDIOFOCUS_GAIN)
         focusManager.onAudioFocusChange(AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK)
@@ -79,7 +80,7 @@ class FocusManagerTest {
     @Test
     fun `multiple rapid focus loss and gain should cancel previous jobs`() = runTest {
         val listener = mock<FocusManager.FocusChangeListener>()
-        val focusManager = FocusManager(context, settings, listener, this)
+        val focusManager = FocusManager(context, settings, listener, this, EmptyCoroutineContext)
 
         focusManager.onAudioFocusChange(AudioManager.AUDIOFOCUS_GAIN)
         focusManager.onAudioFocusChange(AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK)
@@ -102,7 +103,7 @@ class FocusManagerTest {
     @Test
     fun `non-duck audio focus loss should pause immediately`() = runTest {
         val listener = mock<FocusManager.FocusChangeListener>()
-        val focusManager = FocusManager(context, settings, listener, this)
+        val focusManager = FocusManager(context, settings, listener, this, EmptyCoroutineContext)
 
         focusManager.onAudioFocusChange(AudioManager.AUDIOFOCUS_GAIN)
         focusManager.onAudioFocusChange(AudioManager.AUDIOFOCUS_LOSS_TRANSIENT)
@@ -113,7 +114,7 @@ class FocusManagerTest {
     @Test
     fun `permanent audio focus loss should pause immediately`() = runTest {
         val listener = mock<FocusManager.FocusChangeListener>()
-        val focusManager = FocusManager(context, settings, listener, this)
+        val focusManager = FocusManager(context, settings, listener, this, EmptyCoroutineContext)
 
         focusManager.onAudioFocusChange(AudioManager.AUDIOFOCUS_GAIN)
         focusManager.onAudioFocusChange(AudioManager.AUDIOFOCUS_LOSS)
@@ -130,7 +131,7 @@ class FocusManagerTest {
             on { playOverNotification } doReturn duckSetting
         }
         val listener = mock<FocusManager.FocusChangeListener>()
-        val focusManager = FocusManager(context, settingsWithDuck, listener, this)
+        val focusManager = FocusManager(context, settingsWithDuck, listener, this, EmptyCoroutineContext)
 
         focusManager.onAudioFocusChange(AudioManager.AUDIOFOCUS_GAIN)
         focusManager.onAudioFocusChange(AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK)


### PR DESCRIPTION
## Description

The app crashes when the ducking job finishes because we interact with the player not on the main thread.

```
java.lang.IllegalStateException: Player is accessed on the wrong thread.
Current thread: 'DefaultDispatcher-worker-11'
Expected thread: 'main'
See https://developer.android.com/guide/topics/media/issues/player-accessed-on-wrong-thread
  at androidx.media3.exoplayer.ExoPlayerImpl.verifyApplicationThread(ExoPlayerImpl.java:3102)
  at androidx.media3.exoplayer.ExoPlayerImpl.setVolume(ExoPlayerImpl.java:1647)
  at au.com.shiftyjelly.pocketcasts.repositories.playback.SimplePlayer.setVolume(SimplePlayer.kt:169)
  at au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager.onFocusLoss(PlaybackManager.kt:1588)
  at au.com.shiftyjelly.pocketcasts.repositories.playback.FocusManager$onAudioFocusChange$1.invokeSuspend(FocusManager.java:180)
  at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:34)
  at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
  at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:586)
  at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:829)
  at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:717)
  at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:704)
```

Closes PCDROID-423

## Testing Instructions

1. Play something.
2. Trigger a notification that will finish ducking job. Something like directions in Google Maps, etc.
3. The app should not crash.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack