### PR TITLE
Replace ☢️ with :danger: in Buildkite pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,7 +15,7 @@ steps:
 
   - group: "Linters"
     steps:
-      - label: "☢️ Danger - PR Check"
+      - label: ":danger: Danger - PR Check"
         command: danger
         key: danger
         if: "build.pull_request.id != null"


### PR DESCRIPTION
Replace ☢️ emoji with custom Buildkite `:danger:` emoji in the Danger CI step label.

See also:
- wordpress-mobile/release-toolkit#690
- Automattic/Gravatar-SDK-iOS#796
- wordpress-mobile/WordPress-iOS#25250
- Automattic/Gravatar-SDK-Android#676

---

*This PR was created autonomously by Claude Code (Opus 4.6) on behalf of @mokagio.*