### PR TITLE
Move release pipelines from mac-metal to mac queue

### DIFF
--- a/.buildkite/release-pipelines/code-freeze.yml
+++ b/.buildkite/release-pipelines/code-freeze.yml
@@ -3,6 +3,9 @@
 
 # This pipeline is meant to be triggered by the MC scenario in ReleasesV2
 
+env:
+  IMAGE_ID: "xcode-26.2"
+
 steps:
   - label: "🚂 Code Freeze"
     command: |
@@ -19,7 +22,7 @@ steps:
       bundle exec fastlane code_freeze version:"${RELEASE_VERSION}" skip_confirm:true
     plugins: [$CI_TOOLKIT]
     agents:
-      queue: "mac-metal"
+      queue: "mac"
     retry:
       manual:
         reason: If release jobs fail, you should always re-trigger the task from Releases V2 rather than retrying the individual job from Buildkite

--- a/.buildkite/release-pipelines/download-translations.yml
+++ b/.buildkite/release-pipelines/download-translations.yml
@@ -3,6 +3,9 @@
 
 # This pipeline is meant to be triggered by the MC scenario in ReleasesV2
 
+env:
+  IMAGE_ID: "xcode-26.2"
+
 steps:
   - label: "🚂 Download Translations"
     command: |
@@ -19,7 +22,7 @@ steps:
       bundle exec fastlane download_translations
     plugins: [$CI_TOOLKIT]
     agents:
-      queue: "mac-metal"
+      queue: "mac"
     retry:
       manual:
         reason: If release jobs fail, you should always re-trigger the task from Releases V2 rather than retrying the individual job from Buildkite

--- a/.buildkite/release-pipelines/finalize-hotfix-release.yml
+++ b/.buildkite/release-pipelines/finalize-hotfix-release.yml
@@ -3,6 +3,9 @@
 
 # This pipeline is meant to be triggered by the MC scenario in ReleasesV2
 
+env:
+  IMAGE_ID: "xcode-26.2"
+
 steps:
   - label: "🚂 Finalize Hotfix Release"
     command: |
@@ -21,7 +24,7 @@ steps:
       bundle exec fastlane finalize_hotfix_release skip_confirm:true
     plugins: [$CI_TOOLKIT]
     agents:
-      queue: "mac-metal"
+      queue: "mac"
     retry:
       manual:
         reason: If release jobs fail, you should always re-trigger the task from Releases V2 rather than retrying the individual job from Buildkite

--- a/.buildkite/release-pipelines/finalize-release.yml
+++ b/.buildkite/release-pipelines/finalize-release.yml
@@ -3,6 +3,9 @@
 
 # This pipeline is meant to be triggered by the MC scenario in ReleasesV2
 
+env:
+  IMAGE_ID: "xcode-26.2"
+
 steps:
   - label: "🚂 Finalize Release"
     command: |
@@ -21,7 +24,7 @@ steps:
       bundle exec fastlane finalize_release skip_confirm:true skip_translations_download:true
     plugins: [$CI_TOOLKIT]
     agents:
-      queue: "mac-metal"
+      queue: "mac"
     retry:
       manual:
         reason: If release jobs fail, you should always re-trigger the task from Releases V2 rather than retrying the individual job from Buildkite

--- a/.buildkite/release-pipelines/new-beta-release.yml
+++ b/.buildkite/release-pipelines/new-beta-release.yml
@@ -3,6 +3,9 @@
 
 # This pipeline is meant to be triggered by the MC scenario in ReleasesV2
 
+env:
+  IMAGE_ID: "xcode-26.2"
+
 steps:
   - label: "🚂 New Beta Release"
     command: |
@@ -21,7 +24,7 @@ steps:
       bundle exec fastlane new_beta_release skip_confirm:true
     plugins: [$CI_TOOLKIT]
     agents:
-      queue: "mac-metal"
+      queue: "mac"
     retry:
       manual:
         reason: If release jobs fail, you should always re-trigger the task from Releases V2 rather than retrying the individual job from Buildkite

--- a/.buildkite/release-pipelines/new-hotfix-release.yml
+++ b/.buildkite/release-pipelines/new-hotfix-release.yml
@@ -3,6 +3,9 @@
 
 # This pipeline is meant to be triggered by the MC scenario in ReleasesV2
 
+env:
+  IMAGE_ID: "xcode-26.2"
+
 steps:
   - label: "🚂 New Hotfix Release"
     command: |
@@ -19,7 +22,7 @@ steps:
       bundle exec fastlane new_hotfix_release version_name:"$RELEASE_VERSION" version_code:"$VERSION_CODE" skip_confirm:true
     plugins: [$CI_TOOLKIT]
     agents:
-      queue: "mac-metal"
+      queue: "mac"
     retry:
       manual:
         reason: If release jobs fail, you should always re-trigger the task from Releases V2 rather than retrying the individual job from Buildkite

--- a/.buildkite/release-pipelines/update-rollouts.yml
+++ b/.buildkite/release-pipelines/update-rollouts.yml
@@ -5,6 +5,9 @@
 
 # Expected variables passed to the pipeline by ReleasesV2: `TRACK`, `ROLLOUT_PERCENT`
 
+env:
+  IMAGE_ID: "xcode-26.2"
+
 steps:
   - label: "🚂 Update Rollouts"
     command: |
@@ -18,7 +21,7 @@ steps:
       bundle exec fastlane update_rollouts track:"$TRACK" percent:"$ROLLOUT_PERCENT"
     plugins: [$CI_TOOLKIT]
     agents:
-      queue: "mac-metal"
+      queue: "mac"
     retry:
       manual:
         reason: If release jobs fail, you should always re-trigger the task from Releases V2 rather than retrying the individual job from Buildkite
@@ -38,7 +41,7 @@ steps:
       bundle exec fastlane publish_gh_release skip_confirm:true track:"$TRACK"
     plugins: [$CI_TOOLKIT]
     agents:
-      queue: "mac-metal"
+      queue: "mac"
     retry:
       manual:
         reason: If release jobs fail, you should always re-trigger the task from Releases V2 rather than retrying the individual job from Buildkite


### PR DESCRIPTION
Fixes AINFRA-1895

Moving all release pipeline steps from `queue: "mac-metal"` to `queue: "mac"` to avoid release jobs being blocked behind long-running Tumblr UI tests on the single `mac-metal` agent.

The `mac` queue has a lot more agents, so release jobs will have very little wait time. The tradeoff is a minor VM boot overhead (~20s), which is negligible compared to the 24+ min wait that could happen before.

Also adds `IMAGE_ID: "xcode-26.2"` env var required by `mac` agents.