### PR TITLE
Connect with firebase and set default value

### DIFF
--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -195,7 +195,7 @@ enum class Feature(
     MEDIA3_SESSION(
         key = "media3_session",
         title = "Media3 MediaSession",
-        defaultValue = false,
+        defaultValue = isDebugOrPrototypeBuild,
         tier = FeatureTier.Free,
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,


### PR DESCRIPTION
## Description
I created firebase remote config flag and this PR will turn on flag by default in debug and prototype versions.


## Testing Instructions
Just review the code

## Screenshots or Screencast 

<img width="588" height="414" alt="SCR-20260408-rmhm" src="https://github.com/user-attachments/assets/cfc78731-c3c2-4ea5-986f-8b4ab6cd9824" />


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
