### PR TITLE
Encourage login after app restore

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
@@ -251,6 +251,8 @@ class PocketCastsApplication :
                         fileStorage.fixBrokenFiles(episodeManager)
                         // reset stats
                         statsManager.reset()
+                        // Flag for login prompt in MainActivity
+                        settings.setNeedsLoginPromptAfterRestore(true)
                     }
                     settings.setRestoreFromBackupEnded()
                 }

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -484,7 +484,7 @@ class MainActivity :
         if (savedInstanceState == null && needsLoginPromptAfterRestore) {
             settings.setNeedsLoginPromptAfterRestore(false)
             if (!showOnboarding && !isLoggedIn) {
-                settings.showFreeAccountEncouragement = false
+                settings.showFreeAccountEncouragement.set(false, updateModifiedAt = true)
                 openOnboardingFlow(OnboardingFlow.AccountEncouragement)
             }
         }

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -469,10 +469,18 @@ class MainActivity :
 
         playbackManager.setNotificationPermissionChecker(this)
 
-        val showOnboarding = !settings.hasCompletedOnboarding() && !syncManager.isLoggedIn()
+        val hasCompletedOnboarding = settings.hasCompletedOnboarding()
+        val isLoggedIn = syncManager.isLoggedIn()
+        val showOnboarding = !hasCompletedOnboarding && !isLoggedIn
         // Only show if savedInstanceState is null in order to avoid creating onboarding activity twice.
         if (showOnboarding && savedInstanceState == null) {
             openOnboardingFlow(OnboardingFlow.InitialOnboarding)
+        }
+
+        // After restore from backup, prompt user to log in if they're not
+        if (!showOnboarding && settings.getNeedsLoginPromptAfterRestore() && !isLoggedIn && savedInstanceState == null) {
+            settings.setNeedsLoginPromptAfterRestore(false)
+            openOnboardingFlow(OnboardingFlow.AccountEncouragement)
         }
 
         binding = ActivityMainBinding.inflate(layoutInflater)

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -472,15 +472,21 @@ class MainActivity :
         val hasCompletedOnboarding = settings.hasCompletedOnboarding()
         val isLoggedIn = syncManager.isLoggedIn()
         val showOnboarding = !hasCompletedOnboarding && !isLoggedIn
+        val needsLoginPromptAfterRestore = settings.getNeedsLoginPromptAfterRestore()
         // Only show if savedInstanceState is null in order to avoid creating onboarding activity twice.
         if (showOnboarding && savedInstanceState == null) {
             openOnboardingFlow(OnboardingFlow.InitialOnboarding)
         }
 
-        // After restore from backup, prompt user to log in if they're not
-        if (!showOnboarding && settings.getNeedsLoginPromptAfterRestore() && !isLoggedIn && savedInstanceState == null) {
+        // After restore from backup, consume the restore flag on fresh launch so it can't
+        // trigger later unexpectedly, and suppress the generic encouragement flag when this
+        // path launches the same account encouragement flow.
+        if (savedInstanceState == null && needsLoginPromptAfterRestore) {
             settings.setNeedsLoginPromptAfterRestore(false)
-            openOnboardingFlow(OnboardingFlow.AccountEncouragement)
+            if (!showOnboarding && !isLoggedIn) {
+                settings.showFreeAccountEncouragement = false
+                openOnboardingFlow(OnboardingFlow.AccountEncouragement)
+            }
         }
 
         binding = ActivityMainBinding.inflate(layoutInflater)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -361,6 +361,9 @@ interface Settings {
     fun isRestoreFromBackup(): Boolean
     fun setRestoreFromBackupEnded()
 
+    fun setNeedsLoginPromptAfterRestore(value: Boolean)
+    fun getNeedsLoginPromptAfterRestore(): Boolean
+
     fun clearPlusPreferences()
 
     fun setDismissLowStorageModalTime(lastUpdateTime: Long)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -89,6 +89,7 @@ class SettingsImpl @Inject constructor(
         private const val END_OF_YEAR_SHOW_MODAL_2025_KEY = "EndOfYearModalShowModal2025Key"
         private const val DONE_INITIAL_ONBOARDING_KEY = "CompletedOnboardingKey"
         private const val PROCESSED_SIGNOUT_KEY = "ProcessedSignout"
+        private const val NEEDS_LOGIN_PROMPT_AFTER_RESTORE_KEY = "NeedsLoginPromptAfterRestore"
     }
 
     private var languageCode: String? = null
@@ -505,6 +506,14 @@ class SettingsImpl @Inject constructor(
 
     override fun setRestoreFromBackupEnded() {
         setString("deviceUuid", getUniqueDeviceId())
+    }
+
+    override fun setNeedsLoginPromptAfterRestore(value: Boolean) {
+        sharedPreferences.edit().putBoolean(NEEDS_LOGIN_PROMPT_AFTER_RESTORE_KEY, value).apply()
+    }
+
+    override fun getNeedsLoginPromptAfterRestore(): Boolean {
+        return sharedPreferences.getBoolean(NEEDS_LOGIN_PROMPT_AFTER_RESTORE_KEY, false)
     }
 
     @SuppressLint("HardwareIds")


### PR DESCRIPTION
## Description
Since account data is not being restored during a backup (or when you migrate your apps to a new device), we end up seeing our recent podcasts and data (onlydatabase and preferences are being restored, as per our [extraction_rules.xml](https://github.com/Automattic/pocket-casts-android/blob/61a5d1a965655729f12e6656e689cb5d44bc4c2a/modules/services/localization/src/release/res/xml/extraction_rules.xml#L4))
There are some catches, though. 
Backup is only enabled on `release` builds, and the default method (cloud backup where you can store at most 25MB on your google drive per app automatically) is used to store both the database and the prefs file. Since users may have way larger databases than then, this method would silently fail.
There's another method to transfer your apps to a new device: you can connect the old device to the new one via USB cable or connect to the same network so they can find each other and conduct transfers. This way there is no size limitation at all.
How backup works behind the scenes: it basically grabs the files specified in our [backup_scheme.xml](https://github.com/Automattic/pocket-casts-android/blob/61a5d1a965655729f12e6656e689cb5d44bc4c2a/modules/services/localization/src/release/res/xml/backup_scheme.xml#L4) and copies them to the new installation location. AccountManager data is discarded in the process.

What I did here is that I'm storing a new flag in the Settings to notice when we detect restore and we launch `OnboardingFlow.EncourageAccount` to remind the user that they need to log in.

Fixes PCDROID-510 (https://linear.app/a8c/issue/PCDROID-510/check-user-not-logged-out-after-setting-up-a-new-phone)

## Testing Instructions
Testing this would only work with the release build as I called out in the description.
However you can still simulate this scenario with debug builds if you applied this patch: 
[backup-restore-sim.patch](https://github.com/user-attachments/files/26545335/backup-restore-sim.patch)
Apply it on PCA repo
Log in into the app, follow some podcasts
Then you can run `./scripts/test_backup_restore.sh backup` then `./scripts/test_backup_restore.sh restore`. 
The script will copy both database and prefs, uninstall the app, reinstall the apk again, then push the saved database and prefs to their proper folders and finally it launches the app
You should see the "We noticed you're not logged in" screen.

## Screenshots or Screencast

https://github.com/user-attachments/assets/eaf0e79e-f927-4c90-a89b-e77247152b77


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
