### PR TITLE
Add download progress logic

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadProgressCache.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadProgressCache.kt
@@ -1,0 +1,44 @@
+package au.com.shiftyjelly.pocketcasts.repositories.download
+
+import au.com.shiftyjelly.pocketcasts.coroutines.flow.mapState
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.math.roundToInt
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+
+@Singleton
+class DownloadProgressCache @Inject constructor() {
+    private val _cache = MutableStateFlow(emptyMap<String, DownloadProgress>())
+
+    val progressFlow: StateFlow<Map<String, DownloadProgress>> get() = _cache
+
+    fun progressFlow(episodeUuid: String): StateFlow<DownloadProgress?> {
+        return _cache.mapState { data -> data[episodeUuid] }
+    }
+
+    fun updateProgress(episodeUuid: String, downloadedByteCount: Long, contentLength: Long?) {
+        val progress = DownloadProgress(
+            downloadedByteCount = downloadedByteCount,
+            contentLength = contentLength,
+        )
+        _cache.update { data -> data + (episodeUuid to progress) }
+    }
+
+    fun clearProgress(episodeUuid: String) {
+        _cache.update { data -> data - episodeUuid }
+    }
+}
+
+data class DownloadProgress(
+    val downloadedByteCount: Long,
+    val contentLength: Long?,
+) {
+    val progress = if (contentLength != null && contentLength > 0L && downloadedByteCount >= 0L) {
+        val percentage = downloadedByteCount.toDouble() / contentLength
+        (percentage * 100).roundToInt().coerceAtMost(100)
+    } else {
+        null
+    }
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/ReadListeningSource.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/ReadListeningSource.kt
@@ -1,0 +1,29 @@
+package au.com.shiftyjelly.pocketcasts.repositories.download
+
+import okio.Buffer
+import okio.Source
+
+fun Source.withReadListener(onReadByteCount: (Long) -> Unit): Source = ReadListeningSource(this, onReadByteCount)
+
+private class ReadListeningSource(
+    private val upstream: Source,
+    private val onReadByteCount: (Long) -> Unit,
+) : Source {
+    private var totalBytesRead = 0L
+
+    override fun read(sink: Buffer, byteCount: Long): Long {
+        val bytesRead = upstream.read(sink, byteCount)
+
+        if (totalBytesRead == 0L && bytesRead == -1L) {
+            onReadByteCount(0)
+        } else if (bytesRead != -1L) {
+            totalBytesRead += bytesRead
+            onReadByteCount(totalBytesRead)
+        }
+        return bytesRead
+    }
+
+    override fun close() = upstream.close()
+
+    override fun timeout() = upstream.timeout()
+}

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadProgressCacheTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadProgressCacheTest.kt
@@ -1,0 +1,44 @@
+package au.com.shiftyjelly.pocketcasts.repositories.download
+
+import app.cash.turbine.test
+import junit.framework.TestCase.assertNull
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DownloadProgressCacheTest {
+    private val cache = DownloadProgressCache()
+
+    @Test
+    fun `update progress`() = runTest {
+        cache.progressFlow("episode-id").test {
+            assertNull(awaitItem())
+
+            cache.updateProgress("episode-id", 30, 100)
+            assertEquals(DownloadProgress(30, 100), awaitItem())
+
+            cache.updateProgress("episode-id", 50, 100)
+            assertEquals(DownloadProgress(50, 100), awaitItem())
+
+            cancel()
+        }
+    }
+
+    @Test
+    fun `track progress separately for different episodes`() = runTest {
+        cache.updateProgress("episode-id-1", 11, 200)
+        cache.updateProgress("episode-id-2", 77, 100)
+
+        assertEquals(DownloadProgress(11, 200), cache.progressFlow("episode-id-1").value)
+        assertEquals(DownloadProgress(77, 100), cache.progressFlow("episode-id-2").value)
+    }
+
+    @Test
+    fun `clear progress`() = runTest {
+        cache.updateProgress("episode-id", 15, 100)
+
+        cache.clearProgress("episode-id")
+
+        assertNull(cache.progressFlow("episode-id").value)
+    }
+}

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadProgressTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadProgressTest.kt
@@ -1,0 +1,67 @@
+package au.com.shiftyjelly.pocketcasts.repositories.download
+
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertNull
+import org.junit.Test
+
+class DownloadProgressTest {
+    @Test
+    fun `calculate progress`() {
+        val value = DownloadProgress(
+            downloadedByteCount = 372,
+            contentLength = 1000,
+        )
+
+        assertEquals(37, value.progress)
+    }
+
+    @Test
+    fun `limit max progress at 100`() {
+        val value = DownloadProgress(
+            downloadedByteCount = 1000,
+            contentLength = 100,
+        )
+
+        assertEquals(100, value.progress)
+    }
+
+    @Test
+    fun `do not compute progress for negative bytes count`() {
+        val value = DownloadProgress(
+            downloadedByteCount = -100,
+            contentLength = 100,
+        )
+
+        assertNull(value.progress)
+    }
+
+    @Test
+    fun `do not compute progress for negative content length`() {
+        val value = DownloadProgress(
+            downloadedByteCount = 100,
+            contentLength = -100,
+        )
+
+        assertNull(value.progress)
+    }
+
+    @Test
+    fun `do not compute progress for 0 content length`() {
+        val value = DownloadProgress(
+            downloadedByteCount = 100,
+            contentLength = 0,
+        )
+
+        assertNull(value.progress)
+    }
+
+    @Test
+    fun `do not compute progress for null content length`() {
+        val value = DownloadProgress(
+            downloadedByteCount = 100,
+            contentLength = null,
+        )
+
+        assertNull(value.progress)
+    }
+}

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/download/ReadListeningSourceTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/download/ReadListeningSourceTest.kt
@@ -1,0 +1,59 @@
+package au.com.shiftyjelly.pocketcasts.repositories.download
+
+import kotlin.random.Random
+import okio.Buffer
+import okio.ByteString
+import okio.Source
+import okio.blackholeSink
+import okio.buffer
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ReadListeningSourceTest {
+    @Test
+    fun `read full content`() {
+        var bytesRead = 0L
+        val contentLength = 3 * OKIO_SEGMENT_SIZE
+
+        TestSource(contentLength.toInt()).withReadListener { bytesRead = it }.buffer().use { source ->
+            source.readAll(blackholeSink())
+        }
+
+        assertEquals(contentLength, bytesRead)
+    }
+
+    @Test
+    fun `read content progressively`() {
+        val bytesRead = mutableListOf<Long>()
+        val contentLength = 150 + 2 * OKIO_SEGMENT_SIZE
+
+        TestSource(contentLength.toInt()).withReadListener { bytesRead += it }.buffer().use { source ->
+            source.readByteString(byteCount = OKIO_SEGMENT_SIZE)
+            source.readByteString(byteCount = OKIO_SEGMENT_SIZE)
+            source.readByteString()
+        }
+
+        assertEquals(
+            listOf(
+                OKIO_SEGMENT_SIZE,
+                OKIO_SEGMENT_SIZE * 2,
+                contentLength,
+            ),
+            bytesRead,
+        )
+    }
+}
+
+private const val OKIO_SEGMENT_SIZE = 8_192L
+
+private class TestSource(
+    contentLength: Int,
+) : Source {
+    private val content = Buffer().write(Random.nextBytes(contentLength))
+
+    override fun read(sink: Buffer, byteCount: Long): Long = content.read(sink, byteCount)
+
+    override fun close() = content.close()
+
+    override fun timeout() = content.timeout()
+}


### PR DESCRIPTION
## Description

This adds some base classes to improve downloads. These particular ones will allows us to monitor download progress reliably. Right now downloads code is hard to understand and there are many indirection layers. I can't even think of a way to incorporate this code into current downloads. So I'll be submitting smaller pieces of code until it can be integrated with the app.

Relates to PCDROID-429

## Testing Instructions

There is no integration of this code. Green CI is enough.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack