### PR TITLE
Prepare downloads for analytics

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadQueue.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadQueue.kt
@@ -1,15 +1,37 @@
 package au.com.shiftyjelly.pocketcasts.repositories.download
 
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+
 interface DownloadQueue {
-    fun enqueue(episodeUuid: String, downloadType: DownloadType) = enqueueAll(setOf(episodeUuid), downloadType)
+    fun enqueue(
+        episodeUuid: String,
+        downloadType: DownloadType,
+        sourceView: SourceView,
+    ) = enqueueAll(setOf(episodeUuid), downloadType, sourceView)
 
-    fun enqueueAll(episodeUuids: Collection<String>, downloadType: DownloadType)
+    fun enqueueAll(
+        episodeUuids: Collection<String>,
+        downloadType: DownloadType,
+        sourceView: SourceView,
+    )
 
-    fun cancel(episodeUuid: String, disableAutoDownload: Boolean) = cancelAll(setOf(episodeUuid), disableAutoDownload)
+    fun cancel(
+        episodeUuid: String,
+        disableAutoDownload: Boolean,
+        sourceView: SourceView,
+    ) = cancelAll(setOf(episodeUuid), disableAutoDownload, sourceView)
 
-    fun cancelAll(episodeUuids: Collection<String>, disableAutoDownload: Boolean)
+    fun cancelAll(
+        episodeUuids: Collection<String>,
+        disableAutoDownload: Boolean,
+        sourceView: SourceView,
+    )
 
-    fun cancelAll(podcastUuid: String, disableAutoDownload: Boolean)
+    fun cancelAll(
+        podcastUuid: String,
+        disableAutoDownload: Boolean,
+        sourceView: SourceView,
+    )
 }
 
 enum class DownloadType {


### PR DESCRIPTION
## Description

This adds groundwork to track download events:
- Add source view parameter.
- Push downstream podcast UUID parameter.
- Push downstream episode error parameter.
- I decided to change crashing in case of programming errors to surfacing these issues to the end user.

Relates to PCDROID-444

## Testing Instructions

Code review my changes.

## Screenshots or Screencast 

N/A

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack