### PR TITLE
Fix login sync not updating UI state

### DIFF
--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -119,6 +120,9 @@ private fun WearApp(
         waitingForSignIn.value = true
     }
 
+    // Wrap in a State so that composable destinations inside the NavHost can read the latest value even though the nav graph is cached.
+    val currentSyncState = rememberUpdatedState(syncState)
+
     val startDestination = if (userCanAccessWatch) WatchListScreen.ROUTE else RequirePlusScreen.ROUTE
 
     Box(modifier = Modifier.fillMaxSize()) {
@@ -133,7 +137,7 @@ private fun WearApp(
                 ) {
                     RequirePlusScreen(
                         onContinueToLogin = { navController.navigate(AUTHENTICATION_SUB_GRAPH) },
-                        syncState = syncState,
+                        syncState = currentSyncState.value,
                     )
                 }
 
@@ -326,7 +330,7 @@ private fun WearApp(
                             onClose = {},
                         )
                     },
-                    syncState = syncState,
+                    syncState = currentSyncState,
                     onRetrySync = onRetrySync,
                 )
 

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/AuthenticationNavGraph.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/AuthenticationNavGraph.kt
@@ -7,6 +7,7 @@ import android.widget.Toast
 import androidx.activity.compose.LocalActivity
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -38,7 +39,7 @@ fun NavGraphBuilder.authenticationNavGraph(
     navController: NavController,
     onEmailSignInSuccess: () -> Unit,
     googleSignInSuccessScreen: @Composable (GoogleAccountData) -> Unit,
-    syncState: WatchSyncState? = null,
+    syncState: State<WatchSyncState>,
     onRetrySync: () -> Unit = {},
 ) {
     navigation(
@@ -79,7 +80,7 @@ fun NavGraphBuilder.authenticationNavGraph(
         ) {
             LoginWithPhoneScreen(
                 onLoginClick = { navController.popBackStack() },
-                syncState = syncState,
+                syncState = syncState.value,
                 onRetry = onRetrySync,
             )
         }


### PR DESCRIPTION
## Description

Through my testing, I found that if you went to the log in with phone option that the "Syncing with phone..." UI would never change until I navigated away from and back to the screen. 

## Testing Instructions
1. Install the Wear OS app with no user logged in and not connected to a phone
2. Within 30 seconds tap Log in, then tap Log in on phone
3. Wait for at least 30 seconds
4. ✅ Verify the error page is shown.

## Screenshots   

https://github.com/user-attachments/assets/7cf88d10-07ef-4246-a352-c7c4e68bb681

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
