### PR TITLE
[Media3] Automotive fixes

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/AutomotiveSessionStrategy.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/AutomotiveSessionStrategy.kt
@@ -1,0 +1,27 @@
+package au.com.shiftyjelly.pocketcasts.repositories.playback
+
+import android.content.Context
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.session.CommandButton
+import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.Settings.MediaNotificationControls
+
+/**
+ * Strategy interface for automotive-specific custom action layout and metadata formatting.
+ *
+ * Automotive always uses a [MediaLibraryService][androidx.media3.session.MediaLibraryService]
+ * shell, but the internal behavior differs based on the `media3_session` feature flag:
+ * - Flag ON: [Media3AutomotiveStrategy] — new layout with promoted speed button and circular skip icons.
+ * - Flag OFF: [LegacyAutomotiveStrategy] — matches the old `MediaBrowserServiceCompat` behavior.
+ */
+@UnstableApi
+internal interface AutomotiveSessionStrategy {
+
+    fun buildCustomLayout(
+        playbackManager: PlaybackManager,
+        settings: Settings,
+        context: Context,
+        buildCustomActionButton: (MediaNotificationControls, BaseEpisode?) -> CommandButton?,
+    ): List<CommandButton>
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/LegacyAutomotiveStrategy.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/LegacyAutomotiveStrategy.kt
@@ -1,0 +1,62 @@
+package au.com.shiftyjelly.pocketcasts.repositories.playback
+
+import android.content.Context
+import android.os.Bundle
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.session.CommandButton
+import androidx.media3.session.SessionCommand
+import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.Settings.MediaNotificationControls
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+/**
+ * Automotive strategy for the legacy session path (flag OFF).
+ *
+ * Matches the old `MediaBrowserServiceCompat` custom action layout:
+ * skip buttons first (if [useCustomSkipButtons]), then media control items
+ * in settings order (archive, mark as played, play next, speed, star)
+ * up to [MediaNotificationControls.MAX_VISIBLE_OPTIONS].
+ *
+ * Uses generic skip icons (not circular duration icons) to match the old behavior.
+ */
+@UnstableApi
+internal class LegacyAutomotiveStrategy(
+    private val useCustomSkipButtons: () -> Boolean,
+) : AutomotiveSessionStrategy {
+
+    override fun buildCustomLayout(
+        playbackManager: PlaybackManager,
+        settings: Settings,
+        context: Context,
+        buildCustomActionButton: (MediaNotificationControls, BaseEpisode?) -> CommandButton?,
+    ): List<CommandButton> {
+        val buttons = mutableListOf<CommandButton>()
+        val currentEpisode = playbackManager.getCurrentEpisode()
+
+        // Legacy order: skip buttons first, then all media control items in order.
+        if (useCustomSkipButtons()) {
+            buttons.add(
+                CommandButton.Builder(CommandButton.ICON_SKIP_BACK)
+                    .setSessionCommand(SessionCommand(APP_ACTION_SKIP_BACK, Bundle.EMPTY))
+                    .setDisplayName(context.getString(LR.string.skip_back))
+                    .setCustomIconResId(IR.drawable.media_skipback)
+                    .build(),
+            )
+            buttons.add(
+                CommandButton.Builder(CommandButton.ICON_SKIP_FORWARD)
+                    .setSessionCommand(SessionCommand(APP_ACTION_SKIP_FWD, Bundle.EMPTY))
+                    .setDisplayName(context.getString(LR.string.skip_forward))
+                    .setCustomIconResId(IR.drawable.media_skipforward)
+                    .build(),
+            )
+        }
+
+        val visibleCount = if (settings.customMediaActionsVisibility.value) MediaNotificationControls.MAX_VISIBLE_OPTIONS else 0
+        settings.mediaControlItems.value.take(visibleCount).forEach { mediaControl ->
+            buildCustomActionButton(mediaControl, currentEpisode)?.let(buttons::add)
+        }
+        return buttons
+    }
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/LegacyPlaybackService.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/LegacyPlaybackService.kt
@@ -212,7 +212,7 @@ open class LegacyPlaybackService :
                     (state1.state == state2.state && metadata1.getString(METADATA_KEY_MEDIA_ID) == metadata2.getString(METADATA_KEY_MEDIA_ID) && artworkConfiguration1 == artworkConfiguration2) &&
                         (isForegroundService && (state2.state == PlaybackStateCompat.STATE_PLAYING || state2.state == PlaybackStateCompat.STATE_BUFFERING))
                 }
-                .map { (playbackState, _, artworkConfiguration) -> playbackState to buildNotification(artworkConfiguration.useEpisodeArtwork) }
+                .map { (playbackState, metadata, artworkConfiguration) -> playbackState to buildNotification(playbackState.state, metadata, artworkConfiguration.useEpisodeArtwork) }
                 .observeOn(SchedulerProvider.mainThread)
                 .subscribeBy(
                     onNext = { (state: PlaybackStateCompat, notification: Notification?) ->
@@ -316,10 +316,15 @@ open class LegacyPlaybackService :
             settings.setTimesToShowBatteryWarning(2 + currentValue)
         }
 
-        private fun buildNotification(useEpisodeArtwork: Boolean): Notification? {
+        private fun buildNotification(state: Int, metadata: MediaMetadataCompat?, useEpisodeArtwork: Boolean): Notification? {
             if (Util.isAutomotive(this@LegacyPlaybackService)) return null
             val mediaSession = playbackManager.mediaSessionManager.mediaSession ?: return null
-            return notificationDrawer.buildPlayingNotification(mediaSession.sessionToken, useEpisodeArtwork)
+            if (metadata == null || metadata.getString(METADATA_KEY_MEDIA_ID).isNullOrEmpty()) return null
+            return if (state != PlaybackStateCompat.STATE_NONE) {
+                notificationDrawer.buildPlayingNotification(mediaSession.sessionToken, useEpisodeArtwork)
+            } else {
+                null
+            }
         }
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3AutomotiveStrategy.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3AutomotiveStrategy.kt
@@ -1,0 +1,68 @@
+package au.com.shiftyjelly.pocketcasts.repositories.playback
+
+import android.content.Context
+import android.os.Bundle
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.session.CommandButton
+import androidx.media3.session.SessionCommand
+import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.Settings.MediaNotificationControls
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+/**
+ * Automotive strategy for the Media3 session path (flag ON).
+ *
+ * Layout: playback speed first (promoted slot), then circular skip icons
+ * matching the configured duration, then remaining custom actions
+ * (excluding speed since it is already shown).
+ */
+@UnstableApi
+internal class Media3AutomotiveStrategy(
+    private val speedToDrawable: (Double) -> Int,
+    private val skipBackIconForDuration: (Int) -> Int,
+    private val skipForwardIconForDuration: (Int) -> Int,
+) : AutomotiveSessionStrategy {
+
+    override fun buildCustomLayout(
+        playbackManager: PlaybackManager,
+        settings: Settings,
+        context: Context,
+        buildCustomActionButton: (MediaNotificationControls, BaseEpisode?) -> CommandButton?,
+    ): List<CommandButton> {
+        val buttons = mutableListOf<CommandButton>()
+        val currentEpisode = playbackManager.getCurrentEpisode()
+
+        if (playbackManager.isAudioEffectsAvailable()) {
+            buttons.add(
+                CommandButton.Builder(CommandButton.ICON_UNDEFINED)
+                    .setSessionCommand(SessionCommand(APP_ACTION_CHANGE_SPEED, Bundle.EMPTY))
+                    .setDisplayName(context.getString(LR.string.playback_speed))
+                    .setCustomIconResId(speedToDrawable(playbackManager.getPlaybackSpeed()))
+                    .build(),
+            )
+        }
+        buttons.add(
+            CommandButton.Builder(skipBackIconForDuration(settings.skipBackInSecs.value))
+                .setSessionCommand(SessionCommand(APP_ACTION_SKIP_BACK, Bundle.EMPTY))
+                .setDisplayName(context.getString(LR.string.skip_back))
+                .setCustomIconResId(IR.drawable.media_skipback)
+                .build(),
+        )
+        buttons.add(
+            CommandButton.Builder(skipForwardIconForDuration(settings.skipForwardInSecs.value))
+                .setSessionCommand(SessionCommand(APP_ACTION_SKIP_FWD, Bundle.EMPTY))
+                .setDisplayName(context.getString(LR.string.skip_forward))
+                .setCustomIconResId(IR.drawable.media_skipforward)
+                .build(),
+        )
+        val visibleCount = if (settings.customMediaActionsVisibility.value) MediaNotificationControls.MAX_VISIBLE_OPTIONS else 0
+        settings.mediaControlItems.value.take(visibleCount).forEach { mediaControl ->
+            if (mediaControl != MediaNotificationControls.PlaybackSpeed) {
+                buildCustomActionButton(mediaControl, currentEpisode)?.let(buttons::add)
+            }
+        }
+        return buttons
+    }
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3AutomotiveStrategy.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3AutomotiveStrategy.kt
@@ -20,6 +20,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
  */
 @UnstableApi
 internal class Media3AutomotiveStrategy(
+    private val useCustomSkipButtons: () -> Boolean,
     private val speedToDrawable: (Double) -> Int,
     private val skipBackIconForDuration: (Int) -> Int,
     private val skipForwardIconForDuration: (Int) -> Int,
@@ -43,20 +44,22 @@ internal class Media3AutomotiveStrategy(
                     .build(),
             )
         }
-        buttons.add(
-            CommandButton.Builder(skipBackIconForDuration(settings.skipBackInSecs.value))
-                .setSessionCommand(SessionCommand(APP_ACTION_SKIP_BACK, Bundle.EMPTY))
-                .setDisplayName(context.getString(LR.string.skip_back))
-                .setCustomIconResId(IR.drawable.media_skipback)
-                .build(),
-        )
-        buttons.add(
-            CommandButton.Builder(skipForwardIconForDuration(settings.skipForwardInSecs.value))
-                .setSessionCommand(SessionCommand(APP_ACTION_SKIP_FWD, Bundle.EMPTY))
-                .setDisplayName(context.getString(LR.string.skip_forward))
-                .setCustomIconResId(IR.drawable.media_skipforward)
-                .build(),
-        )
+        if (useCustomSkipButtons()) {
+            buttons.add(
+                CommandButton.Builder(skipBackIconForDuration(settings.skipBackInSecs.value))
+                    .setSessionCommand(SessionCommand(APP_ACTION_SKIP_BACK, Bundle.EMPTY))
+                    .setDisplayName(context.getString(LR.string.skip_back))
+                    .setCustomIconResId(IR.drawable.media_skipback)
+                    .build(),
+            )
+            buttons.add(
+                CommandButton.Builder(skipForwardIconForDuration(settings.skipForwardInSecs.value))
+                    .setSessionCommand(SessionCommand(APP_ACTION_SKIP_FWD, Bundle.EMPTY))
+                    .setDisplayName(context.getString(LR.string.skip_forward))
+                    .setCustomIconResId(IR.drawable.media_skipforward)
+                    .build(),
+            )
+        }
         val visibleCount = if (settings.customMediaActionsVisibility.value) MediaNotificationControls.MAX_VISIBLE_OPTIONS else 0
         settings.mediaControlItems.value.take(visibleCount).forEach { mediaControl ->
             if (mediaControl != MediaNotificationControls.PlaybackSpeed) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -113,16 +113,19 @@ class MediaSessionManager(
 
     // Evaluated once at construction — toggling requires a process restart.
     // Swapping between Media3 and legacy session at runtime is not supported.
-    // On automotive, always use Media3: AAOS never uses app-managed notifications,
-    // so the legacy compat session is unnecessary and having a single service avoids
-    // the race condition where AAOS discovers the wrong service before the toggle runs.
-    private val useMedia3Session = FeatureFlag.isEnabled(Feature.MEDIA3_SESSION) || Util.isAutomotive(context)
+    private val useMedia3Session = FeatureFlag.isEnabled(Feature.MEDIA3_SESSION)
+    private val isAutomotive = Util.isAutomotive(context)
 
-    val mediaSession: MediaSessionCompat? = if (!useMedia3Session) {
+    // Automotive always needs a MediaLibrarySession for the service contract (it's the
+    // app entry point on AAOS), even when the Media3 flag is OFF. The internal behavior
+    // is delegated to an AutomotiveSessionStrategy.
+    private val needsMedia3Session = useMedia3Session || isAutomotive
+
+    // On non-automotive platforms with flag OFF, create a MediaSessionCompat.
+    // On automotive (regardless of flag), the MediaLibrarySession handles everything.
+    val mediaSession: MediaSessionCompat? = if (!useMedia3Session && !isAutomotive) {
         MediaSessionCompat(context, "PocketCastsMediaSession").also { session ->
-            if (!Util.isAutomotive(context)) {
-                session.setSessionActivity(context.getLaunchActivityPendingIntent())
-            }
+            session.setSessionActivity(context.getLaunchActivityPendingIntent())
             session.setRatingType(RatingCompat.RATING_HEART)
             session.setExtras(
                 Bundle().apply {
@@ -152,7 +155,7 @@ class MediaSessionManager(
         scopeProvider = { scope },
         source = source,
         onSearchFailed = { message ->
-            if (useMedia3Session) {
+            if (needsMedia3Session) {
                 sendSearchError(message)
             } else {
                 errorPlaybackState(message)
@@ -174,6 +177,17 @@ class MediaSessionManager(
     }
 
     private var bookmarkHelper: BookmarkHelper
+
+    @OptIn(UnstableApi::class)
+    private val automotiveStrategy: AutomotiveSessionStrategy? = if (isAutomotive) {
+        if (useMedia3Session) {
+            Media3AutomotiveStrategy(::speedToDrawable, ::skipBackIconForDuration, ::skipForwardIconForDuration)
+        } else {
+            LegacyAutomotiveStrategy(::useCustomSkipButtons)
+        }
+    } else {
+        null
+    }
 
     @Volatile
     private var media3Session: MediaLibraryService.MediaLibrarySession? = null
@@ -210,8 +224,8 @@ class MediaSessionManager(
             settings,
         )
 
-        if (!useMedia3Session) {
-            mediaSession!!.setCallback(
+        if (mediaSession != null) {
+            mediaSession.setCallback(
                 MediaSessionCallback(
                     playbackManager,
                     episodeManager,
@@ -236,7 +250,7 @@ class MediaSessionManager(
     }
 
     fun startObserving() {
-        if (useMedia3Session) {
+        if (needsMedia3Session) {
             observeForMedia3Updates()
         } else {
             connect()
@@ -268,7 +282,7 @@ class MediaSessionManager(
     @OptIn(UnstableApi::class)
     @MainThread
     fun createSession(service: MediaLibraryService) {
-        if (!useMedia3Session) return
+        if (!needsMedia3Session) return
         // Recreate scope in case release() was called previously (service restart).
         if (scope.coroutineContext[Job]?.isActive != true) {
             scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -395,7 +409,7 @@ class MediaSessionManager(
     @OptIn(UnstableApi::class)
     @MainThread
     fun installPlayer(exoPlayer: androidx.media3.common.Player) {
-        if (!useMedia3Session) return
+        if (!needsMedia3Session) return
         val currentPlayer = forwardingPlayer
         if (currentPlayer == null) {
             Timber.i("installPlayer: session not ready, deferring")
@@ -421,7 +435,7 @@ class MediaSessionManager(
     @OptIn(UnstableApi::class)
     @MainThread
     fun installCastPlayer() {
-        if (!useMedia3Session) return
+        if (!needsMedia3Session) return
         val player = CastStatePlayer(
             applicationLooper = android.os.Looper.getMainLooper(),
             onPlay = { scope.launch { commandMutex.withLock { playbackManager.playQueueSuspend(sourceView = source) } } },
@@ -480,12 +494,12 @@ class MediaSessionManager(
      */
     @MainThread
     fun updateCastState(isPlaying: Boolean, isBuffering: Boolean, positionMs: Long) {
-        if (!useMedia3Session) return
+        if (!needsMedia3Session) return
         castStatePlayer?.updateCastState(isPlaying, isBuffering, positionMs)
     }
 
     fun startServiceIfNeeded(context: Context) {
-        if (useMedia3Session) {
+        if (needsMedia3Session) {
             if (media3Session != null) return
         }
         val component = resolveMediaBrowserServiceComponent(context)
@@ -616,38 +630,8 @@ class MediaSessionManager(
         val buttons = mutableListOf<CommandButton>()
         val currentEpisode = playbackManager.getCurrentEpisode()
 
-        if (Util.isAutomotive(context)) {
-            // Automotive: use circular seek icons matching the configured skip duration.
-            // Playback speed first (gets the extra slot), then skip buttons, then custom actions.
-            if (playbackManager.isAudioEffectsAvailable()) {
-                buttons.add(
-                    CommandButton.Builder(CommandButton.ICON_UNDEFINED)
-                        .setSessionCommand(SessionCommand(APP_ACTION_CHANGE_SPEED, Bundle.EMPTY))
-                        .setDisplayName(context.getString(LR.string.playback_speed))
-                        .setCustomIconResId(speedToDrawable(playbackManager.getPlaybackSpeed()))
-                        .build(),
-                )
-            }
-            buttons.add(
-                CommandButton.Builder(skipBackIconForDuration(settings.skipBackInSecs.value))
-                    .setSessionCommand(SessionCommand(APP_ACTION_SKIP_BACK, Bundle.EMPTY))
-                    .setDisplayName(context.getString(LR.string.skip_back))
-                    .setCustomIconResId(IR.drawable.media_skipback)
-                    .build(),
-            )
-            buttons.add(
-                CommandButton.Builder(skipForwardIconForDuration(settings.skipForwardInSecs.value))
-                    .setSessionCommand(SessionCommand(APP_ACTION_SKIP_FWD, Bundle.EMPTY))
-                    .setDisplayName(context.getString(LR.string.skip_forward))
-                    .setCustomIconResId(IR.drawable.media_skipforward)
-                    .build(),
-            )
-            val visibleCount = if (settings.customMediaActionsVisibility.value) MediaNotificationControls.MAX_VISIBLE_OPTIONS else 0
-            settings.mediaControlItems.value.take(visibleCount).forEach { mediaControl ->
-                if (mediaControl != MediaNotificationControls.PlaybackSpeed) {
-                    buildCustomActionButton(mediaControl, currentEpisode)?.let(buttons::add)
-                }
-            }
+        if (isAutomotive) {
+            buttons.addAll(automotiveStrategy!!.buildCustomLayout(playbackManager, settings, context, ::buildCustomActionButton))
         } else {
             // Mobile/other: existing behavior unchanged
             if (useCustomSkipButtons()) {
@@ -751,7 +735,7 @@ class MediaSessionManager(
     fun release() {
         disposables.clear()
         scope.cancel()
-        if (useMedia3Session) {
+        if (needsMedia3Session) {
             media3Session?.release()
             media3Session = null
             forwardingPlayer = null

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -181,7 +181,7 @@ class MediaSessionManager(
     @OptIn(UnstableApi::class)
     private val automotiveStrategy: AutomotiveSessionStrategy? = if (isAutomotive) {
         if (useMedia3Session) {
-            Media3AutomotiveStrategy(::speedToDrawable, ::skipBackIconForDuration, ::skipForwardIconForDuration)
+            Media3AutomotiveStrategy(::useCustomSkipButtons, ::speedToDrawable, ::skipBackIconForDuration, ::skipForwardIconForDuration)
         } else {
             LegacyAutomotiveStrategy(::useCustomSkipButtons)
         }
@@ -323,6 +323,7 @@ class MediaSessionManager(
                     true
                 }
             },
+            showStandardSkipButtons = !useCustomSkipButtons(),
         )
 
         media3Callback = Media3SessionCallback(
@@ -476,6 +477,7 @@ class MediaSessionManager(
             onSkipForward = { scope.launch { commandMutex.withLock { playbackManager.skipForwardSuspend() } } },
             onSkipBack = { scope.launch { commandMutex.withLock { playbackManager.skipBackwardSuspend() } } },
             playGuard = currentPlayer.playGuard,
+            showStandardSkipButtons = !useCustomSkipButtons(),
         ).also {
             it.currentMediaItem = currentPlayer.currentMediaItem
             it.previousMediaId = currentPlayer.previousMediaId

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -151,12 +151,26 @@ class MediaSessionManager(
         eventHorizon = eventHorizon,
         scopeProvider = { scope },
         source = source,
-        onSearchFailed = { message -> sendSearchError(message) },
+        onSearchFailed = { message ->
+            if (useMedia3Session) {
+                sendSearchError(message)
+            } else {
+                errorPlaybackState(message)
+            }
+        },
     )
 
     @OptIn(UnstableApi::class)
     private fun sendSearchError(message: String) {
         media3Session?.sendError(SessionError(SessionError.ERROR_UNKNOWN, message))
+    }
+
+    private fun errorPlaybackState(message: String) {
+        val stateBuilder = PlaybackStateCompat.Builder()
+            .setState(PlaybackStateCompat.STATE_ERROR, 0, 0f)
+            .setErrorMessage(PlaybackStateCompat.ERROR_CODE_UNKNOWN_ERROR, message)
+            .setActions(getSupportedActions(PlaybackState()))
+        mediaSession?.setPlaybackState(stateBuilder.build())
     }
 
     private var bookmarkHelper: BookmarkHelper

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -69,6 +69,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.rx2.asObservable
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
@@ -363,8 +364,9 @@ class MediaSessionManager(
                     else -> null
                 }
                 val showArtwork = settings.showArtworkOnLockScreen.value
+                val useEpisodeArtwork = settings.artworkConfiguration.value.useEpisodeArtwork
                 withContext(Dispatchers.Main) {
-                    forwardingPlayer?.updateMetadata(ep, podcast, showArtwork)
+                    forwardingPlayer?.updateMetadata(ep, podcast, showArtwork, useEpisodeArtwork)
                 }
             } catch (e: Exception) {
                 Timber.e(e, "Failed to seed initial Media3 metadata")
@@ -486,7 +488,7 @@ class MediaSessionManager(
 
     @OptIn(UnstableApi::class)
     private fun observeForMedia3Updates() {
-        playbackManager.playbackStateRelay
+        val episodeAndState = playbackManager.playbackStateRelay
             .distinctUntilChanged { old, new ->
                 old.episodeUuid == new.episodeUuid &&
                     old.state == new.state &&
@@ -506,8 +508,16 @@ class MediaSessionManager(
                         .toObservable()
                 }
             }
+
+        val artworkConfig = settings.artworkConfiguration.flow.asObservable()
+        val showArtworkOnLockScreen = settings.showArtworkOnLockScreen.flow.asObservable()
+
+        Observables.combineLatest(episodeAndState, artworkConfig, showArtworkOnLockScreen) { episodeState, config, showArtwork ->
+            Triple(episodeState, config.useEpisodeArtwork, showArtwork)
+        }
             .observeOn(Schedulers.io())
-            .map<Optional<MediaUpdateData>> { (episodeOpt, state) ->
+            .map<Optional<MediaUpdateData>> { (episodeState, useEpisodeArtwork, showArtwork) ->
+                val (episodeOpt, state) = episodeState
                 if (!episodeOpt.isPresent()) {
                     return@map Optional.empty()
                 }
@@ -516,12 +526,11 @@ class MediaSessionManager(
                     is PodcastEpisode -> podcastManager.findPodcastByUuidBlocking(episode.podcastUuid)
                     else -> null
                 }
-                val showArtwork = settings.showArtworkOnLockScreen.value
                 val artworkData = if (showArtwork && !Util.isWearOs(context) && !Util.isAutomotive(context)) {
                     AutoConverter.getPodcastArtworkBitmap(
                         episode,
                         context,
-                        settings.artworkConfiguration.value.useEpisodeArtwork,
+                        useEpisodeArtwork,
                     )?.let { bitmap ->
                         java.io.ByteArrayOutputStream().use { stream ->
                             val format = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
@@ -537,7 +546,7 @@ class MediaSessionManager(
                 } else {
                     null
                 }
-                Optional.of(MediaUpdateData(episode, podcast, state, showArtwork, artworkData))
+                Optional.of(MediaUpdateData(episode, podcast, state, showArtwork, useEpisodeArtwork, artworkData))
             }
             .observeOn(AndroidSchedulers.mainThread())
             .subscribeBy(
@@ -548,7 +557,7 @@ class MediaSessionManager(
                         player.clearMetadata()
                         return@subscribeBy
                     }
-                    player.updateMetadata(data.episode, data.podcast, data.showArtwork, data.artworkData)
+                    player.updateMetadata(data.episode, data.podcast, data.showArtwork, data.useEpisodeArtwork, data.artworkData)
                     player.isTransientLoss = data.state.transientLoss
                     updateMedia3CustomLayout()
                 },
@@ -1365,13 +1374,15 @@ private data class MediaUpdateData(
     val podcast: Podcast?,
     val state: PlaybackState,
     val showArtwork: Boolean,
+    val useEpisodeArtwork: Boolean,
     val artworkData: ByteArray?,
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is MediaUpdateData) return false
         return episode == other.episode && podcast == other.podcast && state == other.state &&
-            showArtwork == other.showArtwork && artworkData.contentEquals(other.artworkData)
+            showArtwork == other.showArtwork && useEpisodeArtwork == other.useEpisodeArtwork &&
+            artworkData.contentEquals(other.artworkData)
     }
 
     override fun hashCode(): Int {
@@ -1379,6 +1390,7 @@ private data class MediaUpdateData(
         result = 31 * result + (podcast?.hashCode() ?: 0)
         result = 31 * result + state.hashCode()
         result = 31 * result + showArtwork.hashCode()
+        result = 31 * result + useEpisodeArtwork.hashCode()
         result = 31 * result + (artworkData?.contentHashCode() ?: 0)
         return result
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
@@ -1,7 +1,9 @@
 package au.com.shiftyjelly.pocketcasts.repositories.playback
 
+import android.app.ForegroundServiceStartNotAllowedException
 import android.content.Intent
 import android.os.Binder
+import android.os.Build
 import android.os.IBinder
 import androidx.annotation.OptIn
 import androidx.media3.common.util.UnstableApi
@@ -12,6 +14,8 @@ import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
+import com.automattic.eventhorizon.EventHorizon
+import com.automattic.eventhorizon.PlaybackForegroundServiceErrorEvent
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
@@ -56,6 +60,8 @@ open class PlaybackService :
 
     @Inject lateinit var sleepTimer: SleepTimer
 
+    @Inject lateinit var eventHorizon: EventHorizon
+
     private val job = SupervisorJob()
     override val coroutineContext: CoroutineContext
         get() = job + Dispatchers.Default
@@ -99,7 +105,16 @@ open class PlaybackService :
             stopForeground(STOP_FOREGROUND_REMOVE)
             return
         }
-        super.onUpdateNotification(session, startInForegroundRequired)
+        try {
+            super.onUpdateNotification(session, startInForegroundRequired)
+        } catch (e: Exception) {
+            LogBuffer.e(LogBuffer.TAG_PLAYBACK, "onUpdateNotification failed: $e")
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && e is ForegroundServiceStartNotAllowedException) {
+                val currentValue = settings.getTimesToShowBatteryWarning()
+                settings.setTimesToShowBatteryWarning(2 + currentValue)
+                eventHorizon.track(PlaybackForegroundServiceErrorEvent)
+            }
+        }
     }
 
     @OptIn(UnstableApi::class)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsForwardingPlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsForwardingPlayer.kt
@@ -42,6 +42,7 @@ class PocketCastsForwardingPlayer(
     private val onPause: (() -> Unit)? = null,
     private val onSeekTo: ((Long) -> Unit)? = null,
     internal val playGuard: (() -> Boolean) = { true },
+    private val showStandardSkipButtons: Boolean = true,
 ) : ForwardingPlayer(wrappedPlayer) {
 
     internal var currentMediaItem: MediaItem = MediaItem.EMPTY
@@ -67,7 +68,7 @@ class PocketCastsForwardingPlayer(
     @MainThread
     fun swapPlayer(newPlayer: Player): PocketCastsForwardingPlayer {
         checkMainThread()
-        return PocketCastsForwardingPlayer(newPlayer, onSkipForward, onSkipBack, onStop, onPlay, onPause, onSeekTo, playGuard).also {
+        return PocketCastsForwardingPlayer(newPlayer, onSkipForward, onSkipBack, onStop, onPlay, onPause, onSeekTo, playGuard, showStandardSkipButtons).also {
             it.currentMediaItem = this.currentMediaItem
             it.previousMediaId = this.previousMediaId
             it.isTransientLoss = this.isTransientLoss
@@ -152,19 +153,20 @@ class PocketCastsForwardingPlayer(
     override fun getMediaMetadata(): MediaMetadata = currentMediaItem.mediaMetadata
 
     override fun getAvailableCommands(): Player.Commands {
-        return Player.Commands.Builder()
+        val builder = Player.Commands.Builder()
             .addAll(
                 Player.COMMAND_PLAY_PAUSE,
                 Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM,
                 Player.COMMAND_SEEK_FORWARD,
                 Player.COMMAND_SEEK_BACK,
-                Player.COMMAND_SEEK_TO_NEXT,
-                Player.COMMAND_SEEK_TO_PREVIOUS,
                 Player.COMMAND_STOP,
                 Player.COMMAND_GET_CURRENT_MEDIA_ITEM,
                 Player.COMMAND_GET_METADATA,
             )
-            .build()
+        if (showStandardSkipButtons) {
+            builder.addAll(Player.COMMAND_SEEK_TO_NEXT, Player.COMMAND_SEEK_TO_PREVIOUS)
+        }
+        return builder.build()
     }
 
     override fun seekTo(positionMs: Long) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsForwardingPlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsForwardingPlayer.kt
@@ -78,6 +78,8 @@ class PocketCastsForwardingPlayer(
      * Updates the metadata exposed via [getCurrentMediaItem]. Call this when the
      * current episode changes or when metadata is refreshed (e.g., artwork loaded).
      *
+     * @param showArtwork When false, artwork URI and data are omitted from the metadata.
+     * @param useEpisodeArtwork When true, prefer episode-specific artwork; when false, use podcast artwork.
      * @param artworkData Pre-compressed artwork bytes (e.g. WebP). Compression should
      *   happen off the main thread before calling this method.
      */
@@ -86,11 +88,12 @@ class PocketCastsForwardingPlayer(
         episode: BaseEpisode,
         podcast: Podcast?,
         showArtwork: Boolean = true,
+        useEpisodeArtwork: Boolean = true,
         artworkData: ByteArray? = null,
     ) {
         checkMainThread()
 
-        val artworkUri = if (showArtwork) resolveArtworkUri(episode, podcast) else null
+        val artworkUri = if (showArtwork) resolveArtworkUri(episode, podcast, useEpisodeArtwork) else null
         val podcastTitle = episode.displaySubtitle(podcast)
 
         val metadataBuilder = MediaMetadata.Builder()
@@ -299,11 +302,15 @@ class PocketCastsForwardingPlayer(
         listeners.remove(listener)
     }
 
-    private fun resolveArtworkUri(episode: BaseEpisode, podcast: Podcast?): Uri? {
+    private fun resolveArtworkUri(episode: BaseEpisode, podcast: Podcast?, useEpisodeArtwork: Boolean): Uri? {
         return when (episode) {
             is PodcastEpisode -> {
-                val url = episode.imageUrl?.takeIf { it.isNotBlank() }
-                    ?: podcast?.getArtworkUrl(480)?.takeIf { it.isNotBlank() }
+                val url = if (useEpisodeArtwork) {
+                    episode.imageUrl?.takeIf { it.isNotBlank() }
+                        ?: podcast?.getArtworkUrl(480)?.takeIf { it.isNotBlank() }
+                } else {
+                    podcast?.getArtworkUrl(480)?.takeIf { it.isNotBlank() }
+                }
                 url?.let(Uri::parse)
             }
 

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsForwardingPlayerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsForwardingPlayerTest.kt
@@ -13,6 +13,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import java.util.Date
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -509,6 +510,36 @@ class PocketCastsForwardingPlayerTest {
         val podcast = createPodcast(title = "Podcast")
 
         forwardingPlayer.updateMetadata(episode, podcast, showArtwork = true)
+
+        assertEquals(Uri.parse("https://example.com/art.jpg"), forwardingPlayer.mediaMetadata.artworkUri)
+    }
+
+    @Test
+    fun `updateMetadata uses podcast artwork when useEpisodeArtwork is false`() {
+        val episode = createPodcastEpisode(
+            uuid = "ep-1",
+            title = "Test",
+            imageUrl = "https://example.com/episode-art.jpg",
+        )
+        val podcast = createPodcast(title = "Podcast")
+
+        forwardingPlayer.updateMetadata(episode, podcast, useEpisodeArtwork = false)
+
+        val artworkUri = forwardingPlayer.mediaMetadata.artworkUri
+        assertNotNull(artworkUri)
+        assertFalse(artworkUri.toString().contains("episode-art"))
+    }
+
+    @Test
+    fun `updateMetadata uses episode artwork when useEpisodeArtwork is true`() {
+        val episode = createPodcastEpisode(
+            uuid = "ep-1",
+            title = "Test",
+            imageUrl = "https://example.com/art.jpg",
+        )
+        val podcast = createPodcast(title = "Podcast")
+
+        forwardingPlayer.updateMetadata(episode, podcast, useEpisodeArtwork = true)
 
         assertEquals(Uri.parse("https://example.com/art.jpg"), forwardingPlayer.mediaMetadata.artworkUri)
     }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsForwardingPlayerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsForwardingPlayerTest.kt
@@ -162,7 +162,7 @@ class PocketCastsForwardingPlayerTest {
     }
 
     @Test
-    fun `available commands include expected controls`() {
+    fun `available commands include skip buttons by default`() {
         val commands = forwardingPlayer.availableCommands
 
         assertTrue(commands.contains(Player.COMMAND_PLAY_PAUSE))
@@ -173,6 +173,18 @@ class PocketCastsForwardingPlayerTest {
         assertTrue(commands.contains(Player.COMMAND_SEEK_TO_PREVIOUS))
         assertTrue(commands.contains(Player.COMMAND_GET_CURRENT_MEDIA_ITEM))
         assertTrue(commands.contains(Player.COMMAND_GET_METADATA))
+    }
+
+    @Test
+    fun `available commands exclude standard skip when showStandardSkipButtons is false`() {
+        val player = PocketCastsForwardingPlayer(mockPlayer, showStandardSkipButtons = false)
+        val commands = player.availableCommands
+
+        assertTrue(commands.contains(Player.COMMAND_PLAY_PAUSE))
+        assertTrue(commands.contains(Player.COMMAND_SEEK_FORWARD))
+        assertTrue(commands.contains(Player.COMMAND_SEEK_BACK))
+        assertFalse(commands.contains(Player.COMMAND_SEEK_TO_NEXT))
+        assertFalse(commands.contains(Player.COMMAND_SEEK_TO_PREVIOUS))
     }
 
     @Test
@@ -581,6 +593,19 @@ class PocketCastsForwardingPlayerTest {
 
         assertTrue(skipForwardCalled)
         assertTrue(skipBackCalled)
+    }
+
+    @Test
+    fun `swapPlayer preserves showStandardSkipButtons`() {
+        val player = PocketCastsForwardingPlayer(mockPlayer, showStandardSkipButtons = false)
+
+        val newWrappedPlayer = mock<Player> {
+            on { applicationLooper } doReturn Looper.getMainLooper()
+        }
+        val swapped = player.swapPlayer(newWrappedPlayer)
+
+        assertFalse(swapped.availableCommands.contains(Player.COMMAND_SEEK_TO_NEXT))
+        assertFalse(swapped.availableCommands.contains(Player.COMMAND_SEEK_TO_PREVIOUS))
     }
 
     // --- setMediaItems / addMediaItems / prepare interception tests ---


### PR DESCRIPTION
## Description
This PR addresses several regressions and gaps in the Media3 migration's playback service layer. First, we ensured the legacy playback service correctly passes metadata to notifications so the old service behavior is preserved. We restored voice search error propagation that was lost in the Media3 session manager. We added analytics tracking for when the Media3 foreground service fails to start due to battery restrictions. The biggest piece of work was introducing anautomotive-specific strategy pattern (`AutomotiveSessionStrategy`) for the Media3 feature flag — since Automotive can't use the standard `PlaybackServiceToggle`, we created `Media3AutomotiveStrategy` and `LegacyAutomotiveStrategy` to delegate custom action layout based on the  flag state, and split useMedia3Session into two methods to properly handle the session lifecycle. Finally, we fixed the Mercedes build on Automotive by restoring custom commands in the forwarding player and media session manager, with a corresponding test.   

Fixes PCDROID-537 https://linear.app/a8c/issue/PCDROID-537/media3-address-automotive-discrepancies

## Testing Instructions
Test automotive with feature flag on / off and make sure it shows the same controls as the current prod build + behaves same way as prod build

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 