### PR TITLE
Add download cancellation

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadEpisodeWorker.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadEpisodeWorker.kt
@@ -278,6 +278,7 @@ class DownloadEpisodeWorker @AssistedInject constructor(
 
     data class Args(
         val episodeUuid: String,
+        val podcastUuid: String,
         val waitForWifi: Boolean,
         val waitForPower: Boolean,
     )
@@ -285,9 +286,13 @@ class DownloadEpisodeWorker @AssistedInject constructor(
     companion object {
         const val WORKER_TAG = "EpisodeDownloadWorker"
 
-        internal const val WORKER_EPISODE_TAG_PREFIX = "$WORKER_TAG:"
+        internal const val WORKER_EPISODE_TAG_PREFIX = "$WORKER_TAG:Episode:"
 
-        fun episodeWorkerName(episodeUuid: String) = "$WORKER_EPISODE_TAG_PREFIX$episodeUuid"
+        internal const val WORKER_PODCAST_TAG_PREFIX = "$WORKER_TAG:Podcast:"
+
+        fun episodeTag(episodeUuid: String) = "$WORKER_EPISODE_TAG_PREFIX$episodeUuid"
+
+        fun podcastTag(podcastUuid: String) = "$WORKER_PODCAST_TAG_PREFIX$podcastUuid"
 
         fun createWorkRequest(args: Args): Pair<OneTimeWorkRequest, Constraints> {
             val constraints = Constraints.Builder()
@@ -299,8 +304,8 @@ class DownloadEpisodeWorker @AssistedInject constructor(
                 .setConstraints(constraints)
                 .setInputData(args.toData())
                 .addTag(WORKER_TAG)
-                .addTag(episodeWorkerName(args.episodeUuid))
-                .addTag(args.episodeUuid)
+                .addTag(episodeTag(args.episodeUuid))
+                .addTag(podcastTag(args.podcastUuid))
                 .build()
             return request to constraints
         }
@@ -425,18 +430,21 @@ sealed interface DownloadWorkInfo {
 
 private fun Data.toArgs() = DownloadEpisodeWorker.Args(
     episodeUuid = requireNotNull(getString(EPISODE_UUID_KEY)),
+    podcastUuid = requireNotNull(getString(PODCAST_UUID_KEY)),
     waitForWifi = getBoolean(WAIT_FOR_WIFI_KEY, true),
     waitForPower = getBoolean(WAIT_FOR_POWER_KEY, true),
 )
 
 private fun DownloadEpisodeWorker.Args.toData() = Data.Builder()
     .putString(EPISODE_UUID_KEY, episodeUuid)
+    .putString(PODCAST_UUID_KEY, podcastUuid)
     .putBoolean(WAIT_FOR_WIFI_KEY, waitForWifi)
     .putBoolean(WAIT_FOR_POWER_KEY, waitForPower)
     .build()
 
 // Input keys
 private const val EPISODE_UUID_KEY = "episode_uuid"
+private const val PODCAST_UUID_KEY = "podcast_uuid"
 private const val WAIT_FOR_WIFI_KEY = "wait_for_wifi"
 private const val WAIT_FOR_POWER_KEY = "wait_for_power"
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadQueue.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadQueue.kt
@@ -4,6 +4,12 @@ interface DownloadQueue {
     fun enqueue(episodeUuid: String, downloadType: DownloadType) = enqueueAll(setOf(episodeUuid), downloadType)
 
     fun enqueueAll(episodeUuids: Collection<String>, downloadType: DownloadType)
+
+    fun cancel(episodeUuid: String) = cancelAll(setOf(episodeUuid))
+
+    fun cancelAll(episodeUuids: Collection<String>)
+
+    fun cancelAll(podcastUuid: String)
 }
 
 enum class DownloadType {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/task/UpdateShowNotesTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/task/UpdateShowNotesTask.kt
@@ -29,8 +29,14 @@ class UpdateShowNotesTask @AssistedInject constructor(
 ) : CoroutineWorker(context, params) {
     companion object {
         private const val TASK_NAME = "UpdateShowNotesTask"
+        private const val WORKER_EPISODE_TAG_PREFIX = "$TASK_NAME:Episode:"
+        private const val WORKER_PODCAST_TAG_PREFIX = "$TASK_NAME:Podcast:"
         const val INPUT_PODCAST_UUID = "podcast_uuid"
         const val INPUT_EPISODE_UUID = "episode_uuid"
+
+        fun episodeTag(episodeUuid: String) = "$WORKER_EPISODE_TAG_PREFIX$episodeUuid"
+
+        fun podcastTag(podcastUuid: String) = "$WORKER_PODCAST_TAG_PREFIX$podcastUuid"
 
         fun enqueue(episode: PodcastEpisode, constraints: Constraints = Constraints.NONE, context: Context) {
             LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "$TASK_NAME - enqueued ${episode.uuid}")
@@ -41,6 +47,8 @@ class UpdateShowNotesTask @AssistedInject constructor(
             val workRequest = OneTimeWorkRequestBuilder<UpdateShowNotesTask>()
                 .setInputData(cacheShowNotesData)
                 .addTag(episode.uuid)
+                .addTag(episodeTag(episode.uuid))
+                .addTag(podcastTag(episode.podcastUuid))
                 .setConstraints(constraints)
                 .build()
             WorkManager.getInstance(context).beginUniqueWork(TASK_NAME, ExistingWorkPolicy.APPEND_OR_REPLACE, workRequest).enqueue()

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadWorkInfoTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadWorkInfoTest.kt
@@ -43,7 +43,7 @@ class DownloadWorkInfoTest {
         val workInfo = WorkInfo(
             id = UUID.randomUUID(),
             state = WorkInfo.State.ENQUEUED,
-            tags = setOf(DownloadEpisodeWorker.episodeWorkerName("episode-id")),
+            tags = setOf(DownloadEpisodeWorker.episodeTag("episode-id")),
         )
 
         val downloadInfo = DownloadEpisodeWorker.mapToDownloadWorkInfo(workInfo)
@@ -66,7 +66,7 @@ class DownloadWorkInfoTest {
         val workInfo = WorkInfo(
             id = UUID.randomUUID(),
             state = WorkInfo.State.BLOCKED,
-            tags = setOf(DownloadEpisodeWorker.episodeWorkerName("episode-id")),
+            tags = setOf(DownloadEpisodeWorker.episodeTag("episode-id")),
         )
 
         val downloadInfo = DownloadEpisodeWorker.mapToDownloadWorkInfo(workInfo)
@@ -89,7 +89,7 @@ class DownloadWorkInfoTest {
         val workInfo = WorkInfo(
             id = UUID.randomUUID(),
             state = WorkInfo.State.RUNNING,
-            tags = setOf(DownloadEpisodeWorker.episodeWorkerName("episode-id")),
+            tags = setOf(DownloadEpisodeWorker.episodeTag("episode-id")),
             progress = Data.Builder().putBoolean(IS_WORK_EXECUTING, true).build(),
         )
 
@@ -110,7 +110,7 @@ class DownloadWorkInfoTest {
         val workInfo = WorkInfo(
             id = UUID.randomUUID(),
             state = WorkInfo.State.RUNNING,
-            tags = setOf(DownloadEpisodeWorker.episodeWorkerName("episode-id")),
+            tags = setOf(DownloadEpisodeWorker.episodeTag("episode-id")),
             progress = Data.Builder().putBoolean(IS_WORK_EXECUTING, false).build(),
         )
 
@@ -134,7 +134,7 @@ class DownloadWorkInfoTest {
         val workInfo = WorkInfo(
             id = UUID.randomUUID(),
             state = WorkInfo.State.RUNNING,
-            tags = setOf(DownloadEpisodeWorker.episodeWorkerName("episode-id")),
+            tags = setOf(DownloadEpisodeWorker.episodeTag("episode-id")),
         )
 
         val downloadInfo = DownloadEpisodeWorker.mapToDownloadWorkInfo(workInfo)
@@ -157,7 +157,7 @@ class DownloadWorkInfoTest {
         val workInfo = WorkInfo(
             id = UUID.randomUUID(),
             state = WorkInfo.State.SUCCEEDED,
-            tags = setOf(DownloadEpisodeWorker.episodeWorkerName("episode-id")),
+            tags = setOf(DownloadEpisodeWorker.episodeTag("episode-id")),
             outputData = Data.Builder().putString(DOWNLOAD_FILE_PATH_KEY, "file.mp3").build(),
         )
 
@@ -179,7 +179,7 @@ class DownloadWorkInfoTest {
         val workInfo = WorkInfo(
             id = UUID.randomUUID(),
             state = WorkInfo.State.SUCCEEDED,
-            tags = setOf(DownloadEpisodeWorker.episodeWorkerName("episode-id")),
+            tags = setOf(DownloadEpisodeWorker.episodeTag("episode-id")),
         )
 
         assertThrows("Output file path is missing for the episode episode-id download", IllegalArgumentException::class.java) {
@@ -192,7 +192,7 @@ class DownloadWorkInfoTest {
         val workInfo = WorkInfo(
             id = UUID.randomUUID(),
             state = WorkInfo.State.FAILED,
-            tags = setOf(DownloadEpisodeWorker.episodeWorkerName("episode-id")),
+            tags = setOf(DownloadEpisodeWorker.episodeTag("episode-id")),
             outputData = Data.Builder().putString(ERROR_MESSAGE_KEY, "Whoops!").build(),
         )
 
@@ -214,7 +214,7 @@ class DownloadWorkInfoTest {
         val workInfo = WorkInfo(
             id = UUID.randomUUID(),
             state = WorkInfo.State.FAILED,
-            tags = setOf(DownloadEpisodeWorker.episodeWorkerName("episode-id")),
+            tags = setOf(DownloadEpisodeWorker.episodeTag("episode-id")),
         )
 
         val downloadInfo = DownloadEpisodeWorker.mapToDownloadWorkInfo(workInfo)
@@ -235,7 +235,7 @@ class DownloadWorkInfoTest {
         val workInfo = WorkInfo(
             id = UUID.randomUUID(),
             state = WorkInfo.State.CANCELLED,
-            tags = setOf(DownloadEpisodeWorker.episodeWorkerName("episode-id")),
+            tags = setOf(DownloadEpisodeWorker.episodeTag("episode-id")),
         )
 
         val downloadInfo = DownloadEpisodeWorker.mapToDownloadWorkInfo(workInfo)
@@ -256,7 +256,7 @@ class DownloadWorkInfoTest {
             id = UUID.randomUUID(),
             state = WorkInfo.State.ENQUEUED,
             constraints = Constraints(requiredNetworkType = NetworkType.UNMETERED),
-            tags = setOf(DownloadEpisodeWorker.episodeWorkerName("episode-id")),
+            tags = setOf(DownloadEpisodeWorker.episodeTag("episode-id")),
         )
 
         val downloadInfo = DownloadEpisodeWorker.mapToDownloadWorkInfo(workInfo)
@@ -280,7 +280,7 @@ class DownloadWorkInfoTest {
             id = UUID.randomUUID(),
             state = WorkInfo.State.ENQUEUED,
             constraints = Constraints(requiresCharging = true),
-            tags = setOf(DownloadEpisodeWorker.episodeWorkerName("episode-id")),
+            tags = setOf(DownloadEpisodeWorker.episodeTag("episode-id")),
         )
 
         val downloadInfo = DownloadEpisodeWorker.mapToDownloadWorkInfo(workInfo)
@@ -304,7 +304,7 @@ class DownloadWorkInfoTest {
             id = UUID.randomUUID(),
             state = WorkInfo.State.ENQUEUED,
             constraints = Constraints(requiresStorageNotLow = true),
-            tags = setOf(DownloadEpisodeWorker.episodeWorkerName("episode-id")),
+            tags = setOf(DownloadEpisodeWorker.episodeTag("episode-id")),
         )
 
         val downloadInfo = DownloadEpisodeWorker.mapToDownloadWorkInfo(workInfo)
@@ -328,7 +328,7 @@ class DownloadWorkInfoTest {
             id = UUID.randomUUID(),
             state = WorkInfo.State.ENQUEUED,
             runAttemptCount = 10,
-            tags = setOf(DownloadEpisodeWorker.episodeWorkerName("episode-id")),
+            tags = setOf(DownloadEpisodeWorker.episodeTag("episode-id")),
         )
 
         val downloadInfo = DownloadEpisodeWorker.mapToDownloadWorkInfo(workInfo)


### PR DESCRIPTION
## Description

This adds download cancellation logic by an episode UUID or a podcast UUID.

Relates to PCDROID-429

## Testing Instructions

1. Apply [this patch](https://github.com/user-attachments/files/25262583/download_cancel.patch).
```sh
curl -L https://github.com/user-attachments/files/25262583/download_cancel.patch | git apply
```
2. Install the app.
3. Open any not followed podcast.
4. Tap the follow button to start downloading top 10 episodes.
5. Tap the top left back arrow to cancel episodes downloads using all episode UUIDs.
6. The downloads should stop.
7. Tap the follow button again to start downloads.
8. Tap the share button it the top right corner to cancel downloads using a podcast UUID.
9. The downloads should stop.
10. Tap the follow button again to start downloads.
11. Long press an episode row to cancel its download by its UUID.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack