### PR TITLE
[Media3] Fix automotive controls flicker while playing

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -193,6 +193,8 @@ class MediaSessionManager(
     @Volatile
     private var media3Session: MediaLibraryService.MediaLibrarySession? = null
 
+    private var lastCustomLayout: List<CommandButton> = emptyList()
+
     @Volatile
     private var forwardingPlayer: PocketCastsForwardingPlayer? = null
 
@@ -643,7 +645,11 @@ class MediaSessionManager(
 
         if (isAutomotive) {
             val layout = automotiveStrategy!!.buildLayout(playbackManager, settings, context, ::buildCustomActionButton)
-            session.setCustomLayout(layout.primaryButtons + layout.overflowButtons)
+            val allButtons = layout.primaryButtons + layout.overflowButtons
+            if (allButtons != lastCustomLayout) {
+                lastCustomLayout = allButtons
+                session.setCustomLayout(allButtons)
+            }
             return
         } else {
             // Mobile/other: existing behavior unchanged
@@ -777,6 +783,7 @@ class MediaSessionManager(
         disposables.clear()
         scope.cancel()
         if (needsMedia3Session) {
+            lastCustomLayout = emptyList()
             media3Session?.release()
             media3Session = null
             forwardingPlayer = null


### PR DESCRIPTION
## Description
On Android Automotive, `updateMedia3CustomLayout()` fires on every playback state change (play/pause, buffering, metadata updates), and each call unconditionally invokes `session.setCustomLayout()`, causing AAOS to rebuild the custom action UI and close any open overflow menu. The PR introduces an `AutomotiveSessionStrategy` pattern to separate automotive button layout logic, but the original code still called `setCustomLayout()` on every trigger regardless of whether buttons actually changed. Our fix caches the last `List<CommandButton>` and uses Media3's structural equality to skip `setCustomLayout()` when the  button list is identical, so the overflow menu stays open during normal playback while still updating for genuine changes like star/unstar, speed, or settings. We also clear the cache in `release()` to ensure a fresh session always receives its initial layout.

Fixes PCDROID-539 https://linear.app/a8c/issue/PCDROID-539/actions-disappear-during-playback-in-automotive

## Testing Instructions
1. Build and install automotive
2. Start playing an episode
3. Open the overflow menu while playing
4. Controls should remain open

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 