### PR TITLE
Migrate user account events to Event Horiozn

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/profile/accountmanager/PocketCastsAccountAuthenticatorTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/profile/accountmanager/PocketCastsAccountAuthenticatorTest.kt
@@ -8,13 +8,14 @@ import android.content.Intent
 import androidx.core.os.BundleCompat
 import androidx.test.platform.app.InstrumentationRegistry
 import au.com.shiftyjelly.pocketcasts.account.AccountActivity
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.analytics.testing.TestEventSink
 import au.com.shiftyjelly.pocketcasts.preferences.AccountConstants
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncAccountManagerImpl
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManagerImpl
 import au.com.shiftyjelly.pocketcasts.repositories.sync.TokenErrorNotification
 import au.com.shiftyjelly.pocketcasts.servers.di.NetworkModule
 import au.com.shiftyjelly.pocketcasts.servers.sync.SyncServiceManager
+import com.automattic.eventhorizon.EventHorizon
 import dagger.Lazy
 import java.io.File
 import java.net.HttpURLConnection
@@ -70,7 +71,7 @@ class PocketCastsAccountAuthenticatorTest {
         val syncServiceManager = SyncServiceManager(retrofit.create(), mock(), Lazy { okhttpCache })
 
         val syncManager = SyncManagerImpl(
-            analyticsTracker = AnalyticsTracker.test(),
+            eventHorizon = EventHorizon(TestEventSink()),
             context = context,
             settings = mock(),
             syncAccountManager = syncAccountManager,

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/servers/account/SyncAccountTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/servers/account/SyncAccountTest.kt
@@ -3,7 +3,7 @@ package au.com.shiftyjelly.pocketcasts.servers.account
 import android.accounts.AccountManager
 import android.content.Context
 import androidx.test.platform.app.InstrumentationRegistry
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.analytics.testing.TestEventSink
 import au.com.shiftyjelly.pocketcasts.preferences.AccessToken
 import au.com.shiftyjelly.pocketcasts.preferences.AccountConstants
 import au.com.shiftyjelly.pocketcasts.repositories.sync.LoginResult
@@ -13,6 +13,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManagerImpl
 import au.com.shiftyjelly.pocketcasts.servers.di.NetworkModule
 import au.com.shiftyjelly.pocketcasts.servers.sync.SyncServiceManager
+import com.automattic.eventhorizon.EventHorizon
 import dagger.Lazy
 import java.net.HttpURLConnection
 import kotlinx.coroutines.runBlocking
@@ -52,7 +53,7 @@ internal class SyncAccountTest {
         val syncAccountManager = SyncAccountManagerImpl(mock(), accountManager)
 
         syncManager = SyncManagerImpl(
-            analyticsTracker = AnalyticsTracker.test(),
+            eventHorizon = EventHorizon(TestEventSink()),
             context = context,
             settings = mock(),
             syncAccountManager = syncAccountManager,
@@ -142,6 +143,7 @@ internal class SyncAccountTest {
             syncManager.createUserWithEmailAndPassword(
                 email = "support+register@pocketcasts.com",
                 password = "password_register",
+                signInSource = SignInSource.UserInitiated.Onboarding,
             )
         }
         assert(result is LoginResult.Success)
@@ -187,6 +189,7 @@ internal class SyncAccountTest {
             syncManager.createUserWithEmailAndPassword(
                 email = "support@pocketcasts.com",
                 password = "password",
+                signInSource = SignInSource.UserInitiated.Onboarding,
             )
         }
         assert(result is LoginResult.Failed)

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/CreateAccountViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/CreateAccountViewModel.kt
@@ -7,6 +7,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.LoginResult
+import au.com.shiftyjelly.pocketcasts.repositories.sync.SignInSource
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -128,7 +129,7 @@ class CreateAccountViewModel
         createAccountState.postValue(CreateAccountState.AccountCreating)
 
         viewModelScope.launch {
-            when (val result = syncManager.createUserWithEmailAndPassword(emailString, passwordString)) {
+            when (val result = syncManager.createUserWithEmailAndPassword(emailString, passwordString, SignInSource.UserInitiated.SignInViewModel)) {
                 is LoginResult.Success -> {
                     analyticsTracker.refreshMetadata()
                     podcastManager.refreshPodcastsAfterSignIn()

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/GoogleSignInButtonViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/GoogleSignInButtonViewModel.kt
@@ -25,6 +25,9 @@ import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.utils.extensions.isGooglePlayServicesAvailableSuccess
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
+import com.automattic.eventhorizon.EventHorizon
+import com.automattic.eventhorizon.LoginIdentity
+import com.automattic.eventhorizon.SsoStartedEvent
 import com.google.android.gms.auth.api.identity.Identity
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
@@ -40,6 +43,7 @@ import kotlinx.coroutines.launch
 @HiltViewModel
 class GoogleSignInButtonViewModel @Inject constructor(
     private val analyticsTracker: AnalyticsTracker,
+    private val eventHorizon: EventHorizon,
     @ApplicationContext private val context: Context,
     private val podcastManager: PodcastManager,
     private val syncManager: SyncManager,
@@ -64,7 +68,11 @@ class GoogleSignInButtonViewModel @Inject constructor(
         onLegacySignInIntent: (Intent) -> Unit,
     ) {
         if (flow != null) {
-            analyticsTracker.trackSsoStartedGoogle()
+            eventHorizon.track(
+                SsoStartedEvent(
+                    source = LoginIdentity.Google,
+                ),
+            )
             analyticsTracker.trackSetupAccountButtonTapped(
                 flow = flow.analyticsValue,
                 button = AnalyticsParameter.SetupAccountButton.ContinueWithGoogle,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingCreateAccountViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingCreateAccountViewModel.kt
@@ -11,6 +11,7 @@ import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.LoginResult
+import au.com.shiftyjelly.pocketcasts.repositories.sync.SignInSource
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.utils.Network
@@ -119,6 +120,7 @@ class OnboardingCreateAccountViewModel @Inject constructor(
             val result = syncManager.createUserWithEmailAndPassword(
                 email = state.email,
                 password = state.password,
+                signInSource = SignInSource.UserInitiated.Onboarding,
             )
             when (result) {
                 is LoginResult.Success -> {

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsTracker.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsTracker.kt
@@ -183,15 +183,6 @@ class AnalyticsTracker(
         trackWithFlow(event = AnalyticsEvent.CREATE_ACCOUNT_SHOWN, flow = flow)
     }
 
-    fun trackSsoStartedGoogle() {
-        track(
-            AnalyticsEvent.SSO_STARTED,
-            mapOf(
-                AnalyticsParameter.SOURCE to "google",
-            ),
-        )
-    }
-
     fun trackSetupAccountShown(flow: String) {
         trackWithFlow(event = AnalyticsEvent.SETUP_ACCOUNT_SHOWN, flow = flow)
     }

--- a/modules/services/repositories/build.gradle.kts
+++ b/modules/services/repositories/build.gradle.kts
@@ -81,4 +81,5 @@ dependencies {
     testImplementation(libs.turbine)
 
     testImplementation(projects.modules.services.sharedtest)
+    testImplementation(projects.modules.services.analytics.testing)
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncAccountManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncAccountManagerImpl.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.withContext
+import com.automattic.eventhorizon.SignInSource as EventHorizonSignInSource
 
 @Singleton
 open class SyncAccountManagerImpl @Inject constructor(
@@ -142,7 +143,7 @@ open class SyncAccountManagerImpl @Inject constructor(
         val userData = bundleOf(
             AccountConstants.UUID to uuid,
             AccountConstants.SIGN_IN_TYPE_KEY to AccountConstants.SignInType.Tokens.value,
-            AccountConstants.LOGIN_IDENTITY to loginIdentity.value,
+            AccountConstants.LOGIN_IDENTITY to loginIdentity.key,
         )
         val accountAdded = accountManager.addAccountExplicitly(account, refreshToken.value, userData)
         accountManager.setAuthToken(account, AccountConstants.TOKEN_TYPE, accessToken.value)
@@ -188,10 +189,10 @@ open class SyncAccountManagerImpl @Inject constructor(
 }
 
 sealed class SignInSource {
-    sealed class UserInitiated(val analyticsValue: String) : SignInSource() {
-        object SignInViewModel : UserInitiated("sign_in_view_model")
-        object Onboarding : UserInitiated("onboarding")
-        object Watch : UserInitiated("watch")
+    sealed class UserInitiated(val eventHorizonValue: EventHorizonSignInSource) : SignInSource() {
+        object SignInViewModel : UserInitiated(EventHorizonSignInSource.SignInViewModel)
+        object Onboarding : UserInitiated(EventHorizonSignInSource.Onboarding)
+        object Watch : UserInitiated(EventHorizonSignInSource.Watch)
     }
     object WatchPhoneSync : SignInSource()
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManager.kt
@@ -65,7 +65,7 @@ interface SyncManager : NamedSettingsCaller {
     suspend fun loginWithGoogle(idToken: String, signInSource: SignInSource): LoginResult
     suspend fun loginWithEmailAndPassword(email: String, password: String, signInSource: SignInSource): LoginResult
     suspend fun loginWithToken(token: RefreshToken, loginIdentity: LoginIdentity, signInSource: SignInSource): LoginResult
-    suspend fun createUserWithEmailAndPassword(email: String, password: String): LoginResult
+    suspend fun createUserWithEmailAndPassword(email: String, password: String, signInSource: SignInSource.UserInitiated): LoginResult
     suspend fun forgotPassword(email: String, onSuccess: () -> Unit, onError: (String) -> Unit)
     suspend fun getAccessToken(account: Account): AccessToken
     fun getRefreshToken(): RefreshToken?

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/TokenErrorNotification.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/TokenErrorNotification.kt
@@ -8,19 +8,19 @@ import android.content.pm.PackageManager
 import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationOpenReceiverActivity
 import au.com.shiftyjelly.pocketcasts.utils.AppPlatform
 import au.com.shiftyjelly.pocketcasts.utils.Util
+import com.automattic.eventhorizon.EventHorizon
+import com.automattic.eventhorizon.SignedOutAlertShownEvent
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 open class TokenErrorNotification @Inject constructor(
-    private val analyticsTracker: AnalyticsTracker,
+    private val eventHorizon: EventHorizon,
     @ApplicationContext private val context: Context,
 ) {
 
@@ -28,7 +28,7 @@ open class TokenErrorNotification @Inject constructor(
 
     fun show(intent: Intent) {
         onShowSignInErrorNotificationDebounced {
-            analyticsTracker.track(AnalyticsEvent.SIGNED_OUT_ALERT_SHOWN)
+            eventHorizon.track(SignedOutAlertShownEvent)
         }
 
         if (ActivityCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED) {

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImplTest.kt
@@ -1,7 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.repositories.sync
 
 import android.content.Context
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.analytics.testing.TestEventSink
 import au.com.shiftyjelly.pocketcasts.preferences.AccessToken
 import au.com.shiftyjelly.pocketcasts.preferences.RefreshToken
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -9,6 +9,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationMana
 import au.com.shiftyjelly.pocketcasts.repositories.notification.OnboardingNotificationType
 import au.com.shiftyjelly.pocketcasts.servers.sync.SyncServiceManager
 import au.com.shiftyjelly.pocketcasts.servers.sync.login.LoginTokenResponse
+import com.automattic.eventhorizon.EventHorizon
 import com.squareup.moshi.Moshi
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
@@ -24,9 +25,6 @@ import org.mockito.kotlin.whenever
 
 @RunWith(MockitoJUnitRunner::class)
 class SyncManagerImplTest {
-
-    @Mock
-    private lateinit var analyticsTracker: AnalyticsTracker
 
     @Mock
     private lateinit var context: Context
@@ -53,7 +51,7 @@ class SyncManagerImplTest {
         MockitoAnnotations.openMocks(this)
 
         syncManager = SyncManagerImpl(
-            analyticsTracker = analyticsTracker,
+            eventHorizon = EventHorizon(TestEventSink()),
             context = context,
             settings = settings,
             syncAccountManager = syncAccountManager,
@@ -67,7 +65,7 @@ class SyncManagerImplTest {
     fun `should update user interaction with sync feature on user registration with password`() = runTest {
         val response = createMockLoginResponse(isNew = true)
         whenever(syncServiceManager.register(any(), any())).thenReturn(response)
-        syncManager.createUserWithEmailAndPassword("test@example.com", "password123")
+        syncManager.createUserWithEmailAndPassword("test@example.com", "password123", SignInSource.UserInitiated.Onboarding)
         verifyNotificationCalled()
     }
 

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/LoginIdentity.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/LoginIdentity.kt
@@ -2,16 +2,27 @@ package au.com.shiftyjelly.pocketcasts.servers.sync
 
 import com.squareup.moshi.FromJson
 import com.squareup.moshi.ToJson
+import com.automattic.eventhorizon.LoginIdentity as EventHorizonLoginIdentity
 
-sealed class LoginIdentity(val value: String) {
-    object PocketCasts : LoginIdentity("PocketCasts")
-    object Google : LoginIdentity("Google")
+sealed class LoginIdentity(
+    val key: String,
+    val eventHorizonValue: EventHorizonLoginIdentity,
+) {
+    object PocketCasts : LoginIdentity(
+        key = "PocketCasts",
+        eventHorizonValue = EventHorizonLoginIdentity.Password,
+    )
+
+    object Google : LoginIdentity(
+        key = "Google",
+        eventHorizonValue = EventHorizonLoginIdentity.Google,
+    )
 
     companion object {
         fun valueOf(value: String?): LoginIdentity? {
             return when (value) {
-                PocketCasts.value -> PocketCasts
-                Google.value -> Google
+                PocketCasts.key -> PocketCasts
+                Google.key -> Google
                 else -> null
             }
         }
@@ -19,7 +30,7 @@ sealed class LoginIdentity(val value: String) {
 
     object Adapter {
         @ToJson
-        fun toJson(loginIdentity: LoginIdentity): String = loginIdentity.value
+        fun toJson(loginIdentity: LoginIdentity): String = loginIdentity.key
 
         @FromJson
         fun fromJson(value: String): LoginIdentity? = valueOf(value)


### PR DESCRIPTION
## Description

This migrates user account related events to Event Horizon.

Relates to PCDROID-419

## Testing Instructions

Verify that the events below are tracked. Failures and `signed_out_alert_shown_event` might be hard to test. In general AI is good at reviewing these types of changes so I wouldn't put too much stress on it if you can't verify all of them.

- `sso_started`
- `user_email_updated`
- `user_account_deleted`
- `user_password_updated`
- `user_password_reset`
- `user_signed_in_watch_from_phone`
- `user_account_created`
- `user_signed_in`
- `user_signin_watch_from_phone_failed`
- `user_signin_failed`
- `user_account_creation_failed`
- `signed_out_alert_shown`
- `user_signed_out`

## Screenshots or Screencast 

N/A

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack