### PR TITLE
Remove the Smart Categories feature flag

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/categories/CategoriesManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/categories/CategoriesManager.kt
@@ -4,8 +4,6 @@ import au.com.shiftyjelly.pocketcasts.coroutines.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.models.db.dao.UserCategoryVisitsDao
 import au.com.shiftyjelly.pocketcasts.repositories.lists.ListRepository
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.time.Duration
@@ -48,29 +46,21 @@ class CategoriesManager @Inject constructor(
             State.Selected(selectedCategory, categories, areAllShown)
         } else {
             val featuredCategories = buildList {
-                if (FeatureFlag.isEnabled(Feature.SMART_CATEGORIES)) {
-                    val categoriesWithVisits = categories
-                        .filter { it.totalVisits > 0 }
-                        .sortedByDescending { it.totalVisits }
-                    val groupedBySponsoredWithVisits = categoriesWithVisits.groupBy { rowInfo.sponsoredCategoryIds.contains(it.id) }
+                val categoriesWithVisits = categories
+                    .filter { it.totalVisits > 0 }
+                    .sortedByDescending { it.totalVisits }
+                val groupedBySponsoredWithVisits = categoriesWithVisits.groupBy { rowInfo.sponsoredCategoryIds.contains(it.id) }
 
-                    addAll((groupedBySponsoredWithVisits[true] ?: emptyList()).map { it.copy(isSponsored = true) })
-                    addAll((groupedBySponsoredWithVisits[false] ?: emptyList()).map { it.copy(isSponsored = false) })
+                addAll((groupedBySponsoredWithVisits[true] ?: emptyList()).map { it.copy(isSponsored = true) })
+                addAll((groupedBySponsoredWithVisits[false] ?: emptyList()).map { it.copy(isSponsored = false) })
 
-                    if (size < FEATURED_CATEGORY_COUNT) {
-                        val popularFillers = categories
-                            .filter { !contains(it) }
-                            .filter { it.id in rowInfo.popularCategoryIds }
-                            .sortedBy { rowInfo.popularCategoryIds.indexOf(it.id) }
-                            .take(FEATURED_CATEGORY_COUNT - size)
-                        addAll(popularFillers)
-                    }
-                } else {
-                    addAll(
-                        categories
-                            .filter { it.id in rowInfo.popularCategoryIds }
-                            .sortedBy { rowInfo.popularCategoryIds.indexOf(it.id) },
-                    )
+                if (size < FEATURED_CATEGORY_COUNT) {
+                    val popularFillers = categories
+                        .filter { !contains(it) }
+                        .filter { it.id in rowInfo.popularCategoryIds }
+                        .sortedBy { rowInfo.popularCategoryIds.indexOf(it.id) }
+                        .take(FEATURED_CATEGORY_COUNT - size)
+                    addAll(popularFillers)
                 }
             }.ifEmpty {
                 categories

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/categories/CategoriesManagerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/categories/CategoriesManagerTest.kt
@@ -5,18 +5,13 @@ import au.com.shiftyjelly.pocketcasts.models.db.dao.UserCategoryVisitsDao
 import au.com.shiftyjelly.pocketcasts.models.entity.UserCategoryVisits
 import au.com.shiftyjelly.pocketcasts.repositories.lists.ListRepository
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
-import au.com.shiftyjelly.pocketcasts.sharedtest.InMemoryFeatureFlagRule
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
@@ -24,9 +19,6 @@ import org.mockito.kotlin.whenever
 
 @OptIn(ExperimentalCoroutinesApi::class)
 internal class CategoriesManagerTest {
-    @get:Rule
-    val featureFlagRule = InMemoryFeatureFlagRule()
-
     private val listRepository = mock<ListRepository>()
     private val userCategoryVisitsDao = mock<UserCategoryVisitsDao>()
     private val coroutineScope = CoroutineScope(UnconfinedTestDispatcher())
@@ -42,7 +34,6 @@ internal class CategoriesManagerTest {
 
     @Test
     fun `GIVEN no visits WHEN categories evaluated THEN popular categories are returned`() = runBlocking {
-        FeatureFlag.setEnabled(Feature.SMART_CATEGORIES, true)
         whenever(listRepository.getCategoriesList(any())).thenReturn(testCategories)
         whenever(userCategoryVisitsDao.getCategoryVisitsOrdered()).thenReturn(emptyList())
 
@@ -60,7 +51,6 @@ internal class CategoriesManagerTest {
 
     @Test
     fun `GIVEN less than 6 visited categories WHEN categories evaluated THEN visited categories are ordered as expected`() = runBlocking {
-        FeatureFlag.setEnabled(Feature.SMART_CATEGORIES, true)
         whenever(listRepository.getCategoriesList(any())).thenReturn(testCategories)
         whenever(userCategoryVisitsDao.getCategoryVisitsOrdered()).thenReturn(
             listOf(
@@ -85,7 +75,6 @@ internal class CategoriesManagerTest {
 
     @Test
     fun `GIVEN more than 6 visited categories WHEN categories evaluated THEN visited categories are ordered as expected`() = runBlocking {
-        FeatureFlag.setEnabled(Feature.SMART_CATEGORIES, true)
         whenever(listRepository.getCategoriesList(any())).thenReturn(testCategories)
         whenever(userCategoryVisitsDao.getCategoryVisitsOrdered()).thenReturn(
             listOf(
@@ -112,7 +101,6 @@ internal class CategoriesManagerTest {
 
     @Test
     fun `GIVEN no visited categories and no populars WHEN categories evaluated THEN categories are ordered as expected`() = runBlocking {
-        FeatureFlag.setEnabled(Feature.SMART_CATEGORIES, true)
         whenever(listRepository.getCategoriesList(any())).thenReturn(testCategories)
         whenever(userCategoryVisitsDao.getCategoryVisitsOrdered()).thenReturn(
             emptyList(),
@@ -126,25 +114,6 @@ internal class CategoriesManagerTest {
             val state = awaitItem()
             assert(state is CategoriesManager.State.Idle)
             assertEquals((0..5).toList(), (state as CategoriesManager.State.Idle).featuredCategories.map { it.id })
-        }
-    }
-
-    @Test
-    fun `GIVEN FF disabled WHEN categories evaluated THEN popular categories are returned`() = runTest {
-        FeatureFlag.setEnabled(Feature.SMART_CATEGORIES, false)
-        whenever(listRepository.getCategoriesList(any())).thenReturn(testCategories)
-        whenever(userCategoryVisitsDao.getCategoryVisitsOrdered()).thenReturn(
-            emptyList(),
-        )
-
-        val categoriesManager = CategoriesManager(listRepository, userCategoryVisitsDao, coroutineScope)
-        categoriesManager.loadCategories("whatever")
-        categoriesManager.setRowInfo(popularCategoryIds = (5..9).toList(), sponsoredCategoryIds = listOf(4, 5, 6, 7))
-
-        categoriesManager.state.test {
-            val state = awaitItem()
-            assert(state is CategoriesManager.State.Idle)
-            assertEquals((5..9).toList(), (state as CategoriesManager.State.Idle).featuredCategories.map { it.id })
         }
     }
 }

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -116,14 +116,6 @@ enum class Feature(
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
     ),
-    SMART_CATEGORIES(
-        key = "smart_categories",
-        title = "Smart Categories",
-        defaultValue = isDebugOrPrototypeBuild,
-        tier = FeatureTier.Free,
-        hasFirebaseRemoteFlag = true,
-        hasDevToggle = true,
-    ),
     SHARE_TRANSCRIPTS(
         key = "share_transcripts",
         title = "Share transcripts",


### PR DESCRIPTION
## Description

I’m currently working on a fix for the duplicate category chips issue. As a first step, I’ve removed the feature flag to simplify the setup and avoid additional complexity while we implement the fix. This change removes that flag.

## Testing Instructions

1. Fresh install the app
2. Open the Discover section
3. Tap on "All categories"
4. Tap on "Music"
5. Force close the app
6. Notice the "Music" chip is at the front

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
