### PR TITLE
Add waiting for storage download status

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/EpisodeDaoDownloadStatusTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/EpisodeDaoDownloadStatusTest.kt
@@ -84,6 +84,17 @@ class EpisodeDaoDownloadStatusTest {
     }
 
     @Test
+    fun updateDownloadStatusToWaitingForStorage() = runTest {
+        episodeDao.updateDownloadStatuses(mapOf(episode.uuid to DownloadStatusUpdate.WaitingForStorage))
+
+        val result = episodeDao.findByUuid(episode.uuid)!!
+
+        assertEquals(EpisodeDownloadStatus.WaitingForStorage, result.downloadStatus)
+        assertEquals(null, result.downloadedFilePath)
+        assertEquals(null, result.downloadErrorDetails)
+    }
+
+    @Test
     fun updateDownloadStatusToEnqueued() = runTest {
         episodeDao.updateDownloadStatuses(mapOf(episode.uuid to DownloadStatusUpdate.Enqueued))
 

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/UserEpisodeDaoDownloadStatusTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/UserEpisodeDaoDownloadStatusTest.kt
@@ -84,6 +84,17 @@ class UserEpisodeDaoDownloadStatusTest {
     }
 
     @Test
+    fun updateDownloadStatusToWaitingForStorage() = runTest {
+        userEpisodeDao.updateDownloadStatuses(mapOf(episode.uuid to DownloadStatusUpdate.WaitingForStorage))
+
+        val result = userEpisodeDao.findEpisodeByUuid(episode.uuid)!!
+
+        assertEquals(EpisodeDownloadStatus.WaitingForStorage, result.downloadStatus)
+        assertEquals(null, result.downloadedFilePath)
+        assertEquals(null, result.downloadErrorDetails)
+    }
+
+    @Test
     fun updateDownloadStatusToEnqueued() = runTest {
         userEpisodeDao.updateDownloadStatuses(mapOf(episode.uuid to DownloadStatusUpdate.Enqueued))
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -320,13 +320,17 @@ class EpisodeFragment : BaseFragment() {
                         val playbackError = state.episode.playErrorDetails
 
                         if (playbackError == null) {
-                            binding.errorLayout.isVisible = episodeStatus == EpisodeDownloadStatus.DownloadFailed || episodeStatus == EpisodeDownloadStatus.WaitingForPower || episodeStatus == EpisodeDownloadStatus.WaitingForWifi
+                            binding.errorLayout.isVisible = episodeStatus == EpisodeDownloadStatus.DownloadFailed ||
+                                episodeStatus == EpisodeDownloadStatus.WaitingForPower ||
+                                episodeStatus == EpisodeDownloadStatus.WaitingForWifi ||
+                                episodeStatus == EpisodeDownloadStatus.WaitingForStorage
                             binding.lblErrorDetail.isVisible = false
 
                             binding.lblError.text = when (episodeStatus) {
                                 EpisodeDownloadStatus.DownloadFailed -> getString(LR.string.podcasts_download_failed)
                                 EpisodeDownloadStatus.WaitingForWifi -> getString(LR.string.podcasts_download_wifi)
                                 EpisodeDownloadStatus.WaitingForPower -> getString(LR.string.podcasts_download_power)
+                                EpisodeDownloadStatus.WaitingForStorage -> getString(LR.string.podcasts_download_storage)
                                 else -> null
                             }
                             if (episodeStatus == EpisodeDownloadStatus.DownloadFailed) {
@@ -337,6 +341,7 @@ class EpisodeFragment : BaseFragment() {
                                 EpisodeDownloadStatus.DownloadFailed -> IR.drawable.ic_failedwarning
                                 EpisodeDownloadStatus.WaitingForWifi -> IR.drawable.ic_waitingforwifi
                                 EpisodeDownloadStatus.WaitingForPower -> IR.drawable.ic_waitingforpower
+                                EpisodeDownloadStatus.WaitingForStorage -> IR.drawable.ic_waitingforstorage
                                 else -> null
                             }
                             if (iconResource != null) {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/BaseEpisodeViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/BaseEpisodeViewHolder.kt
@@ -229,6 +229,12 @@ abstract class BaseEpisodeViewHolder<T : Any>(
                 iconId = IR.drawable.ic_waitingforpower,
                 iconTint = primaryIcon02Tint,
             )
+        } else if (episode.isWaitingForStorage) {
+            bindStatus(
+                text = context.getString(LR.string.episode_row_waiting_for_storage),
+                iconId = IR.drawable.ic_waitingforstorage,
+                iconTint = primaryIcon02Tint,
+            )
         } else if (episode.isWaitingForWifi) {
             bindStatus(
                 text = context.getString(LR.string.episode_row_waiting_for_wifi),

--- a/modules/services/images/src/main/res/drawable/ic_waitingforstorage.xml
+++ b/modules/services/images/src/main/res/drawable/ic_waitingforstorage.xml
@@ -1,0 +1,16 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M7.8284,5L6,6.8284L6,19L18,19L18,5L7.8284,5ZM7,3L17.9972,3C19.1033,3 20,3.8926 20,4.9951L20,19.0049C20,20.1068 19.1055,21 18.0059,21L5.9941,21C4.8928,21 4,20.1066 4,19.0081L4,6L7,3Z"
+      android:fillColor="#000"
+      android:fillType="nonZero"/>
+  <path
+      android:pathData="M9,6.9998C9,6.4476 9.4439,6 10,6C10.5523,6 11,6.4437 11,6.9998L11,10.0002C11,10.5524 10.5561,11 10,11C9.4477,11 9,10.5563 9,10.0002L9,6.9998ZM12,6.9998C12,6.4476 12.4439,6 13,6C13.5523,6 14,6.4437 14,6.9998L14,10.0002C14,10.5524 13.5561,11 13,11C12.4477,11 12,10.5563 12,10.0002L12,6.9998ZM15,6.9998C15,6.4476 15.4439,6 16,6C16.5523,6 17,6.4437 17,6.9998L17,10.0002C17,10.5524 16.5561,11 16,11C15.4477,11 15,10.5563 15,10.0002L15,6.9998Z"
+      android:strokeAlpha="0.5"
+      android:fillColor="#000"
+      android:fillType="evenOdd"
+      android:fillAlpha="0.5"/>
+</vector>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -511,6 +511,7 @@
     <string name="podcasts_download_download" translatable="false">@string/download</string>
     <string name="podcasts_download_failed">Download Failed</string>
     <string name="podcasts_download_power">Auto download waiting for power</string>
+    <string name="podcasts_download_storage">Download waiting for storage space</string>
     <string name="podcasts_download_queued">Queued</string>
     <string name="podcasts_download_retry" translatable="false">@string/retry</string>
     <string name="podcasts_download_wifi">Auto download waiting for WiFi</string>
@@ -831,6 +832,7 @@
     <string name="episode_row_queued_upload">Queued for upload</string>
     <string name="episode_row_uploading">Uploading&#x2026; (%d%%)</string>
     <string name="episode_row_waiting_for_power">Waiting for power</string>
+    <string name="episode_row_waiting_for_storage">Waiting for storage space</string>
     <string name="episode_row_waiting_for_wifi">Waiting for WiFi</string>
     <string name="episode_sort_custom_order">Custom order</string>
     <string name="episode_sort_long_to_short">Longest to shortest</string>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/converter/EpisodeDownloadStatusConverter.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/converter/EpisodeDownloadStatusConverter.kt
@@ -8,6 +8,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.EpisodeDownloadStatus.Download
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeDownloadStatus.Downloading
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeDownloadStatus.Queued
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeDownloadStatus.WaitingForPower
+import au.com.shiftyjelly.pocketcasts.models.type.EpisodeDownloadStatus.WaitingForStorage
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeDownloadStatus.WaitingForWifi
 
 class EpisodeDownloadStatusConverter {
@@ -35,6 +36,7 @@ private val EpisodeDownloadStatus.dbValue get() = when (this) {
     Downloaded -> 4
     WaitingForWifi -> 5
     WaitingForPower -> 6
+    WaitingForStorage -> 7
 }
 
 private val DB_VALUE_MAP = EpisodeDownloadStatus.entries.associateBy { it.dbValue }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/BaseEpisode.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/BaseEpisode.kt
@@ -80,6 +80,9 @@ sealed interface BaseEpisode {
     val isWaitingForPower
         get() = downloadStatus == EpisodeDownloadStatus.WaitingForPower
 
+    val isWaitingForStorage
+        get() = downloadStatus == EpisodeDownloadStatus.WaitingForStorage
+
     val isDownloadPending
         get() = downloadStatus.isPending
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/DownloadStatusUpdate.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/DownloadStatusUpdate.kt
@@ -25,6 +25,12 @@ sealed interface DownloadStatusUpdate {
         override val errorMessage get() = null
     }
 
+    data object WaitingForStorage : DownloadStatusUpdate {
+        override val episodeStatus get() = EpisodeDownloadStatus.WaitingForStorage
+        override val outputFile get() = null
+        override val errorMessage get() = null
+    }
+
     data object Enqueued : DownloadStatusUpdate {
         override val episodeStatus get() = EpisodeDownloadStatus.Queued
         override val outputFile get() = null

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/EpisodeDownloadStatus.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/EpisodeDownloadStatus.kt
@@ -20,6 +20,10 @@ enum class EpisodeDownloadStatus(
         isCancellable = true,
         isPending = true,
     ),
+    WaitingForStorage(
+        isCancellable = true,
+        isPending = true,
+    ),
     Downloading(
         isCancellable = true,
         isPending = false,

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SmartRules.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SmartRules.kt
@@ -80,17 +80,8 @@ data class SmartRules(
         override fun toSqlWhereClause(clock: Clock) = buildString {
             val statuses = when (this@DownloadStatusRule) {
                 Any -> return@buildString
-
                 Downloaded -> listOf(EpisodeDownloadStatus.Downloaded)
-
-                NotDownloaded -> listOf(
-                    EpisodeDownloadStatus.Downloading,
-                    EpisodeDownloadStatus.Queued,
-                    EpisodeDownloadStatus.WaitingForPower,
-                    EpisodeDownloadStatus.WaitingForWifi,
-                    EpisodeDownloadStatus.DownloadNotRequested,
-                    EpisodeDownloadStatus.DownloadFailed,
-                )
+                NotDownloaded -> EpisodeDownloadStatus.entries - EpisodeDownloadStatus.Downloaded
             }
             append("episode.episode_status IN (")
             val converter = EpisodeDownloadStatusConverter()

--- a/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/type/SmartRulesTest.kt
+++ b/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/type/SmartRulesTest.kt
@@ -102,7 +102,7 @@ class SmartRulesTest {
 
         val clause = rule.toSqlWhereClause(clock)
 
-        assertEquals("episode.episode_status IN (2,1,6,5,0,3)", clause)
+        assertEquals("episode.episode_status IN (0,1,5,6,7,2,3)", clause)
     }
 
     @Test

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadEpisodeWorker.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadEpisodeWorker.kt
@@ -282,7 +282,7 @@ class DownloadEpisodeWorker @AssistedInject constructor(
         val waitForPower: Boolean,
     )
 
-    companion object Companion {
+    companion object {
         private const val WORKER_TAG = "EpisodeDownloadWorker"
 
         fun episodeWorkerName(episodeUuid: String) = "$WORKER_TAG:$episodeUuid"

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/component/FileStatusIconsView.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/component/FileStatusIconsView.kt
@@ -115,6 +115,13 @@ class FileStatusIconsView @JvmOverloads constructor(
                     imgIcon.setImageResource(IR.drawable.ic_waitingforpower)
                     lblStatus.text = context.getString(LR.string.episode_row_waiting_for_power)
                     ImageViewCompat.setImageTintList(imgIcon, ColorStateList.valueOf(iconColor))
+                } else if (episode.isWaitingForStorage) {
+                    imgIcon.isVisible = true
+                    progressBar.isVisible = false
+                    progressCircle.isVisible = false
+                    imgIcon.setImageResource(IR.drawable.ic_waitingforstorage)
+                    lblStatus.text = context.getString(LR.string.episode_row_waiting_for_storage)
+                    ImageViewCompat.setImageTintList(imgIcon, ColorStateList.valueOf(iconColor))
                 } else if (episode.isWaitingForWifi) {
                     imgIcon.isVisible = true
                     progressBar.isVisible = false

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeScreen.kt
@@ -135,6 +135,7 @@ fun EpisodeScreen(
                         EpisodeDownloadStatus.Queued,
                         EpisodeDownloadStatus.WaitingForWifi,
                         EpisodeDownloadStatus.WaitingForPower,
+                        EpisodeDownloadStatus.WaitingForStorage,
                         -> DownloadButtonState.Queued
 
                         EpisodeDownloadStatus.Downloading -> DownloadButtonState.Downloading(

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeViewModel.kt
@@ -200,6 +200,7 @@ class EpisodeViewModel @Inject constructor(
                 EpisodeDownloadStatus.DownloadFailed -> LR.string.podcasts_download_failed
                 EpisodeDownloadStatus.WaitingForWifi -> LR.string.podcasts_download_wifi
                 EpisodeDownloadStatus.WaitingForPower -> LR.string.podcasts_download_power
+                EpisodeDownloadStatus.WaitingForStorage -> LR.string.podcasts_download_storage
                 else -> null
             }
             if (episodeStatus == EpisodeDownloadStatus.DownloadFailed) {
@@ -209,6 +210,7 @@ class EpisodeViewModel @Inject constructor(
                 EpisodeDownloadStatus.DownloadFailed -> IR.drawable.ic_failedwarning
                 EpisodeDownloadStatus.WaitingForWifi -> IR.drawable.ic_waitingforwifi
                 EpisodeDownloadStatus.WaitingForPower -> IR.drawable.ic_waitingforpower
+                EpisodeDownloadStatus.WaitingForStorage -> IR.drawable.ic_waitingforstorage
                 else -> null
             }
         } else {


### PR DESCRIPTION
## Description

This adds a state to inform users that downloads are pending due to low storage. This isn't integrated with the current downloads logic as it's not available there but I'll add support for it in the new one.

Relates to PCDROID-429

## Testing Instructions

1. Follow some podcasts.
2. Execute this query.
```sql
UPDATE podcast_episodes SET episode_status = 7
```
3. Go to any podcast page.
4. You should see the waiting for storage status.
5. Got to any episode details.
6. You should see the waiting for storage status.

## Screenshots or Screencast 

| Podcast | Episode |
| - | - |
| <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/8dcd576b-b30b-49fa-b499-0fc8b560f89a" /> | <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/90d977a5-dc6d-43d2-b57e-65c1958d1d5b" /> |

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack