### PR TITLE
Add Claude Code skill for creating pull requests

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -39,7 +39,7 @@ Commits on this branch:
     - `[Type] Core` — Core infrastructure changes.
     - `[Type] Other` — Issues not covered by other types, such as refactoring and documentation.
 5. Add an `[Area]` label that matches the changes. Run `gh label list --search "[Area]"` to find the best match, then apply with `gh pr edit --add-label`.
-6. Set the milestone to the current one (not past its due date). Run `gh api repos/Automattic/pocket-casts-android/milestones --jq '[.[] | select(.due_on != null and (.due_on | fromdateiso8601) >= now)] | sort_by(.due_on) | .[0].title'` to find it, then apply with `gh pr edit --milestone`.
+6. Set the milestone to the current one (not past its due date). Run `gh api repos/Automattic/pocket-casts-android/milestones --jq '[.[] | select(.due_on) | select((.due_on | fromdateiso8601) >= now)] | sort_by(.due_on) | .[0].title'` to find it, then apply with `gh pr edit --milestone`.
 7. After creating the PR, output the PR URL.
 
 ## PR Template


### PR DESCRIPTION
## Description
Add a new Claude Code skill (`create-pr`) that automates pull request creation. The skill provides a structured workflow that:

- Verifies `gh` CLI is installed
- Reads the branch diff to understand changes
- Creates a draft PR using the repository's PR template with all sections filled in
- Applies appropriate `[Type]` and `[Area]` labels
- Sets the current milestone

This makes it easier to create consistent, well-formatted PRs directly from Claude Code.

Fixes # <!-- No linked issue -->

## Testing Instructions
1. Check out this branch
2. Run `/create-pr` in Claude Code on a branch with changes
3. Verify the PR is created as a draft against `main` with the correct template, labels, and milestone

## Screenshots or Screencast 
Not applicable — no UI changes.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack