### PR TITLE
[Player] Track if service is running via a static flag

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
@@ -1,9 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.repositories.playback
 
-import android.app.ActivityManager
 import android.app.ForegroundServiceStartNotAllowedException
 import android.app.Notification
-import android.content.Context
 import android.content.Intent
 import android.os.Binder
 import android.os.Build
@@ -161,6 +159,8 @@ open class PlaybackService :
 
     private val disposables = CompositeDisposable()
 
+    @Volatile
+    private var isForeground: Boolean = false
     private var sleepTimerDisposable: Disposable? = null
     private var currentTimeLeft: Duration = ZERO
 
@@ -188,6 +188,7 @@ open class PlaybackService :
 
     override fun onDestroy() {
         super.onDestroy()
+        isForeground = false
 
         disposables.clear()
         sleepTimerDisposable?.dispose()
@@ -195,16 +196,8 @@ open class PlaybackService :
         LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Playback service destroyed")
     }
 
-    @Suppress("DEPRECATION")
     fun isForegroundService(): Boolean {
-        val manager = baseContext.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
-        for (service in manager.getRunningServices(Int.MAX_VALUE)) {
-            if (this::class.java.name == service.service.className) {
-                return service.foreground
-            }
-        }
-        Timber.e("isServiceRunningInForeground found no matching service")
-        return false
+        return isForeground
     }
 
     private inner class MediaControllerCallback(currentMetadataCompat: MediaMetadataCompat?) : MediaControllerCompat.Callback() {
@@ -285,6 +278,7 @@ open class PlaybackService :
                     if (notification != null) {
                         try {
                             startForeground(Settings.NotificationId.PLAYING.value, notification)
+                            isForeground = true
                             notificationManager.enteredForeground(notification)
                             LogBuffer.i(LogBuffer.TAG_PLAYBACK, "startForeground state: $state")
                         } catch (e: Exception) {
@@ -323,6 +317,7 @@ open class PlaybackService :
 
                         // When paused keep the notification otherwise remove it
                         stopForeground(if (removeNotification) STOP_FOREGROUND_REMOVE else STOP_FOREGROUND_DETACH)
+                        isForeground = false
                         if (removeNotification) {
                             notificationManager.cancel(Settings.NotificationId.PLAYING.value)
                         }


### PR DESCRIPTION
## Description
Instead of relying on `getRunningServices()`, we now track if the service is running via a volatile static flag that we set/clear at the right moment (hooked into the proper lc callbacks)
Advantages of this approach:
 - No IPC overhead: getRunningServices() makes a Binder IPC call to ActivityManager on every invocation. The flag is a local memory read.
  - No deprecated API: getRunningServices() is deprecated since API 26 and documented as unreliable for anything beyond the caller's own services.
  - No "not found" edge case: The old code had a fallback Timber.e("isServiceRunningInForeground found no matching service") → return false. This could fire spuriously if the service was in a
  transitional state. The flag has no such ambiguity.

Fixes PCDROID-474

## Testing Instructions
Just review the code

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
