### PR TITLE
Fix stack overflow in legacy UI

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -1522,10 +1522,10 @@ class MainActivity :
     }
 
     override fun showAccountUpgradeNow(autoSelectPlus: Boolean) {
-        showAccountUpgradeNowDialog(shouldClose = false, autoSelectPlus = autoSelectPlus)
+        showAccountUpgradeNowDialog(autoSelectPlus = autoSelectPlus)
     }
 
-    private fun showAccountUpgradeNowDialog(shouldClose: Boolean, autoSelectPlus: Boolean = false) {
+    private fun showAccountUpgradeNowDialog(autoSelectPlus: Boolean = false) {
         val observer: Observer<SignInState> = Observer { value ->
             val intent = if (value.isSignedInAsFree) {
                 AccountActivity.newUpgradeInstance(this)
@@ -1537,10 +1537,6 @@ class MainActivity :
                 Intent(this, AccountActivity::class.java)
             }
             startActivity(intent)
-
-            if (shouldClose) {
-                finish()
-            }
         }
 
         viewModel.signInState.observeOnce(this, observer)
@@ -1693,7 +1689,7 @@ class MainActivity :
                 }
 
                 is UpgradeAccountDeepLink -> {
-                    showAccountUpgradeNowDialog(shouldClose = true)
+                    showAccountUpgradeNowDialog()
                 }
 
                 is PromoCodeDeepLink -> {

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/AccountActivity.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/AccountActivity.kt
@@ -7,10 +7,15 @@ import android.content.Intent
 import android.os.Build
 import android.os.Bundle
 import androidx.activity.OnBackPressedCallback
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.IntentCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isVisible
+import androidx.core.view.updatePadding
+import androidx.navigation.NavController
 import androidx.navigation.NavDestination
 import androidx.navigation.findNavController
 import androidx.navigation.ui.AppBarConfiguration
@@ -22,7 +27,6 @@ import au.com.shiftyjelly.pocketcasts.account.viewmodel.SubscriptionType
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.Util
-import au.com.shiftyjelly.pocketcasts.views.helper.UiUtil
 import com.automattic.eventhorizon.AccountUpdatedDismissedEvent
 import com.automattic.eventhorizon.AccountUpdatedShownEvent
 import com.automattic.eventhorizon.CreateAccountDismissedLegacyEvent
@@ -52,19 +56,21 @@ class AccountActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         theme.setupThemeForConfig(this, resources.configuration)
+        enableEdgeToEdge(navigationBarStyle = theme.getNavigationBarStyle(this))
 
         binding = AccountActivityBinding.inflate(layoutInflater)
         val view = binding.root
         setContentView(view)
-
-        onBackPressedDispatcher.addCallback(
-            this,
-            object : OnBackPressedCallback(true) {
-                override fun handleOnBackPressed() {
-                    handleBackPressed()
-                }
-            },
-        )
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { _, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout())
+            binding.root.updatePadding(
+                left = insets.left,
+                right = insets.right,
+                bottom = insets.bottom,
+                top = insets.top,
+            )
+            windowInsets
+        }
 
         val navController = findNavController(R.id.nav_host_fragment)
         binding.carHeader?.btnClose?.setOnClickListener {
@@ -72,6 +78,15 @@ class AccountActivity : AppCompatActivity() {
                 finish()
             }
         }
+
+        onBackPressedDispatcher.addCallback(
+            this,
+            object : OnBackPressedCallback(true) {
+                override fun handleOnBackPressed() {
+                    handleBackNavigation(navController)
+                }
+            },
+        )
 
         if (savedInstanceState == null) {
             val navInflater = navController.navInflater
@@ -99,7 +114,9 @@ class AccountActivity : AppCompatActivity() {
 
             val navConfiguration = AppBarConfiguration(navController.graph)
             binding.toolbar?.setupWithNavController(navController, navConfiguration)
-            binding.toolbar?.setNavigationOnClickListener { _ -> handleBackPressed() }
+            binding.toolbar?.setNavigationOnClickListener { _ ->
+                handleBackNavigation(navController)
+            }
 
             navController.addOnDestinationChangedListener { _, destination, _ ->
                 destination.trackShown()
@@ -129,17 +146,13 @@ class AccountActivity : AppCompatActivity() {
         }
     }
 
-    private fun handleBackPressed() {
-        val currentFragment = findNavController(R.id.nav_host_fragment).currentDestination
+    private fun handleBackNavigation(navController: NavController) {
+        val currentFragment = navController.currentDestination
         currentFragment?.trackDismissed()
 
-        if (currentFragment?.id == R.id.createDoneFragment) {
+        if (currentFragment?.id == R.id.createDoneFragment || !navController.popBackStack()) {
             finish()
-            return
         }
-
-        UiUtil.hideKeyboard(binding.root)
-        onBackPressedDispatcher.onBackPressed()
     }
 
     private fun NavDestination.trackShown() {

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/AccountActivity.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/AccountActivity.kt
@@ -27,6 +27,7 @@ import au.com.shiftyjelly.pocketcasts.account.viewmodel.SubscriptionType
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.Util
+import au.com.shiftyjelly.pocketcasts.views.helper.UiUtil
 import com.automattic.eventhorizon.AccountUpdatedDismissedEvent
 import com.automattic.eventhorizon.AccountUpdatedShownEvent
 import com.automattic.eventhorizon.CreateAccountDismissedLegacyEvent
@@ -150,6 +151,7 @@ class AccountActivity : AppCompatActivity() {
         val currentFragment = navController.currentDestination
         currentFragment?.trackDismissed()
 
+        UiUtil.hideKeyboard(binding.root)
         if (currentFragment?.id == R.id.createDoneFragment || !navController.popBackStack()) {
             finish()
         }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/AccountFragment.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/AccountFragment.kt
@@ -108,9 +108,7 @@ class AccountFragment : BaseFragment() {
                 ),
             )
             if (view.findNavController().currentDestination?.id == R.id.accountFragment) {
-                if (Util.isCarUiMode(view.context)) { // We can't sign up to plus on cars so skip that step
-                    view.findNavController().navigate(R.id.action_accountFragment_to_createEmailFragment)
-                }
+                view.findNavController().navigate(R.id.action_accountFragment_to_createEmailFragment)
             }
         }
 


### PR DESCRIPTION
## Description

This fixes a stack overflow issue in the legacy code. I don't know how it can really be used from the app but we can't remove it as parts of the code are used in the Automotive app. And there are still deep links to it.

Fixes PCDROID-520

## Testing Instructions

1. Install the`debugProd` app.
2. Open it.
3. Execute this:
```
adb shell am start \
  -a android.intent.action.VIEW \
  -d "pktc://upgrade" \
  au.com.shiftyjelly.pocketcasts.debug
```
4. Go back.
5. App should not crash.

## Screenshots or Screencast 

N/A

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
