### PR TITLE
Add download progress cache

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadProgressCache.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadProgressCache.kt
@@ -1,0 +1,32 @@
+package au.com.shiftyjelly.pocketcasts.repositories.download
+
+import au.com.shiftyjelly.pocketcasts.coroutines.flow.mapState
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.math.roundToInt
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+
+@Singleton
+class DownloadProgressCache @Inject constructor() {
+    private val cache = MutableStateFlow(emptyMap<String, Double?>())
+
+    fun progressFlow(episodeUuid: String): StateFlow<Double?> {
+        return cache.mapState { data ->
+            when (val value = data[episodeUuid]) {
+                null, 0.0, 1.0 -> value
+                else -> (value * 100).roundToInt() / 100.0
+            }
+        }
+    }
+
+    fun updateProgress(episodeUuid: String, progress: Double) {
+        val value = progress.coerceIn(0.0, 1.0)
+        cache.update { data -> data + (episodeUuid to value) }
+    }
+
+    fun clearProgress(episodeUuid: String) {
+        cache.update { data -> data - episodeUuid }
+    }
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/ReadListeningSource.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/ReadListeningSource.kt
@@ -1,0 +1,29 @@
+package au.com.shiftyjelly.pocketcasts.repositories.download
+
+import okio.Buffer
+import okio.Source
+
+fun Source.withReadListener(onReadByteCount: (Long) -> Unit): Source = ReadListeningSource(this, onReadByteCount)
+
+private class ReadListeningSource(
+    private val upstream: Source,
+    private val onReadByteCount: (Long) -> Unit,
+) : Source {
+    private var totalBytesRead = 0L
+
+    override fun read(sink: Buffer, byteCount: Long): Long {
+        val bytesRead = upstream.read(sink, byteCount)
+
+        if (totalBytesRead == 0L && bytesRead == -1L) {
+            onReadByteCount(0)
+        } else if (bytesRead != -1L) {
+            totalBytesRead += bytesRead
+            onReadByteCount(totalBytesRead)
+        }
+        return bytesRead
+    }
+
+    override fun close() = upstream.close()
+
+    override fun timeout() = upstream.timeout()
+}

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadProgressCacheTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadProgressCacheTest.kt
@@ -1,0 +1,74 @@
+package au.com.shiftyjelly.pocketcasts.repositories.download
+
+import app.cash.turbine.test
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DownloadProgressCacheTest {
+    private val cache = DownloadProgressCache()
+
+    @Test
+    fun `update progress`() = runTest {
+        cache.progressFlow("episode-id").test {
+            assertEquals(null, awaitItem())
+
+            cache.updateProgress("episode-id", 0.3)
+            assertEquals(0.3, awaitItem()!!, 0.001)
+
+            cache.updateProgress("episode-id", 0.5)
+            assertEquals(0.5, awaitItem()!!, 0.001)
+
+            cancel()
+        }
+    }
+
+    @Test
+    fun `do not update progress for small increments`() = runTest {
+        cache.progressFlow("episode-id").test {
+            assertEquals(null, awaitItem())
+
+            cache.updateProgress("episode-id", 0.001)
+            assertEquals(0.0, awaitItem()!!, 0.001)
+
+            cache.updateProgress("episode-id", 0.004)
+            expectNoEvents()
+
+            cache.updateProgress("episode-id", 0.005)
+            assertEquals(0.01, awaitItem()!!, 0.001)
+
+            cancel()
+        }
+    }
+
+    @Test
+    fun `track progress separately for different episodes`() = runTest {
+        cache.updateProgress("episode-id-1", 0.5)
+        cache.updateProgress("episode-id-2", 0.4)
+
+        assertEquals(0.5, cache.progressFlow("episode-id-1").value!!, 0.001)
+        assertEquals(0.4, cache.progressFlow("episode-id-2").value!!, 0.001)
+    }
+
+    @Test
+    fun `coerce min progress to 0`() = runTest {
+        cache.updateProgress("episode-id", -0.1)
+
+        assertEquals(0.0, cache.progressFlow("episode-id").value!!, 0.001)
+    }
+
+    @Test
+    fun `coerce max progress to 1`() = runTest {
+        cache.updateProgress("episode-id", 1.1)
+
+        assertEquals(1.0, cache.progressFlow("episode-id").value!!, 0.001)
+    }
+
+    @Test
+    fun `clear progress`() = runTest {
+        cache.updateProgress("episode-id", 0.5)
+        cache.clearProgress("episode-id")
+
+        assertEquals(null, cache.progressFlow("episode-id").value)
+    }
+}

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/download/ReadListeningSourceTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/download/ReadListeningSourceTest.kt
@@ -1,0 +1,59 @@
+package au.com.shiftyjelly.pocketcasts.repositories.download
+
+import kotlin.random.Random
+import okio.Buffer
+import okio.ByteString
+import okio.Source
+import okio.blackholeSink
+import okio.buffer
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ReadListeningSourceTest {
+    @Test
+    fun `read full content`() {
+        var bytesRead = 0L
+        val contentLength = 3 * OKIO_SEGMENT_SIZE
+
+        TestSource(contentLength.toInt()).withReadListener { bytesRead = it }.buffer().use { source ->
+            source.readAll(blackholeSink())
+        }
+
+        assertEquals(contentLength, bytesRead)
+    }
+
+    @Test
+    fun `read content progressively`() {
+        val bytesRead = mutableListOf<Long>()
+        val contentLength = 150 + 2 * OKIO_SEGMENT_SIZE
+
+        TestSource(contentLength.toInt()).withReadListener { bytesRead += it }.buffer().use { source ->
+            source.readByteString(byteCount = OKIO_SEGMENT_SIZE)
+            source.readByteString(byteCount = OKIO_SEGMENT_SIZE)
+            source.readByteString()
+        }
+
+        assertEquals(
+            listOf(
+                OKIO_SEGMENT_SIZE,
+                OKIO_SEGMENT_SIZE * 2,
+                contentLength,
+            ),
+            bytesRead,
+        )
+    }
+}
+
+private const val OKIO_SEGMENT_SIZE = 8_192L
+
+private class TestSource(
+    contentLength: Int,
+) : Source {
+    private val content = Buffer().write(Random.nextBytes(contentLength))
+
+    override fun read(sink: Buffer, byteCount: Long): Long = content.read(sink, byteCount)
+
+    override fun close() = content.close()
+
+    override fun timeout() = content.timeout()
+}


### PR DESCRIPTION
## Description

This adds some base classes to improve downloads. Right now downloads code is hard to understand and there are many indirection layers. I can't even think of a way to incorporate this code into current downloads. So I'll be submitting smaller pieces of code until it can be integrated with the app.

Relates to PCDROID-429

## Testing Instructions

There is no integration of this code. Green CI is enough.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack