### PR TITLE
Make sure archived episode status is preserved across sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 8.11
 -----
-
+*   Updates
+    *   Make sure archived episode status is preserved across sync
+        ([#5227](https://github.com/Automattic/pocket-casts-android/pull/5227))
 
 8.10
 -----

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/EpisodeDaoDownloadStatusTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/EpisodeDaoDownloadStatusTest.kt
@@ -217,6 +217,52 @@ class EpisodeDaoDownloadStatusTest {
     }
 
     @Test
+    fun setReadyForDownloadSetsArchiveFieldsForArchivedEpisode() = runTest {
+        episodeDao.update(
+            episode.copy(
+                isArchived = true,
+                archivedModified = 0L,
+                lastArchiveInteraction = 0L,
+                excludeFromEpisodeLimit = false,
+                downloadStatus = EpisodeDownloadStatus.DownloadNotRequested,
+                downloadTaskId = null,
+            ),
+        )
+
+        episodeDao.setReadyForDownload(episode.uuid, workerId, now, forceNewDownload = false)
+
+        val updatedEpisode = episodeDao.findByUuid(episode.uuid)!!
+        assertEquals(false, updatedEpisode.isArchived)
+        assertEquals(now.toEpochMilli(), updatedEpisode.archivedModified)
+        assertEquals(now.toEpochMilli(), updatedEpisode.lastArchiveInteraction)
+        assertEquals(true, updatedEpisode.excludeFromEpisodeLimit)
+    }
+
+    @Test
+    fun setReadyForDownloadDoesNotModifyArchiveFieldsForNonArchivedEpisode() = runTest {
+        val originalArchivedModified = 1000L
+        val originalLastArchiveInteraction = 2000L
+        episodeDao.update(
+            episode.copy(
+                isArchived = false,
+                archivedModified = originalArchivedModified,
+                lastArchiveInteraction = originalLastArchiveInteraction,
+                excludeFromEpisodeLimit = false,
+                downloadStatus = EpisodeDownloadStatus.DownloadNotRequested,
+                downloadTaskId = null,
+            ),
+        )
+
+        episodeDao.setReadyForDownload(episode.uuid, workerId, now, forceNewDownload = false)
+
+        val updatedEpisode = episodeDao.findByUuid(episode.uuid)!!
+        assertEquals(false, updatedEpisode.isArchived)
+        assertEquals(originalArchivedModified, updatedEpisode.archivedModified)
+        assertEquals(originalLastArchiveInteraction, updatedEpisode.lastArchiveInteraction)
+        assertEquals(false, updatedEpisode.excludeFromEpisodeLimit)
+    }
+
+    @Test
     fun setReadyForDownloadWithWorkerId() = runTest {
         val episode = episode.copy(
             isArchived = true,

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -13,6 +13,7 @@ import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
 import au.com.shiftyjelly.pocketcasts.models.db.helper.QueryHelper
 import au.com.shiftyjelly.pocketcasts.models.db.helper.UuidCount
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
+import au.com.shiftyjelly.pocketcasts.models.entity.ChapterIndices
 import au.com.shiftyjelly.pocketcasts.models.entity.EpisodeDownloadFailureStatistics
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
@@ -315,6 +316,67 @@ abstract class EpisodeDao {
     @Update
     abstract suspend fun updateAll(episodes: Collection<PodcastEpisode>)
 
+    @Query(
+        """
+        UPDATE podcast_episodes SET
+          starred = :starred,
+          starred_modified = :starredModified,
+          last_starred_date = :lastStarredDate,
+          duration = :duration,
+          duration_modified = :durationModified,
+          deselected_chapters = :deselectedChapters,
+          deselected_chapters_modified = :deselectedChaptersModified,
+          archived = :archived,
+          archived_modified = :archivedModified,
+          last_archive_interaction_date = :lastArchiveInteraction,
+          playing_status = :playingStatus,
+          playing_status_modified = :playingStatusModified,
+          played_up_to = :playedUpTo,
+          played_up_to_modified = :playedUpToModified
+        WHERE uuid = :uuid
+        """,
+    )
+    protected abstract suspend fun updateSyncFields(
+        uuid: String,
+        starred: Boolean,
+        starredModified: Long?,
+        lastStarredDate: Long?,
+        duration: Double,
+        durationModified: Long?,
+        deselectedChapters: String?,
+        deselectedChaptersModified: Date?,
+        archived: Boolean,
+        archivedModified: Long?,
+        lastArchiveInteraction: Long?,
+        playingStatus: EpisodePlayingStatus,
+        playingStatusModified: Long?,
+        playedUpTo: Double,
+        playedUpToModified: Long?,
+    )
+
+    @Transaction
+    open suspend fun updateAllSyncFields(episodes: Collection<PodcastEpisode>) {
+        episodes.forEach { episode ->
+            updateSyncFields(
+                uuid = episode.uuid,
+                starred = episode.isStarred,
+                starredModified = episode.starredModified,
+                lastStarredDate = episode.lastStarredDate,
+                duration = episode.duration,
+                durationModified = episode.durationModified,
+                deselectedChapters = ChapterIndices.toString(episode.deselectedChapters),
+                deselectedChaptersModified = episode.deselectedChaptersModified,
+                archived = episode.isArchived,
+                archivedModified = episode.archivedModified,
+                lastArchiveInteraction = episode.lastArchiveInteraction,
+                playingStatus = episode.playingStatus,
+                playingStatusModified = episode.playingStatusModified,
+                playedUpTo = episode.playedUpTo,
+                playedUpToModified = episode.playedUpToModified,
+            )
+        }
+    }
+
     @Delete
     abstract fun deleteBlocking(episode: PodcastEpisode)
 
@@ -580,6 +642,9 @@ abstract class EpisodeDao {
         UPDATE podcast_episodes
         SET
           archived = 0,
+          archived_modified = CASE WHEN archived = 1 THEN :archivedModified ELSE archived_modified END,
+          last_archive_interaction_date = CASE WHEN archived = 1 THEN :archivedModified ELSE last_archive_interaction_date END,
+          exclude_from_episode_limit = CASE WHEN archived = 1 THEN 1 ELSE exclude_from_episode_limit END,
           episode_status = 1,
           download_task_id = :downloadTaskId,
           last_download_attempt_date = :issuedAt
@@ -592,6 +657,7 @@ abstract class EpisodeDao {
         episodeUuid: String,
         downloadTaskId: String,
         issuedAt: Date,
+        archivedModified: Long,
         forceNewDownload: Boolean,
     ): Int
 
@@ -605,6 +671,7 @@ abstract class EpisodeDao {
             episodeUuid = episodeUuid,
             downloadTaskId = downloadTaskId.toString(),
             issuedAt = Date.from(issuedAt),
+            archivedModified = issuedAt.toEpochMilli(),
             forceNewDownload = forceNewDownload,
         )
         return rowUpdateCount == 1

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -99,6 +99,7 @@ import io.reactivex.rxkotlin.subscribeBy
 import io.reactivex.schedulers.Schedulers
 import java.io.File
 import java.io.FileInputStream
+import java.io.FileNotFoundException
 import java.util.Date
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
@@ -1288,6 +1289,16 @@ open class PlaybackManager @Inject constructor(
 
         LogBuffer.e(LogBuffer.TAG_PLAYBACK, "Player error %s", event.message)
 
+        // If a downloaded episode's file is missing, clear the stale download status
+        // and retry playback via streaming instead of leaving the user stuck.
+        if (episode != null && episode.isDownloaded && episode.downloadUrl != null && isDownloadedFileMissing(event)) {
+            LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Downloaded file missing for ${episode.uuid}, clearing download status and retrying via stream")
+            downloadQueue.cancel(episode.uuid, SourceView.UNKNOWN).join()
+            episodeManager.clearPlaybackErrorBlocking(episode)
+            playNow(episode = episode, forceStream = true, sourceView = SourceView.UNKNOWN)
+            return
+        }
+
         val currentEpisode = getCurrentEpisode()
         if (currentEpisode is BaseEpisode) {
             episodeManager.markAsPlaybackErrorBlocking(currentEpisode, event, isPlaybackRemote())
@@ -1344,6 +1355,15 @@ open class PlaybackManager @Inject constructor(
                 )
             }
         }
+    }
+
+    private fun isDownloadedFileMissing(event: PlayerEvent.PlayerError): Boolean {
+        var cause: Throwable? = event.error
+        while (cause != null) {
+            if (cause is FileNotFoundException) return true
+            cause = cause.cause
+        }
+        return false
     }
 
     @OptIn(UnstableApi::class)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -63,6 +63,7 @@ interface EpisodeManager {
     fun updateBlocking(episode: PodcastEpisode?)
     suspend fun update(episode: PodcastEpisode?)
     suspend fun updateAll(episodes: Collection<PodcastEpisode>)
+    suspend fun updateAllSyncFields(episodes: Collection<PodcastEpisode>)
 
     fun updatePlayedUpToBlocking(episode: BaseEpisode?, playedUpTo: Double, forceUpdate: Boolean)
     fun updateDurationBlocking(episode: BaseEpisode?, durationInSecs: Double, syncChanges: Boolean)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -552,6 +552,10 @@ class EpisodeManagerImpl @Inject constructor(
         episodeDao.updateAll(episodes)
     }
 
+    override suspend fun updateAllSyncFields(episodes: Collection<PodcastEpisode>) {
+        episodeDao.updateAllSyncFields(episodes)
+    }
+
     override fun clearPlaybackErrorBlocking(episode: BaseEpisode?) {
         if (episode?.playErrorDetails == null) {
             return

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/data/EpisodeSync.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/data/EpisodeSync.kt
@@ -88,7 +88,7 @@ internal class EpisodeSync(
         episodeToFinish.forEach { episode ->
             episodeManager.markedAsPlayedExternally(episode, playbackManager, podcastManager)
         }
-        episodeManager.updateAll(localEpisodes)
+        episodeManager.updateAllSyncFields(localEpisodes)
     }
 
     private fun PodcastEpisode.applyServerEpisode(


### PR DESCRIPTION
## Description
A user reported that downloaded episodes in their Up Next queue were becoming unplayable — the app showed them as downloaded but the actual files were missing from disk, resulting in FileNotFoundException errors. Log analysis revealed two bugs working together: first, when a user re-downloads a previously auto-archived episode, the `setReadyForDownload` SQL query un-archives it locally but doesn't set `archived_modified`, so the server never learns about the un-archival and re-archives the episode on the next sync, deleting the file again. Second, `EpisodeSync.processIncrementalResponse()` uses Room's `@Update` (which writes ALL columns) after firing off an async download cancellation — creating a race where stale in-memory `episode_status=4` overwrites the `resetDownloadStatus()` that already set it to 0, leaving the DB saying "Downloaded" while the file is gone.
 We fixed the sync loop by adding conditional `CASE WHEN archived = 1` guards to `setReadyForDownload` that set `archived_modified, last_archive_interaction_date, and exclude_from_episode_limit` only when the episode is actually archived — mirroring the existing unarchiveBlocking() pattern and ensuring the un-archival syncs to the server without creating spurious sync traffic for fresh downloads. We eliminated the race condition by replacing `updateAll()` with a new `updateAllSyncFields()` method that only writes the 14 sync-relevant columns, never touching local-only fields like `episode_status or downloaded_file_path`. As defense-in-depth, we added ENOENT detection in `PlaybackManager.onPlayerError` that uses `downloadQueue.cancel().join()` to atomically reset the stale download state, then retries via streaming — with `forcePlayerSwitch` guaranteeing `loadCurrentEpisode` re-reads fresh state from the DB before creating the player.

Fixes PCDROID-538 https://linear.app/a8c/issue/PCDROID-538/downloaded-files-gets-lost

## Testing Instructions
  1. Subscribe to any podcast, let an episode auto-download
  2. Play it to completion — confirm "Download deleted" appears in logs (auto-archive fires)
  3. Go back to the episode and re-download it manually
  4. Open the app fresh to trigger a sync (or pull-to-refresh on the podcast list)
  5. Before fix: the sync re-archives and deletes the file; playback fails with ENOENT
  6. After fix: the sync should NOT re-archive because archived_modified was set, and the episode remains playable

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 