### PR TITLE
Set playback position of an active episode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 *   Updates
     *   Make sure users with new accounts land on the Podcasts tab when they followed some recommended podcasts
         ([#5197](https://github.com/Automattic/pocket-casts-android/pull/5197))
+*   Bug Fixes
+    *   Fix active episode not syncing its playback position
+        ([#5213](https://github.com/Automattic/pocket-casts-android/pull/5213))
 
 8.9
 -----

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/data/EpisodeSync.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/data/EpisodeSync.kt
@@ -148,6 +148,7 @@ internal class EpisodeSync(
             ?.takeIf { !isEpisodePlaying && it >= 0 && it !in (playedUpTo - seekThresholdSecs)..(playedUpTo + 2) }
             ?.let { value ->
                 playedUpTo = value
+                playbackManager.seekIfPlayingToTimeMs(uuid, (playedUpTo * 1000).toInt())
             }
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/data/EpisodeSync.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/data/EpisodeSync.kt
@@ -148,7 +148,7 @@ internal class EpisodeSync(
             ?.takeIf { !isEpisodePlaying && it >= 0 && it !in (playedUpTo - seekThresholdSecs)..(playedUpTo + 2) }
             ?.let { value ->
                 playedUpTo = value
-                playbackManager.seekIfPlayingToTimeMs(uuid, (playedUpTo * 1000).toInt())
+                playbackManager.seekIfPlayingToTimeMs(uuid, playedUpToMs)
             }
     }
 }


### PR DESCRIPTION
## Description

This addresses an issue that was introduced during protobuf sync migration. The currently active episode position was not being sought to leaving it at the recently known one.

Fixes PCDROID-415

## Testing Instructions

1. Play an episode on Android.
2. Pause it.
3. Resume playback in the Web app.
4. Move the playback position.
5. Pause the episode in the Web app.
6. Sync Android device.
7. The playback position should sync as well and resuming playback should resume from the position in the Web app.

## Screenshots or Screencast 

N/A

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
