### PR TITLE
Pin faraday >= 1.10.5 for security fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,3 +20,7 @@ gem 'google-apis-sheets_v4', '~> 0.26'
 #
 # See https://github.com/ruby/openssl/issues/949
 gem 'openssl', '~> 4.0'
+
+# Security: https://github.com/lostisland/faraday/pull/1665
+# Faraday 2.0 is not compatible with Fastlane
+gem 'faraday', '~> 1.10', '>= 1.10.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,7 +93,7 @@ GEM
     drb (2.2.3)
     emoji_regex (3.2.3)
     excon (0.112.0)
-    faraday (1.10.4)
+    faraday (1.10.5)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
@@ -114,7 +114,7 @@ GEM
     faraday-http-cache (2.5.1)
       faraday (>= 0.8)
     faraday-httpclient (1.0.1)
-    faraday-multipart (1.1.1)
+    faraday-multipart (1.2.0)
       multipart-post (~> 2.0)
     faraday-net_http (1.0.2)
     faraday-net_http_persistent (1.2.0)
@@ -364,6 +364,7 @@ PLATFORMS
 
 DEPENDENCIES
   danger-dangermattic (~> 1.2.1)
+  faraday (~> 1.10, >= 1.10.5)
   fastlane (~> 2.226)
   fastlane-plugin-firebase_app_distribution (~> 0.10)
   fastlane-plugin-wpmreleasetoolkit (~> 13.8)


### PR DESCRIPTION
## Summary

- Pins `faraday` to `~> 1.10, >= 1.10.5` to address a security vulnerability.
- See [faraday#1665](https://github.com/lostisland/faraday/pull/1665) for the fix.
- Tracked in [AINFRA-1976](https://linear.app/a8c/issue/AINFRA-1976/track-security-alert-upgrade-fastlane-to-use-faraday-2x).

## Test plan

- [ ] CI passes — no functional change, only a transitive dependency version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*Posted by Claude (Opus 4.6) on behalf of @mokagio with approval.*