### PR TITLE
PCDROID-397: Skip data warning on Android Auto to allow streaming

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -401,10 +401,14 @@ open class PlaybackManager @Inject constructor(
     }
 
     fun shouldWarnAboutPlayback(episodeUUID: String? = upNextQueue.currentEpisode?.uuid): Boolean {
-        return settings.warnOnMeteredNetwork.value && !Network.isUnmeteredConnection(application) && lastWarnedPlayedEpisodeUuid != episodeUUID
+        return !Util.isCarUiMode(application) &&
+            settings.warnOnMeteredNetwork.value &&
+            !Network.isUnmeteredConnection(application) &&
+            lastWarnedPlayedEpisodeUuid != episodeUUID
     }
 
-    private fun shouldWarnWhenSwitchingToMeteredConnection(episodeUUID: String): Boolean = settings.warnOnMeteredNetwork.value &&
+    private fun shouldWarnWhenSwitchingToMeteredConnection(episodeUUID: String): Boolean = !Util.isCarUiMode(application) &&
+        settings.warnOnMeteredNetwork.value &&
         lastWarnedPlayedEpisodeUuid != episodeUUID &&
         (player is LocalPlayer) &&
         // don't warn if chromecasting


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/PCDROID-397/android-auto-not-ignoring-warn-before-using-data-setting

## Summary
- Android Auto was pausing undownloaded episodes at 00:00 instead of streaming them when "Warn Before using Data" was enabled on a metered network
- The data warning notification only appears on the phone, which the driver cannot interact with while driving

## Changes
- Added `!Util.isCarUiMode(application)` check to `shouldWarnAboutPlayback()` in `PlaybackManager.kt`
- Added `!Util.isCarUiMode(application)` check to `shouldWarnWhenSwitchingToMeteredConnection()` in `PlaybackManager.kt`
- These two functions were missing the car UI mode check that was already present in the `loadCurrentEpisode` function (line 1727)

## Testing
- `spotlessCheck` passes
- The fix is consistent with the existing Android Auto exemption pattern already used in `loadCurrentEpisode()` and documented in the string resource `settings_storage_data_warning_car`

---
🤖 This PR was created autonomously by linear-solver.