### PR TITLE
Fix buttons on Wear with FF on

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -588,12 +588,26 @@ class MediaSessionManager(
     @OptIn(UnstableApi::class)
     private fun updateMedia3CustomLayout() {
         val session = media3Session ?: return
-        if (Util.isWearOs(context)) return
-
         val buttons = mutableListOf<CommandButton>()
         val currentEpisode = playbackManager.getCurrentEpisode()
 
-        if (Util.isAutomotive(context)) {
+        if (Util.isWearOs(context)) {
+            // WearOS: only skip back and skip forward, no custom actions.
+            buttons.add(
+                CommandButton.Builder(skipBackIconForDuration(settings.skipBackInSecs.value))
+                    .setSessionCommand(SessionCommand(APP_ACTION_SKIP_BACK, Bundle.EMPTY))
+                    .setDisplayName(context.getString(LR.string.skip_back))
+                    .setCustomIconResId(IR.drawable.media_skipback)
+                    .build(),
+            )
+            buttons.add(
+                CommandButton.Builder(skipForwardIconForDuration(settings.skipForwardInSecs.value))
+                    .setSessionCommand(SessionCommand(APP_ACTION_SKIP_FWD, Bundle.EMPTY))
+                    .setDisplayName(context.getString(LR.string.skip_forward))
+                    .setCustomIconResId(IR.drawable.media_skipforward)
+                    .build(),
+            )
+        } else if (Util.isAutomotive(context)) {
             // Automotive: use circular seek icons matching the configured skip duration.
             // Playback speed first (gets the extra slot), then skip buttons, then custom actions.
             if (playbackManager.isAudioEffectsAvailable()) {


### PR DESCRIPTION
## Description
This PR attemts to fix the player controls issue Philip spotted on his Pixel Watch. Unfortunately I didn't manage to reproduce it on my Galaxy watch 4 nor on the emulator.

Fixes PCDROID-529 https://linear.app/a8c/issue/PCDROID-529/media3-wearos-controls-lack-skip-fwd

## Testing Instructions
1. Build the wear app with `media3_session` flag turned ON
2. Login and start playing a podcast
3. Verify controls are the same as we have on the prod app (flag off)

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
