### PR TITLE
Remove the border from a selected Discover category chip

### DIFF
--- a/modules/features/discover/src/main/res/drawable/category_pill_selected_background.xml
+++ b/modules/features/discover/src/main/res/drawable/category_pill_selected_background.xml
@@ -1,9 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android" >
-    <stroke
-        android:width="1dp"
-        android:color="?attr/primary_field_03" />
-
     <solid android:color="?attr/secondary_icon_01" />
 
     <padding


### PR DESCRIPTION
## Description

Removes the grey border (stroke) from the selected category chip in the Discover tab. The selected state now only uses the solid background color without an additional 1dp border outline, resulting in a cleaner visual appearance and matching the iOS design.

Fixes [PCDROID-399](https://linear.app/a8c/issue/PCDROID-399/android-discover-section-a-grey-border-around-the-category-chip)

## Testing Instructions
1. Open the app and navigate to the **Discover** tab
2. Tap on any category chip (e.g., "True Crime", "Comedy")
3. Verify the selected chip has a solid background without a grey border outline
4. Verify unselected chips still appear correctly

## Screenshots 

| Before | After |
| --- | --- |
| <img width="1198" height="2531" alt="Screenshot_20260304_141843" src="https://github.com/user-attachments/assets/aa89f360-b0bd-4604-a337-e44d1eb35941" /> |  <img width="1198" height="2531" alt="Screenshot_20260304_132009" src="https://github.com/user-attachments/assets/9ed996e3-1223-40ab-bcb2-ba7d7c6217d6" /> | 

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack