### PR TITLE
[Playback Errors] Display special text for episode access issues

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -514,6 +514,7 @@ class MainActivity :
                         }
                         PlaybackErrorInfoBar(
                             message = notice.message,
+                            linkText = notice.linkText,
                             onClick = when (notice.type) {
                                 PlaybackNoticeType.PLAYBACK -> {
                                     {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -705,6 +705,7 @@ class PlayerHeaderFragment :
                     PlaybackErrorInfoBar(
                         message = issue.message,
                         playerColors = playerColors,
+                        linkText = issue.linkText,
                         onClick = when (issue.type) {
                             PlaybackNoticeType.PLAYBACK -> {
                                 {

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PlaybackErrorInfoBar.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PlaybackErrorInfoBar.kt
@@ -12,14 +12,23 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.PlayerColors
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.images.R as IR
@@ -33,6 +42,7 @@ fun PlaybackErrorInfoBar(
     playerColors: PlayerColors,
     onClick: (() -> Unit)?,
     modifier: Modifier = Modifier,
+    linkText: String? = null,
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
@@ -43,11 +53,11 @@ fun PlaybackErrorInfoBar(
             .then(if (onClick != null) Modifier.clickable(role = Role.Button, onClick = onClick) else Modifier)
             .padding(horizontal = 16.dp),
     ) {
-        TextH50(
-            text = message,
+        InfoBarText(
+            message = message,
+            linkText = linkText,
             color = playerColors.contrast01,
-            disableAutoScale = true,
-            textAlign = TextAlign.Center,
+            linkColor = MaterialTheme.theme.colors.primaryInteractive01,
             modifier = Modifier.weight(1f, fill = false),
         )
         if (onClick != null) {
@@ -70,6 +80,7 @@ fun PlaybackErrorInfoBar(
     message: String,
     onClick: (() -> Unit)?,
     modifier: Modifier = Modifier,
+    linkText: String? = null,
 ) {
     val colors = MaterialTheme.theme.colors
     Row(
@@ -82,11 +93,11 @@ fun PlaybackErrorInfoBar(
             .then(if (onClick != null) Modifier.clickable(role = Role.Button, onClick = onClick) else Modifier)
             .padding(horizontal = 28.dp),
     ) {
-        TextH50(
-            text = message,
+        InfoBarText(
+            message = message,
+            linkText = linkText,
             color = colors.primaryText01,
-            disableAutoScale = true,
-            textAlign = TextAlign.Center,
+            linkColor = colors.primaryInteractive01,
             modifier = Modifier.weight(1f, fill = false),
         )
         if (onClick != null) {
@@ -98,5 +109,42 @@ fun PlaybackErrorInfoBar(
                 modifier = Modifier.size(16.dp),
             )
         }
+    }
+}
+
+@Composable
+private fun InfoBarText(
+    message: String,
+    linkText: String?,
+    color: Color,
+    linkColor: Color,
+    modifier: Modifier = Modifier,
+) {
+    if (linkText != null) {
+        val annotatedString = buildAnnotatedString {
+            append("$message ")
+            withStyle(SpanStyle(color = linkColor, textDecoration = TextDecoration.Underline)) {
+                append(linkText)
+            }
+        }
+        Text(
+            text = annotatedString,
+            color = color,
+            fontSize = 14.sp,
+            lineHeight = 20.sp,
+            fontWeight = FontWeight.W500,
+            textAlign = TextAlign.Center,
+            maxLines = Int.MAX_VALUE,
+            overflow = TextOverflow.Ellipsis,
+            modifier = modifier,
+        )
+    } else {
+        TextH50(
+            text = message,
+            color = color,
+            disableAutoScale = true,
+            textAlign = TextAlign.Center,
+            modifier = modifier,
+        )
     }
 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PlaybackErrorInfoBar.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PlaybackErrorInfoBar.kt
@@ -1,24 +1,18 @@
 package au.com.shiftyjelly.pocketcasts.compose.components
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -30,7 +24,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.PlayerColors
 import au.com.shiftyjelly.pocketcasts.compose.theme
-import au.com.shiftyjelly.pocketcasts.images.R as IR
 
 /**
  * Fullscreen player variant uses player colors.
@@ -59,15 +52,6 @@ fun PlaybackErrorInfoBar(
             linkColor = MaterialTheme.theme.colors.primaryInteractive01,
             modifier = Modifier.weight(1f, fill = false),
         )
-        if (onClick != null && linkText == null) {
-            Spacer(modifier = Modifier.width(4.dp))
-            Image(
-                painter = painterResource(IR.drawable.ic_chevron_right),
-                colorFilter = ColorFilter.tint(playerColors.contrast03),
-                contentDescription = null,
-                modifier = Modifier.size(16.dp),
-            )
-        }
     }
 }
 
@@ -99,15 +83,6 @@ fun PlaybackErrorInfoBar(
             linkColor = colors.primaryInteractive01,
             modifier = Modifier.weight(1f, fill = false),
         )
-        if (onClick != null && linkText == null) {
-            Spacer(modifier = Modifier.width(4.dp))
-            Image(
-                painter = painterResource(IR.drawable.ic_chevron_right),
-                colorFilter = ColorFilter.tint(colors.primaryIcon02),
-                contentDescription = null,
-                modifier = Modifier.size(16.dp),
-            )
-        }
     }
 }
 

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PlaybackErrorInfoBar.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PlaybackErrorInfoBar.kt
@@ -121,7 +121,8 @@ private fun InfoBarText(
 ) {
     if (linkText != null) {
         val annotatedString = buildAnnotatedString {
-            append("$message\n")
+            append(message)
+            append(" ")
             withStyle(SpanStyle(color = linkColor)) {
                 append(linkText)
             }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PlaybackErrorInfoBar.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PlaybackErrorInfoBar.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
@@ -60,7 +59,7 @@ fun PlaybackErrorInfoBar(
             linkColor = MaterialTheme.theme.colors.primaryInteractive01,
             modifier = Modifier.weight(1f, fill = false),
         )
-        if (onClick != null) {
+        if (onClick != null && linkText == null) {
             Spacer(modifier = Modifier.width(4.dp))
             Image(
                 painter = painterResource(IR.drawable.ic_chevron_right),
@@ -100,7 +99,7 @@ fun PlaybackErrorInfoBar(
             linkColor = colors.primaryInteractive01,
             modifier = Modifier.weight(1f, fill = false),
         )
-        if (onClick != null) {
+        if (onClick != null && linkText == null) {
             Spacer(modifier = Modifier.width(4.dp))
             Image(
                 painter = painterResource(IR.drawable.ic_chevron_right),
@@ -122,8 +121,8 @@ private fun InfoBarText(
 ) {
     if (linkText != null) {
         val annotatedString = buildAnnotatedString {
-            append("$message ")
-            withStyle(SpanStyle(color = linkColor, textDecoration = TextDecoration.Underline)) {
+            append("$message\n")
+            withStyle(SpanStyle(color = linkColor)) {
                 append(linkText)
             }
         }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1848,7 +1848,8 @@
     <string name="error_chartable_streaming">Streaming failed. The producer is using Chartable analytics which is being blocked, if you run any filtering app such as AdGuard you will need to whitelist chtbl.com to play the episode.</string>
     <string name="error_streaming_internet">Streaming failed check your internet connection.</string>
     <string name="error_streaming_try_downloading">Streaming failed. Try downloading the episode.</string>
-    <string name="error_streaming_access_denied">You no longer have access to play this episode.</string>
+    <string name="error_streaming_access_denied">This episode can\'t be played.</string>
+    <string name="error_streaming_access_denied_action">Learn about possible causes</string>
     <string name="error_streaming_not_found">This episode could not be found on the server. It may have been removed by the publisher.</string>
     <string name="error_streaming_no_longer_available">This episode is no longer available from the publisher.</string>
     <string name="error_streaming_server_error">The podcast server is experiencing issues. Please try again later.</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1849,7 +1849,6 @@
     <string name="error_streaming_internet">Streaming failed check your internet connection.</string>
     <string name="error_streaming_try_downloading">Streaming failed. Try downloading the episode.</string>
     <string name="error_streaming_access_denied">This episode can\'t be played.</string>
-    <string name="error_streaming_access_denied_action">Learn about possible causes</string>
     <string name="error_streaming_not_found">This episode could not be found on the server. It may have been removed by the publisher.</string>
     <string name="error_streaming_no_longer_available">This episode is no longer available from the publisher.</string>
     <string name="error_streaming_server_error">The podcast server is experiencing issues. Please try again later.</string>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackErrorClassifier.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackErrorClassifier.kt
@@ -71,6 +71,14 @@ class PlaybackErrorClassifier @Inject constructor() {
     }
 
     @StringRes
+    fun classifyLinkTextResId(responseCode: Int): Int? {
+        return when (responseCode) {
+            401, 403 -> LR.string.error_streaming_access_denied_action
+            else -> null
+        }
+    }
+
+    @StringRes
     fun classifyHttpError(responseCode: Int): Int {
         return when (responseCode) {
             401, 403 -> LR.string.error_streaming_access_denied

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackErrorClassifier.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackErrorClassifier.kt
@@ -24,13 +24,6 @@ class PlaybackErrorClassifier @Inject constructor() {
     }
 
     @OptIn(UnstableApi::class)
-    fun isConnectionError(event: PlayerEvent.PlayerError): Boolean {
-        val cause = event.error?.cause
-        return cause is HttpDataSource.HttpDataSourceException &&
-            cause !is HttpDataSource.InvalidResponseCodeException
-    }
-
-    @OptIn(UnstableApi::class)
     @StringRes
     fun classifyErrorStringId(event: PlayerEvent.PlayerError): Int {
         val error = event.error ?: return LR.string.error_unable_to_play
@@ -67,14 +60,6 @@ class PlaybackErrorClassifier @Inject constructor() {
             -> LR.string.player_play_failed_check_internet
 
             else -> LR.string.error_unable_to_play
-        }
-    }
-
-    @StringRes
-    fun classifyLinkTextResId(responseCode: Int): Int? {
-        return when (responseCode) {
-            401, 403 -> LR.string.error_streaming_access_denied_action
-            else -> null
         }
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackNoticeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackNoticeManager.kt
@@ -124,21 +124,19 @@ class PlaybackNoticeManager @Inject constructor(
                     )
 
                     playbackState.playbackIssue is PlaybackIssue.StuckPlayer -> PlaybackNoticeInfo(
-                        message = context.getString(playbackState.playbackIssue.messageResId),
+                        message = context.getString(LR.string.error_streaming_access_denied),
                         type = PlaybackNoticeType.PLAYBACK,
                         supportUrl = Settings.INFO_DOWNLOAD_AND_PLAYBACK_URL,
+                        linkText = context.getString(LR.string.settings_battery_learn_more),
                     )
 
                     else -> {
                         val httpCode = (playbackState.playbackIssue as? PlaybackIssue.HttpError)?.statusCode
-                        val isAccessDenied = httpCode == 401 || httpCode == 403
                         PlaybackNoticeInfo(
-                            message = context.getString(
-                                if (isAccessDenied) LR.string.error_streaming_access_denied else LR.string.error_episode_not_available,
-                            ),
+                            message = context.getString(LR.string.error_streaming_access_denied),
                             type = PlaybackNoticeType.PLAYBACK,
                             supportUrl = errorClassifier.classifyHelpUrl(httpCode),
-                            linkText = if (isAccessDenied) context.getString(LR.string.settings_battery_learn_more) else null,
+                            linkText = context.getString(LR.string.settings_battery_learn_more),
                         )
                     }
                 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackNoticeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackNoticeManager.kt
@@ -116,6 +116,8 @@ class PlaybackNoticeManager @Inject constructor(
                 when {
                     !playbackState.isError -> null
 
+                    playbackState.transientLoss -> null
+
                     !isForeground -> null
 
                     playbackState.playbackIssue is PlaybackIssue.ConnectionError -> PlaybackNoticeInfo(

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackNoticeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackNoticeManager.kt
@@ -30,6 +30,7 @@ data class PlaybackNoticeInfo(
     val message: String,
     val type: PlaybackNoticeType,
     val supportUrl: String? = null,
+    val linkText: String? = null,
 )
 
 @Singleton
@@ -130,10 +131,14 @@ class PlaybackNoticeManager @Inject constructor(
 
                     else -> {
                         val httpCode = (playbackState.playbackIssue as? PlaybackIssue.HttpError)?.statusCode
+                        val isAccessDenied = httpCode == 401 || httpCode == 403
                         PlaybackNoticeInfo(
-                            message = context.getString(LR.string.error_episode_not_available),
+                            message = context.getString(
+                                if (isAccessDenied) LR.string.error_streaming_access_denied else LR.string.error_episode_not_available,
+                            ),
                             type = PlaybackNoticeType.PLAYBACK,
                             supportUrl = errorClassifier.classifyHelpUrl(httpCode),
+                            linkText = if (isAccessDenied) context.getString(LR.string.error_streaming_access_denied_action) else null,
                         )
                     }
                 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackNoticeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackNoticeManager.kt
@@ -138,7 +138,7 @@ class PlaybackNoticeManager @Inject constructor(
                             ),
                             type = PlaybackNoticeType.PLAYBACK,
                             supportUrl = errorClassifier.classifyHelpUrl(httpCode),
-                            linkText = if (isAccessDenied) context.getString(LR.string.error_streaming_access_denied_action) else null,
+                            linkText = if (isAccessDenied) context.getString(LR.string.settings_battery_learn_more) else null,
                         )
                     }
                 }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackNoticeManagerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackNoticeManagerTest.kt
@@ -261,7 +261,8 @@ class PlaybackNoticeManagerTest {
             playbackStateFlow.value = PlaybackState(state = PlaybackState.State.ERROR)
             val notice = awaitItem()
             assertEquals(PlaybackNoticeType.PLAYBACK, notice?.type)
-            assertEquals(episodeNotAvailableMessage, notice?.message)
+            assertEquals(accessDeniedMessage, notice?.message)
+            assertEquals(accessDeniedAction, notice?.linkText)
 
             advanceTimeBy(PlaybackNoticeManager.AUTO_DISMISS_DURATION)
             runCurrent()
@@ -594,7 +595,8 @@ class PlaybackNoticeManagerTest {
             )
             val notice = awaitItem()
             assertEquals(PlaybackNoticeType.PLAYBACK, notice?.type)
-            assertEquals(unableToPlayMessage, notice?.message)
+            assertEquals(accessDeniedMessage, notice?.message)
+            assertEquals(accessDeniedAction, notice?.linkText)
             assertEquals(Settings.INFO_DOWNLOAD_AND_PLAYBACK_URL, notice?.supportUrl)
         }
     }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackNoticeManagerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackNoticeManagerTest.kt
@@ -37,12 +37,16 @@ class PlaybackNoticeManagerTest {
     private val connectedMessage = "You're connected"
     private val episodeNotAvailableMessage = "Episode not available"
     private val unableToPlayMessage = "Unable to play"
+    private val accessDeniedMessage = "This episode can't be played."
+    private val accessDeniedAction = "Learn about possible causes"
 
     private val context: Context = mock {
         on { getString(au.com.shiftyjelly.pocketcasts.localization.R.string.error_playback_offline) } doReturn offlineMessage
         on { getString(au.com.shiftyjelly.pocketcasts.localization.R.string.error_playback_connected) } doReturn connectedMessage
         on { getString(au.com.shiftyjelly.pocketcasts.localization.R.string.error_episode_not_available) } doReturn episodeNotAvailableMessage
         on { getString(au.com.shiftyjelly.pocketcasts.localization.R.string.error_unable_to_play) } doReturn unableToPlayMessage
+        on { getString(au.com.shiftyjelly.pocketcasts.localization.R.string.error_streaming_access_denied) } doReturn accessDeniedMessage
+        on { getString(au.com.shiftyjelly.pocketcasts.localization.R.string.error_streaming_access_denied_action) } doReturn accessDeniedAction
     }
 
     private val networkConnectionWatcher = object : NetworkConnectionWatcher {

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackNoticeManagerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackNoticeManagerTest.kt
@@ -38,7 +38,7 @@ class PlaybackNoticeManagerTest {
     private val episodeNotAvailableMessage = "Episode not available"
     private val unableToPlayMessage = "Unable to play"
     private val accessDeniedMessage = "This episode can't be played."
-    private val accessDeniedAction = "Learn about possible causes"
+    private val accessDeniedAction = "Learn more"
 
     private val context: Context = mock {
         on { getString(au.com.shiftyjelly.pocketcasts.localization.R.string.error_playback_offline) } doReturn offlineMessage
@@ -46,7 +46,7 @@ class PlaybackNoticeManagerTest {
         on { getString(au.com.shiftyjelly.pocketcasts.localization.R.string.error_episode_not_available) } doReturn episodeNotAvailableMessage
         on { getString(au.com.shiftyjelly.pocketcasts.localization.R.string.error_unable_to_play) } doReturn unableToPlayMessage
         on { getString(au.com.shiftyjelly.pocketcasts.localization.R.string.error_streaming_access_denied) } doReturn accessDeniedMessage
-        on { getString(au.com.shiftyjelly.pocketcasts.localization.R.string.error_streaming_access_denied_action) } doReturn accessDeniedAction
+        on { getString(au.com.shiftyjelly.pocketcasts.localization.R.string.settings_battery_learn_more) } doReturn accessDeniedAction
     }
 
     private val networkConnectionWatcher = object : NetworkConnectionWatcher {

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackNoticeManagerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackNoticeManagerTest.kt
@@ -601,6 +601,40 @@ class PlaybackNoticeManagerTest {
         }
     }
 
+    @Test
+    fun `transient error state during player switch does not trigger notice`() = runTest {
+        FeatureFlag.setEnabled(Feature.PLAYBACK_ERROR_INFO_BAR, true)
+        networkCapabilities.value = onlineCapabilities()
+        val manager = createManager(backgroundScope)
+        runCurrent()
+
+        manager.playbackNotice.test {
+            assertNull(awaitItem())
+
+            // Simulate pause(transientLoss=true) re-emitting an ERROR state during player switch
+            playbackStateFlow.value = PlaybackState(
+                state = PlaybackState.State.ERROR,
+                playbackIssue = PlaybackIssue.HttpError(401),
+                transientLoss = true,
+            )
+            runCurrent()
+            expectNoEvents()
+
+            // loadCurrentEpisode emits PLAYING state
+            playbackStateFlow.value = PlaybackState(state = PlaybackState.State.PLAYING)
+            runCurrent()
+            expectNoEvents()
+
+            // Real error arrives with transientLoss=false
+            playbackStateFlow.value = PlaybackState(
+                state = PlaybackState.State.ERROR,
+                playbackIssue = PlaybackIssue.HttpError(401),
+            )
+            val notice = awaitItem()
+            assertEquals(PlaybackNoticeType.PLAYBACK, notice?.type)
+        }
+    }
+
     private fun onlineCapabilities() = mock<NetworkCapabilities> {
         on { hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) } doReturn true
     }


### PR DESCRIPTION
## Description
In case of 401 and 403 errors, we have decided to show the 
~"This episode can't be played. Learn about possible causes"~  "This episode can't be played. Learn more" text.

comms: p1775075776708869/1774342537.838119-slack-C05RR9P9RAT

## Testing Instructions
1. Apply this patch 
[patch-debug-as-prod.patch](https://github.com/user-attachments/files/26508017/patch-debug-as-prod.patch)
2. Build debug version
3. Sign in with your prod credentials
4. Follow [test podcast](https://pca.st/private/25cc6130-0a1b-013f-b6fa-0affe8d08c2d)
5. Play episodes with 401 and 403
6. Verify that the new text is shown on the error bar
7. Play other episodes
8. Verify that error text is unchanged

## Screenshots or Screencast 
<img width="1080" height="2400" alt="Screenshot_20260408_195600" src="https://github.com/user-attachments/assets/8ec9ec26-b21b-44ca-b323-86b2c2065388" />





## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
