### PR TITLE
Add heat map component

### DIFF
--- a/modules/services/compose/build.gradle.kts
+++ b/modules/services/compose/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     implementation(libs.compose.material)
     implementation(libs.compose.material.icons.extended)
     implementation(libs.compose.ui)
+    implementation(libs.compose.ui.tooling)
     implementation(libs.compose.ui.tooling.preview)
     implementation(libs.compose.ui.util)
     implementation(libs.fragment.compose)

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/stats/CalendarHeatMap.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/stats/CalendarHeatMap.kt
@@ -1,0 +1,397 @@
+package au.com.shiftyjelly.pocketcasts.compose.stats
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalResources
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.extensions.nonScaledSp
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.ui.helper.ColorUtils
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.Month
+import java.time.temporal.ChronoUnit
+import kotlin.random.Random
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+import java.time.format.TextStyle as DateTextStyle
+
+enum class HeatLevel {
+    None,
+    Low,
+    Medium,
+    High,
+    Max,
+}
+
+@Composable
+fun CalendarHeatMap(
+    start: LocalDate,
+    end: LocalDate,
+    cellHeatLevel: (LocalDate) -> HeatLevel,
+    modifier: Modifier = Modifier,
+    cellSize: Dp = 12.dp,
+    cellSpacing: Dp = 4.dp,
+    scrollState: ScrollState = rememberScrollState(initial = Int.MAX_VALUE),
+) {
+    val colors = rememberHeatColors()
+    val data = rememberHeatMapData(
+        start = start,
+        end = end.plusDays(1).coerceAtLeast(start),
+    )
+    val dimensions = rememberHeatMapDimensions(
+        weeks = data.weeks,
+        cellSize = cellSize,
+        cellSpacing = cellSpacing,
+    )
+
+    val locale = LocalResources.current.configuration.locales[0]
+    val dayLabelsByRow = remember(locale) {
+        Days.associateWith { day -> day.getDisplayName(DateTextStyle.SHORT, locale) }
+    }
+    val textStyle = TextStyle(
+        fontSize = 12.nonScaledSp,
+    )
+
+    Column(
+        modifier = modifier,
+    ) {
+        val dayLabelWidth = measureWeekdayLabels(dayLabelsByRow.values, textStyle)
+        MonthLabels(
+            data = data,
+            dimensions = dimensions,
+            textStyle = textStyle,
+            modifier = Modifier
+                .padding(start = dayLabelWidth + 4.dp, bottom = 2.dp)
+                .horizontalScroll(scrollState),
+        )
+
+        Row {
+            WeekdayLabels(
+                dayLabelsByRow = dayLabelsByRow,
+                dimensions = dimensions,
+                textStyle = textStyle,
+                modifier = Modifier.padding(end = 4.dp),
+            )
+            Cells(
+                data = data,
+                dimensions = dimensions,
+                colors = colors,
+                cellHeatLevel = cellHeatLevel,
+                modifier = Modifier.horizontalScroll(scrollState),
+            )
+        }
+
+        Legend(
+            dimensions = dimensions,
+            colors = colors,
+            textStyle = textStyle,
+            modifier = Modifier
+                .padding(top = 6.dp, end = dimensions.cellPitch)
+                .align(Alignment.End),
+        )
+    }
+}
+
+@Composable
+private fun WeekdayLabels(
+    dayLabelsByRow: Map<DayOfWeek, String>,
+    dimensions: HeatMapDimensions,
+    textStyle: TextStyle,
+    modifier: Modifier = Modifier,
+) {
+    val density = LocalDensity.current
+    val textMeasurer = rememberTextMeasurer()
+
+    Box(
+        modifier = modifier.height(dimensions.mapHeight),
+    ) {
+        dayLabelsByRow.forEach { (dayOfWeek, label) ->
+            val labelHeight = with(density) {
+                textMeasurer.measure(label, textStyle).size.height.toDp()
+            }
+            Text(
+                text = label,
+                modifier = Modifier.offset(y = dimensions.cellPitch * dayOfWeek.value + (dimensions.cellSize - labelHeight) / 2),
+                color = MaterialTheme.theme.colors.primaryText02,
+                style = textStyle,
+            )
+        }
+    }
+}
+
+@Composable
+private fun measureWeekdayLabels(
+    dayLabels: Collection<String>,
+    textStyle: TextStyle,
+): Dp {
+    val density = LocalDensity.current
+    val textMeasurer = rememberTextMeasurer()
+
+    val maxLabelWidth = dayLabels.maxOfOrNull { label ->
+        textMeasurer.measure(label, textStyle).size.width
+    } ?: 0
+
+    return with(density) { maxLabelWidth.toDp() }
+}
+
+private val Days = listOf(DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY, DayOfWeek.FRIDAY)
+
+@Composable
+private fun MonthLabels(
+    data: HeatMapData,
+    dimensions: HeatMapDimensions,
+    textStyle: TextStyle,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier.width(dimensions.mapWidth),
+    ) {
+        val locale = LocalResources.current.configuration.locales[0]
+        data.monthLabels.forEach { monthLabel ->
+            Text(
+                text = monthLabel.month.getDisplayName(DateTextStyle.SHORT, locale),
+                modifier = Modifier.offset(x = dimensions.cellPitch * monthLabel.column),
+                color = MaterialTheme.theme.colors.primaryText02,
+                style = textStyle,
+            )
+        }
+    }
+}
+
+@Composable
+private fun Cells(
+    data: HeatMapData,
+    dimensions: HeatMapDimensions,
+    colors: HeatColors,
+    cellHeatLevel: (LocalDate) -> HeatLevel,
+    modifier: Modifier = Modifier,
+) {
+    Canvas(
+        modifier = modifier.size(dimensions.mapWidth, dimensions.mapHeight),
+    ) {
+        val cellSizePx = dimensions.cellSize.toPx()
+        val cellPitchPx = dimensions.cellPitch.toPx()
+
+        data.cells.forEach { cell ->
+            drawHeatSquare(
+                topLeft = Offset(cell.column * cellPitchPx, cell.row * cellPitchPx),
+                cellSizePx = cellSizePx,
+                color = colors[cellHeatLevel(cell.date)],
+            )
+        }
+    }
+}
+
+@Composable
+private fun Legend(
+    dimensions: HeatMapDimensions,
+    colors: HeatColors,
+    textStyle: TextStyle,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Text(
+            text = stringResource(LR.string.less),
+            color = MaterialTheme.theme.colors.primaryText02,
+            style = textStyle,
+        )
+        Canvas(
+            modifier = Modifier.size(dimensions.legendWidth, dimensions.cellSize),
+        ) {
+            val cellSizePx = dimensions.cellSize.toPx()
+            val cellPitchPx = dimensions.cellPitch.toPx()
+
+            HeatLevel.entries.forEachIndexed { cellIndex, heatLevel ->
+                drawHeatSquare(
+                    topLeft = Offset(cellIndex * cellPitchPx, 0f),
+                    cellSizePx = cellSizePx,
+                    color = colors[heatLevel],
+                )
+            }
+        }
+        Text(
+            text = stringResource(LR.string.more),
+            color = MaterialTheme.theme.colors.primaryText02,
+            style = textStyle,
+        )
+    }
+}
+
+private fun DrawScope.drawHeatSquare(
+    topLeft: Offset,
+    cellSizePx: Float,
+    color: Color,
+) {
+    drawRoundRect(
+        topLeft = topLeft,
+        size = Size(cellSizePx, cellSizePx),
+        cornerRadius = CornerRadius(cellSizePx * 0.2f),
+        color = color,
+    )
+}
+
+private data class HeatMapDimensions(
+    val cellSize: Dp,
+    val cellPitch: Dp,
+    val mapWidth: Dp,
+    val mapHeight: Dp,
+    val legendWidth: Dp,
+)
+
+@Composable
+private fun rememberHeatMapDimensions(
+    weeks: Int,
+    cellSize: Dp,
+    cellSpacing: Dp,
+): HeatMapDimensions {
+    return remember(weeks, cellSize, cellSpacing) {
+        val cellPitch = cellSize + cellSpacing
+
+        HeatMapDimensions(
+            cellSize = cellSize,
+            cellPitch = cellPitch,
+            mapWidth = cellSize * weeks + cellSpacing * (weeks - 1).coerceAtLeast(0),
+            mapHeight = cellSize * 7 + cellSpacing * 6,
+            legendWidth = cellSize * HeatLevel.entries.size + cellSpacing * (HeatLevel.entries.size - 1),
+        )
+    }
+}
+
+private data class HeatColors(
+    val none: Color,
+    val low: Color,
+    val medium: Color,
+    val high: Color,
+    val max: Color,
+) {
+    operator fun get(level: HeatLevel): Color = when (level) {
+        HeatLevel.None -> none
+        HeatLevel.Low -> low
+        HeatLevel.Medium -> medium
+        HeatLevel.High -> high
+        HeatLevel.Max -> max
+    }
+}
+
+@Composable
+private fun rememberHeatColors(): HeatColors {
+    val none = MaterialTheme.theme.colors.primaryUi05
+    val max = MaterialTheme.theme.colors.primaryIcon01
+    return remember(none, max) {
+        HeatColors(
+            none = none,
+            low = ColorUtils.blendColors(none, max, 0.25f),
+            medium = ColorUtils.blendColors(none, max, 0.5f),
+            high = ColorUtils.blendColors(none, max, 0.75f),
+            max = max,
+        )
+    }
+}
+
+private data class HeatMapData(
+    val weeks: Int,
+    val monthLabels: List<HeatMapMonthLabel>,
+    val cells: List<HeatMapCell>,
+)
+
+private data class HeatMapMonthLabel(
+    val month: Month,
+    val column: Int,
+)
+
+private data class HeatMapCell(
+    val date: LocalDate,
+    val column: Int,
+    val row: Int,
+)
+
+@Composable
+private fun rememberHeatMapData(start: LocalDate, end: LocalDate): HeatMapData {
+    return remember(start, end) {
+        // Use sunday based index
+        val startOffset = start.dayOfWeek.value % 7
+
+        val monthLabels = buildList {
+            var monthStart = start.withDayOfMonth(1)
+            if (monthStart.isBefore(start)) {
+                monthStart = monthStart.plusMonths(1)
+            }
+
+            while (monthStart.isBefore(end)) {
+                val daysFromStart = ChronoUnit.DAYS.between(start, monthStart).toInt()
+                add(
+                    HeatMapMonthLabel(
+                        month = monthStart.month,
+                        column = (startOffset + daysFromStart) / 7,
+                    ),
+                )
+                monthStart = monthStart.plusMonths(1)
+            }
+        }
+
+        val daysCount = ChronoUnit.DAYS.between(start, end).toInt()
+        val cells = List(daysCount) { dayIndex ->
+            val cellIndex = startOffset + dayIndex
+            HeatMapCell(
+                date = start.plusDays(dayIndex.toLong()),
+                column = cellIndex / 7,
+                row = cellIndex % 7,
+            )
+        }
+
+        val cellsCount = startOffset + daysCount
+        HeatMapData(
+            // Round up partial weeks, then reserve one empty trailing week for labels.
+            weeks = (cellsCount + 6) / 7 + 1,
+            monthLabels = monthLabels,
+            cells = cells,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun CalendarHeatMapPreview() {
+    val previewHeatLevels = remember {
+        val random = Random(0)
+        List(366) { HeatLevel.entries.random(random) }
+    }
+
+    CalendarHeatMap(
+        start = LocalDate.of(2025, 3, 6),
+        end = LocalDate.of(2026, 1, 1),
+        cellHeatLevel = { date -> previewHeatLevels[date.dayOfYear] },
+    )
+}

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/stats/CalendarHeatMap.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/stats/CalendarHeatMap.kt
@@ -386,7 +386,7 @@ private fun rememberHeatMapData(start: LocalDate, end: LocalDate): HeatMapData {
 private fun CalendarHeatMapPreview() {
     val previewHeatLevels = remember {
         val random = Random(0)
-        List(366) { HeatLevel.entries.random(random) }
+        List(400) { HeatLevel.entries.random(random) }
     }
 
     CalendarHeatMap(

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/stats/CalendarHeatMap.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/stats/CalendarHeatMap.kt
@@ -60,7 +60,7 @@ enum class HeatLevel {
 fun CalendarHeatMap(
     start: LocalDate,
     end: LocalDate,
-    cellHeatLevel: (LocalDate) -> HeatLevel,
+    heatLevels: Map<LocalDate, HeatLevel>,
     modifier: Modifier = Modifier,
     cellSize: Dp = 12.dp,
     cellSpacing: Dp = 4.dp,
@@ -104,7 +104,7 @@ fun CalendarHeatMap(
                 data = data,
                 sizing = sizing,
                 colors = colors,
-                cellHeatLevel = cellHeatLevel,
+                heatLevels = heatLevels,
                 modifier = Modifier.horizontalScroll(scrollState),
             )
         }
@@ -188,7 +188,7 @@ private fun Cells(
     data: HeatMapData,
     sizing: HeatMapSizing,
     colors: HeatColors,
-    cellHeatLevel: (LocalDate) -> HeatLevel,
+    heatLevels: Map<LocalDate, HeatLevel>,
     modifier: Modifier = Modifier,
 ) {
     Canvas(
@@ -196,12 +196,11 @@ private fun Cells(
     ) {
         val cellSizePx = sizing.cellSize.toPx()
         val cellPitchPx = sizing.cellPitch.toPx()
-
         data.cells.forEach { cell ->
             drawHeatSquare(
                 topLeft = Offset(cell.column * cellPitchPx, cell.row * cellPitchPx),
                 cellSizePx = cellSizePx,
-                color = colors[cellHeatLevel(cell.date)],
+                color = colors[heatLevels[cell.date] ?: HeatLevel.None],
             )
         }
     }
@@ -388,50 +387,62 @@ private fun rememberHeatMapData(start: LocalDate, end: LocalDate): HeatMapData {
 private fun CalendarHeatMapPreview(
     @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
 ) {
-    val previewHeatLevels = remember {
+    val start = LocalDate.of(2025, 3, 6)
+    val end = LocalDate.of(2026, 1, 1)
+    val heatLevels = remember {
         val random = Random(0)
-        List(400) { HeatLevel.entries.random(random) }
+        var date = start
+        buildMap {
+            while (date <= end) {
+                put(date, HeatLevel.entries.random(random))
+                date = date.plusDays(1)
+            }
+        }
     }
 
     AppThemeWithBackground(themeType) {
-        CalendarHeatMap(
-            start = LocalDate.of(2025, 3, 6),
-            end = LocalDate.of(2026, 1, 1),
-            cellHeatLevel = { date -> previewHeatLevels[date.dayOfYear] },
-        )
+        CalendarHeatMap(start, end, heatLevels)
     }
 }
 
 @Preview(fontScale = 1.5f)
 @Composable
 private fun CalendarHeatMapPreviewFont150Percent() {
-    val previewHeatLevels = remember {
+    val start = LocalDate.of(2025, 3, 6)
+    val end = LocalDate.of(2026, 1, 1)
+    val heatLevels = remember {
         val random = Random(0)
-        List(366) { HeatLevel.entries.random(random) }
+        var date = start
+        buildMap {
+            while (date <= end) {
+                put(date, HeatLevel.entries.random(random))
+                date = date.plusDays(1)
+            }
+        }
     }
 
     AppThemeWithBackground(Theme.ThemeType.CLASSIC_LIGHT) {
-        CalendarHeatMap(
-            start = LocalDate.of(2025, 3, 6),
-            end = LocalDate.of(2026, 1, 1),
-            cellHeatLevel = { date -> previewHeatLevels[date.dayOfYear] },
-        )
+        CalendarHeatMap(start, end, heatLevels)
     }
 }
 
 @Preview(fontScale = 2f)
 @Composable
 private fun CalendarHeatMapPreviewFont200Percent() {
-    val previewHeatLevels = remember {
+    val start = LocalDate.of(2025, 3, 6)
+    val end = LocalDate.of(2026, 1, 1)
+    val heatLevels = remember {
         val random = Random(0)
-        List(366) { HeatLevel.entries.random(random) }
+        var date = start
+        buildMap {
+            while (date <= end) {
+                put(date, HeatLevel.entries.random(random))
+                date = date.plusDays(1)
+            }
+        }
     }
 
     AppThemeWithBackground(Theme.ThemeType.CLASSIC_LIGHT) {
-        CalendarHeatMap(
-            start = LocalDate.of(2025, 3, 6),
-            end = LocalDate.of(2026, 1, 1),
-            cellHeatLevel = { date -> previewHeatLevels[date.dayOfYear] },
-        )
+        CalendarHeatMap(start, end, heatLevels)
     }
 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/stats/CalendarHeatMap.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/stats/CalendarHeatMap.kt
@@ -113,7 +113,7 @@ fun CalendarHeatMap(
             sizing = sizing,
             colors = colors,
             modifier = Modifier
-                .padding(top = 6.dp, end = sizing.cellPitch)
+                .padding(top = 6.dp)
                 .align(Alignment.End),
         )
     }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/stats/CalendarHeatMap.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/stats/CalendarHeatMap.kt
@@ -30,15 +30,20 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import au.com.shiftyjelly.pocketcasts.compose.extensions.nonScaledSp
+import androidx.compose.ui.unit.sp
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.ui.helper.ColorUtils
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.Month
 import java.time.temporal.ChronoUnit
+import kotlin.math.max
 import kotlin.random.Random
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import java.time.format.TextStyle as DateTextStyle
@@ -66,7 +71,7 @@ fun CalendarHeatMap(
         start = start,
         end = end.plusDays(1).coerceAtLeast(start),
     )
-    val dimensions = rememberHeatMapDimensions(
+    val sizing = rememberHeatMapSizing(
         weeks = data.weeks,
         cellSize = cellSize,
         cellSpacing = cellSpacing,
@@ -76,18 +81,14 @@ fun CalendarHeatMap(
     val dayLabelsByRow = remember(locale) {
         Days.associateWith { day -> day.getDisplayName(DateTextStyle.SHORT, locale) }
     }
-    val textStyle = TextStyle(
-        fontSize = 12.nonScaledSp,
-    )
 
     Column(
         modifier = modifier,
     ) {
-        val dayLabelWidth = measureWeekdayLabels(dayLabelsByRow.values, textStyle)
+        val dayLabelWidth = measureWeekdayLabels(dayLabelsByRow.values, sizing.textStyle)
         MonthLabels(
             data = data,
-            dimensions = dimensions,
-            textStyle = textStyle,
+            sizing = sizing,
             modifier = Modifier
                 .padding(start = dayLabelWidth + 4.dp, bottom = 2.dp)
                 .horizontalScroll(scrollState),
@@ -96,13 +97,12 @@ fun CalendarHeatMap(
         Row {
             WeekdayLabels(
                 dayLabelsByRow = dayLabelsByRow,
-                dimensions = dimensions,
-                textStyle = textStyle,
+                sizing = sizing,
                 modifier = Modifier.padding(end = 4.dp),
             )
             Cells(
                 data = data,
-                dimensions = dimensions,
+                sizing = sizing,
                 colors = colors,
                 cellHeatLevel = cellHeatLevel,
                 modifier = Modifier.horizontalScroll(scrollState),
@@ -110,11 +110,10 @@ fun CalendarHeatMap(
         }
 
         Legend(
-            dimensions = dimensions,
+            sizing = sizing,
             colors = colors,
-            textStyle = textStyle,
             modifier = Modifier
-                .padding(top = 6.dp, end = dimensions.cellPitch)
+                .padding(top = 6.dp, end = sizing.cellPitch)
                 .align(Alignment.End),
         )
     }
@@ -123,25 +122,24 @@ fun CalendarHeatMap(
 @Composable
 private fun WeekdayLabels(
     dayLabelsByRow: Map<DayOfWeek, String>,
-    dimensions: HeatMapDimensions,
-    textStyle: TextStyle,
+    sizing: HeatMapSizing,
     modifier: Modifier = Modifier,
 ) {
     val density = LocalDensity.current
     val textMeasurer = rememberTextMeasurer()
 
     Box(
-        modifier = modifier.height(dimensions.mapHeight),
+        modifier = modifier.height(sizing.mapHeight),
     ) {
         dayLabelsByRow.forEach { (dayOfWeek, label) ->
             val labelHeight = with(density) {
-                textMeasurer.measure(label, textStyle).size.height.toDp()
+                textMeasurer.measure(label, sizing.textStyle).size.height.toDp()
             }
             Text(
                 text = label,
-                modifier = Modifier.offset(y = dimensions.cellPitch * dayOfWeek.value + (dimensions.cellSize - labelHeight) / 2),
+                modifier = Modifier.offset(y = sizing.cellPitch * dayOfWeek.value + (sizing.cellSize - labelHeight) / 2),
                 color = MaterialTheme.theme.colors.primaryText02,
-                style = textStyle,
+                style = sizing.textStyle,
             )
         }
     }
@@ -167,20 +165,19 @@ private val Days = listOf(DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY, DayOfWeek.FRIDA
 @Composable
 private fun MonthLabels(
     data: HeatMapData,
-    dimensions: HeatMapDimensions,
-    textStyle: TextStyle,
+    sizing: HeatMapSizing,
     modifier: Modifier = Modifier,
 ) {
     Box(
-        modifier = modifier.width(dimensions.mapWidth),
+        modifier = modifier.width(sizing.mapWidth),
     ) {
         val locale = LocalResources.current.configuration.locales[0]
         data.monthLabels.forEach { monthLabel ->
             Text(
                 text = monthLabel.month.getDisplayName(DateTextStyle.SHORT, locale),
-                modifier = Modifier.offset(x = dimensions.cellPitch * monthLabel.column),
+                modifier = Modifier.offset(x = sizing.cellPitch * monthLabel.column),
                 color = MaterialTheme.theme.colors.primaryText02,
-                style = textStyle,
+                style = sizing.textStyle,
             )
         }
     }
@@ -189,16 +186,16 @@ private fun MonthLabels(
 @Composable
 private fun Cells(
     data: HeatMapData,
-    dimensions: HeatMapDimensions,
+    sizing: HeatMapSizing,
     colors: HeatColors,
     cellHeatLevel: (LocalDate) -> HeatLevel,
     modifier: Modifier = Modifier,
 ) {
     Canvas(
-        modifier = modifier.size(dimensions.mapWidth, dimensions.mapHeight),
+        modifier = modifier.size(sizing.mapWidth, sizing.mapHeight),
     ) {
-        val cellSizePx = dimensions.cellSize.toPx()
-        val cellPitchPx = dimensions.cellPitch.toPx()
+        val cellSizePx = sizing.cellSize.toPx()
+        val cellPitchPx = sizing.cellPitch.toPx()
 
         data.cells.forEach { cell ->
             drawHeatSquare(
@@ -212,9 +209,8 @@ private fun Cells(
 
 @Composable
 private fun Legend(
-    dimensions: HeatMapDimensions,
+    sizing: HeatMapSizing,
     colors: HeatColors,
-    textStyle: TextStyle,
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -225,13 +221,13 @@ private fun Legend(
         Text(
             text = stringResource(LR.string.less),
             color = MaterialTheme.theme.colors.primaryText02,
-            style = textStyle,
+            style = sizing.textStyle,
         )
         Canvas(
-            modifier = Modifier.size(dimensions.legendWidth, dimensions.cellSize),
+            modifier = Modifier.size(sizing.legendWidth, sizing.cellSize),
         ) {
-            val cellSizePx = dimensions.cellSize.toPx()
-            val cellPitchPx = dimensions.cellPitch.toPx()
+            val cellSizePx = sizing.cellSize.toPx()
+            val cellPitchPx = sizing.cellPitch.toPx()
 
             HeatLevel.entries.forEachIndexed { cellIndex, heatLevel ->
                 drawHeatSquare(
@@ -244,7 +240,7 @@ private fun Legend(
         Text(
             text = stringResource(LR.string.more),
             color = MaterialTheme.theme.colors.primaryText02,
-            style = textStyle,
+            style = sizing.textStyle,
         )
     }
 }
@@ -262,29 +258,35 @@ private fun DrawScope.drawHeatSquare(
     )
 }
 
-private data class HeatMapDimensions(
+private data class HeatMapSizing(
     val cellSize: Dp,
     val cellPitch: Dp,
     val mapWidth: Dp,
     val mapHeight: Dp,
     val legendWidth: Dp,
+    val textStyle: TextStyle,
 )
 
 @Composable
-private fun rememberHeatMapDimensions(
+private fun rememberHeatMapSizing(
     weeks: Int,
     cellSize: Dp,
     cellSpacing: Dp,
-): HeatMapDimensions {
-    return remember(weeks, cellSize, cellSpacing) {
-        val cellPitch = cellSize + cellSpacing
+): HeatMapSizing {
+    val fontScale = LocalDensity.current.fontScale
 
-        HeatMapDimensions(
-            cellSize = cellSize,
+    return remember(weeks, cellSize, cellSpacing, fontScale) {
+        val resizeScale = max(fontScale, 1f)
+        val resizedCellSize = cellSize * resizeScale
+        val cellPitch = resizedCellSize + cellSpacing
+
+        HeatMapSizing(
+            cellSize = resizedCellSize,
             cellPitch = cellPitch,
-            mapWidth = cellSize * weeks + cellSpacing * (weeks - 1).coerceAtLeast(0),
-            mapHeight = cellSize * 7 + cellSpacing * 6,
-            legendWidth = cellSize * HeatLevel.entries.size + cellSpacing * (HeatLevel.entries.size - 1),
+            mapWidth = resizedCellSize * weeks + cellSpacing * (weeks - 1).coerceAtLeast(0),
+            mapHeight = resizedCellSize * 7 + cellSpacing * 6,
+            legendWidth = resizedCellSize * HeatLevel.entries.size + cellSpacing * (HeatLevel.entries.size - 1),
+            textStyle = TextStyle(fontSize = cellSize.value.sp),
         )
     }
 }
@@ -383,15 +385,53 @@ private fun rememberHeatMapData(start: LocalDate, end: LocalDate): HeatMapData {
 
 @Preview
 @Composable
-private fun CalendarHeatMapPreview() {
+private fun CalendarHeatMapPreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
+) {
     val previewHeatLevels = remember {
         val random = Random(0)
         List(400) { HeatLevel.entries.random(random) }
     }
 
-    CalendarHeatMap(
-        start = LocalDate.of(2025, 3, 6),
-        end = LocalDate.of(2026, 1, 1),
-        cellHeatLevel = { date -> previewHeatLevels[date.dayOfYear] },
-    )
+    AppThemeWithBackground(themeType) {
+        CalendarHeatMap(
+            start = LocalDate.of(2025, 3, 6),
+            end = LocalDate.of(2026, 1, 1),
+            cellHeatLevel = { date -> previewHeatLevels[date.dayOfYear] },
+        )
+    }
+}
+
+@Preview(fontScale = 1.5f)
+@Composable
+private fun CalendarHeatMapPreviewFont150Percent() {
+    val previewHeatLevels = remember {
+        val random = Random(0)
+        List(366) { HeatLevel.entries.random(random) }
+    }
+
+    AppThemeWithBackground(Theme.ThemeType.CLASSIC_LIGHT) {
+        CalendarHeatMap(
+            start = LocalDate.of(2025, 3, 6),
+            end = LocalDate.of(2026, 1, 1),
+            cellHeatLevel = { date -> previewHeatLevels[date.dayOfYear] },
+        )
+    }
+}
+
+@Preview(fontScale = 2f)
+@Composable
+private fun CalendarHeatMapPreviewFont200Percent() {
+    val previewHeatLevels = remember {
+        val random = Random(0)
+        List(366) { HeatLevel.entries.random(random) }
+    }
+
+    AppThemeWithBackground(Theme.ThemeType.CLASSIC_LIGHT) {
+        CalendarHeatMap(
+            start = LocalDate.of(2025, 3, 6),
+            end = LocalDate.of(2026, 1, 1),
+            cellHeatLevel = { date -> previewHeatLevels[date.dayOfYear] },
+        )
+    }
 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/stats/CalendarHeatMap.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/stats/CalendarHeatMap.kt
@@ -467,8 +467,8 @@ private fun CalendarHeatMapPreviewFont200Percent() {
 @Preview
 @Composable
 private fun CalendarHeatMapPreviewLocale() {
-    val start = LocalDate.of(2025, 3, 6)
-    val end = LocalDate.of(2026, 1, 1)
+    val start = LocalDate.of(2024, 1, 1)
+    val end = LocalDate.of(2024, 4, 30)
     val heatLevels = remember {
         val random = Random(0)
         var date = start

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/stats/CalendarHeatMap.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/stats/CalendarHeatMap.kt
@@ -43,6 +43,8 @@ import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.Month
 import java.time.temporal.ChronoUnit
+import java.util.Calendar
+import java.util.Locale
 import kotlin.math.max
 import kotlin.random.Random
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -65,11 +67,13 @@ fun CalendarHeatMap(
     cellSize: Dp = 12.dp,
     cellSpacing: Dp = 4.dp,
     scrollState: ScrollState = rememberScrollState(initial = Int.MAX_VALUE),
+    locale: Locale = LocalResources.current.configuration.locales[0],
 ) {
     val colors = rememberHeatColors()
     val data = rememberHeatMapData(
         start = start,
         end = end.plusDays(1).coerceAtLeast(start),
+        locale = locale,
     )
     val sizing = rememberHeatMapSizing(
         weeks = data.weeks,
@@ -77,9 +81,13 @@ fun CalendarHeatMap(
         cellSpacing = cellSpacing,
     )
 
-    val locale = LocalResources.current.configuration.locales[0]
     val dayLabelsByRow = remember(locale) {
-        Days.associateWith { day -> day.getDisplayName(DateTextStyle.SHORT, locale) }
+        val days = if (locale.isSundayBased()) {
+            listOf(DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY, DayOfWeek.FRIDAY)
+        } else {
+            listOf(DayOfWeek.TUESDAY, DayOfWeek.THURSDAY, DayOfWeek.SATURDAY)
+        }
+        days.associateWith { day -> day.getDisplayName(DateTextStyle.SHORT, locale) }
     }
 
     Column(
@@ -89,6 +97,7 @@ fun CalendarHeatMap(
         MonthLabels(
             data = data,
             sizing = sizing,
+            locale = locale,
             modifier = Modifier
                 .padding(start = dayLabelWidth + 4.dp, bottom = 2.dp)
                 .horizontalScroll(scrollState),
@@ -98,6 +107,7 @@ fun CalendarHeatMap(
             WeekdayLabels(
                 dayLabelsByRow = dayLabelsByRow,
                 sizing = sizing,
+                locale = locale,
                 modifier = Modifier.padding(end = 4.dp),
             )
             Cells(
@@ -123,6 +133,7 @@ fun CalendarHeatMap(
 private fun WeekdayLabels(
     dayLabelsByRow: Map<DayOfWeek, String>,
     sizing: HeatMapSizing,
+    locale: Locale,
     modifier: Modifier = Modifier,
 ) {
     val density = LocalDensity.current
@@ -135,9 +146,14 @@ private fun WeekdayLabels(
             val labelHeight = with(density) {
                 textMeasurer.measure(label, sizing.textStyle).size.height.toDp()
             }
+            val dayOfWeekOffset = if (locale.isSundayBased()) {
+                dayOfWeek.value % 7
+            } else {
+                dayOfWeek.ordinal
+            }
             Text(
                 text = label,
-                modifier = Modifier.offset(y = sizing.cellPitch * dayOfWeek.value + (sizing.cellSize - labelHeight) / 2),
+                modifier = Modifier.offset(y = sizing.cellPitch * dayOfWeekOffset + (sizing.cellSize - labelHeight) / 2),
                 color = MaterialTheme.theme.colors.primaryText02,
                 style = sizing.textStyle,
             )
@@ -160,18 +176,16 @@ private fun measureWeekdayLabels(
     return with(density) { maxLabelWidth.toDp() }
 }
 
-private val Days = listOf(DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY, DayOfWeek.FRIDAY)
-
 @Composable
 private fun MonthLabels(
     data: HeatMapData,
     sizing: HeatMapSizing,
+    locale: Locale,
     modifier: Modifier = Modifier,
 ) {
     Box(
         modifier = modifier.width(sizing.mapWidth),
     ) {
-        val locale = LocalResources.current.configuration.locales[0]
         data.monthLabels.forEach { monthLabel ->
             Text(
                 text = monthLabel.month.getDisplayName(DateTextStyle.SHORT, locale),
@@ -339,10 +353,13 @@ private data class HeatMapCell(
 )
 
 @Composable
-private fun rememberHeatMapData(start: LocalDate, end: LocalDate): HeatMapData {
-    return remember(start, end) {
-        // Use Sunday-based index
-        val startOffset = start.dayOfWeek.value % 7
+private fun rememberHeatMapData(start: LocalDate, end: LocalDate, locale: Locale): HeatMapData {
+    return remember(start, end, locale) {
+        val startOffset = if (locale.isSundayBased()) {
+            start.dayOfWeek.value % 7
+        } else {
+            start.dayOfWeek.ordinal
+        }
 
         val monthLabels = buildList {
             var monthStart = start.withDayOfMonth(1)
@@ -381,6 +398,8 @@ private fun rememberHeatMapData(start: LocalDate, end: LocalDate): HeatMapData {
         )
     }
 }
+
+private fun Locale.isSundayBased() = Calendar.getInstance(this).firstDayOfWeek == Calendar.SUNDAY
 
 @Preview
 @Composable
@@ -444,5 +463,32 @@ private fun CalendarHeatMapPreviewFont200Percent() {
 
     AppThemeWithBackground(Theme.ThemeType.CLASSIC_LIGHT) {
         CalendarHeatMap(start, end, heatLevels)
+    }
+}
+
+@Preview
+@Composable
+private fun CalendarHeatMapPreviewMondayBasedLocale() {
+    val start = LocalDate.of(2025, 3, 6)
+    val end = LocalDate.of(2026, 1, 1)
+    val heatLevels = remember {
+        val random = Random(0)
+        var date = start
+        buildMap {
+            while (date <= end) {
+                put(date, HeatLevel.entries.random(random))
+                date = date.plusDays(1)
+            }
+        }
+    }
+
+    AppThemeWithBackground(Theme.ThemeType.CLASSIC_LIGHT) {
+        @Suppress("DEPRECATION")
+        CalendarHeatMap(
+            start = start,
+            end = end,
+            heatLevels = heatLevels,
+            locale = Locale("US", "pl"),
+        )
     }
 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/stats/CalendarHeatMap.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/stats/CalendarHeatMap.kt
@@ -142,11 +142,12 @@ private fun WeekdayLabels(
     Box(
         modifier = modifier.height(sizing.mapHeight),
     ) {
+        val isSundayBased = locale.isSundayBased()
         dayLabelsByRow.forEach { (dayOfWeek, label) ->
             val labelHeight = with(density) {
                 textMeasurer.measure(label, sizing.textStyle).size.height.toDp()
             }
-            val dayOfWeekOffset = if (locale.isSundayBased()) {
+            val dayOfWeekOffset = if (isSundayBased) {
                 dayOfWeek.value % 7
             } else {
                 dayOfWeek.ordinal

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/stats/CalendarHeatMap.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/stats/CalendarHeatMap.kt
@@ -76,18 +76,13 @@ fun CalendarHeatMap(
         locale = locale,
     )
     val sizing = rememberHeatMapSizing(
-        weeks = data.weeks,
+        weeks = data.weekCount,
         cellSize = cellSize,
         cellSpacing = cellSpacing,
     )
 
-    val dayLabelsByRow = remember(locale) {
-        val days = if (locale.isSundayBased()) {
-            listOf(DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY, DayOfWeek.FRIDAY)
-        } else {
-            listOf(DayOfWeek.TUESDAY, DayOfWeek.THURSDAY, DayOfWeek.SATURDAY)
-        }
-        days.associateWith { day -> day.getDisplayName(DateTextStyle.SHORT, locale) }
+    val dayLabelsByRow = remember(locale, data.displayedDays) {
+        data.displayedDays.associateWith { day -> day.getDisplayName(DateTextStyle.SHORT, locale) }
     }
 
     Column(
@@ -107,7 +102,7 @@ fun CalendarHeatMap(
             WeekdayLabels(
                 dayLabelsByRow = dayLabelsByRow,
                 sizing = sizing,
-                locale = locale,
+                dayOfWeekOffset = data.dayOfWeekOffset,
                 modifier = Modifier.padding(end = 4.dp),
             )
             Cells(
@@ -133,7 +128,7 @@ fun CalendarHeatMap(
 private fun WeekdayLabels(
     dayLabelsByRow: Map<DayOfWeek, String>,
     sizing: HeatMapSizing,
-    locale: Locale,
+    dayOfWeekOffset: (DayOfWeek) -> Int,
     modifier: Modifier = Modifier,
 ) {
     val density = LocalDensity.current
@@ -142,19 +137,13 @@ private fun WeekdayLabels(
     Box(
         modifier = modifier.height(sizing.mapHeight),
     ) {
-        val isSundayBased = locale.isSundayBased()
         dayLabelsByRow.forEach { (dayOfWeek, label) ->
             val labelHeight = with(density) {
                 textMeasurer.measure(label, sizing.textStyle).size.height.toDp()
             }
-            val dayOfWeekOffset = if (isSundayBased) {
-                dayOfWeek.value % 7
-            } else {
-                dayOfWeek.ordinal
-            }
             Text(
                 text = label,
-                modifier = Modifier.offset(y = sizing.cellPitch * dayOfWeekOffset + (sizing.cellSize - labelHeight) / 2),
+                modifier = Modifier.offset(y = sizing.cellPitch * dayOfWeekOffset(dayOfWeek) + (sizing.cellSize - labelHeight) / 2),
                 color = MaterialTheme.theme.colors.primaryText02,
                 style = sizing.textStyle,
             )
@@ -337,9 +326,11 @@ private fun rememberHeatColors(): HeatColors {
 }
 
 private data class HeatMapData(
-    val weeks: Int,
+    val weekCount: Int,
     val monthLabels: List<HeatMapMonthLabel>,
     val cells: List<HeatMapCell>,
+    val displayedDays: List<DayOfWeek>,
+    val dayOfWeekOffset: (DayOfWeek) -> Int,
 )
 
 private data class HeatMapMonthLabel(
@@ -356,11 +347,9 @@ private data class HeatMapCell(
 @Composable
 private fun rememberHeatMapData(start: LocalDate, end: LocalDate, locale: Locale): HeatMapData {
     return remember(start, end, locale) {
-        val startOffset = if (locale.isSundayBased()) {
-            start.dayOfWeek.value % 7
-        } else {
-            start.dayOfWeek.ordinal
-        }
+        val firstDayIso = calendarToIsoDay(Calendar.getInstance(locale).firstDayOfWeek)
+        val dayOfWeekOffset: (DayOfWeek) -> Int = { day -> (day.value - firstDayIso + 7) % 7 }
+        val startOffset = dayOfWeekOffset(start.dayOfWeek)
 
         val monthLabels = buildList {
             var monthStart = start.withDayOfMonth(1)
@@ -393,14 +382,22 @@ private fun rememberHeatMapData(start: LocalDate, end: LocalDate, locale: Locale
         val cellsCount = startOffset + daysCount
         HeatMapData(
             // Round up partial weeks, then reserve one empty trailing week for labels.
-            weeks = (cellsCount + 6) / 7 + 1,
+            weekCount = (cellsCount + 6) / 7 + 1,
             monthLabels = monthLabels,
             cells = cells,
+            displayedDays = everySecondDays(firstDayIso),
+            dayOfWeekOffset = dayOfWeekOffset,
         )
     }
 }
 
-private fun Locale.isSundayBased() = Calendar.getInstance(this).firstDayOfWeek == Calendar.SUNDAY
+private fun calendarToIsoDay(calendarDay: Int): Int {
+    return ((calendarDay + 5) % 7) + 1
+}
+
+private fun everySecondDays(isoFirstDay: Int): List<DayOfWeek> {
+    return listOf(1, 3, 5).map { offset -> DayOfWeek.of(((isoFirstDay - 1 + offset) % 7) + 1) }
+}
 
 @Preview
 @Composable
@@ -469,7 +466,7 @@ private fun CalendarHeatMapPreviewFont200Percent() {
 
 @Preview
 @Composable
-private fun CalendarHeatMapPreviewMondayBasedLocale() {
+private fun CalendarHeatMapPreviewLocale() {
     val start = LocalDate.of(2025, 3, 6)
     val end = LocalDate.of(2026, 1, 1)
     val heatLevels = remember {
@@ -483,13 +480,35 @@ private fun CalendarHeatMapPreviewMondayBasedLocale() {
         }
     }
 
+    @Suppress("DEPRECATION")
     AppThemeWithBackground(Theme.ThemeType.CLASSIC_LIGHT) {
-        @Suppress("DEPRECATION")
-        CalendarHeatMap(
-            start = start,
-            end = end,
-            heatLevels = heatLevels,
-            locale = Locale("US", "pl"),
-        )
+        Column(
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            CalendarHeatMap(
+                start = start,
+                end = end,
+                heatLevels = heatLevels,
+                locale = Locale("en", "US"),
+            )
+            CalendarHeatMap(
+                start = start,
+                end = end,
+                heatLevels = heatLevels,
+                locale = Locale("en", "PL"),
+            )
+            CalendarHeatMap(
+                start = start,
+                end = end,
+                heatLevels = heatLevels,
+                locale = Locale("en", "IR"),
+            )
+            CalendarHeatMap(
+                start = start,
+                end = end,
+                heatLevels = heatLevels,
+                locale = Locale("en", "MV"),
+            )
+        }
     }
 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/stats/CalendarHeatMap.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/stats/CalendarHeatMap.kt
@@ -340,7 +340,7 @@ private data class HeatMapCell(
 @Composable
 private fun rememberHeatMapData(start: LocalDate, end: LocalDate): HeatMapData {
     return remember(start, end) {
-        // Use sunday based index
+        // Use Sunday-based index
         val startOffset = start.dayOfWeek.value % 7
 
         val monthLabels = buildList {

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -64,6 +64,7 @@
     <string name="mark_as_unplayed">Mark as unplayed</string>
     <string name="mark_played">Mark played</string>
     <string name="mark_unplayed">Mark unplayed</string>
+    <string name="less">Less</string>
     <string name="more">More</string>
     <string name="more_options">More options</string>
     <string name="next_episode">Next episode</string>

--- a/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/helper/ColorUtils.kt
+++ b/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/helper/ColorUtils.kt
@@ -54,6 +54,18 @@ object ColorUtils {
     fun calculateContrast(backgroundColor: ComposeColor, foregroundColor: ComposeColor): Double {
         return AndroidColorUtils.calculateContrast(foregroundColor.toArgb(), backgroundColor.toArgb())
     }
+
+    fun blendColors(first: ComposeColor, second: ComposeColor, fraction: Float): ComposeColor {
+        val clampedFraction = fraction.coerceIn(0f, 1f)
+        val inverseFraction = 1f - clampedFraction
+
+        return ComposeColor(
+            red = first.red * inverseFraction + second.red * clampedFraction,
+            green = first.green * inverseFraction + second.green * clampedFraction,
+            blue = first.blue * inverseFraction + second.blue * clampedFraction,
+            alpha = first.alpha * inverseFraction + second.alpha * clampedFraction,
+        )
+    }
 }
 
 fun Int.colorIntWithAlpha(alpha: Int): Int {


### PR DESCRIPTION
## Description

This change adds a generic GitHub-style heat map component.

## Testing Instructions

Code review my changes. This isn't integrated with anything yet.

## Screenshots or Screencast 

<img width="1354" height="1269" alt="SCR-20260420-pftn" src="https://github.com/user-attachments/assets/c8af6e79-d724-4dd8-9682-f3bc27e9b09b" />

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
