### PR TITLE
Remove grey border from selected Discover category chips

### DIFF
--- a/modules/features/discover/src/main/res/drawable/category_clear_all_pill_background.xml
+++ b/modules/features/discover/src/main/res/drawable/category_clear_all_pill_background.xml
@@ -1,9 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android" >
-    <stroke
-        android:width="1dp"
-        android:color="?attr/primary_field_03" />
-
     <solid android:color="?attr/primary_ui_01" />
 
     <padding

--- a/modules/features/discover/src/main/res/drawable/category_pill_selected_background.xml
+++ b/modules/features/discover/src/main/res/drawable/category_pill_selected_background.xml
@@ -1,9 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android" >
-    <stroke
-        android:width="1dp"
-        android:color="?attr/primary_field_03" />
-
     <solid android:color="?attr/secondary_icon_01" />
 
     <padding


### PR DESCRIPTION
## Summary

- Remove the 1dp grey stroke border from `category_pill_selected_background` and `category_clear_all_pill_background` drawables
- The stroke used `primary_field_03` which created a visible grey border around selected category chips and the dismiss button in the Discover tab

Fixes PCDROID-399

## Test plan

- [ ] Open the Discover tab
- [ ] Tap a category chip
- [ ] Verify the selected chip no longer has a grey border around it
- [ ] Verify the dismiss (X) button pill no longer has a grey border
- [ ] Verify unselected chips still display correctly with their border
- [ ] Test in both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)