### PR TITLE
Add Glance actions R8 rule

### DIFF
--- a/proguard-rules.pro
+++ b/proguard-rules.pro
@@ -39,6 +39,10 @@
 # https://issuetracker.google.com/issues/374691245
 -dontwarn com.google.android.gms.common.annotation.**
 
+# R8 shipped with AGP 9 broke Glance actions and they stopped triggering.
+# https://github.com/Automattic/pocket-casts-android/issues/5005
+-keep class au.com.shiftyjelly.pocketcasts.widget.action.** { *; }
+
 #
 # ██      ███████  ██████   █████   ██████ ██    ██      ██████  ██████  ███    ██ ███████ ██  ██████
 # ██      ██      ██       ██   ██ ██       ██  ██      ██      ██    ██ ████   ██ ██      ██ ██


### PR DESCRIPTION
## Description

After AGP 9 upgrade widgets became unresponsive to any actions. This fixes that.

Closes PCDROID-452

## Testing Instructions

1. Install the release version of the app.
2. Add widgets to your home screen.
3. Verify that widget actions like opening the app, playing, pausing, and so on work.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack