### PR TITLE
Update outdated GitHub Actions

### DIFF
--- a/.github/workflows/submit-gradle-dependencies.yml
+++ b/.github/workflows/submit-gradle-dependencies.yml
@@ -16,8 +16,4 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: Setup Gradle to generate and submit dependency graphs
-        uses: gradle/gradle-build-action@v2
-        with:
-          dependency-graph: generate-and-submit
-      - name: Generate the dependency graph which will be submitted post-job
-        run: ./gradlew :app:dependencies :automotive:dependencies :wear:dependencies
+        uses: gradle/actions/dependency-submission@v4


### PR DESCRIPTION
Fixes AINFRA-2297

## Summary
- Replace deprecated `gradle/gradle-build-action@v2` with `gradle/actions/dependency-submission@v4`

## Test plan
- [ ] Verify dependency submission workflow runs successfully on next push to main

🤖 Generated with [Claude Code](https://claude.ai/code)