### PR TITLE
Update Up Next limit message

### DIFF
--- a/modules/services/localization/src/main/res/values-en-rGB/strings.xml
+++ b/modules/services/localization/src/main/res/values-en-rGB/strings.xml
@@ -643,7 +643,7 @@ Language: en_GB
     <string name="settings_stats_funny_empty">You really don\'t listen much, do you?</string>
     <string name="settings_auto_up_next_limit_reached_stop_summary">New episodes will stop being added when Up Next reaches %d.</string>
     <string name="settings_auto_up_next_limit_reached_stop">Stop adding</string>
-    <string name="settings_auto_up_next_limit_reached_top_summary">When Up Next reaches %d, new episodes auto-added to the top will remove the last episode in the queue. No new episodes will be added to the bottom.</string>
+    <string name="settings_auto_up_next_limit_reached_top_summary">When Up Next reaches %d, new episodes auto‑added to the top will remove the last episode in the queue. Episodes set to auto‑add to the bottom won’t be added until Up Next is below the limit.</string>
     <string name="settings_auto_up_next_limit_reached_top">Only add to top</string>
     <string name="settings_auto_up_next_limit_reached">If limit reached</string>
     <string name="settings_auto_up_next_to_bottom">To bottom</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1690,7 +1690,7 @@
     <string name="settings_auto_up_next_to_bottom">To bottom</string>
     <string name="settings_auto_up_next_limit_reached">If limit reached</string>
     <string name="settings_auto_up_next_limit_reached_top">Only add to top</string>
-    <string name="settings_auto_up_next_limit_reached_top_summary">When Up Next reaches %d, new episodes auto-added to the top will remove the last episode in the queue. No new episodes will be added to the bottom.</string>
+    <string name="settings_auto_up_next_limit_reached_top_summary">When Up Next reaches %d, new episodes auto‑added to the top will remove the last episode in the queue. Episodes set to auto‑add to the bottom won’t be added until Up Next is below the limit.</string>
     <string name="settings_auto_up_next_limit_reached_stop">Stop adding</string>
     <string name="settings_auto_up_next_limit_reached_stop_summary">New episodes will stop being added when Up Next reaches %d.</string>
     <string name="settings_stats_funny_empty">You really don\'t listen much, do you?</string>


### PR DESCRIPTION

Made-with: Cursor

## Description

Update the limit-reached description to clarify what happens for top vs bottom auto-add when Up Next is at the limit.

Fixes # 

## Testing Instructions

1. Go to Profile
2. Go to Settings
3. Go to "Auto Add to Up Next"
4. Select "Only Add to top" in "If Limit Reached"
5. Observe the new copy

## Screenshots or Screencast 

<img width="1440" height="3120" alt="image" src="https://github.com/user-attachments/assets/7e34bc72-6bc7-4eaa-bf92-5cbd0eb402c3" />


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
