### PR TITLE
[Media3] Respect user's setting of artworks on notification

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -207,20 +207,22 @@ class MediaSessionManager(
 
     fun startObserving() {
         if (!useMedia3Session) {
-            mediaSession!!.setCallback(
-                MediaSessionCallback(
-                    playbackManager,
-                    episodeManager,
-                    enqueueCommand = { tag, command ->
-                        val added = commandQueue.tryEmit(Pair(tag, command))
-                        if (added) {
-                            Timber.i("Added command to queue: $tag")
-                        } else {
-                            LogBuffer.e(LogBuffer.TAG_PLAYBACK, "Failed to add command to queue: $tag")
-                        }
-                    },
-                ),
-            )
+            applicationScope.launch(Dispatchers.Main) {
+                mediaSession!!.setCallback(
+                    MediaSessionCallback(
+                        playbackManager,
+                        episodeManager,
+                        enqueueCommand = { tag, command ->
+                            val added = commandQueue.tryEmit(Pair(tag, command))
+                            if (added) {
+                                Timber.i("Added command to queue: $tag")
+                            } else {
+                                LogBuffer.e(LogBuffer.TAG_PLAYBACK, "Failed to add command to queue: $tag")
+                            }
+                        },
+                    ),
+                )
+            }
 
             applicationScope.launch {
                 commandQueue.collect { (tag, command) ->

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -87,7 +87,7 @@ class MediaSessionManager(
     val eventHorizon: EventHorizon,
     val bookmarkManager: BookmarkManager,
     val browseTreeProvider: BrowseTreeProvider,
-    applicationScope: CoroutineScope,
+    private val applicationScope: CoroutineScope,
 ) {
     companion object {
         const val EXTRA_TRANSIENT = "pocketcasts_transient_loss"
@@ -111,27 +111,32 @@ class MediaSessionManager(
         }
     }
 
-    // Evaluated once at construction — toggling requires a process restart.
-    // Swapping between Media3 and legacy session at runtime is not supported.
+    // Evaluated lazily on first access — must not be read before FeatureFlag.initialize().
+    // In practice the first access is in startObserving(), which runs after FeatureFlag init.
+    // Toggling requires a process restart; swapping at runtime is not supported.
     // On automotive, always use Media3: AAOS never uses app-managed notifications,
     // so the legacy compat session is unnecessary and having a single service avoids
     // the race condition where AAOS discovers the wrong service before the toggle runs.
-    private val useMedia3Session = FeatureFlag.isEnabled(Feature.MEDIA3_SESSION) || Util.isAutomotive(context)
+    private val useMedia3Session by lazy {
+        FeatureFlag.isEnabled(Feature.MEDIA3_SESSION) || Util.isAutomotive(context)
+    }
 
-    val mediaSession: MediaSessionCompat? = if (!useMedia3Session) {
-        MediaSessionCompat(context, "PocketCastsMediaSession").also { session ->
-            if (!Util.isAutomotive(context)) {
-                session.setSessionActivity(context.getLaunchActivityPendingIntent())
+    val mediaSession: MediaSessionCompat? by lazy {
+        if (!useMedia3Session) {
+            MediaSessionCompat(context, "PocketCastsMediaSession").also { session ->
+                if (!Util.isAutomotive(context)) {
+                    session.setSessionActivity(context.getLaunchActivityPendingIntent())
+                }
+                session.setRatingType(RatingCompat.RATING_HEART)
+                session.setExtras(
+                    Bundle().apply {
+                        putBoolean("com.google.android.gms.car.media.ALWAYS_RESERVE_SPACE_FOR.ACTION_QUEUE", true)
+                    },
+                )
             }
-            session.setRatingType(RatingCompat.RATING_HEART)
-            session.setExtras(
-                Bundle().apply {
-                    putBoolean("com.google.android.gms.car.media.ALWAYS_RESERVE_SPACE_FOR.ACTION_QUEUE", true)
-                },
-            )
+        } else {
+            null
         }
-    } else {
-        null
     }
 
     val disposables = CompositeDisposable()
@@ -165,6 +170,9 @@ class MediaSessionManager(
     private var media3Session: MediaLibraryService.MediaLibrarySession? = null
 
     @Volatile
+    private var media3Service: MediaLibraryService? = null
+
+    @Volatile
     private var forwardingPlayer: PocketCastsForwardingPlayer? = null
 
     @Volatile
@@ -195,7 +203,9 @@ class MediaSessionManager(
             bookmarkManager,
             settings,
         )
+    }
 
+    fun startObserving() {
         if (!useMedia3Session) {
             mediaSession!!.setCallback(
                 MediaSessionCallback(
@@ -219,9 +229,7 @@ class MediaSessionManager(
                 }
             }
         }
-    }
 
-    fun startObserving() {
         if (useMedia3Session) {
             observeForMedia3Updates()
         } else {
@@ -255,6 +263,7 @@ class MediaSessionManager(
     @MainThread
     fun createSession(service: MediaLibraryService) {
         if (!useMedia3Session) return
+        media3Service = service
         // Recreate scope in case release() was called previously (service restart).
         if (scope.coroutineContext[Job]?.isActive != true) {
             scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -356,22 +365,7 @@ class MediaSessionManager(
         }
 
         // Asynchronously enrich metadata with podcast name + artwork.
-        scope.launch(Dispatchers.IO) {
-            try {
-                val ep = playbackManager.getCurrentEpisode() ?: return@launch
-                val podcast = when (ep) {
-                    is PodcastEpisode -> podcastManager.findPodcastByUuid(ep.podcastUuid)
-                    else -> null
-                }
-                val showArtwork = settings.showArtworkOnLockScreen.value
-                val useEpisodeArtwork = settings.artworkConfiguration.value.useEpisodeArtwork
-                withContext(Dispatchers.Main) {
-                    forwardingPlayer?.updateMetadata(ep, podcast, showArtwork, useEpisodeArtwork)
-                }
-            } catch (e: Exception) {
-                Timber.e(e, "Failed to seed initial Media3 metadata")
-            }
-        }
+        forwardingPlayer?.let { replayMetadataToPlayer(it) }
     }
 
     /**
@@ -397,6 +391,7 @@ class MediaSessionManager(
         media3Session?.player = swapped
         placeholderPlayer?.release()
         placeholderPlayer = null
+        replayMetadataToPlayer(swapped)
         Timber.i("Media3 session player swapped")
     }
 
@@ -457,7 +452,61 @@ class MediaSessionManager(
         media3Session?.player = swapped
         placeholderPlayer?.release()
         placeholderPlayer = null
+        replayMetadataToPlayer(swapped)
         Timber.i("Media3 session cast player installed (no transport callbacks)")
+    }
+
+    /**
+     * Asynchronously fetches the current episode metadata and artwork, then applies
+     * it to the given [player]. Guarded by an identity check so that a stale replay
+     * (e.g., if another player swap happened during the async work) is discarded.
+     *
+     * Called after every player swap ([installPlayer], [installCastPlayerInternal],
+     * [createSession]) to ensure the Media3 notification has content. This is
+     * necessary because [observeForMedia3Updates] may have dropped the playback
+     * state event while [forwardingPlayer] was still null.
+     */
+    @OptIn(UnstableApi::class)
+    private fun replayMetadataToPlayer(player: PocketCastsForwardingPlayer) {
+        scope.launch(Dispatchers.IO) {
+            try {
+                val state = playbackManager.playbackStateRelay.blockingFirst()
+                if (state.isEmpty) return@launch
+                val episode = episodeManager.findEpisodeByUuid(state.episodeUuid) ?: return@launch
+                val podcast = when (episode) {
+                    is PodcastEpisode -> podcastManager.findPodcastByUuidBlocking(episode.podcastUuid)
+                    else -> null
+                }
+                val showArtwork = settings.showArtworkOnLockScreen.value
+                val useEpisodeArtwork = settings.artworkConfiguration.value.useEpisodeArtwork
+                val artworkData = if (showArtwork && !Util.isWearOs(context) && !Util.isAutomotive(context)) {
+                    AutoConverter.getPodcastArtworkBitmap(episode, context, useEpisodeArtwork)?.let { bitmap ->
+                        java.io.ByteArrayOutputStream().use { stream ->
+                            val format = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                                android.graphics.Bitmap.CompressFormat.WEBP_LOSSY
+                            } else {
+                                @Suppress("DEPRECATION")
+                                android.graphics.Bitmap.CompressFormat.WEBP
+                            }
+                            bitmap.compress(format, 80, stream)
+                            stream.toByteArray()
+                        }
+                    }
+                } else {
+                    null
+                }
+                withContext(Dispatchers.Main) {
+                    if (forwardingPlayer === player) {
+                        player.updateMetadata(episode, podcast, showArtwork, useEpisodeArtwork, artworkData)
+                        player.isTransientLoss = state.transientLoss
+                        updateMedia3CustomLayout()
+                        media3Service?.triggerNotificationUpdate()
+                    }
+                }
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to replay metadata after player install")
+            }
+        }
     }
 
     /**
@@ -740,6 +789,7 @@ class MediaSessionManager(
         if (useMedia3Session) {
             media3Session?.release()
             media3Session = null
+            media3Service = null
             forwardingPlayer = null
             placeholderPlayer?.release()
             placeholderPlayer = null

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -69,6 +69,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.rx2.asObservable
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
@@ -363,8 +364,9 @@ class MediaSessionManager(
                     else -> null
                 }
                 val showArtwork = settings.showArtworkOnLockScreen.value
+                val useEpisodeArtwork = settings.artworkConfiguration.value.useEpisodeArtwork
                 withContext(Dispatchers.Main) {
-                    forwardingPlayer?.updateMetadata(ep, podcast, showArtwork)
+                    forwardingPlayer?.updateMetadata(ep, podcast, showArtwork, useEpisodeArtwork)
                 }
             } catch (e: Exception) {
                 Timber.e(e, "Failed to seed initial Media3 metadata")
@@ -486,7 +488,7 @@ class MediaSessionManager(
 
     @OptIn(UnstableApi::class)
     private fun observeForMedia3Updates() {
-        playbackManager.playbackStateRelay
+        val episodeAndState = playbackManager.playbackStateRelay
             .distinctUntilChanged { old, new ->
                 old.episodeUuid == new.episodeUuid &&
                     old.state == new.state &&
@@ -506,8 +508,16 @@ class MediaSessionManager(
                         .toObservable()
                 }
             }
+
+        val artworkConfig = settings.artworkConfiguration.flow.asObservable()
+        val showArtworkOnLockScreen = settings.showArtworkOnLockScreen.flow.asObservable()
+
+        Observables.combineLatest(episodeAndState, artworkConfig, showArtworkOnLockScreen) { episodeState, config, showArtwork ->
+            Triple(episodeState, config.useEpisodeArtwork, showArtwork)
+        }
             .observeOn(Schedulers.io())
-            .map<Optional<MediaUpdateData>> { (episodeOpt, state) ->
+            .map<Optional<MediaUpdateData>> { (episodeState, useEpisodeArtwork, showArtwork) ->
+                val (episodeOpt, state) = episodeState
                 if (!episodeOpt.isPresent()) {
                     return@map Optional.empty()
                 }
@@ -516,12 +526,11 @@ class MediaSessionManager(
                     is PodcastEpisode -> podcastManager.findPodcastByUuidBlocking(episode.podcastUuid)
                     else -> null
                 }
-                val showArtwork = settings.showArtworkOnLockScreen.value
                 val artworkData = if (showArtwork && !Util.isWearOs(context) && !Util.isAutomotive(context)) {
                     AutoConverter.getPodcastArtworkBitmap(
                         episode,
                         context,
-                        settings.artworkConfiguration.value.useEpisodeArtwork,
+                        useEpisodeArtwork,
                     )?.let { bitmap ->
                         java.io.ByteArrayOutputStream().use { stream ->
                             val format = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
@@ -537,7 +546,7 @@ class MediaSessionManager(
                 } else {
                     null
                 }
-                Optional.of(MediaUpdateData(episode, podcast, state, showArtwork, artworkData))
+                Optional.of(MediaUpdateData(episode, podcast, state, showArtwork, useEpisodeArtwork, artworkData))
             }
             .observeOn(AndroidSchedulers.mainThread())
             .subscribeBy(
@@ -548,7 +557,7 @@ class MediaSessionManager(
                         player.clearMetadata()
                         return@subscribeBy
                     }
-                    player.updateMetadata(data.episode, data.podcast, data.showArtwork, data.artworkData)
+                    player.updateMetadata(data.episode, data.podcast, data.showArtwork, data.useEpisodeArtwork, data.artworkData)
                     player.isTransientLoss = data.state.transientLoss
                     updateMedia3CustomLayout()
                 },
@@ -1365,13 +1374,15 @@ private data class MediaUpdateData(
     val podcast: Podcast?,
     val state: PlaybackState,
     val showArtwork: Boolean,
+    val useEpisodeArtwork: Boolean,
     val artworkData: ByteArray?,
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is MediaUpdateData) return false
         return episode == other.episode && podcast == other.podcast && state == other.state &&
-            showArtwork == other.showArtwork && artworkData.contentEquals(other.artworkData)
+            showArtwork == other.showArtwork && useEpisodeArtwork == other.useEpisodeArtwork &&
+            artworkData.contentEquals(other.artworkData)
     }
 
     override fun hashCode(): Int {
@@ -1379,6 +1390,7 @@ private data class MediaUpdateData(
         result = 31 * result + (podcast?.hashCode() ?: 0)
         result = 31 * result + state.hashCode()
         result = 31 * result + showArtwork.hashCode()
+        result = 31 * result + useEpisodeArtwork.hashCode()
         result = 31 * result + (artworkData?.contentHashCode() ?: 0)
         return result
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsForwardingPlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsForwardingPlayer.kt
@@ -78,6 +78,8 @@ class PocketCastsForwardingPlayer(
      * Updates the metadata exposed via [getCurrentMediaItem]. Call this when the
      * current episode changes or when metadata is refreshed (e.g., artwork loaded).
      *
+     * @param showArtwork When false, artwork URI and data are omitted from the metadata.
+     * @param useEpisodeArtwork When true, prefer episode-specific artwork; when false, use podcast artwork.
      * @param artworkData Pre-compressed artwork bytes (e.g. WebP). Compression should
      *   happen off the main thread before calling this method.
      */
@@ -86,11 +88,12 @@ class PocketCastsForwardingPlayer(
         episode: BaseEpisode,
         podcast: Podcast?,
         showArtwork: Boolean = true,
+        useEpisodeArtwork: Boolean = true,
         artworkData: ByteArray? = null,
     ) {
         checkMainThread()
 
-        val artworkUri = if (showArtwork) resolveArtworkUri(episode, podcast) else null
+        val artworkUri = if (showArtwork) resolveArtworkUri(episode, podcast, useEpisodeArtwork) else null
         val podcastTitle = episode.displaySubtitle(podcast)
 
         val metadataBuilder = MediaMetadata.Builder()
@@ -299,11 +302,15 @@ class PocketCastsForwardingPlayer(
         listeners.remove(listener)
     }
 
-    private fun resolveArtworkUri(episode: BaseEpisode, podcast: Podcast?): Uri? {
+    private fun resolveArtworkUri(episode: BaseEpisode, podcast: Podcast?, useEpisodeArtwork: Boolean): Uri? {
         return when (episode) {
             is PodcastEpisode -> {
-                val url = episode.imageUrl?.takeIf { it.isNotBlank() }
-                    ?: podcast?.getArtworkUrl(480)?.takeIf { it.isNotBlank() }
+                val url = if (useEpisodeArtwork) {
+                    episode.imageUrl?.takeIf { it.isNotBlank() }
+                        ?: podcast?.getArtworkUrl(480)?.takeIf { it.isNotBlank() }
+                } else {
+                    podcast?.getArtworkUrl(480)?.takeIf { it.isNotBlank() }
+                }
                 url?.let(Uri::parse)
             }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsForwardingPlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsForwardingPlayer.kt
@@ -5,6 +5,7 @@ import android.os.Looper
 import androidx.annotation.MainThread
 import androidx.annotation.OptIn
 import androidx.media3.common.C
+import androidx.media3.common.FlagSet
 import androidx.media3.common.ForwardingPlayer
 import androidx.media3.common.HeartRating
 import androidx.media3.common.MediaItem
@@ -131,6 +132,11 @@ class PocketCastsForwardingPlayer(
                 )
             }
         }
+        if (episodeChanged) {
+            dispatchEvents(Player.EVENT_MEDIA_METADATA_CHANGED, Player.EVENT_MEDIA_ITEM_TRANSITION)
+        } else {
+            dispatchEvents(Player.EVENT_MEDIA_METADATA_CHANGED)
+        }
     }
 
     /**
@@ -145,6 +151,7 @@ class PocketCastsForwardingPlayer(
         listeners.forEach { listener ->
             listener.onMediaMetadataChanged(MediaMetadata.EMPTY)
         }
+        dispatchEvents(Player.EVENT_MEDIA_METADATA_CHANGED)
     }
 
     override fun getCurrentMediaItem(): MediaItem = currentMediaItem
@@ -278,6 +285,11 @@ class PocketCastsForwardingPlayer(
                 )
             }
         }
+        if (episodeChanged) {
+            dispatchEvents(Player.EVENT_MEDIA_METADATA_CHANGED, Player.EVENT_MEDIA_ITEM_TRANSITION)
+        } else {
+            dispatchEvents(Player.EVENT_MEDIA_METADATA_CHANGED)
+        }
     }
 
     override fun getDuration(): Long {
@@ -310,6 +322,7 @@ class PocketCastsForwardingPlayer(
                         ?: podcast?.getArtworkUrl(480)?.takeIf { it.isNotBlank() }
                 } else {
                     podcast?.getArtworkUrl(480)?.takeIf { it.isNotBlank() }
+                        ?: episode.imageUrl?.takeIf { it.isNotBlank() }
                 }
                 url?.let(Uri::parse)
             }
@@ -322,6 +335,16 @@ class PocketCastsForwardingPlayer(
 
     private fun buildRating(episode: BaseEpisode): HeartRating {
         return HeartRating(episode.isStarred)
+    }
+
+    /**
+     * Dispatches a batched [Player.Events] callback to all listeners.
+     * Media3's notification system reacts to [Player.Listener.onEvents], not
+     * individual callbacks, so this must be called after individual callbacks.
+     */
+    private fun dispatchEvents(vararg eventFlags: @Player.Event Int) {
+        val events = Player.Events(FlagSet.Builder().addAll(*eventFlags).build())
+        listeners.forEach { it.onEvents(this@PocketCastsForwardingPlayer, events) }
     }
 
     private fun checkMainThread() {

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsForwardingPlayerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsForwardingPlayerTest.kt
@@ -14,7 +14,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.extensions.getArtworkUrl
 import java.util.Date
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsForwardingPlayerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsForwardingPlayerTest.kt
@@ -10,6 +10,7 @@ import androidx.media3.common.Player
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
+import au.com.shiftyjelly.pocketcasts.repositories.extensions.getArtworkUrl
 import java.util.Date
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -526,8 +527,7 @@ class PocketCastsForwardingPlayerTest {
         forwardingPlayer.updateMetadata(episode, podcast, useEpisodeArtwork = false)
 
         val artworkUri = forwardingPlayer.mediaMetadata.artworkUri
-        assertNotNull(artworkUri)
-        assertFalse(artworkUri.toString().contains("episode-art"))
+        assertEquals(Uri.parse(podcast.getArtworkUrl(480)), artworkUri)
     }
 
     @Test
@@ -542,6 +542,19 @@ class PocketCastsForwardingPlayerTest {
         forwardingPlayer.updateMetadata(episode, podcast, useEpisodeArtwork = true)
 
         assertEquals(Uri.parse("https://example.com/art.jpg"), forwardingPlayer.mediaMetadata.artworkUri)
+    }
+
+    @Test
+    fun `updateMetadata falls back to episode artwork when useEpisodeArtwork is false and podcast is null`() {
+        val episode = createPodcastEpisode(
+            uuid = "ep-1",
+            title = "Test",
+            imageUrl = "https://example.com/episode-art.jpg",
+        )
+
+        forwardingPlayer.updateMetadata(episode, podcast = null, useEpisodeArtwork = false)
+
+        assertEquals(Uri.parse("https://example.com/episode-art.jpg"), forwardingPlayer.mediaMetadata.artworkUri)
     }
 
     @Test

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsForwardingPlayerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsForwardingPlayerTest.kt
@@ -13,6 +13,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import java.util.Date
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -509,6 +510,36 @@ class PocketCastsForwardingPlayerTest {
         val podcast = createPodcast(title = "Podcast")
 
         forwardingPlayer.updateMetadata(episode, podcast, showArtwork = true)
+
+        assertEquals(Uri.parse("https://example.com/art.jpg"), forwardingPlayer.mediaMetadata.artworkUri)
+    }
+
+    @Test
+    fun `updateMetadata uses podcast artwork when useEpisodeArtwork is false`() {
+        val episode = createPodcastEpisode(
+            uuid = "ep-1",
+            title = "Test",
+            imageUrl = "https://example.com/episode-art.jpg",
+        )
+        val podcast = createPodcast(title = "Podcast")
+
+        forwardingPlayer.updateMetadata(episode, podcast, useEpisodeArtwork = false)
+
+        val artworkUri = forwardingPlayer.mediaMetadata.artworkUri
+        assertNotNull(artworkUri)
+        assertFalse(artworkUri.toString().contains("episode-art"))
+    }
+
+    @Test
+    fun `updateMetadata uses episode artwork when useEpisodeArtwork is true`() {
+        val episode = createPodcastEpisode(
+            uuid = "ep-1",
+            title = "Test",
+            imageUrl = "https://example.com/art.jpg",
+        )
+        val podcast = createPodcast(title = "Podcast")
+
+        forwardingPlayer.updateMetadata(episode, podcast, useEpisodeArtwork = true)
 
         assertEquals(Uri.parse("https://example.com/art.jpg"), forwardingPlayer.mediaMetadata.artworkUri)
     }


### PR DESCRIPTION
## Description
We noticed that the new media3 playback notification doesn't respect the users' choice wheter to show episode or podcast artwork as background.
This PR addresses that, plus also enhances the behavior a bit, so you won't need to dismiss the notification to see the effects of your setting change -- now the notifcation will be updated as you toggle artwork settings.

Fixes PCDROID-530 https://linear.app/a8c/issue/PCDROID-530/media3-phone-artwork-is-used-on-notification-when-settings-is-off


## Testing Instructions
0. Check your current settings on Profile -> Cogwheel > Appearance > Podcast artwork
1. Enable Media3 sessions FF (then restart the app just to be sure)
2. Find a podcast where  episodes have unique artworks
3. With the Use episode artwork off, start playing an episode
4. Check playback notification -- it shows the podcast artwork
5. Now turn ON the episode artwrok setting
6. Check notification -- it now shows the episode artwork

## Screenshots or Screencast 
| with episode artwork ON | OFF |
| --- | --- |
| <img width="1080" height="2400" alt="Screenshot_20260410_093142" src="https://github.com/user-attachments/assets/a716f121-e236-40b4-99f8-c9480f9ec8b1" /> | <img width="1080" height="2400" alt="Screenshot_20260410_093158" src="https://github.com/user-attachments/assets/8a08a998-0ac9-413e-b10f-a0107abc333a" /> |

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 