### PR TITLE
Bug/5201 download warning bottom sheet shown again when stopping download on mobile data

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -555,7 +555,7 @@ class EpisodeFragment : BaseFragment() {
                         warningsHelper
                             .downloadWarning(episodeUUID, SourceView.EPISODE_DETAILS)
                             .show(parentFragmentManager, "download warning")
-                    }else {
+                    } else {
                         viewModel.downloadEpisode()
                     }
                 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -555,6 +555,8 @@ class EpisodeFragment : BaseFragment() {
                         warningsHelper
                             .downloadWarning(episodeUUID, SourceView.EPISODE_DETAILS)
                             .show(parentFragmentManager, "download warning")
+                    } else if (settings.warnOnMeteredNetwork.value && !Network.isUnmeteredConnection(context) && episode.isDownloading) {
+                        viewModel.downloadEpisode()
                     } else {
                         viewModel.downloadEpisode()
                     }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -551,13 +551,11 @@ class EpisodeFragment : BaseFragment() {
                 }
             } else {
                 context?.let { context ->
-                    if (settings.warnOnMeteredNetwork.value && !Network.isUnmeteredConnection(context)) {
+                    if (settings.warnOnMeteredNetwork.value && !Network.isUnmeteredConnection(context) && !episode.isDownloadCancellable) {
                         warningsHelper
                             .downloadWarning(episodeUUID, SourceView.EPISODE_DETAILS)
                             .show(parentFragmentManager, "download warning")
-                    } else if (settings.warnOnMeteredNetwork.value && !Network.isUnmeteredConnection(context) && episode.isDownloading) {
-                        viewModel.downloadEpisode()
-                    } else {
+                    }else {
                         viewModel.downloadEpisode()
                     }
                 }


### PR DESCRIPTION
## Description
Fixes an issue where the "Warn before using data" bottom sheet was incorrectly shown when attempting to stop/cancel an ongoing download on mobile data.

Previously, the warning was triggered both when initiating and canceling a download. This behavior was incorrect, as the warning should only appear before starting a download on mobile data—not when stopping it.

### Changes
- Show warning bottom sheet **only when initiating a download**
- Prevent warning from appearing when **stopping/canceling an active download**

Fixes #5201

---

## Testing Instructions
1. Enable **"Warn before using data"** in *Storage & Data Use* settings  
2. Turn off WiFi (ensure device is on mobile data)  
3. Open any podcast episode  
4. Tap **Download**  
5. Verify that the warning bottom sheet is shown  
6. Tap **"Download now"** to start downloading  
7. Once the download starts, tap the **stop/cancel (X)** button  
8. Verify that:
   - The download stops successfully  
   - ❌ No warning bottom sheet is shown again  

---

## Screenshots / Screencast

### Before Fix
<p align="center">
  <video src="https://github.com/user-attachments/assets/26e68d6e-48b4-4540-b979-30d9bf6bdca7" width="300" controls></video>
</p>


### After Fix
<p align="center">
  <video src="https://github.com/user-attachments/assets/c7d91964-fc7d-4085-98b0-76637a804bc0" width="300" controls></video>
</p>

> Replace `BEFORE_VIDEO_URL_HERE` and `AFTER_VIDEO_URL_HERE` with your uploaded GitHub asset links.

---
## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
