### PR TITLE
[Media3] Respect user's setting on media controls on automotive

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3AutomotiveStrategy.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3AutomotiveStrategy.kt
@@ -14,9 +14,6 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 @UnstableApi
 internal class Media3AutomotiveStrategy(
     private val useCustomSkipButtons: () -> Boolean,
-    private val speedToDrawable: (Double) -> Int,
-    @Suppress("unused") private val skipBackIconForDuration: (Int) -> Int,
-    @Suppress("unused") private val skipForwardIconForDuration: (Int) -> Int,
 ) : AutomotiveSessionStrategy {
 
     override fun buildLayout(
@@ -25,19 +22,18 @@ internal class Media3AutomotiveStrategy(
         context: Context,
         buildCustomActionButton: (MediaNotificationControls, BaseEpisode?) -> CommandButton?,
     ): AutomotiveSessionStrategy.ButtonLayout {
-        val primaryButtons = mutableListOf<CommandButton>()
-        val overflowButtons = mutableListOf<CommandButton>()
+        val buttons = mutableListOf<CommandButton>()
         val currentEpisode = playbackManager.getCurrentEpisode()
 
         if (useCustomSkipButtons()) {
-            primaryButtons.add(
+            buttons.add(
                 CommandButton.Builder(CommandButton.ICON_UNDEFINED)
                     .setSessionCommand(SessionCommand(APP_ACTION_SKIP_BACK, Bundle.EMPTY))
                     .setDisplayName(context.getString(LR.string.skip_back))
                     .setCustomIconResId(IR.drawable.media_skipback)
                     .build(),
             )
-            primaryButtons.add(
+            buttons.add(
                 CommandButton.Builder(CommandButton.ICON_UNDEFINED)
                     .setSessionCommand(SessionCommand(APP_ACTION_SKIP_FWD, Bundle.EMPTY))
                     .setDisplayName(context.getString(LR.string.skip_forward))
@@ -46,21 +42,11 @@ internal class Media3AutomotiveStrategy(
             )
         }
 
-        primaryButtons.add(
-            CommandButton.Builder(CommandButton.ICON_UNDEFINED)
-                .setSessionCommand(SessionCommand(APP_ACTION_CHANGE_SPEED, Bundle.EMPTY))
-                .setDisplayName(context.getString(LR.string.playback_speed))
-                .setCustomIconResId(speedToDrawable(playbackManager.getPlaybackSpeed()))
-                .build(),
-        )
-
         val visibleCount = if (settings.customMediaActionsVisibility.value) MediaNotificationControls.MAX_VISIBLE_OPTIONS else 0
         settings.mediaControlItems.value.take(visibleCount).forEach { mediaControl ->
-            if (mediaControl != MediaNotificationControls.PlaybackSpeed) {
-                buildCustomActionButton(mediaControl, currentEpisode)?.let(overflowButtons::add)
-            }
+            buildCustomActionButton(mediaControl, currentEpisode)?.let(buttons::add)
         }
 
-        return AutomotiveSessionStrategy.ButtonLayout(primaryButtons, overflowButtons)
+        return AutomotiveSessionStrategy.ButtonLayout(primaryButtons = buttons, overflowButtons = emptyList())
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -192,7 +192,7 @@ class MediaSessionManager(
     @OptIn(UnstableApi::class)
     @Suppress("UnsafeOptInUsageError")
     private val automotiveStrategy: AutomotiveSessionStrategy? = if (isAutomotive) {
-        Media3AutomotiveStrategy(::useCustomSkipButtons, ::speedToDrawable, ::skipBackIconForDuration, ::skipForwardIconForDuration)
+        Media3AutomotiveStrategy(::useCustomSkipButtons)
     } else {
         null
     }


### PR DESCRIPTION
## Description
`Media3AutomotiveStrategy` introduced a change that influences how we display the control buttons on automotive's Now Playing screen. This PR restores the legacy behavior and respects user's media control settings.

internal discussion: p1776302242098229-slack-C0ARHV3P6HY

## Testing Instructions
Just review the code as these settings are never synced on Automotive.


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 