### PR TITLE
Enable metered network data warning by default

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/StorageSettingsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/StorageSettingsViewModel.kt
@@ -467,7 +467,7 @@ class StorageSettingsViewModel @Inject constructor(
         )
 
         data class StorageDataWarningState(
-            val isChecked: Boolean = false,
+            val isChecked: Boolean = true,
             val onCheckedChange: (Boolean) -> Unit,
         )
     }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -436,7 +436,7 @@ class SettingsImpl @Inject constructor(
 
     override val warnOnMeteredNetwork = UserSetting.BoolPref(
         sharedPrefKey = Settings.PREFERENCE_WARN_WHEN_NOT_ON_WIFI,
-        defaultValue = false,
+        defaultValue = true,
         sharedPrefs = sharedPreferences,
     )
 


### PR DESCRIPTION
## Description
Enables **"Warn before using data"** by default to prevent unintended mobile data usage.

Previously, this setting was disabled by default, which led to users accidentally consuming large amounts of mobile data. In some cases, users assumed that **"Only on unmetered WiFi"** under Auto Download applied globally, which caused confusion.

### Changes
- Enable **"Warn before using data"** by default
- Add a **deep link to the setting** from the warning bottom sheet, allowing users to easily disable it if desired
- Improve overall clarity and prevent accidental mobile data usage

Slack Reference: p1749029285430589-slack-C028JAG44VD  
iOS issue: Automattic/pocket-casts-ios#3227  

---

## Testing Instructions
1. Install or reset the app (fresh state)
2. Navigate to **Storage & Data Use** settings  
3. Verify that:
   - ✅ "Warn before using data" is **enabled by default**
4. Turn off WiFi (use mobile data)
5. Open any podcast episode  
6. Tap **Download**
7. Verify:
   - Warning bottom sheet is shown  
   - Bottom sheet includes option/link to open the relevant setting  
8. Tap on the settings link from the warning  
9. Verify:
   - User is deep-linked to **"Warn before using data"** setting  
10. Disable the setting and retry download
11. Verify:
   - No warning is shown when disabled  

---

## Screenshots / Screencast

### After Fix
<p align="center">
  <video src="https://github.com/user-attachments/assets/7813c43e-f92d-48b7-af4d-1fe3a7738586" width="300" controls></video>
</p>

---

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md  
- [ ] Ensure the linter passes (`./gradlew spotlessApply`)  
- [ ] I have considered whether it makes sense to add tests for my changes  
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`  
- [ ] Any Jetpack Compose components I added or changed are covered by previews  
- [ ] I have updated (or requested update for) analytics tracking if needed  

#### UI Testing
- [ ] Tested with different themes  
- [ ] Tested in landscape orientation  
- [ ] Tested with large display and font size  
- [ ] Tested accessibility with TalkBack  