### PR TITLE
[Media3] Add support for queues on media3 sessions

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3AutomotiveStrategy.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3AutomotiveStrategy.kt
@@ -14,6 +14,9 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 @UnstableApi
 internal class Media3AutomotiveStrategy(
     private val useCustomSkipButtons: () -> Boolean,
+    private val speedToDrawable: (Double) -> Int,
+    @Suppress("unused") private val skipBackIconForDuration: (Int) -> Int,
+    @Suppress("unused") private val skipForwardIconForDuration: (Int) -> Int,
 ) : AutomotiveSessionStrategy {
 
     override fun buildLayout(
@@ -22,18 +25,19 @@ internal class Media3AutomotiveStrategy(
         context: Context,
         buildCustomActionButton: (MediaNotificationControls, BaseEpisode?) -> CommandButton?,
     ): AutomotiveSessionStrategy.ButtonLayout {
-        val buttons = mutableListOf<CommandButton>()
+        val primaryButtons = mutableListOf<CommandButton>()
+        val overflowButtons = mutableListOf<CommandButton>()
         val currentEpisode = playbackManager.getCurrentEpisode()
 
         if (useCustomSkipButtons()) {
-            buttons.add(
+            primaryButtons.add(
                 CommandButton.Builder(CommandButton.ICON_UNDEFINED)
                     .setSessionCommand(SessionCommand(APP_ACTION_SKIP_BACK, Bundle.EMPTY))
                     .setDisplayName(context.getString(LR.string.skip_back))
                     .setCustomIconResId(IR.drawable.media_skipback)
                     .build(),
             )
-            buttons.add(
+            primaryButtons.add(
                 CommandButton.Builder(CommandButton.ICON_UNDEFINED)
                     .setSessionCommand(SessionCommand(APP_ACTION_SKIP_FWD, Bundle.EMPTY))
                     .setDisplayName(context.getString(LR.string.skip_forward))
@@ -42,11 +46,21 @@ internal class Media3AutomotiveStrategy(
             )
         }
 
+        primaryButtons.add(
+            CommandButton.Builder(CommandButton.ICON_UNDEFINED)
+                .setSessionCommand(SessionCommand(APP_ACTION_CHANGE_SPEED, Bundle.EMPTY))
+                .setDisplayName(context.getString(LR.string.playback_speed))
+                .setCustomIconResId(speedToDrawable(playbackManager.getPlaybackSpeed()))
+                .build(),
+        )
+
         val visibleCount = if (settings.customMediaActionsVisibility.value) MediaNotificationControls.MAX_VISIBLE_OPTIONS else 0
         settings.mediaControlItems.value.take(visibleCount).forEach { mediaControl ->
-            buildCustomActionButton(mediaControl, currentEpisode)?.let(buttons::add)
+            if (mediaControl != MediaNotificationControls.PlaybackSpeed) {
+                buildCustomActionButton(mediaControl, currentEpisode)?.let(overflowButtons::add)
+            }
         }
 
-        return AutomotiveSessionStrategy.ButtonLayout(primaryButtons = buttons, overflowButtons = emptyList())
+        return AutomotiveSessionStrategy.ButtonLayout(primaryButtons, overflowButtons)
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3SessionCallback.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3SessionCallback.kt
@@ -24,9 +24,11 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.model.AutoPlaySource
 import au.com.shiftyjelly.pocketcasts.preferences.model.HeadphoneAction
 import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkHelper
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.getArtworkUrl
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.auto.AutoMediaId
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
@@ -56,6 +58,7 @@ internal class Media3SessionCallback(
     private val playbackManager: PlaybackManager,
     private val episodeManager: EpisodeManager,
     private val podcastManager: PodcastManager,
+    private val playlistManager: PlaylistManager,
     private val settings: Settings,
     private val actions: MediaSessionActions,
     private val bookmarkHelper: BookmarkHelper,
@@ -154,6 +157,15 @@ internal class Media3SessionCallback(
                 try {
                     val autoMediaId = AutoMediaId.fromMediaId(mediaId)
                     val episodeId = autoMediaId.episodeId
+                    val sourceId = autoMediaId.sourceId?.takeIf { it.isNotBlank() }
+
+                    if (sourceId != null) {
+                        val autoPlaySource = AutoPlaySource.fromId(sourceId)
+                        if (autoPlaySource != AutoPlaySource.Predefined.None) {
+                            settings.trackingAutoPlaySource.set(autoPlaySource, updateModifiedAt = false)
+                        }
+                    }
+
                     val episode = episodeManager.findEpisodeByUuid(episodeId)
                     if (episode == null) {
                         future.set(emptyList())
@@ -167,7 +179,14 @@ internal class Media3SessionCallback(
                     val resolvedItem = buildEpisodeMediaItem(episode, podcast, mediaId)
                     future.set(listOf(resolvedItem))
 
-                    playbackManager.playNowSuspend(episode = episode, sourceView = source)
+                    // Queue remaining playlist episodes so playback continues in order.
+                    val playlistEpisodes = sourceId?.let { loadPlaylistEpisodesFrom(it, episodeId) }
+                    if (playlistEpisodes != null && playlistEpisodes.size > 1) {
+                        playbackManager.playNowSuspend(episode = episode, sourceView = source)
+                        playbackManager.upNextQueue.clearAndPlayAll(playlistEpisodes.drop(1))
+                    } else {
+                        playbackManager.playNowSuspend(episode = episode, sourceView = source)
+                    }
                 } catch (e: Exception) {
                     Timber.e(e, "Play from media ID failed")
                     future.set(emptyList())
@@ -329,6 +348,28 @@ internal class Media3SessionCallback(
             }
         }
         return future
+    }
+
+    /**
+     * Loads episodes from a playlist starting from [episodeId].
+     * Returns the sublist beginning with [episodeId], or null if [sourceId]
+     * is not a playlist (e.g., it's a podcast UUID) or the episode isn't found.
+     */
+    private suspend fun loadPlaylistEpisodesFrom(sourceId: String, episodeId: String): List<BaseEpisode>? {
+        return try {
+            if (podcastManager.findPodcastByUuid(sourceId) != null) return null
+
+            val episodes = playlistManager.getAutoPlayEpisodes(sourceId, null)
+            if (episodes.isEmpty()) return null
+
+            val selectedIndex = episodes.indexOfFirst { it.uuid == episodeId }
+            if (selectedIndex < 0) return null
+
+            episodes.subList(selectedIndex, episodes.size)
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to load playlist episodes for source $sourceId")
+            null
+        }
     }
 
     private fun handleMediaButtonAction(action: HeadphoneAction) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3SessionCallback.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3SessionCallback.kt
@@ -28,8 +28,8 @@ import au.com.shiftyjelly.pocketcasts.preferences.model.AutoPlaySource
 import au.com.shiftyjelly.pocketcasts.preferences.model.HeadphoneAction
 import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkHelper
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.getArtworkUrl
-import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.auto.AutoMediaId
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.utils.Util

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3SessionCallback.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3SessionCallback.kt
@@ -94,18 +94,7 @@ internal class Media3SessionCallback(
             .add(SessionCommand(SessionCommand.COMMAND_CODE_SESSION_SET_RATING))
             .build()
 
-        val playerCommands = Player.Commands.Builder()
-            .addAll(
-                Player.COMMAND_PLAY_PAUSE,
-                Player.COMMAND_SET_MEDIA_ITEM,
-                Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM,
-                Player.COMMAND_STOP,
-                Player.COMMAND_GET_CURRENT_MEDIA_ITEM,
-                Player.COMMAND_GET_METADATA,
-            )
-            .build()
-
-        return MediaSession.ConnectionResult.accept(sessionCommands, playerCommands)
+        return MediaSession.ConnectionResult.accept(sessionCommands, TRANSPORT_PLAYER_COMMANDS)
     }
 
     override fun onCustomCommand(
@@ -377,6 +366,23 @@ internal class Media3SessionCallback(
         }
     }
 }
+
+/**
+ * Player commands granted to all connected controllers (known and unknown).
+ * Covers basic transport controls: play/pause, stop, seek, and metadata retrieval.
+ */
+@OptIn(UnstableApi::class)
+@Suppress("UnsafeOptInUsageError")
+internal val TRANSPORT_PLAYER_COMMANDS: Player.Commands = Player.Commands.Builder()
+    .addAll(
+        Player.COMMAND_PLAY_PAUSE,
+        Player.COMMAND_SET_MEDIA_ITEM,
+        Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM,
+        Player.COMMAND_STOP,
+        Player.COMMAND_GET_CURRENT_MEDIA_ITEM,
+        Player.COMMAND_GET_METADATA,
+    )
+    .build()
 
 internal fun resolveArtworkUri(episode: BaseEpisode, podcast: Podcast?): Uri? {
     return when (episode) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3SessionCallback.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3SessionCallback.kt
@@ -94,7 +94,18 @@ internal class Media3SessionCallback(
             .add(SessionCommand(SessionCommand.COMMAND_CODE_SESSION_SET_RATING))
             .build()
 
-        return MediaSession.ConnectionResult.accept(sessionCommands, TRANSPORT_PLAYER_COMMANDS)
+        val playerCommands = Player.Commands.Builder()
+            .addAll(
+                Player.COMMAND_PLAY_PAUSE,
+                Player.COMMAND_SET_MEDIA_ITEM,
+                Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM,
+                Player.COMMAND_STOP,
+                Player.COMMAND_GET_CURRENT_MEDIA_ITEM,
+                Player.COMMAND_GET_METADATA,
+            )
+            .build()
+
+        return MediaSession.ConnectionResult.accept(sessionCommands, playerCommands)
     }
 
     override fun onCustomCommand(
@@ -366,23 +377,6 @@ internal class Media3SessionCallback(
         }
     }
 }
-
-/**
- * Player commands granted to all connected controllers (known and unknown).
- * Covers basic transport controls: play/pause, stop, seek, and metadata retrieval.
- */
-@OptIn(UnstableApi::class)
-@Suppress("UnsafeOptInUsageError")
-internal val TRANSPORT_PLAYER_COMMANDS: Player.Commands = Player.Commands.Builder()
-    .addAll(
-        Player.COMMAND_PLAY_PAUSE,
-        Player.COMMAND_SET_MEDIA_ITEM,
-        Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM,
-        Player.COMMAND_STOP,
-        Player.COMMAND_GET_CURRENT_MEDIA_ITEM,
-        Player.COMMAND_GET_METADATA,
-    )
-    .build()
 
 internal fun resolveArtworkUri(episode: BaseEpisode, podcast: Podcast?): Uri? {
     return when (episode) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3SessionCallback.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3SessionCallback.kt
@@ -103,6 +103,7 @@ internal class Media3SessionCallback(
                 Player.COMMAND_GET_CURRENT_MEDIA_ITEM,
                 Player.COMMAND_GET_METADATA,
                 Player.COMMAND_GET_TIMELINE,
+                Player.COMMAND_SEEK_TO_MEDIA_ITEM,
             )
             .build()
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3SessionCallback.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3SessionCallback.kt
@@ -94,7 +94,19 @@ internal class Media3SessionCallback(
             .add(SessionCommand(SessionCommand.COMMAND_CODE_SESSION_SET_RATING))
             .build()
 
-        return MediaSession.ConnectionResult.accept(sessionCommands, TRANSPORT_PLAYER_COMMANDS)
+        val playerCommands = Player.Commands.Builder()
+            .addAll(
+                Player.COMMAND_PLAY_PAUSE,
+                Player.COMMAND_SET_MEDIA_ITEM,
+                Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM,
+                Player.COMMAND_STOP,
+                Player.COMMAND_GET_CURRENT_MEDIA_ITEM,
+                Player.COMMAND_GET_METADATA,
+                Player.COMMAND_GET_TIMELINE,
+            )
+            .build()
+
+        return MediaSession.ConnectionResult.accept(sessionCommands, playerCommands)
     }
 
     override fun onCustomCommand(

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -639,9 +639,15 @@ class MediaSessionManager(
             .switchMap { state ->
                 if (state is UpNextQueue.State.Loaded) {
                     Observable.fromCallable {
+                        // De-duplicate podcast lookups by uuid so a queue containing
+                        // several episodes of the same podcast only hits the DB once.
+                        val podcastsByUuid = state.queue
+                            .mapNotNull { (it as? PodcastEpisode)?.podcastUuid }
+                            .toSet()
+                            .associateWith { podcastManager.findPodcastByUuidBlocking(it) }
                         state.queue.map { episode ->
                             val podcast = (episode as? PodcastEpisode)?.let {
-                                podcastManager.findPodcastByUuidBlocking(it.podcastUuid)
+                                podcastsByUuid[it.podcastUuid]
                             }
                             buildEpisodeMediaItem(episode, podcast)
                         }
@@ -654,7 +660,7 @@ class MediaSessionManager(
             .subscribeBy(
                 onNext = { items ->
                     forwardingPlayer?.updateQueue(items)
-                    media3Session?.notifyChildrenChanged(UP_NEXT_ROOT, Int.MAX_VALUE, null)
+                    media3Session?.notifyChildrenChanged(UP_NEXT_ROOT, items.size, null)
                 },
                 onError = { Timber.e(it, "Error observing Up Next changes") },
             )

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -318,6 +318,16 @@ class MediaSessionManager(
                     }
                 }
             },
+            onSeekToQueueItem = { mediaId ->
+                scope.launch {
+                    commandMutex.withLock {
+                        val episode = episodeManager.findEpisodeByUuid(mediaId)
+                        if (episode != null) {
+                            playbackManager.playNowSuspend(episode = episode, sourceView = source)
+                        }
+                    }
+                }
+            },
             playGuard = {
                 if (Util.isAutomotive(context) && !settings.automotiveConnectedToMediaSession()) {
                     LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Auto start playback ignored just after automotive app restart.")
@@ -626,8 +636,24 @@ class MediaSessionManager(
 
         playbackManager.upNextQueue.changesObservable
             .observeOn(Schedulers.io())
+            .switchMap { state ->
+                if (state is UpNextQueue.State.Loaded) {
+                    Observable.fromCallable {
+                        state.queue.map { episode ->
+                            val podcast = (episode as? PodcastEpisode)?.let {
+                                podcastManager.findPodcastByUuidBlocking(it.podcastUuid)
+                            }
+                            buildEpisodeMediaItem(episode, podcast)
+                        }
+                    }
+                } else {
+                    Observable.just(emptyList())
+                }
+            }
+            .observeOn(AndroidSchedulers.mainThread())
             .subscribeBy(
-                onNext = {
+                onNext = { items ->
+                    forwardingPlayer?.updateQueue(items)
                     media3Session?.notifyChildrenChanged(UP_NEXT_ROOT, Int.MAX_VALUE, null)
                 },
                 onError = { Timber.e(it, "Error observing Up Next changes") },

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -193,6 +193,8 @@ class MediaSessionManager(
     @Volatile
     private var media3Session: MediaLibraryService.MediaLibrarySession? = null
 
+    private var lastCustomLayout: List<CommandButton> = emptyList()
+
     @Volatile
     private var forwardingPlayer: PocketCastsForwardingPlayer? = null
 
@@ -643,7 +645,11 @@ class MediaSessionManager(
 
         if (isAutomotive) {
             val layout = automotiveStrategy!!.buildLayout(playbackManager, settings, context, ::buildCustomActionButton)
-            session.setCustomLayout(layout.primaryButtons + layout.overflowButtons)
+            val allButtons = layout.primaryButtons + layout.overflowButtons
+            if (allButtons != lastCustomLayout) {
+                lastCustomLayout = allButtons
+                session.setCustomLayout(allButtons)
+            }
             return
         } else {
             // Mobile/other: existing behavior unchanged
@@ -777,6 +783,7 @@ class MediaSessionManager(
         disposables.clear()
         scope.cancel()
         if (needsMedia3Session) {
+            lastCustomLayout = emptyList()
             media3Session?.release()
             media3Session = null
             forwardingPlayer = null

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -115,30 +115,29 @@ class MediaSessionManager(
         }
     }
 
-    // Evaluated once at construction — toggling requires a process restart.
-    // Swapping between Media3 and legacy session at runtime is not supported.
-    private val useMedia3Session = FeatureFlag.isEnabled(Feature.MEDIA3_SESSION)
+    // Evaluated lazily so that FeatureFlag.initialize() has completed before the
+    // first read. Toggling requires a process restart.
+    private val useMedia3Session by lazy { FeatureFlag.isEnabled(Feature.MEDIA3_SESSION) }
     private val isAutomotive = Util.isAutomotive(context)
 
     // Automotive always needs a MediaLibrarySession for the service contract (it's the
-    // app entry point on AAOS), even when the Media3 flag is OFF. The internal behavior
-    // is delegated to an AutomotiveSessionStrategy.
-    private val needsMedia3Session = useMedia3Session || isAutomotive
+    // app entry point on AAOS), even when the Media3 flag is OFF.
+    private val needsMedia3Session by lazy { useMedia3Session || isAutomotive }
 
-    // On non-automotive platforms with flag OFF, create a MediaSessionCompat.
-    // On automotive (regardless of flag), the MediaLibrarySession handles everything.
-    val mediaSession: MediaSessionCompat? = if (!useMedia3Session && !isAutomotive) {
-        MediaSessionCompat(context, "PocketCastsMediaSession").also { session ->
-            session.setSessionActivity(context.getLaunchActivityPendingIntent())
-            session.setRatingType(RatingCompat.RATING_HEART)
-            session.setExtras(
-                Bundle().apply {
-                    putBoolean("com.google.android.gms.car.media.ALWAYS_RESERVE_SPACE_FOR.ACTION_QUEUE", true)
-                },
-            )
+    val mediaSession: MediaSessionCompat? by lazy {
+        if (!useMedia3Session && !isAutomotive) {
+            MediaSessionCompat(context, "PocketCastsMediaSession").also { session ->
+                session.setSessionActivity(context.getLaunchActivityPendingIntent())
+                session.setRatingType(RatingCompat.RATING_HEART)
+                session.setExtras(
+                    Bundle().apply {
+                        putBoolean("com.google.android.gms.car.media.ALWAYS_RESERVE_SPACE_FOR.ACTION_QUEUE", true)
+                    },
+                )
+            }
+        } else {
+            null
         }
-    } else {
-        null
     }
 
     val disposables = CompositeDisposable()
@@ -227,8 +226,8 @@ class MediaSessionManager(
             settings,
         )
 
-        if (mediaSession != null) {
-            mediaSession.setCallback(
+        mediaSession?.let { session ->
+            session.setCallback(
                 MediaSessionCallback(
                     playbackManager,
                     episodeManager,
@@ -499,6 +498,7 @@ class MediaSessionManager(
             it.currentMediaItem = currentPlayer.currentMediaItem
             it.previousMediaId = currentPlayer.previousMediaId
             it.isTransientLoss = currentPlayer.isTransientLoss
+            it.queueItems = currentPlayer.queueItems
         }
         forwardingPlayer = swapped
         media3Session?.player = swapped

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -342,6 +342,7 @@ class MediaSessionManager(
             playbackManager = playbackManager,
             episodeManager = episodeManager,
             podcastManager = podcastManager,
+            playlistManager = playlistManager,
             settings = settings,
             actions = actions,
             bookmarkHelper = bookmarkHelper,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -91,7 +91,7 @@ class MediaSessionManager(
     val eventHorizon: EventHorizon,
     val bookmarkManager: BookmarkManager,
     val browseTreeProvider: BrowseTreeProvider,
-    private val applicationScope: CoroutineScope,
+    applicationScope: CoroutineScope,
 ) {
     companion object {
         const val EXTRA_TRANSIENT = "pocketcasts_transient_loss"
@@ -115,37 +115,30 @@ class MediaSessionManager(
         }
     }
 
-    // Evaluated lazily on first access — must not be read before FeatureFlag.initialize().
-    // In practice the first access is in startObserving(), which runs after FeatureFlag init.
-    // Toggling requires a process restart; swapping at runtime is not supported.
-    private val useMedia3Session by lazy {
-        FeatureFlag.isEnabled(Feature.MEDIA3_SESSION)
-    }
+    // Evaluated once at construction — toggling requires a process restart.
+    // Swapping between Media3 and legacy session at runtime is not supported.
+    private val useMedia3Session = FeatureFlag.isEnabled(Feature.MEDIA3_SESSION)
     private val isAutomotive = Util.isAutomotive(context)
 
     // Automotive always needs a MediaLibrarySession for the service contract (it's the
     // app entry point on AAOS), even when the Media3 flag is OFF. The internal behavior
     // is delegated to an AutomotiveSessionStrategy.
-    private val needsMedia3Session by lazy {
-        useMedia3Session || isAutomotive
-    }
+    private val needsMedia3Session = useMedia3Session || isAutomotive
 
     // On non-automotive platforms with flag OFF, create a MediaSessionCompat.
     // On automotive (regardless of flag), the MediaLibrarySession handles everything.
-    val mediaSession: MediaSessionCompat? by lazy {
-        if (!useMedia3Session && !isAutomotive) {
-            MediaSessionCompat(context, "PocketCastsMediaSession").also { session ->
-                session.setSessionActivity(context.getLaunchActivityPendingIntent())
-                session.setRatingType(RatingCompat.RATING_HEART)
-                session.setExtras(
-                    Bundle().apply {
-                        putBoolean("com.google.android.gms.car.media.ALWAYS_RESERVE_SPACE_FOR.ACTION_QUEUE", true)
-                    },
-                )
-            }
-        } else {
-            null
+    val mediaSession: MediaSessionCompat? = if (!useMedia3Session && !isAutomotive) {
+        MediaSessionCompat(context, "PocketCastsMediaSession").also { session ->
+            session.setSessionActivity(context.getLaunchActivityPendingIntent())
+            session.setRatingType(RatingCompat.RATING_HEART)
+            session.setExtras(
+                Bundle().apply {
+                    putBoolean("com.google.android.gms.car.media.ALWAYS_RESERVE_SPACE_FOR.ACTION_QUEUE", true)
+                },
+            )
         }
+    } else {
+        null
     }
 
     val disposables = CompositeDisposable()
@@ -192,18 +185,13 @@ class MediaSessionManager(
     @OptIn(UnstableApi::class)
     @Suppress("UnsafeOptInUsageError")
     private val automotiveStrategy: AutomotiveSessionStrategy? = if (isAutomotive) {
-        Media3AutomotiveStrategy(::useCustomSkipButtons)
+        Media3AutomotiveStrategy(::useCustomSkipButtons, ::speedToDrawable, ::skipBackIconForDuration, ::skipForwardIconForDuration)
     } else {
         null
     }
 
     @Volatile
     private var media3Session: MediaLibraryService.MediaLibrarySession? = null
-
-    private var lastCustomLayout: List<CommandButton> = emptyList()
-
-    @Volatile
-    private var media3Service: MediaLibraryService? = null
 
     @Volatile
     private var forwardingPlayer: PocketCastsForwardingPlayer? = null
@@ -236,26 +224,22 @@ class MediaSessionManager(
             bookmarkManager,
             settings,
         )
-    }
 
-    fun startObserving() {
-        if (!needsMedia3Session) {
-            applicationScope.launch(Dispatchers.Main) {
-                mediaSession!!.setCallback(
-                    MediaSessionCallback(
-                        playbackManager,
-                        episodeManager,
-                        enqueueCommand = { tag, command ->
-                            val added = commandQueue.tryEmit(Pair(tag, command))
-                            if (added) {
-                                Timber.i("Added command to queue: $tag")
-                            } else {
-                                LogBuffer.e(LogBuffer.TAG_PLAYBACK, "Failed to add command to queue: $tag")
-                            }
-                        },
-                    ),
-                )
-            }
+        if (mediaSession != null) {
+            mediaSession.setCallback(
+                MediaSessionCallback(
+                    playbackManager,
+                    episodeManager,
+                    enqueueCommand = { tag, command ->
+                        val added = commandQueue.tryEmit(Pair(tag, command))
+                        if (added) {
+                            Timber.i("Added command to queue: $tag")
+                        } else {
+                            LogBuffer.e(LogBuffer.TAG_PLAYBACK, "Failed to add command to queue: $tag")
+                        }
+                    },
+                ),
+            )
 
             applicationScope.launch {
                 commandQueue.collect { (tag, command) ->
@@ -264,7 +248,9 @@ class MediaSessionManager(
                 }
             }
         }
+    }
 
+    fun startObserving() {
         if (needsMedia3Session) {
             observeForMedia3Updates()
         } else {
@@ -298,7 +284,6 @@ class MediaSessionManager(
     @MainThread
     fun createSession(service: MediaLibraryService) {
         if (!needsMedia3Session) return
-        media3Service = service
         // Recreate scope in case release() was called previously (service restart).
         if (scope.coroutineContext[Job]?.isActive != true) {
             scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -400,7 +385,27 @@ class MediaSessionManager(
         }
 
         // Asynchronously enrich metadata with podcast name + artwork.
-        forwardingPlayer?.let { replayMetadataToPlayer(it) }
+        scope.launch(Dispatchers.IO) {
+            try {
+                val ep = playbackManager.getCurrentEpisode() ?: return@launch
+                val podcast = when (ep) {
+                    is PodcastEpisode -> podcastManager.findPodcastByUuid(ep.podcastUuid)
+                    else -> null
+                }
+                val showArtwork = settings.showArtworkOnLockScreen.value
+                val useEpisodeArtwork = settings.artworkConfiguration.value.useEpisodeArtwork
+                val wrappedArtworkUri = if (showArtwork) {
+                    resolveAndWrapArtworkUri(ep, podcast, useEpisodeArtwork)
+                } else {
+                    null
+                }
+                withContext(Dispatchers.Main) {
+                    forwardingPlayer?.updateMetadata(ep, podcast, showArtwork, useEpisodeArtwork, artworkUri = wrappedArtworkUri, showRating = !isAutomotive)
+                }
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to seed initial Media3 metadata")
+            }
+        }
     }
 
     /**
@@ -426,7 +431,6 @@ class MediaSessionManager(
         media3Session?.player = swapped
         placeholderPlayer?.release()
         placeholderPlayer = null
-        replayMetadataToPlayer(swapped)
         Timber.i("Media3 session player swapped")
     }
 
@@ -487,66 +491,7 @@ class MediaSessionManager(
         media3Session?.player = swapped
         placeholderPlayer?.release()
         placeholderPlayer = null
-        replayMetadataToPlayer(swapped)
         Timber.i("Media3 session cast player installed (no transport callbacks)")
-    }
-
-    /**
-     * Asynchronously fetches the current episode metadata and artwork, then applies
-     * it to the given [player]. Guarded by an identity check so that a stale replay
-     * (e.g., if another player swap happened during the async work) is discarded.
-     *
-     * Called after every player swap ([installPlayer], [installCastPlayerInternal],
-     * [createSession]) to ensure the Media3 notification has content. This is
-     * necessary because [observeForMedia3Updates] may have dropped the playback
-     * state event while [forwardingPlayer] was still null.
-     */
-    @OptIn(UnstableApi::class)
-    private fun replayMetadataToPlayer(player: PocketCastsForwardingPlayer) {
-        scope.launch(Dispatchers.IO) {
-            try {
-                val state = playbackManager.playbackStateRelay.blockingFirst()
-                if (state.isEmpty) return@launch
-                val episode = episodeManager.findEpisodeByUuid(state.episodeUuid) ?: return@launch
-                val podcast = when (episode) {
-                    is PodcastEpisode -> podcastManager.findPodcastByUuidBlocking(episode.podcastUuid)
-                    else -> null
-                }
-                val showArtwork = settings.showArtworkOnLockScreen.value
-                val useEpisodeArtwork = settings.artworkConfiguration.value.useEpisodeArtwork
-                val artworkData = if (showArtwork && !Util.isWearOs(context) && !Util.isAutomotive(context)) {
-                    AutoConverter.getPodcastArtworkBitmap(episode, context, useEpisodeArtwork)?.let { bitmap ->
-                        java.io.ByteArrayOutputStream().use { stream ->
-                            val format = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                                android.graphics.Bitmap.CompressFormat.WEBP_LOSSY
-                            } else {
-                                @Suppress("DEPRECATION")
-                                android.graphics.Bitmap.CompressFormat.WEBP
-                            }
-                            bitmap.compress(format, 80, stream)
-                            stream.toByteArray()
-                        }
-                    }
-                } else {
-                    null
-                }
-                val wrappedArtworkUri = if (showArtwork) {
-                    resolveAndWrapArtworkUri(episode, podcast, useEpisodeArtwork)
-                } else {
-                    null
-                }
-                withContext(Dispatchers.Main) {
-                    if (forwardingPlayer === player) {
-                        player.updateMetadata(episode, podcast, showArtwork, useEpisodeArtwork, artworkData, artworkUri = wrappedArtworkUri, showRating = !isAutomotive)
-                        player.isTransientLoss = state.transientLoss
-                        updateMedia3CustomLayout()
-                        media3Service?.triggerNotificationUpdate()
-                    }
-                }
-            } catch (e: Exception) {
-                Timber.e(e, "Failed to replay metadata after player install")
-            }
-        }
     }
 
     /**
@@ -698,11 +643,7 @@ class MediaSessionManager(
 
         if (isAutomotive) {
             val layout = automotiveStrategy!!.buildLayout(playbackManager, settings, context, ::buildCustomActionButton)
-            val allButtons = layout.primaryButtons + layout.overflowButtons
-            if (allButtons != lastCustomLayout) {
-                lastCustomLayout = allButtons
-                session.setCustomLayout(allButtons)
-            }
+            session.setCustomLayout(layout.primaryButtons + layout.overflowButtons)
             return
         } else {
             // Mobile/other: existing behavior unchanged
@@ -836,10 +777,8 @@ class MediaSessionManager(
         disposables.clear()
         scope.cancel()
         if (needsMedia3Session) {
-            lastCustomLayout = emptyList()
             media3Session?.release()
             media3Session = null
-            media3Service = null
             forwardingPlayer = null
             placeholderPlayer?.release()
             placeholderPlayer = null

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsForwardingPlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsForwardingPlayer.kt
@@ -110,10 +110,18 @@ class PocketCastsForwardingPlayer(
                     currentMediaItem,
                     Player.MEDIA_ITEM_TRANSITION_REASON_PLAYLIST_CHANGED,
                 )
+                // The first window of the timeline tracks currentMediaItem, so changing the
+                // episode also changes the timeline. The legacy MediaSessionCompat bridge
+                // relies on this event to rebuild setQueue for external controllers (Wear OS).
+                listener.onTimelineChanged(currentTimeline, Player.TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED)
             }
         }
         if (episodeChanged) {
-            dispatchEvents(Player.EVENT_MEDIA_METADATA_CHANGED, Player.EVENT_MEDIA_ITEM_TRANSITION)
+            dispatchEvents(
+                Player.EVENT_MEDIA_METADATA_CHANGED,
+                Player.EVENT_MEDIA_ITEM_TRANSITION,
+                Player.EVENT_TIMELINE_CHANGED,
+            )
         } else {
             dispatchEvents(Player.EVENT_MEDIA_METADATA_CHANGED)
         }
@@ -127,6 +135,7 @@ class PocketCastsForwardingPlayer(
         listeners.forEach { listener ->
             listener.onTimelineChanged(currentTimeline, Player.TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED)
         }
+        dispatchEvents(Player.EVENT_TIMELINE_CHANGED)
     }
 
     @MainThread
@@ -140,7 +149,7 @@ class PocketCastsForwardingPlayer(
             listener.onMediaMetadataChanged(MediaMetadata.EMPTY)
             listener.onTimelineChanged(currentTimeline, Player.TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED)
         }
-        dispatchEvents(Player.EVENT_MEDIA_METADATA_CHANGED)
+        dispatchEvents(Player.EVENT_MEDIA_METADATA_CHANGED, Player.EVENT_TIMELINE_CHANGED)
     }
 
     override fun getCurrentMediaItem(): MediaItem = currentMediaItem
@@ -155,7 +164,13 @@ class PocketCastsForwardingPlayer(
         return if (allItems.isEmpty()) Timeline.EMPTY else QueueTimeline(allItems)
     }
 
-    override fun getCurrentMediaItemIndex(): Int = 0
+    override fun getCurrentMediaItemIndex(): Int {
+        // Per Player contract, return C.INDEX_UNSET when there's no current window.
+        // Returning 0 would make controllers think the first queue item is currently
+        // playing when playback is idle, and prevents the legacy bridge from setting
+        // a valid active queue item id (breaks Wear OS Up Next affordance).
+        return if (currentMediaItem == MediaItem.EMPTY) C.INDEX_UNSET else 0
+    }
 
     override fun getMediaItemCount(): Int = currentTimeline.windowCount
 
@@ -186,10 +201,13 @@ class PocketCastsForwardingPlayer(
     }
 
     override fun seekTo(mediaItemIndex: Int, positionMs: Long) {
-        if (mediaItemIndex > 0 && mediaItemIndex < 1 + queueItems.size) {
+        val queueCallback = onSeekToQueueItem
+        if (queueCallback != null && mediaItemIndex > 0 && mediaItemIndex < 1 + queueItems.size) {
             val mediaId = queueItems[mediaItemIndex - 1].mediaId
-            onSeekToQueueItem?.invoke(mediaId)
+            queueCallback.invoke(mediaId)
         } else {
+            // No queue callback wired (e.g. cast install path) or index outside the
+            // queue range — delegate to the wrapped player, matching seekTo(positionMs).
             onSeekTo?.invoke(positionMs)
             super.seekTo(mediaItemIndex, positionMs)
         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsForwardingPlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsForwardingPlayer.kt
@@ -310,10 +310,30 @@ class PocketCastsForwardingPlayer(
         }
     }
 
+    // Wrapped ExoPlayer returns false while loading; report true to keep AAOS seek bar visible.
+    override fun isCurrentMediaItemSeekable(): Boolean = currentMediaItem != MediaItem.EMPTY
+
+    // Avoid exposing STATE_IDLE before ExoPlayer's async prepare transition fires.
+    override fun getPlaybackState(): Int {
+        val state = super.getPlaybackState()
+        if (state == Player.STATE_IDLE && currentMediaItem != MediaItem.EMPTY) {
+            return Player.STATE_BUFFERING
+        }
+        return state
+    }
+
     override fun getDuration(): Long {
         val playerDuration = super.getDuration()
         if (playerDuration != C.TIME_UNSET) {
             return playerDuration
+        }
+        return currentMediaItem.mediaMetadata.durationMs ?: C.TIME_UNSET
+    }
+
+    override fun getContentDuration(): Long {
+        val contentDuration = super.getContentDuration()
+        if (contentDuration != C.TIME_UNSET) {
+            return contentDuration
         }
         return currentMediaItem.mediaMetadata.durationMs ?: C.TIME_UNSET
     }
@@ -354,11 +374,7 @@ class PocketCastsForwardingPlayer(
         return HeartRating(episode.isStarred)
     }
 
-    /**
-     * Dispatches a batched [Player.Events] callback to all listeners.
-     * Media3's notification system reacts to [Player.Listener.onEvents], not
-     * individual callbacks, so this must be called after individual callbacks.
-     */
+    /** Dispatches a batched [Player.Events] to all listeners after individual callbacks. */
     private fun dispatchEvents(vararg eventFlags: @Player.Event Int) {
         val events = Player.Events(FlagSet.Builder().addAll(*eventFlags).build())
         listeners.forEach { it.onEvents(this@PocketCastsForwardingPlayer, events) }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsForwardingPlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsForwardingPlayer.kt
@@ -11,6 +11,7 @@ import androidx.media3.common.HeartRating
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import androidx.media3.common.Player
+import androidx.media3.common.Timeline
 import androidx.media3.common.util.UnstableApi
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
@@ -19,19 +20,10 @@ import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.getArtworkUrl
 
 /**
- * Bridges the app's playback layer to Media3's [Player] interface.
+ * Wraps an ExoPlayer and enriches it with episode metadata and an up next
+ * queue timeline so that Media3 MediaSession exposes them to external controllers.
  *
- * Wraps an ExoPlayer (from [SimplePlayer.exoPlayer]) and enriches it with
- * episode metadata so that a Media3 MediaSession can read the current media item
- * directly from the player.
- *
- * This player must only be accessed on the main thread, consistent with
- * ExoPlayer's threading requirements.
- *
- * **Player swapping** (local ↔ cast): Call [swapPlayer] to create a new
- * [PocketCastsForwardingPlayer] wrapping a different player while preserving
- * metadata state. The caller then installs the new player on the MediaSession
- * via `MediaSession.setPlayer()`.
+ * Must only be accessed on the main thread.
  */
 @OptIn(UnstableApi::class)
 class PocketCastsForwardingPlayer(
@@ -42,36 +34,24 @@ class PocketCastsForwardingPlayer(
     private val onPlay: (() -> Unit)? = null,
     private val onPause: (() -> Unit)? = null,
     private val onSeekTo: ((Long) -> Unit)? = null,
+    private val onSeekToQueueItem: ((mediaId: String) -> Unit)? = null,
     internal val playGuard: (() -> Boolean) = { true },
 ) : ForwardingPlayer(wrappedPlayer) {
 
     internal var currentMediaItem: MediaItem = MediaItem.EMPTY
     internal var previousMediaId: String? = null
+    internal var queueItems: List<MediaItem> = emptyList()
 
-    /**
-     * Indicates the player is in a transient loss state (e.g., audio focus lost temporarily).
-     * Media3 has no built-in equivalent. The notification provider reads this to decide
-     * whether to keep the foreground service alive.
-     */
     var isTransientLoss: Boolean = false
 
-    /**
-     * Creates a new [PocketCastsForwardingPlayer] wrapping [newPlayer] while
-     * preserving the current metadata and transient loss state.
-     *
-     * After calling this, install the returned player on the MediaSession:
-     * ```
-     * val newForwardingPlayer = forwardingPlayer.swapPlayer(castPlayer)
-     * mediaSession.setPlayer(newForwardingPlayer)
-     * ```
-     */
     @MainThread
     fun swapPlayer(newPlayer: Player): PocketCastsForwardingPlayer {
         checkMainThread()
-        return PocketCastsForwardingPlayer(newPlayer, onSkipForward, onSkipBack, onStop, onPlay, onPause, onSeekTo, playGuard).also {
+        return PocketCastsForwardingPlayer(newPlayer, onSkipForward, onSkipBack, onStop, onPlay, onPause, onSeekTo, onSeekToQueueItem, playGuard).also {
             it.currentMediaItem = this.currentMediaItem
             it.previousMediaId = this.previousMediaId
             it.isTransientLoss = this.isTransientLoss
+            it.queueItems = this.queueItems
         }
     }
 
@@ -139,17 +119,26 @@ class PocketCastsForwardingPlayer(
         }
     }
 
-    /**
-     * Clears metadata when nothing is playing, so the session doesn't show stale info.
-     */
+    /** @param items Up next episodes, not including the currently playing episode. */
+    @MainThread
+    fun updateQueue(items: List<MediaItem>) {
+        checkMainThread()
+        queueItems = items
+        listeners.forEach { listener ->
+            listener.onTimelineChanged(currentTimeline, Player.TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED)
+        }
+    }
+
     @MainThread
     fun clearMetadata() {
         checkMainThread()
         currentMediaItem = MediaItem.EMPTY
         previousMediaId = null
         isTransientLoss = false
+        queueItems = emptyList()
         listeners.forEach { listener ->
             listener.onMediaMetadataChanged(MediaMetadata.EMPTY)
+            listener.onTimelineChanged(currentTimeline, Player.TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED)
         }
         dispatchEvents(Player.EVENT_MEDIA_METADATA_CHANGED)
     }
@@ -157,6 +146,25 @@ class PocketCastsForwardingPlayer(
     override fun getCurrentMediaItem(): MediaItem = currentMediaItem
 
     override fun getMediaMetadata(): MediaMetadata = currentMediaItem.mediaMetadata
+
+    override fun getCurrentTimeline(): Timeline {
+        val allItems = buildList {
+            if (currentMediaItem != MediaItem.EMPTY) add(currentMediaItem)
+            addAll(queueItems)
+        }
+        return if (allItems.isEmpty()) Timeline.EMPTY else QueueTimeline(allItems)
+    }
+
+    override fun getCurrentMediaItemIndex(): Int = 0
+
+    override fun getMediaItemCount(): Int = currentTimeline.windowCount
+
+    override fun getMediaItemAt(index: Int): MediaItem {
+        val timeline = currentTimeline
+        val window = Timeline.Window()
+        timeline.getWindow(index, window)
+        return window.mediaItem
+    }
 
     override fun getAvailableCommands(): Player.Commands {
         return Player.Commands.Builder()
@@ -167,6 +175,7 @@ class PocketCastsForwardingPlayer(
                 Player.COMMAND_STOP,
                 Player.COMMAND_GET_CURRENT_MEDIA_ITEM,
                 Player.COMMAND_GET_METADATA,
+                Player.COMMAND_GET_TIMELINE,
             )
             .build()
     }
@@ -177,8 +186,13 @@ class PocketCastsForwardingPlayer(
     }
 
     override fun seekTo(mediaItemIndex: Int, positionMs: Long) {
-        onSeekTo?.invoke(positionMs)
-        super.seekTo(mediaItemIndex, positionMs)
+        if (mediaItemIndex > 0 && mediaItemIndex < 1 + queueItems.size) {
+            val mediaId = queueItems[mediaItemIndex - 1].mediaId
+            onSeekToQueueItem?.invoke(mediaId)
+        } else {
+            onSeekTo?.invoke(positionMs)
+            super.seekTo(mediaItemIndex, positionMs)
+        }
     }
 
     override fun seekToNext() {
@@ -190,32 +204,18 @@ class PocketCastsForwardingPlayer(
     }
 
     override fun stop() {
-        // Either delegate to the app's stop handler (which pauses via PlaybackManager)
-        // or fall through to the wrapped player. Calling both would stop the ExoPlayer
-        // (releasing decoders) before PlaybackManager can interact with it.
         onStop?.invoke() ?: super.stop()
     }
 
     override fun play() {
         if (playGuard()) {
-            // Either delegate to the app's play handler (which plays via PlaybackManager)
-            // or fall through to the wrapped player. Calling both would cause double-play
-            // because PlaybackManager.playQueueSuspend() already drives the player.
             onPlay?.invoke() ?: super.play()
         }
     }
 
     override fun pause() {
-        // Same pattern as play() and stop() — the pause callback drives the player
-        // through PlaybackManager, so calling both would cause double-pause.
         onPause?.invoke() ?: super.pause()
     }
-
-    // ---- Media3 controller protocol interception ----
-    // After onAddMediaItems resolves, Media3 calls setMediaItems → prepare → play.
-    // We intercept setMediaItems/addMediaItems to update metadata from the resolved
-    // MediaItem and intercept prepare() as a no-op, because actual playback preparation
-    // is handled by PlaybackManager through the side-channel (playNowSuspend).
 
     override fun setMediaItems(mediaItems: MutableList<MediaItem>) {
         applyResolvedMediaItems(mediaItems)
@@ -261,9 +261,7 @@ class PocketCastsForwardingPlayer(
         applyResolvedMediaItems(mutableListOf(mediaItem))
     }
 
-    override fun prepare() {
-        // No-op — actual preparation is handled by PlaybackManager via playNowSuspend.
-    }
+    override fun prepare() = Unit
 
     private fun applyResolvedMediaItems(mediaItems: List<MediaItem>) {
         val item = mediaItems.firstOrNull() ?: return
@@ -347,5 +345,69 @@ class PocketCastsForwardingPlayer(
         check(Looper.myLooper() == Looper.getMainLooper()) {
             "PocketCastsForwardingPlayer must be accessed on the main thread"
         }
+    }
+
+    private class QueueTimeline(private val items: List<MediaItem>) : Timeline() {
+        override fun getWindowCount() = items.size
+
+        override fun getWindow(windowIndex: Int, window: Window, defaultPositionProjectionUs: Long): Window {
+            val item = items[windowIndex]
+            val durationUs = item.mediaMetadata.durationMs?.let { it * 1000 } ?: C.TIME_UNSET
+            window.set(
+                /* uid = */
+                windowIndex,
+                /* mediaItem = */
+                item,
+                /* manifest = */
+                null,
+                /* presentationStartTimeMs = */
+                C.TIME_UNSET,
+                /* windowStartTimeMs = */
+                C.TIME_UNSET,
+                /* elapsedRealtimeEpochOffsetMs = */
+                C.TIME_UNSET,
+                /* isSeekable = */
+                true,
+                /* isDynamic = */
+                false,
+                /* liveConfiguration = */
+                null,
+                /* defaultPositionUs = */
+                0L,
+                /* durationUs = */
+                durationUs,
+                /* firstPeriodIndex = */
+                windowIndex,
+                /* lastPeriodIndex = */
+                windowIndex,
+                /* positionInFirstPeriodUs = */
+                0L,
+            )
+            return window
+        }
+
+        override fun getPeriodCount() = items.size
+
+        override fun getPeriod(periodIndex: Int, period: Period, setIds: Boolean): Period {
+            period.set(
+                /* id = */
+                periodIndex,
+                /* uid = */
+                periodIndex,
+                /* windowIndex = */
+                periodIndex,
+                /* durationUs = */
+                C.TIME_UNSET,
+                /* positionInWindowUs = */
+                0L,
+            )
+            return period
+        }
+
+        override fun getIndexOfPeriod(uid: Any): Int {
+            return if (uid is Int && uid in items.indices) uid else C.INDEX_UNSET
+        }
+
+        override fun getUidOfPeriod(periodIndex: Int) = periodIndex
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsForwardingPlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsForwardingPlayer.kt
@@ -161,7 +161,7 @@ class PocketCastsForwardingPlayer(
             if (currentMediaItem != MediaItem.EMPTY) add(currentMediaItem)
             addAll(queueItems)
         }
-        return if (allItems.isEmpty()) Timeline.EMPTY else QueueTimeline(allItems)
+        return if (allItems.isEmpty()) super.getCurrentTimeline() else QueueTimeline(allItems)
     }
 
     override fun getCurrentMediaItemIndex(): Int = 0

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsForwardingPlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsForwardingPlayer.kt
@@ -164,13 +164,7 @@ class PocketCastsForwardingPlayer(
         return if (allItems.isEmpty()) Timeline.EMPTY else QueueTimeline(allItems)
     }
 
-    override fun getCurrentMediaItemIndex(): Int {
-        // Per Player contract, return C.INDEX_UNSET when there's no current window.
-        // Returning 0 would make controllers think the first queue item is currently
-        // playing when playback is idle, and prevents the legacy bridge from setting
-        // a valid active queue item id (breaks Wear OS Up Next affordance).
-        return if (currentMediaItem == MediaItem.EMPTY) C.INDEX_UNSET else 0
-    }
+    override fun getCurrentMediaItemIndex(): Int = 0
 
     override fun getMediaItemCount(): Int = currentTimeline.windowCount
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsForwardingPlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsForwardingPlayer.kt
@@ -191,6 +191,7 @@ class PocketCastsForwardingPlayer(
                 Player.COMMAND_GET_CURRENT_MEDIA_ITEM,
                 Player.COMMAND_GET_METADATA,
                 Player.COMMAND_GET_TIMELINE,
+                Player.COMMAND_SEEK_TO_MEDIA_ITEM,
             )
             .build()
     }
@@ -210,6 +211,16 @@ class PocketCastsForwardingPlayer(
             // queue range — delegate to the wrapped player, matching seekTo(positionMs).
             onSeekTo?.invoke(positionMs)
             super.seekTo(mediaItemIndex, positionMs)
+        }
+    }
+
+    override fun seekToDefaultPosition(mediaItemIndex: Int) {
+        val queueCallback = onSeekToQueueItem
+        if (queueCallback != null && mediaItemIndex > 0 && mediaItemIndex < 1 + queueItems.size) {
+            val mediaId = queueItems[mediaItemIndex - 1].mediaId
+            queueCallback.invoke(mediaId)
+        } else {
+            super.seekToDefaultPosition(mediaItemIndex)
         }
     }
 

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3SessionCallbackTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3SessionCallbackTest.kt
@@ -16,6 +16,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.model.HeadphoneAction
 import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkHelper
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import java.util.Date
@@ -47,6 +48,7 @@ class Media3SessionCallbackTest {
     private lateinit var playbackManager: PlaybackManager
     private lateinit var episodeManager: EpisodeManager
     private lateinit var podcastManager: PodcastManager
+    private lateinit var playlistManager: PlaylistManager
     private lateinit var settings: Settings
     private lateinit var actions: MediaSessionActions
     private lateinit var bookmarkHelper: BookmarkHelper
@@ -60,6 +62,7 @@ class Media3SessionCallbackTest {
         playbackManager = mock()
         episodeManager = mock()
         podcastManager = mock()
+        playlistManager = mock()
         settings = mock()
         actions = mock()
         bookmarkHelper = mock()
@@ -71,6 +74,7 @@ class Media3SessionCallbackTest {
             playbackManager = playbackManager,
             episodeManager = episodeManager,
             podcastManager = podcastManager,
+            playlistManager = playlistManager,
             settings = settings,
             actions = actions,
             bookmarkHelper = bookmarkHelper,

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3SessionCallbackTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3SessionCallbackTest.kt
@@ -111,6 +111,7 @@ class Media3SessionCallbackTest {
         assertTrue(playerCommands.contains(Player.COMMAND_STOP))
         assertTrue(playerCommands.contains(Player.COMMAND_GET_CURRENT_MEDIA_ITEM))
         assertTrue(playerCommands.contains(Player.COMMAND_GET_METADATA))
+        assertTrue(playerCommands.contains(Player.COMMAND_SEEK_TO_MEDIA_ITEM))
     }
 
     @Test

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsForwardingPlayerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsForwardingPlayerTest.kt
@@ -174,6 +174,7 @@ class PocketCastsForwardingPlayerTest {
         assertTrue(commands.contains(Player.COMMAND_STOP))
         assertTrue(commands.contains(Player.COMMAND_GET_CURRENT_MEDIA_ITEM))
         assertTrue(commands.contains(Player.COMMAND_GET_METADATA))
+        assertTrue(commands.contains(Player.COMMAND_SEEK_TO_MEDIA_ITEM))
         assertFalse(commands.contains(Player.COMMAND_SEEK_FORWARD))
         assertFalse(commands.contains(Player.COMMAND_SEEK_BACK))
         assertFalse(commands.contains(Player.COMMAND_SEEK_TO_NEXT))
@@ -814,6 +815,54 @@ class PocketCastsForwardingPlayerTest {
 
         assertNull(capturedMediaId)
         verify(mockPlayer).seekTo(5, 0L)
+    }
+
+    @Test
+    fun `seekToDefaultPosition with queue index invokes onSeekToQueueItem`() {
+        var capturedMediaId: String? = null
+        val player = PocketCastsForwardingPlayer(
+            wrappedPlayer = mockPlayer,
+            onSeekToQueueItem = { capturedMediaId = it },
+        )
+        player.updateMetadata(createPodcastEpisode(uuid = "ep-current"), null)
+        player.updateQueue(listOf(queueItemOf("q1"), queueItemOf("q2")))
+
+        player.seekToDefaultPosition(2)
+
+        assertEquals("q2", capturedMediaId)
+        verify(mockPlayer, never()).seekToDefaultPosition(any<Int>())
+    }
+
+    @Test
+    fun `seekToDefaultPosition with index 0 falls back to super`() {
+        var capturedMediaId: String? = null
+        val player = PocketCastsForwardingPlayer(
+            wrappedPlayer = mockPlayer,
+            onSeekToQueueItem = { capturedMediaId = it },
+        )
+        player.updateMetadata(createPodcastEpisode(uuid = "ep-current"), null)
+        player.updateQueue(listOf(queueItemOf("q1")))
+
+        player.seekToDefaultPosition(0)
+
+        assertNull(capturedMediaId)
+        verify(mockPlayer).seekToDefaultPosition(0)
+    }
+
+    @Test
+    fun `seekToDefaultPosition with out of range index falls back to super`() {
+        var capturedMediaId: String? = null
+        val player = PocketCastsForwardingPlayer(
+            wrappedPlayer = mockPlayer,
+            onSeekToQueueItem = { capturedMediaId = it },
+        )
+        player.updateMetadata(createPodcastEpisode(uuid = "ep-current"), null)
+        player.updateQueue(listOf(queueItemOf("q1")))
+
+        player.seekToDefaultPosition(5)
+
+        assertNull(capturedMediaId)
+        verify(mockPlayer).seekToDefaultPosition(5)
     }
 
     @Test

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsForwardingPlayerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsForwardingPlayerTest.kt
@@ -7,6 +7,7 @@ import androidx.media3.common.HeartRating
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import androidx.media3.common.Player
+import androidx.media3.common.Timeline
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
@@ -45,6 +46,7 @@ class PocketCastsForwardingPlayerTest {
             on { seekBackIncrement } doReturn 10_000L
             on { duration } doReturn C.TIME_UNSET
             on { applicationLooper } doReturn Looper.getMainLooper()
+            on { currentTimeline } doReturn Timeline.EMPTY
         }
         shadowOf(Looper.getMainLooper()).idle()
         forwardingPlayer = PocketCastsForwardingPlayer(mockPlayer)
@@ -694,8 +696,8 @@ class PocketCastsForwardingPlayerTest {
     }
 
     @Test
-    fun `currentTimeline is empty by default`() {
-        assertTrue(forwardingPlayer.currentTimeline.isEmpty)
+    fun `currentTimeline delegates to wrapped player by default`() {
+        assertEquals(mockPlayer.currentTimeline, forwardingPlayer.currentTimeline)
     }
 
     @Test
@@ -905,7 +907,8 @@ class PocketCastsForwardingPlayerTest {
 
         forwardingPlayer.clearMetadata()
 
-        assertTrue(forwardingPlayer.currentTimeline.isEmpty)
+        assertEquals(MediaItem.EMPTY, forwardingPlayer.currentMediaItem)
+        assertTrue(forwardingPlayer.queueItems.isEmpty())
         verify(listener).onTimelineChanged(any(), eq(Player.TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED))
         val events = argumentCaptor<Player.Events>()
         verify(listener).onEvents(eq(forwardingPlayer), events.capture())

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsForwardingPlayerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsForwardingPlayerTest.kt
@@ -22,7 +22,9 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
@@ -673,6 +675,200 @@ class PocketCastsForwardingPlayerTest {
 
         verify(listener, times(2)).onMediaMetadataChanged(any())
         verify(listener, times(1)).onMediaItemTransition(any(), any())
+    }
+
+    // --- Queue / timeline tests ---
+
+    @Test
+    fun `getCurrentMediaItemIndex returns INDEX_UNSET when no current item`() {
+        assertEquals(C.INDEX_UNSET, forwardingPlayer.currentMediaItemIndex)
+    }
+
+    @Test
+    fun `getCurrentMediaItemIndex returns zero when current item set`() {
+        val episode = createPodcastEpisode(uuid = "ep-1")
+        forwardingPlayer.updateMetadata(episode, null)
+
+        assertEquals(0, forwardingPlayer.currentMediaItemIndex)
+    }
+
+    @Test
+    fun `currentTimeline is empty by default`() {
+        assertTrue(forwardingPlayer.currentTimeline.isEmpty)
+    }
+
+    @Test
+    fun `currentTimeline contains current item plus queue items`() {
+        forwardingPlayer.updateMetadata(createPodcastEpisode(uuid = "ep-current"), null)
+        val queue = listOf(queueItemOf("q1"), queueItemOf("q2"))
+
+        forwardingPlayer.updateQueue(queue)
+
+        val timeline = forwardingPlayer.currentTimeline
+        assertEquals(3, timeline.windowCount)
+        assertEquals("ep-current", forwardingPlayer.getMediaItemAt(0).mediaId)
+        assertEquals("q1", forwardingPlayer.getMediaItemAt(1).mediaId)
+        assertEquals("q2", forwardingPlayer.getMediaItemAt(2).mediaId)
+    }
+
+    @Test
+    fun `updateQueue without current item exposes queue-only timeline`() {
+        val queue = listOf(queueItemOf("q1"), queueItemOf("q2"))
+
+        forwardingPlayer.updateQueue(queue)
+
+        assertEquals(2, forwardingPlayer.currentTimeline.windowCount)
+        assertEquals("q1", forwardingPlayer.getMediaItemAt(0).mediaId)
+    }
+
+    @Test
+    fun `updateQueue fires onTimelineChanged with PLAYLIST_CHANGED reason`() {
+        val listener = mock<Player.Listener>()
+        forwardingPlayer.addListener(listener)
+
+        forwardingPlayer.updateQueue(listOf(queueItemOf("q1")))
+
+        verify(listener).onTimelineChanged(
+            forwardingPlayer.currentTimeline,
+            Player.TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED,
+        )
+    }
+
+    @Test
+    fun `updateQueue dispatches onEvents with EVENT_TIMELINE_CHANGED`() {
+        val listener = mock<Player.Listener>()
+        forwardingPlayer.addListener(listener)
+
+        forwardingPlayer.updateQueue(listOf(queueItemOf("q1")))
+
+        val events = argumentCaptor<Player.Events>()
+        verify(listener).onEvents(eq(forwardingPlayer), events.capture())
+        assertTrue(events.firstValue.contains(Player.EVENT_TIMELINE_CHANGED))
+    }
+
+    @Test
+    fun `updateMetadata fires onTimelineChanged when episode changes`() {
+        val listener = mock<Player.Listener>()
+        forwardingPlayer.addListener(listener)
+
+        forwardingPlayer.updateMetadata(createPodcastEpisode(uuid = "ep-1"), null)
+
+        verify(listener).onTimelineChanged(
+            forwardingPlayer.currentTimeline,
+            Player.TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED,
+        )
+        val events = argumentCaptor<Player.Events>()
+        verify(listener).onEvents(eq(forwardingPlayer), events.capture())
+        assertTrue(events.firstValue.contains(Player.EVENT_TIMELINE_CHANGED))
+    }
+
+    @Test
+    fun `updateMetadata does not fire onTimelineChanged when episode unchanged`() {
+        val listener = mock<Player.Listener>()
+        val episode = createPodcastEpisode(uuid = "ep-same")
+        forwardingPlayer.updateMetadata(episode, null)
+        forwardingPlayer.addListener(listener)
+
+        forwardingPlayer.updateMetadata(episode, null)
+
+        verify(listener, never()).onTimelineChanged(any(), any())
+    }
+
+    @Test
+    fun `seekTo with queue index invokes onSeekToQueueItem with correct mediaId`() {
+        var capturedMediaId: String? = null
+        val player = PocketCastsForwardingPlayer(
+            wrappedPlayer = mockPlayer,
+            onSeekToQueueItem = { capturedMediaId = it },
+        )
+        player.updateMetadata(createPodcastEpisode(uuid = "ep-current"), null)
+        player.updateQueue(listOf(queueItemOf("q1"), queueItemOf("q2")))
+
+        player.seekTo(2, 0L)
+
+        assertEquals("q2", capturedMediaId)
+        verify(mockPlayer, never()).seekTo(any<Int>(), any())
+    }
+
+    @Test
+    fun `seekTo with queue index falls back to super when onSeekToQueueItem is null`() {
+        forwardingPlayer.updateMetadata(createPodcastEpisode(uuid = "ep-current"), null)
+        forwardingPlayer.updateQueue(listOf(queueItemOf("q1")))
+
+        forwardingPlayer.seekTo(1, 5_000L)
+
+        verify(mockPlayer).seekTo(1, 5_000L)
+    }
+
+    @Test
+    fun `seekTo with queue index out of range falls back to super`() {
+        var capturedMediaId: String? = null
+        val player = PocketCastsForwardingPlayer(
+            wrappedPlayer = mockPlayer,
+            onSeekToQueueItem = { capturedMediaId = it },
+        )
+        player.updateMetadata(createPodcastEpisode(uuid = "ep-current"), null)
+        player.updateQueue(listOf(queueItemOf("q1")))
+
+        player.seekTo(5, 0L)
+
+        assertNull(capturedMediaId)
+        verify(mockPlayer).seekTo(5, 0L)
+    }
+
+    @Test
+    fun `swapPlayer preserves queue items`() {
+        forwardingPlayer.updateQueue(listOf(queueItemOf("q1"), queueItemOf("q2")))
+
+        val newWrappedPlayer = mock<Player> {
+            on { applicationLooper } doReturn Looper.getMainLooper()
+        }
+        val swapped = forwardingPlayer.swapPlayer(newWrappedPlayer)
+
+        assertEquals(2, swapped.currentTimeline.windowCount)
+        assertEquals("q1", swapped.getMediaItemAt(0).mediaId)
+    }
+
+    @Test
+    fun `swapPlayer preserves onSeekToQueueItem callback`() {
+        var capturedMediaId: String? = null
+        val player = PocketCastsForwardingPlayer(
+            wrappedPlayer = mockPlayer,
+            onSeekToQueueItem = { capturedMediaId = it },
+        )
+        player.updateQueue(listOf(queueItemOf("q1")))
+
+        val newWrappedPlayer = mock<Player> {
+            on { applicationLooper } doReturn Looper.getMainLooper()
+        }
+        val swapped = player.swapPlayer(newWrappedPlayer)
+        swapped.seekTo(1, 0L)
+
+        assertEquals("q1", capturedMediaId)
+    }
+
+    @Test
+    fun `clearMetadata clears queue and fires timeline change`() {
+        forwardingPlayer.updateMetadata(createPodcastEpisode(uuid = "ep-1"), null)
+        forwardingPlayer.updateQueue(listOf(queueItemOf("q1")))
+        val listener = mock<Player.Listener>()
+        forwardingPlayer.addListener(listener)
+
+        forwardingPlayer.clearMetadata()
+
+        assertTrue(forwardingPlayer.currentTimeline.isEmpty)
+        verify(listener).onTimelineChanged(any(), eq(Player.TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED))
+        val events = argumentCaptor<Player.Events>()
+        verify(listener).onEvents(eq(forwardingPlayer), events.capture())
+        assertTrue(events.firstValue.contains(Player.EVENT_TIMELINE_CHANGED))
+        assertTrue(events.firstValue.contains(Player.EVENT_MEDIA_METADATA_CHANGED))
+    }
+
+    private fun queueItemOf(mediaId: String): MediaItem {
+        return MediaItem.Builder()
+            .setMediaId(mediaId)
+            .setMediaMetadata(MediaMetadata.Builder().setTitle(mediaId).build())
+            .build()
     }
 
     private fun createPodcastEpisode(

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsForwardingPlayerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsForwardingPlayerTest.kt
@@ -681,8 +681,8 @@ class PocketCastsForwardingPlayerTest {
     // --- Queue / timeline tests ---
 
     @Test
-    fun `getCurrentMediaItemIndex returns INDEX_UNSET when no current item`() {
-        assertEquals(C.INDEX_UNSET, forwardingPlayer.currentMediaItemIndex)
+    fun `getCurrentMediaItemIndex returns zero when no current item`() {
+        assertEquals(0, forwardingPlayer.currentMediaItemIndex)
     }
 
     @Test


### PR DESCRIPTION
## Description
With `media3_session` flag enabled we didn't support up next queue. This PR addresses that.

Fixes PCDROID-533 https://linear.app/a8c/issue/PCDROID-533/media3-wearos-media-session-up-next-button-disabled

## Testing Instructions
1. Install wear app with FF ON
2. Put together a queue
3. Start playing an episode
4. Start an excercise on your watch
5. Swipe right to see the media session
6. Verify up next button works

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 