### PR TITLE
Remove border from selected category chip in Discover

### DIFF
--- a/modules/features/discover/src/main/res/drawable/category_pill_selected_background.xml
+++ b/modules/features/discover/src/main/res/drawable/category_pill_selected_background.xml
@@ -1,9 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android" >
-    <stroke
-        android:width="1dp"
-        android:color="?attr/primary_field_03" />
-
     <solid android:color="?attr/secondary_icon_01" />
 
     <padding


### PR DESCRIPTION
## Description

Removes the 1dp border/stroke from the selected category pill background in the Discover section. The selected state now only uses a solid background color without an additional border outline.

Fixes https://linear.app/a8c/issue/PCDROID-399/android-discover-section-a-grey-border-around-the-category-chip

## Testing Instructions

1. Open the app and go to the Discover tab
2. Tap on a category chip to select it
3. Verify the selected chip has a solid background without a visible border/stroke around it

## Screenshots or Screencast
<!-- UI changed — please add a screenshot showing the selected category chip without the border -->

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack