### PR TITLE
Show snackbar after creating a playlist

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/AddToPlaylistFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/AddToPlaylistFragment.kt
@@ -189,10 +189,16 @@ internal class AddToPlaylistFragment : BaseDialogFragment() {
     @Composable
     private fun OpenCreatedPlaylistEffect() {
         LaunchedEffect(Unit) {
-            val playlistUuid = viewModel.createdPlaylist.await()
+            val playlist = viewModel.createdPlaylist.await()
+
+            val hostListener = requireActivity() as FragmentHostListener
+            val snackbarView = hostListener.snackBarView()
+            val message = getString(LR.string.added_to_playlist_single, playlist.title)
 
             dismiss()
-            (requireActivity() as FragmentHostListener).openManualPlaylist(playlistUuid)
+            Snackbar.make(snackbarView, message, Snackbar.LENGTH_LONG)
+                .setAction(LR.string.view) { hostListener.openManualPlaylist(playlist.uuid) }
+                .show()
         }
     }
 

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/AddToPlaylistViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/AddToPlaylistViewModel.kt
@@ -56,8 +56,8 @@ class AddToPlaylistViewModel @AssistedInject constructor(
         }
     }
 
-    private val _createdPlaylist = CompletableDeferred<String>(viewModelScope.coroutineContext[Job])
-    val createdPlaylist: Deferred<String> get() = _createdPlaylist
+    private val _createdPlaylist = CompletableDeferred<CreatedPlaylist>(viewModelScope.coroutineContext[Job])
+    val createdPlaylist: Deferred<CreatedPlaylist> get() = _createdPlaylist
 
     val newPlaylistNameState = TextFieldState(
         initialText = initialPlaylistTitle,
@@ -125,7 +125,9 @@ class AddToPlaylistViewModel @AssistedInject constructor(
             val uuids = episodeUuids.map(EpisodeUuidPair::episodeUuid)
             playlistManager.addManualEpisodes(playlistUuid, uuids)
             tracker.track(AnalyticsEvent.FILTER_CREATED)
-            _createdPlaylist.complete(playlistUuid)
+
+            val playlist = CreatedPlaylist(uuid = playlistUuid, title = sanitizedName)
+            _createdPlaylist.complete(playlist)
         }
     }
 
@@ -277,6 +279,11 @@ class AddToPlaylistViewModel @AssistedInject constructor(
         val playlistPreviews: List<PlaylistPreviewForEpisode>,
         val unfilteredPlaylistsCount: Int,
         val episodeLimit: Int,
+    )
+
+    data class CreatedPlaylist(
+        val uuid: String,
+        val title: String,
     )
 
     @AssistedFactory


### PR DESCRIPTION
## Description

This change shows a snackbar to navigate to a playlist instead of navigating to it directly after creation.

Closes PCDROID-441

## Testing Instructions

1. Swipe left on any episode.
2. Tap playlists button.
3. Create a new playlist.
4. You should see a snackbar.
5. Tapping the snackbar action button should navigate you to the playlist.

## Screenshots or Screencast 

https://github.com/user-attachments/assets/72c761cc-054b-4e14-a0f2-5a04a0b3cba2

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
