### PR TITLE
Track playback events

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabaseTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabaseTest.kt
@@ -194,6 +194,7 @@ class AppDatabaseTest {
                 AppDatabase.MIGRATION_122_123,
                 AppDatabase.MIGRATION_123_124,
                 AppDatabase.MIGRATION_124_125,
+                AppDatabase.MIGRATION_125_126,
             )
             .build()
         // close the database and release any stream resources when the test finishes

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/utils/MutableClock.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/utils/MutableClock.kt
@@ -7,13 +7,21 @@ import kotlin.time.Duration
 
 class MutableClock(
     private var instant: Instant = Instant.EPOCH,
-    private val zoneId: ZoneId = ZoneId.of("UTC"),
+    private var zoneId: ZoneId = ZoneId.of("UTC"),
 ) : Clock() {
     override fun instant() = instant
 
     override fun getZone() = zoneId
 
     override fun withZone(zone: ZoneId) = MutableClock(instant, zone)
+
+    fun setInstant(instant: Instant) {
+        this.instant = instant
+    }
+
+    fun setZone(zoneId: ZoneId) {
+        this.zoneId = zoneId
+    }
 
     operator fun plusAssign(duration: Duration) {
         instant = instant.plusMillis(duration.inWholeMilliseconds)

--- a/modules/services/model/schemas/au.com.shiftyjelly.pocketcasts.models.db.AppDatabase/126.json
+++ b/modules/services/model/schemas/au.com.shiftyjelly.pocketcasts.models.db.AppDatabase/126.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 126,
-    "identityHash": "b328a095769b3a934bb55b075b20d83a",
+    "identityHash": "a2f2caf6020cf0016e64bd1e718860db",
     "entities": [
       {
         "tableName": "bump_stats",
@@ -2038,7 +2038,7 @@
       },
       {
         "tableName": "playback_stats_events",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `episode_uuid` TEXT NOT NULL, `podcast_uuid` TEXT NOT NULL, `episode_title` TEXT NOT NULL, `podcast_title` TEXT NOT NULL, `podcast_category` TEXT NOT NULL, `started_at_ms` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `is_synced` INTEGER NOT NULL, PRIMARY KEY(`uuid`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `episode_uuid` TEXT NOT NULL, `podcast_uuid` TEXT NOT NULL, `started_at_ms` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, PRIMARY KEY(`uuid`))",
         "fields": [
           {
             "fieldPath": "uuid",
@@ -2059,24 +2059,6 @@
             "notNull": true
           },
           {
-            "fieldPath": "episodeTitle",
-            "columnName": "episode_title",
-            "affinity": "TEXT",
-            "notNull": true
-          },
-          {
-            "fieldPath": "podcastTitle",
-            "columnName": "podcast_title",
-            "affinity": "TEXT",
-            "notNull": true
-          },
-          {
-            "fieldPath": "podcastCategory",
-            "columnName": "podcast_category",
-            "affinity": "TEXT",
-            "notNull": true
-          },
-          {
             "fieldPath": "startedAtMs",
             "columnName": "started_at_ms",
             "affinity": "INTEGER",
@@ -2085,12 +2067,6 @@
           {
             "fieldPath": "durationMs",
             "columnName": "duration_ms",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
-            "fieldPath": "isSynced",
-            "columnName": "is_synced",
             "affinity": "INTEGER",
             "notNull": true
           }
@@ -2110,31 +2086,13 @@
             ],
             "orders": [],
             "createSql": "CREATE INDEX IF NOT EXISTS `playback_stats_events_started_at_ms` ON `${TABLE_NAME}` (`started_at_ms`)"
-          },
-          {
-            "name": "playback_stats_events_podcast_uuid",
-            "unique": false,
-            "columnNames": [
-              "podcast_uuid"
-            ],
-            "orders": [],
-            "createSql": "CREATE INDEX IF NOT EXISTS `playback_stats_events_podcast_uuid` ON `${TABLE_NAME}` (`podcast_uuid`)"
-          },
-          {
-            "name": "playback_stats_events_podcast_category",
-            "unique": false,
-            "columnNames": [
-              "podcast_category"
-            ],
-            "orders": [],
-            "createSql": "CREATE INDEX IF NOT EXISTS `playback_stats_events_podcast_category` ON `${TABLE_NAME}` (`podcast_category`)"
           }
         ]
       }
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'b328a095769b3a934bb55b075b20d83a')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'a2f2caf6020cf0016e64bd1e718860db')"
     ]
   }
 }

--- a/modules/services/model/schemas/au.com.shiftyjelly.pocketcasts.models.db.AppDatabase/126.json
+++ b/modules/services/model/schemas/au.com.shiftyjelly.pocketcasts.models.db.AppDatabase/126.json
@@ -1,0 +1,2140 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 126,
+    "identityHash": "b328a095769b3a934bb55b075b20d83a",
+    "entities": [
+      {
+        "tableName": "bump_stats",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `event_time` INTEGER NOT NULL, `custom_event_props` TEXT NOT NULL, PRIMARY KEY(`name`, `event_time`, `custom_event_props`))",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventTime",
+            "columnName": "event_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customEventProps",
+            "columnName": "custom_event_props",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "name",
+            "event_time",
+            "custom_event_props"
+          ]
+        }
+      },
+      {
+        "tableName": "bookmarks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `podcast_uuid` TEXT NOT NULL, `episode_uuid` TEXT NOT NULL, `time` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, `title` TEXT NOT NULL, `title_modified` INTEGER, `deleted` INTEGER NOT NULL, `deleted_modified` INTEGER, `sync_status` INTEGER NOT NULL, `clean_title` TEXT NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcast_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeUuid",
+            "columnName": "episode_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timeSecs",
+            "columnName": "time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "titleModified",
+            "columnName": "title_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedModified",
+            "columnName": "deleted_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "sync_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cleanTitle",
+            "columnName": "clean_title",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "bookmarks_podcast_uuid",
+            "unique": false,
+            "columnNames": [
+              "podcast_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `bookmarks_podcast_uuid` ON `${TABLE_NAME}` (`podcast_uuid`)"
+          }
+        ]
+      },
+      {
+        "tableName": "podcast_episodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `episode_description` TEXT NOT NULL, `published_date` INTEGER NOT NULL, `title` TEXT NOT NULL, `size_in_bytes` INTEGER NOT NULL, `episode_status` INTEGER NOT NULL, `file_type` TEXT, `duration` REAL NOT NULL, `download_url` TEXT, `downloaded_file_path` TEXT, `downloaded_error_details` TEXT, `play_error_details` TEXT, `played_up_to` REAL NOT NULL, `playing_status` INTEGER NOT NULL, `podcast_id` TEXT NOT NULL, `added_date` INTEGER NOT NULL, `auto_download_status` INTEGER NOT NULL, `starred` INTEGER NOT NULL, `thumbnail_status` INTEGER NOT NULL, `last_download_attempt_date` INTEGER, `playing_status_modified` INTEGER, `played_up_to_modified` INTEGER, `duration_modified` INTEGER, `starred_modified` INTEGER, `last_starred_date` INTEGER, `archived` INTEGER NOT NULL, `archived_modified` INTEGER, `season` INTEGER, `number` INTEGER, `type` TEXT, `last_playback_interaction_date` INTEGER, `last_playback_interaction_sync_status` INTEGER NOT NULL, `exclude_from_episode_limit` INTEGER NOT NULL, `download_task_id` TEXT, `last_archive_interaction_date` INTEGER, `image_url` TEXT, `deselected_chapters` TEXT NOT NULL, `deselected_chapters_modified` INTEGER, `slug` TEXT NOT NULL, `has_generated_transcript` INTEGER NOT NULL, `cleanTitle` TEXT, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeDescription",
+            "columnName": "episode_description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publishedDate",
+            "columnName": "published_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeInBytes",
+            "columnName": "size_in_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadStatus",
+            "columnName": "episode_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileType",
+            "columnName": "file_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadUrl",
+            "columnName": "download_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadedFilePath",
+            "columnName": "downloaded_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadErrorDetails",
+            "columnName": "downloaded_error_details",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playErrorDetails",
+            "columnName": "play_error_details",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playedUpTo",
+            "columnName": "played_up_to",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playingStatus",
+            "columnName": "playing_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcast_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedDate",
+            "columnName": "added_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoDownloadStatus",
+            "columnName": "auto_download_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isStarred",
+            "columnName": "starred",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailStatus",
+            "columnName": "thumbnail_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDownloadAttemptDate",
+            "columnName": "last_download_attempt_date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "playingStatusModified",
+            "columnName": "playing_status_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "playedUpToModified",
+            "columnName": "played_up_to_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "durationModified",
+            "columnName": "duration_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "starredModified",
+            "columnName": "starred_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastStarredDate",
+            "columnName": "last_starred_date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isArchived",
+            "columnName": "archived",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "archivedModified",
+            "columnName": "archived_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "season",
+            "columnName": "season",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "number",
+            "columnName": "number",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastPlaybackInteraction",
+            "columnName": "last_playback_interaction_date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastPlaybackInteractionSyncStatus",
+            "columnName": "last_playback_interaction_sync_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "excludeFromEpisodeLimit",
+            "columnName": "exclude_from_episode_limit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadTaskId",
+            "columnName": "download_task_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastArchiveInteraction",
+            "columnName": "last_archive_interaction_date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "image_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "deselectedChapters",
+            "columnName": "deselected_chapters",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deselectedChaptersModified",
+            "columnName": "deselected_chapters_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "slug",
+            "columnName": "slug",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasGeneratedTranscript",
+            "columnName": "has_generated_transcript",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cleanTitle",
+            "columnName": "cleanTitle",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "episode_last_download_attempt_date",
+            "unique": false,
+            "columnNames": [
+              "last_download_attempt_date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `episode_last_download_attempt_date` ON `${TABLE_NAME}` (`last_download_attempt_date`)"
+          },
+          {
+            "name": "episode_podcast_id",
+            "unique": false,
+            "columnNames": [
+              "podcast_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `episode_podcast_id` ON `${TABLE_NAME}` (`podcast_id`)"
+          },
+          {
+            "name": "episode_published_date",
+            "unique": false,
+            "columnNames": [
+              "published_date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `episode_published_date` ON `${TABLE_NAME}` (`published_date`)"
+          }
+        ]
+      },
+      {
+        "tableName": "folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `name` TEXT NOT NULL, `color` INTEGER NOT NULL, `added_date` INTEGER NOT NULL, `sort_position` INTEGER NOT NULL, `podcasts_sort_type` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, `sync_modified` INTEGER NOT NULL, `clean_name` TEXT NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedDate",
+            "columnName": "added_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortPosition",
+            "columnName": "sort_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastsSortType",
+            "columnName": "podcasts_sort_type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncModified",
+            "columnName": "sync_modified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cleanName",
+            "columnName": "clean_name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        }
+      },
+      {
+        "tableName": "suggested_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`folder_name` TEXT NOT NULL, `podcast_uuid` TEXT NOT NULL, PRIMARY KEY(`folder_name`, `podcast_uuid`))",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "folder_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcast_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "folder_name",
+            "podcast_uuid"
+          ]
+        }
+      },
+      {
+        "tableName": "playlists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `title` TEXT NOT NULL, `iconId` INTEGER NOT NULL, `sortPosition` INTEGER, `sortId` INTEGER NOT NULL, `manual` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, `syncStatus` INTEGER NOT NULL, `autoDownload` INTEGER NOT NULL, `autoDownloadLimit` INTEGER NOT NULL, `unplayed` INTEGER NOT NULL, `partiallyPlayed` INTEGER NOT NULL, `finished` INTEGER NOT NULL, `downloaded` INTEGER NOT NULL, `notDownloaded` INTEGER NOT NULL, `audioVideo` INTEGER NOT NULL, `filterHours` INTEGER NOT NULL, `starred` INTEGER NOT NULL, `allPodcasts` INTEGER NOT NULL, `podcastUuids` TEXT, `filterDuration` INTEGER NOT NULL, `longerThan` INTEGER NOT NULL, `shorterThan` INTEGER NOT NULL, `showArchivedEpisodes` INTEGER NOT NULL, `clean_title` TEXT NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iconId",
+            "columnName": "iconId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortPosition",
+            "columnName": "sortPosition",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "sortType",
+            "columnName": "sortId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "manual",
+            "columnName": "manual",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "syncStatus",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoDownload",
+            "columnName": "autoDownload",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autodownloadLimit",
+            "columnName": "autoDownloadLimit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unplayed",
+            "columnName": "unplayed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "partiallyPlayed",
+            "columnName": "partiallyPlayed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "finished",
+            "columnName": "finished",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloaded",
+            "columnName": "downloaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notDownloaded",
+            "columnName": "notDownloaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioVideo",
+            "columnName": "audioVideo",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filterHours",
+            "columnName": "filterHours",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "starred",
+            "columnName": "starred",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "allPodcasts",
+            "columnName": "allPodcasts",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastUuids",
+            "columnName": "podcastUuids",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "filterDuration",
+            "columnName": "filterDuration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longerThan",
+            "columnName": "longerThan",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shorterThan",
+            "columnName": "shorterThan",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showArchivedEpisodes",
+            "columnName": "showArchivedEpisodes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cleanTitle",
+            "columnName": "clean_title",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        }
+      },
+      {
+        "tableName": "podcasts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `added_date` INTEGER, `thumbnail_url` TEXT, `title` TEXT NOT NULL, `podcast_url` TEXT, `podcast_description` TEXT NOT NULL, `podcast_html_description` TEXT NOT NULL, `podcast_category` TEXT NOT NULL, `podcast_language` TEXT NOT NULL, `media_type` TEXT, `latest_episode_uuid` TEXT, `author` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, `episodes_sort_order` INTEGER NOT NULL, `episodes_sort_order_modified` INTEGER, `latest_episode_date` INTEGER, `episodes_to_keep` INTEGER NOT NULL, `override_global_settings` INTEGER NOT NULL, `override_global_effects` INTEGER NOT NULL, `override_global_effects_modified` INTEGER, `start_from` INTEGER NOT NULL, `start_from_modified` INTEGER, `playback_speed` REAL NOT NULL, `playback_speed_modified` INTEGER, `volume_boosted` INTEGER NOT NULL, `volume_boosted_modified` INTEGER, `is_folder` INTEGER NOT NULL, `subscribed` INTEGER NOT NULL, `show_notifications` INTEGER NOT NULL, `show_notifications_modified` INTEGER, `auto_download_status` INTEGER NOT NULL, `auto_add_to_up_next` INTEGER NOT NULL, `auto_add_to_up_next_modified` INTEGER, `most_popular_color` INTEGER NOT NULL, `primary_color` INTEGER NOT NULL, `secondary_color` INTEGER NOT NULL, `light_overlay_color` INTEGER NOT NULL, `fab_for_light_bg` INTEGER NOT NULL, `link_for_dark_bg` INTEGER NOT NULL, `link_for_light_bg` INTEGER NOT NULL, `color_version` INTEGER NOT NULL, `color_last_downloaded` INTEGER NOT NULL, `sync_status` INTEGER NOT NULL, `exclude_from_auto_archive` INTEGER NOT NULL, `override_global_archive` INTEGER NOT NULL, `override_global_archive_modified` INTEGER, `auto_archive_played_after` INTEGER NOT NULL, `auto_archive_played_after_modified` INTEGER, `auto_archive_inactive_after` INTEGER NOT NULL, `auto_archive_inactive_after_modified` INTEGER, `auto_archive_episode_limit` INTEGER NOT NULL, `auto_archive_episode_limit_modified` INTEGER, `estimated_next_episode` INTEGER, `episode_frequency` TEXT, `grouping` INTEGER NOT NULL, `grouping_modified` INTEGER, `skip_last` INTEGER NOT NULL, `skip_last_modified` INTEGER, `show_archived` INTEGER NOT NULL, `show_archived_modified` INTEGER, `trim_silence_level` INTEGER NOT NULL, `trim_silence_level_modified` INTEGER, `refresh_available` INTEGER NOT NULL, `folder_uuid` TEXT, `licensing` INTEGER NOT NULL, `isPaid` INTEGER NOT NULL, `is_private` INTEGER NOT NULL, `is_header_expanded` INTEGER NOT NULL DEFAULT 1, `funding_url` TEXT, `slug` TEXT NOT NULL, `clean_title` TEXT NOT NULL, `bundleuuid` TEXT, `bundlebundleUrl` TEXT, `bundlepaymentUrl` TEXT, `bundledescription` TEXT, `bundlepodcastUuid` TEXT, `bundlepaidType` TEXT, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedDate",
+            "columnName": "added_date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnail_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastUrl",
+            "columnName": "podcast_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "podcastDescription",
+            "columnName": "podcast_description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastHtmlDescription",
+            "columnName": "podcast_html_description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastCategory",
+            "columnName": "podcast_category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastLanguage",
+            "columnName": "podcast_language",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "media_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latestEpisodeUuid",
+            "columnName": "latest_episode_uuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortPosition",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodesSortType",
+            "columnName": "episodes_sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodesSortTypeModified",
+            "columnName": "episodes_sort_order_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "latestEpisodeDate",
+            "columnName": "latest_episode_date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "episodesToKeep",
+            "columnName": "episodes_to_keep",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "overrideGlobalSettings",
+            "columnName": "override_global_settings",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "overrideGlobalEffects",
+            "columnName": "override_global_effects",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "overrideGlobalEffectsModified",
+            "columnName": "override_global_effects_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "startFromSecs",
+            "columnName": "start_from",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startFromModified",
+            "columnName": "start_from_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "playbackSpeed",
+            "columnName": "playback_speed",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playbackSpeedModified",
+            "columnName": "playback_speed_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isVolumeBoosted",
+            "columnName": "volume_boosted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "volumeBoostedModified",
+            "columnName": "volume_boosted_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isFolder",
+            "columnName": "is_folder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSubscribed",
+            "columnName": "subscribed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isShowNotifications",
+            "columnName": "show_notifications",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showNotificationsModified",
+            "columnName": "show_notifications_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "autoDownloadStatus",
+            "columnName": "auto_download_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoAddToUpNext",
+            "columnName": "auto_add_to_up_next",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoAddToUpNextModified",
+            "columnName": "auto_add_to_up_next_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "backgroundColor",
+            "columnName": "most_popular_color",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tintColorForLightBg",
+            "columnName": "primary_color",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tintColorForDarkBg",
+            "columnName": "secondary_color",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fabColorForDarkBg",
+            "columnName": "light_overlay_color",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fabColorForLightBg",
+            "columnName": "fab_for_light_bg",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "linkColorForLightBg",
+            "columnName": "link_for_dark_bg",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "linkColorForDarkBg",
+            "columnName": "link_for_light_bg",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "colorVersion",
+            "columnName": "color_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "colorLastDownloaded",
+            "columnName": "color_last_downloaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "sync_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "excludeFromAutoArchive",
+            "columnName": "exclude_from_auto_archive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "overrideGlobalArchive",
+            "columnName": "override_global_archive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "overrideGlobalArchiveModified",
+            "columnName": "override_global_archive_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "rawAutoArchiveAfterPlaying",
+            "columnName": "auto_archive_played_after",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoArchiveAfterPlayingModified",
+            "columnName": "auto_archive_played_after_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "rawAutoArchiveInactive",
+            "columnName": "auto_archive_inactive_after",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoArchiveInactiveModified",
+            "columnName": "auto_archive_inactive_after_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "rawAutoArchiveEpisodeLimit",
+            "columnName": "auto_archive_episode_limit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoArchiveEpisodeLimitModified",
+            "columnName": "auto_archive_episode_limit_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "estimatedNextEpisode",
+            "columnName": "estimated_next_episode",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "episodeFrequency",
+            "columnName": "episode_frequency",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "grouping",
+            "columnName": "grouping",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "groupingModified",
+            "columnName": "grouping_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "skipLastSecs",
+            "columnName": "skip_last",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skipLastModified",
+            "columnName": "skip_last_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showArchived",
+            "columnName": "show_archived",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showArchivedModified",
+            "columnName": "show_archived_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "trimMode",
+            "columnName": "trim_silence_level",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trimModeModified",
+            "columnName": "trim_silence_level_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "refreshAvailable",
+            "columnName": "refresh_available",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rawFolderUuid",
+            "columnName": "folder_uuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "licensing",
+            "columnName": "licensing",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPaid",
+            "columnName": "isPaid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPrivate",
+            "columnName": "is_private",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isHeaderExpanded",
+            "columnName": "is_header_expanded",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "fundingUrl",
+            "columnName": "funding_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "slug",
+            "columnName": "slug",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cleanTitle",
+            "columnName": "clean_title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "singleBundle.uuid",
+            "columnName": "bundleuuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "singleBundle.bundleUrl",
+            "columnName": "bundlebundleUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "singleBundle.paymentUrl",
+            "columnName": "bundlepaymentUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "singleBundle.description",
+            "columnName": "bundledescription",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "singleBundle.podcastUuid",
+            "columnName": "bundlepodcastUuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "singleBundle.paidType",
+            "columnName": "bundlepaidType",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        }
+      },
+      {
+        "tableName": "search_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT, `modified` INTEGER NOT NULL, `term` TEXT, `podcast_uuid` TEXT, `podcast_title` TEXT, `podcast_author` TEXT, `folder_uuid` TEXT, `folder_title` TEXT, `folder_color` INTEGER, `folder_podcastIds` TEXT, `episode_uuid` TEXT, `episode_title` TEXT, `episode_duration` REAL, `episode_podcastUuid` TEXT, `episode_podcastTitle` TEXT, `episode_artworkUrl` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "modified",
+            "columnName": "modified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "term",
+            "columnName": "term",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "podcast.uuid",
+            "columnName": "podcast_uuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "podcast.title",
+            "columnName": "podcast_title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "podcast.author",
+            "columnName": "podcast_author",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "folder.uuid",
+            "columnName": "folder_uuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "folder.title",
+            "columnName": "folder_title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "folder.color",
+            "columnName": "folder_color",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "folder.podcastIds",
+            "columnName": "folder_podcastIds",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "episode.uuid",
+            "columnName": "episode_uuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "episode.title",
+            "columnName": "episode_title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "episode.duration",
+            "columnName": "episode_duration",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "episode.podcastUuid",
+            "columnName": "episode_podcastUuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "episode.podcastTitle",
+            "columnName": "episode_podcastTitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "episode.artworkUrl",
+            "columnName": "episode_artworkUrl",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_search_history_term",
+            "unique": true,
+            "columnNames": [
+              "term"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_search_history_term` ON `${TABLE_NAME}` (`term`)"
+          },
+          {
+            "name": "index_search_history_podcast_uuid",
+            "unique": true,
+            "columnNames": [
+              "podcast_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_search_history_podcast_uuid` ON `${TABLE_NAME}` (`podcast_uuid`)"
+          },
+          {
+            "name": "index_search_history_folder_uuid",
+            "unique": true,
+            "columnNames": [
+              "folder_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_search_history_folder_uuid` ON `${TABLE_NAME}` (`folder_uuid`)"
+          },
+          {
+            "name": "index_search_history_episode_uuid",
+            "unique": true,
+            "columnNames": [
+              "episode_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_search_history_episode_uuid` ON `${TABLE_NAME}` (`episode_uuid`)"
+          }
+        ]
+      },
+      {
+        "tableName": "up_next_changes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT, `type` INTEGER NOT NULL, `uuid` TEXT, `uuids` TEXT, `modified` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "uuids",
+            "columnName": "uuids",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "modified",
+            "columnName": "modified",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        }
+      },
+      {
+        "tableName": "up_next_episodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT, `episodeUuid` TEXT NOT NULL, `position` INTEGER NOT NULL, `playlistId` INTEGER, `title` TEXT NOT NULL, `publishedDate` INTEGER, `downloadUrl` TEXT, `podcastUuid` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "episodeUuid",
+            "columnName": "episodeUuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publishedDate",
+            "columnName": "publishedDate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "downloadUrl",
+            "columnName": "downloadUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcastUuid",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "up_next_episode_episodeUuid",
+            "unique": false,
+            "columnNames": [
+              "episodeUuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `up_next_episode_episodeUuid` ON `${TABLE_NAME}` (`episodeUuid`)"
+          }
+        ]
+      },
+      {
+        "tableName": "user_episodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `published_date` INTEGER NOT NULL, `episode_description` TEXT NOT NULL, `title` TEXT NOT NULL, `size_in_bytes` INTEGER NOT NULL, `episode_status` INTEGER NOT NULL, `file_type` TEXT, `duration` REAL NOT NULL, `download_url` TEXT, `played_up_to` REAL NOT NULL, `playing_status` INTEGER NOT NULL, `added_date` INTEGER NOT NULL, `auto_download_status` INTEGER NOT NULL, `last_download_attempt_date` INTEGER, `archived` INTEGER NOT NULL, `download_task_id` TEXT, `downloaded_file_path` TEXT, `playing_status_modified` INTEGER, `played_up_to_modified` INTEGER, `artwork_url` TEXT, `play_error_details` TEXT, `server_status` INTEGER NOT NULL, `upload_error_details` TEXT, `downloaded_error_details` TEXT, `tint_color_index` INTEGER NOT NULL, `has_custom_image` INTEGER NOT NULL, `upload_task_id` TEXT, `deselected_chapters` TEXT NOT NULL, `deselected_chapters_modified` INTEGER, `clean_title` TEXT NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publishedDate",
+            "columnName": "published_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeDescription",
+            "columnName": "episode_description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeInBytes",
+            "columnName": "size_in_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadStatus",
+            "columnName": "episode_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileType",
+            "columnName": "file_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadUrl",
+            "columnName": "download_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playedUpTo",
+            "columnName": "played_up_to",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playingStatus",
+            "columnName": "playing_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedDate",
+            "columnName": "added_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoDownloadStatus",
+            "columnName": "auto_download_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDownloadAttemptDate",
+            "columnName": "last_download_attempt_date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isArchived",
+            "columnName": "archived",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadTaskId",
+            "columnName": "download_task_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadedFilePath",
+            "columnName": "downloaded_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playingStatusModified",
+            "columnName": "playing_status_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "playedUpToModified",
+            "columnName": "played_up_to_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "artworkUrl",
+            "columnName": "artwork_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playErrorDetails",
+            "columnName": "play_error_details",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "serverStatus",
+            "columnName": "server_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uploadErrorDetails",
+            "columnName": "upload_error_details",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadErrorDetails",
+            "columnName": "downloaded_error_details",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tintColorIndex",
+            "columnName": "tint_color_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasCustomImage",
+            "columnName": "has_custom_image",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uploadTaskId",
+            "columnName": "upload_task_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "deselectedChapters",
+            "columnName": "deselected_chapters",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deselectedChaptersModified",
+            "columnName": "deselected_chapters_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "cleanTitle",
+            "columnName": "clean_title",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "user_episode_last_download_attempt_date",
+            "unique": false,
+            "columnNames": [
+              "last_download_attempt_date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `user_episode_last_download_attempt_date` ON `${TABLE_NAME}` (`last_download_attempt_date`)"
+          },
+          {
+            "name": "user_episode_published_date",
+            "unique": false,
+            "columnNames": [
+              "published_date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `user_episode_published_date` ON `${TABLE_NAME}` (`published_date`)"
+          }
+        ]
+      },
+      {
+        "tableName": "podcast_ratings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`podcast_uuid` TEXT NOT NULL, `average` REAL, `total` INTEGER, PRIMARY KEY(`podcast_uuid`))",
+        "fields": [
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcast_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "average",
+            "columnName": "average",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "total",
+            "columnName": "total",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "podcast_uuid"
+          ]
+        }
+      },
+      {
+        "tableName": "episode_chapters",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`chapter_index` INTEGER NOT NULL, `episode_uuid` TEXT NOT NULL, `start_time` INTEGER NOT NULL, `end_time` INTEGER, `title` TEXT, `image_url` TEXT, `url` TEXT, `is_embedded` INTEGER NOT NULL, PRIMARY KEY(`episode_uuid`, `chapter_index`))",
+        "fields": [
+          {
+            "fieldPath": "index",
+            "columnName": "chapter_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeUuid",
+            "columnName": "episode_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTimeMs",
+            "columnName": "start_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endTimeMs",
+            "columnName": "end_time",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "image_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isEmbedded",
+            "columnName": "is_embedded",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "episode_uuid",
+            "chapter_index"
+          ]
+        },
+        "indices": [
+          {
+            "name": "chapter_episode_uuid_index",
+            "unique": false,
+            "columnNames": [
+              "episode_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `chapter_episode_uuid_index` ON `${TABLE_NAME}` (`episode_uuid`)"
+          }
+        ]
+      },
+      {
+        "tableName": "curated_podcasts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`list_id` TEXT NOT NULL, `list_title` TEXT NOT NULL, `podcast_id` TEXT NOT NULL, `podcast_title` TEXT NOT NULL, `podcast_description` TEXT, PRIMARY KEY(`list_id`, `podcast_id`))",
+        "fields": [
+          {
+            "fieldPath": "listId",
+            "columnName": "list_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listTitle",
+            "columnName": "list_title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastId",
+            "columnName": "podcast_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastTitle",
+            "columnName": "podcast_title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastDescription",
+            "columnName": "podcast_description",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "list_id",
+            "podcast_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "curated_podcasts_list_id_index",
+            "unique": false,
+            "columnNames": [
+              "list_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `curated_podcasts_list_id_index` ON `${TABLE_NAME}` (`list_id`)"
+          },
+          {
+            "name": "curated_podcasts_podcast_id_index",
+            "unique": false,
+            "columnNames": [
+              "podcast_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `curated_podcasts_podcast_id_index` ON `${TABLE_NAME}` (`podcast_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "episode_transcript",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`episode_uuid` TEXT NOT NULL, `url` TEXT NOT NULL, `type` TEXT NOT NULL, `is_generated` INTEGER NOT NULL, `language` TEXT, PRIMARY KEY(`episode_uuid`, `url`))",
+        "fields": [
+          {
+            "fieldPath": "episodeUuid",
+            "columnName": "episode_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isGenerated",
+            "columnName": "is_generated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "episode_uuid",
+            "url"
+          ]
+        }
+      },
+      {
+        "tableName": "user_podcast_ratings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`podcast_uuid` TEXT NOT NULL, `rating` INTEGER NOT NULL, `modified_at` INTEGER NOT NULL, PRIMARY KEY(`podcast_uuid`))",
+        "fields": [
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcast_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "podcast_uuid"
+          ]
+        }
+      },
+      {
+        "tableName": "up_next_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`episodeUuid` TEXT NOT NULL, `position` INTEGER NOT NULL, `playlistId` INTEGER, `title` TEXT NOT NULL, `publishedDate` INTEGER, `downloadUrl` TEXT, `podcastUuid` TEXT, `addedDate` INTEGER NOT NULL, PRIMARY KEY(`episodeUuid`, `addedDate`))",
+        "fields": [
+          {
+            "fieldPath": "episodeUuid",
+            "columnName": "episodeUuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publishedDate",
+            "columnName": "publishedDate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "downloadUrl",
+            "columnName": "downloadUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcastUuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addedDate",
+            "columnName": "addedDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "episodeUuid",
+            "addedDate"
+          ]
+        }
+      },
+      {
+        "tableName": "user_notifications",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`notification_id` INTEGER NOT NULL, `sent_this_week` INTEGER NOT NULL, `last_sent_at` INTEGER NOT NULL, `interacted_at` INTEGER, PRIMARY KEY(`notification_id`))",
+        "fields": [
+          {
+            "fieldPath": "notificationId",
+            "columnName": "notification_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sentThisWeek",
+            "columnName": "sent_this_week",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSentAt",
+            "columnName": "last_sent_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "interactedAt",
+            "columnName": "interacted_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "notification_id"
+          ]
+        }
+      },
+      {
+        "tableName": "user_category_visits",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`category_id` INTEGER NOT NULL, `total_visits` INTEGER NOT NULL, PRIMARY KEY(`category_id`))",
+        "fields": [
+          {
+            "fieldPath": "categoryId",
+            "columnName": "category_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalVisits",
+            "columnName": "total_visits",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "category_id"
+          ]
+        }
+      },
+      {
+        "tableName": "manual_playlist_episodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_uuid` TEXT NOT NULL, `episode_uuid` TEXT NOT NULL, `podcast_uuid` TEXT NOT NULL, `title` TEXT NOT NULL, `added_at` INTEGER NOT NULL, `published_at` INTEGER NOT NULL, `download_url` TEXT, `episode_slug` TEXT NOT NULL, `podcast_slug` TEXT NOT NULL, `sort_position` INTEGER NOT NULL, `is_synced` INTEGER NOT NULL, `clean_title` TEXT NOT NULL, PRIMARY KEY(`playlist_uuid`, `episode_uuid`))",
+        "fields": [
+          {
+            "fieldPath": "playlistUuid",
+            "columnName": "playlist_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeUuid",
+            "columnName": "episode_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcast_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publishedAt",
+            "columnName": "published_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadUrl",
+            "columnName": "download_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "episodeSlug",
+            "columnName": "episode_slug",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastSlug",
+            "columnName": "podcast_slug",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortPosition",
+            "columnName": "sort_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSynced",
+            "columnName": "is_synced",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cleanTitle",
+            "columnName": "clean_title",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_uuid",
+            "episode_uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "manual_playlist_episodes_playlist_uuid_index",
+            "unique": false,
+            "columnNames": [
+              "playlist_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `manual_playlist_episodes_playlist_uuid_index` ON `${TABLE_NAME}` (`playlist_uuid`)"
+          },
+          {
+            "name": "manual_playlist_episodes_episode_uuid_index",
+            "unique": false,
+            "columnNames": [
+              "episode_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `manual_playlist_episodes_episode_uuid_index` ON `${TABLE_NAME}` (`episode_uuid`)"
+          },
+          {
+            "name": "manual_playlist_episodes_podcast_uuid_index",
+            "unique": false,
+            "columnNames": [
+              "podcast_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `manual_playlist_episodes_podcast_uuid_index` ON `${TABLE_NAME}` (`podcast_uuid`)"
+          },
+          {
+            "name": "manual_playlist_episodes_playlist_uuid_is_synced_index",
+            "unique": false,
+            "columnNames": [
+              "playlist_uuid",
+              "is_synced"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `manual_playlist_episodes_playlist_uuid_is_synced_index` ON `${TABLE_NAME}` (`playlist_uuid`, `is_synced`)"
+          }
+        ]
+      },
+      {
+        "tableName": "blaze_ads",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `text` TEXT NOT NULL, `image_url` TEXT NOT NULL, `url_title` TEXT NOT NULL, `url` TEXT NOT NULL, `location` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "image_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "urlTitle",
+            "columnName": "url_title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "location",
+            "columnName": "location",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "playback_stats_events",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `episode_uuid` TEXT NOT NULL, `podcast_uuid` TEXT NOT NULL, `episode_title` TEXT NOT NULL, `podcast_title` TEXT NOT NULL, `podcast_category` TEXT NOT NULL, `started_at_ms` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `is_synced` INTEGER NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeUuid",
+            "columnName": "episode_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcast_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeTitle",
+            "columnName": "episode_title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastTitle",
+            "columnName": "podcast_title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastCategory",
+            "columnName": "podcast_category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAtMs",
+            "columnName": "started_at_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSynced",
+            "columnName": "is_synced",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "playback_stats_events_started_at_ms",
+            "unique": false,
+            "columnNames": [
+              "started_at_ms"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `playback_stats_events_started_at_ms` ON `${TABLE_NAME}` (`started_at_ms`)"
+          },
+          {
+            "name": "playback_stats_events_podcast_uuid",
+            "unique": false,
+            "columnNames": [
+              "podcast_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `playback_stats_events_podcast_uuid` ON `${TABLE_NAME}` (`podcast_uuid`)"
+          },
+          {
+            "name": "playback_stats_events_podcast_category",
+            "unique": false,
+            "columnNames": [
+              "podcast_category"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `playback_stats_events_podcast_category` ON `${TABLE_NAME}` (`podcast_category`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'b328a095769b3a934bb55b075b20d83a')"
+    ]
+  }
+}

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabase.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabase.kt
@@ -1421,7 +1421,7 @@ abstract class AppDatabase : RoomDatabase() {
             database.execSQL(
                 """
                     CREATE TABLE playback_stats_events (
-                        uuid TEXT PRIMARY_KEY NOT NULL,
+                        uuid TEXT PRIMARY KEY NOT NULL,
                         episode_uuid TEXT NOT NULL,
                         podcast_uuid TEXT NOT NULL,
                         episode_title TEXT NOT NULL,

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabase.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabase.kt
@@ -1433,7 +1433,7 @@ abstract class AppDatabase : RoomDatabase() {
                     );
                 """.trimIndent(),
             )
-            database.execSQL("CREATE INDEX playback_stats_events_started_at_ms ON smart_playlists(started_at_ms)")
+            database.execSQL("CREATE INDEX playback_stats_events_started_at_ms ON playback_stats_events(started_at_ms)")
             database.execSQL("CREATE INDEX playback_stats_events_podcast_uuid ON playback_stats_events(podcast_uuid)")
             database.execSQL("CREATE INDEX playback_stats_events_podcast_category ON playback_stats_events(podcast_category)")
         }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabase.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabase.kt
@@ -43,6 +43,7 @@ import au.com.shiftyjelly.pocketcasts.models.db.dao.EndOfYearDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.EpisodeDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.ExternalDataDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.FolderDao
+import au.com.shiftyjelly.pocketcasts.models.db.dao.PlaybackStatsDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.PlaylistDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.PodcastDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.PodcastRatingsDao
@@ -62,6 +63,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.ChapterIndices
 import au.com.shiftyjelly.pocketcasts.models.entity.CuratedPodcast
 import au.com.shiftyjelly.pocketcasts.models.entity.Folder
 import au.com.shiftyjelly.pocketcasts.models.entity.ManualPlaylistEpisode
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaybackStatsEvent
 import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
@@ -106,8 +108,9 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
         UserCategoryVisits::class,
         ManualPlaylistEpisode::class,
         BlazeAd::class,
+        PlaybackStatsEvent::class,
     ],
-    version = 125,
+    version = 126,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 81, to = 82, spec = AppDatabase.Companion.DeleteSilenceRemovedMigration::class),
@@ -159,6 +162,7 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun userNotificationsDao(): UserNotificationsDao
     abstract fun userCategoryVisitsDao(): UserCategoryVisitsDao
     abstract fun blazeAdDao(): BlazeAdDao
+    abstract fun playbackStatsDao(): PlaybackStatsDao
 
     fun databaseFiles() = openHelper.readableDatabase.path?.let {
         listOf(
@@ -1413,6 +1417,27 @@ abstract class AppDatabase : RoomDatabase() {
             database.execSQL("ALTER TABLE podcast_episodes ADD COLUMN has_generated_transcript INTEGER NOT NULL DEFAULT 0")
         }
 
+        val MIGRATION_125_126 = addMigration(125, 126) { database ->
+            database.execSQL(
+                """
+                    CREATE TABLE playback_stats_events (
+                        uuid TEXT PRIMARY_KEY NOT NULL,
+                        episode_uuid TEXT NOT NULL,
+                        podcast_uuid TEXT NOT NULL,
+                        episode_title TEXT NOT NULL,
+                        podcast_title TEXT NOT NULL,
+                        podcast_category TEXT NOT NULL,
+                        started_at_ms INTEGER NOT NULL,
+                        duration_ms INTEGER NOT NULL,
+                        is_synced INTEGER NOT NULL
+                    );
+                """.trimIndent(),
+            )
+            database.execSQL("CREATE INDEX playback_stats_events_started_at_ms ON smart_playlists(started_at_ms)")
+            database.execSQL("CREATE INDEX playback_stats_events_podcast_uuid ON playback_stats_events(podcast_uuid)")
+            database.execSQL("CREATE INDEX playback_stats_events_podcast_category ON playback_stats_events(podcast_category)")
+        }
+
         fun addMigrations(databaseBuilder: Builder<AppDatabase>, context: Context) {
             databaseBuilder.addMigrations(
                 addMigration(1, 2) { },
@@ -1828,6 +1853,7 @@ abstract class AppDatabase : RoomDatabase() {
                 MIGRATION_122_123,
                 MIGRATION_123_124,
                 MIGRATION_124_125,
+                MIGRATION_125_126,
             )
         }
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabase.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabase.kt
@@ -1424,18 +1424,12 @@ abstract class AppDatabase : RoomDatabase() {
                         uuid TEXT PRIMARY KEY NOT NULL,
                         episode_uuid TEXT NOT NULL,
                         podcast_uuid TEXT NOT NULL,
-                        episode_title TEXT NOT NULL,
-                        podcast_title TEXT NOT NULL,
-                        podcast_category TEXT NOT NULL,
                         started_at_ms INTEGER NOT NULL,
-                        duration_ms INTEGER NOT NULL,
-                        is_synced INTEGER NOT NULL
+                        duration_ms INTEGER NOT NULL
                     );
                 """.trimIndent(),
             )
             database.execSQL("CREATE INDEX playback_stats_events_started_at_ms ON playback_stats_events(started_at_ms)")
-            database.execSQL("CREATE INDEX playback_stats_events_podcast_uuid ON playback_stats_events(podcast_uuid)")
-            database.execSQL("CREATE INDEX playback_stats_events_podcast_category ON playback_stats_events(podcast_category)")
         }
 
         fun addMigrations(databaseBuilder: Builder<AppDatabase>, context: Context) {

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaybackStatsDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaybackStatsDao.kt
@@ -1,0 +1,12 @@
+package au.com.shiftyjelly.pocketcasts.models.db.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaybackStatsEvent
+
+@Dao
+abstract class PlaybackStatsDao {
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    abstract suspend fun insertOrIgnore(events: Collection<PlaybackStatsEvent>)
+}

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/di/ModelModule.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/di/ModelModule.kt
@@ -8,6 +8,7 @@ import au.com.shiftyjelly.pocketcasts.models.db.dao.ChapterDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.EndOfYearDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.EpisodeDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.ExternalDataDao
+import au.com.shiftyjelly.pocketcasts.models.db.dao.PlaybackStatsDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.PlaylistDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.PodcastDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.TranscriptDao
@@ -79,6 +80,9 @@ object ModelModule {
 
     @Provides
     fun userCategoryVisits(database: AppDatabase): UserCategoryVisitsDao = database.userCategoryVisitsDao()
+
+    @Provides
+    fun playbackStatsDao(database: AppDatabase): PlaybackStatsDao = database.playbackStatsDao()
 }
 
 @Qualifier

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/PlaybackStatsEvent.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/PlaybackStatsEvent.kt
@@ -1,0 +1,26 @@
+package au.com.shiftyjelly.pocketcasts.models.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "playback_stats_events",
+    indices = [
+        Index(value = ["started_at_ms"], name = "playback_stats_events_started_at_ms"),
+        Index(value = ["podcast_uuid"], name = "playback_stats_events_podcast_uuid"),
+        Index(value = ["podcast_category"], name = "playback_stats_events_podcast_category"),
+    ],
+)
+data class PlaybackStatsEvent(
+    @PrimaryKey @ColumnInfo(name = "uuid") val uuid: String,
+    @ColumnInfo(name = "episode_uuid") val episodeUuid: String,
+    @ColumnInfo(name = "podcast_uuid") val podcastUuid: String,
+    @ColumnInfo(name = "episode_title") val episodeTitle: String,
+    @ColumnInfo(name = "podcast_title") val podcastTitle: String,
+    @ColumnInfo(name = "podcast_category") val podcastCategory: String,
+    @ColumnInfo(name = "started_at_ms") val startedAtMs: Long,
+    @ColumnInfo(name = "duration_ms") val durationMs: Long,
+    @ColumnInfo(name = "is_synced") val isSynced: Boolean,
+)

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/PlaybackStatsEvent.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/PlaybackStatsEvent.kt
@@ -9,18 +9,12 @@ import androidx.room.PrimaryKey
     tableName = "playback_stats_events",
     indices = [
         Index(value = ["started_at_ms"], name = "playback_stats_events_started_at_ms"),
-        Index(value = ["podcast_uuid"], name = "playback_stats_events_podcast_uuid"),
-        Index(value = ["podcast_category"], name = "playback_stats_events_podcast_category"),
     ],
 )
 data class PlaybackStatsEvent(
     @PrimaryKey @ColumnInfo(name = "uuid") val uuid: String,
     @ColumnInfo(name = "episode_uuid") val episodeUuid: String,
     @ColumnInfo(name = "podcast_uuid") val podcastUuid: String,
-    @ColumnInfo(name = "episode_title") val episodeTitle: String,
-    @ColumnInfo(name = "podcast_title") val podcastTitle: String,
-    @ColumnInfo(name = "podcast_category") val podcastCategory: String,
     @ColumnInfo(name = "started_at_ms") val startedAtMs: Long,
     @ColumnInfo(name = "duration_ms") val durationMs: Long,
-    @ColumnInfo(name = "is_synced") val isSynced: Boolean,
 )

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/RepositoryModule.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/RepositoryModule.kt
@@ -63,6 +63,8 @@ import au.com.shiftyjelly.pocketcasts.repositories.search.ImprovedSearchManager
 import au.com.shiftyjelly.pocketcasts.repositories.search.ImprovedSearchManagerImpl
 import au.com.shiftyjelly.pocketcasts.repositories.searchhistory.SearchHistoryManager
 import au.com.shiftyjelly.pocketcasts.repositories.searchhistory.SearchHistoryManagerImpl
+import au.com.shiftyjelly.pocketcasts.repositories.stats.PersistentPlaybackStatsCollector
+import au.com.shiftyjelly.pocketcasts.repositories.stats.PlaybackStatsCollector
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.ServerPurchaseApprover
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManagerImpl
@@ -249,6 +251,9 @@ abstract class RepositoryModule {
 
     @Binds
     abstract fun provideDownloadStatusObserver(manager: DownloadManager): DownloadStatusObserver
+
+    @Binds
+    abstract fun providePlaybackStatsCollector(collector: PersistentPlaybackStatsCollector): PlaybackStatsCollector
 
     companion object {
         @Provides

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CastPlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CastPlayer.kt
@@ -169,6 +169,7 @@ class CastPlayer(
             remoteListenerAdded = false
             remoteMediaClient?.unregisterCallback(remoteMediaClientListener)
             remoteMediaClient?.unregisterCallback(playPauseCallback)
+            playbackStatsCollector.onStop()
         }
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CastPlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CastPlayer.kt
@@ -1,6 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.repositories.playback
 
-import android.content.Context
 import android.net.Uri
 import android.text.TextUtils
 import androidx.annotation.OptIn
@@ -12,6 +11,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.PlaybackEffects
 import au.com.shiftyjelly.pocketcasts.models.type.UserEpisodeServerStatus
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.getArtworkUrl
+import au.com.shiftyjelly.pocketcasts.repositories.stats.PlaybackStatsCollector
 import com.google.android.gms.cast.MediaInfo
 import com.google.android.gms.cast.MediaLoadOptions
 import com.google.android.gms.cast.MediaMetadata
@@ -28,7 +28,10 @@ import org.json.JSONException
 import org.json.JSONObject
 import timber.log.Timber
 
-class CastPlayer(val context: Context, override val onPlayerEvent: (Player, PlayerEvent) -> Unit) : Player {
+class CastPlayer(
+    private val playbackStatsCollector: PlaybackStatsCollector,
+    override val onPlayerEvent: (Player, PlayerEvent) -> Unit,
+) : Player {
 
     private enum class CastPlaybackState { NONE, STOPPED, BUFFERING, PLAYING, PAUSED }
 
@@ -40,6 +43,7 @@ class CastPlayer(val context: Context, override val onPlayerEvent: (Player, Play
     private var remoteEpisodeUuid: String? = null
     private var playbackEffects: PlaybackEffects? = null
     private val remoteMediaClientListener = RemoteMediaClientListener()
+    private val playPauseCallback = PlayPauseCallback(playbackStatsCollector, currentClient = { remoteMediaClient })
 
     override var isPip: Boolean = false
 
@@ -164,6 +168,7 @@ class CastPlayer(val context: Context, override val onPlayerEvent: (Player, Play
             state = CastPlaybackState.STOPPED
             remoteListenerAdded = false
             remoteMediaClient?.unregisterCallback(remoteMediaClientListener)
+            remoteMediaClient?.unregisterCallback(playPauseCallback)
         }
     }
 
@@ -242,6 +247,7 @@ class CastPlayer(val context: Context, override val onPlayerEvent: (Player, Play
         }
         remoteListenerAdded = true
         remoteMediaClient?.registerCallback(remoteMediaClientListener)
+        remoteMediaClient?.registerCallback(playPauseCallback)
     }
 
     private fun loadEpisode(episodeUuid: String, currentPositionMs: Int, autoPlay: Boolean) {
@@ -420,5 +426,19 @@ class CastPlayer(val context: Context, override val onPlayerEvent: (Player, Play
 
     companion object {
         private const val CUSTOM_DATA_EPISODE_UUID = "EPISODE_UUID"
+    }
+}
+
+private class PlayPauseCallback(
+    private val statsCollector: PlaybackStatsCollector,
+    private val currentClient: () -> RemoteMediaClient?,
+) : RemoteMediaClient.Callback() {
+    override fun onStatusUpdated() {
+        val playerState = currentClient()?.playerState ?: return
+        if (playerState == MediaStatus.PLAYER_STATE_PLAYING) {
+            statsCollector.onStart()
+        } else {
+            statsCollector.onStop()
+        }
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayerFactoryImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayerFactoryImpl.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.repositories.playback
 
 import android.content.Context
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.stats.PlaybackStatsCollector
 import au.com.shiftyjelly.pocketcasts.repositories.user.StatsManager
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
@@ -9,18 +10,26 @@ import javax.inject.Inject
 class PlayerFactoryImpl @Inject constructor(
     private val settings: Settings,
     private val statsManager: StatsManager,
+    private val playbackStatsCollector: PlaybackStatsCollector,
     private val dataSourceFactory: ExoPlayerDataSourceFactory,
     @ApplicationContext private val context: Context,
 ) : PlayerFactory {
 
     override fun createCastPlayer(onPlayerEvent: (Player, PlayerEvent) -> Unit): Player {
         return CastPlayer(
-            context,
-            onPlayerEvent,
+            playbackStatsCollector = playbackStatsCollector,
+            onPlayerEvent = onPlayerEvent,
         )
     }
 
     override fun createSimplePlayer(onPlayerEvent: (Player, PlayerEvent) -> Unit): Player {
-        return SimplePlayer(settings, statsManager, context, dataSourceFactory, onPlayerEvent)
+        return SimplePlayer(
+            settings = settings,
+            statsManager = statsManager,
+            playbackStatsCollector = playbackStatsCollector,
+            context = context,
+            dataSourceFactory = dataSourceFactory,
+            onPlayerEvent = onPlayerEvent,
+        )
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -22,6 +22,7 @@ import androidx.media3.ui.WearUnsuitableOutputPlaybackSuppressionResolverListene
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.PlaybackEffects
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.stats.PlaybackStatsCollector
 import au.com.shiftyjelly.pocketcasts.repositories.user.StatsManager
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
@@ -31,9 +32,10 @@ import kotlinx.coroutines.withContext
 import timber.log.Timber
 
 class SimplePlayer(
-    val settings: Settings,
-    val statsManager: StatsManager,
-    val context: Context,
+    private val settings: Settings,
+    private val statsManager: StatsManager,
+    private val playbackStatsCollector: PlaybackStatsCollector,
+    private val context: Context,
     private val dataSourceFactory: ExoPlayerDataSourceFactory,
     override val onPlayerEvent: (au.com.shiftyjelly.pocketcasts.repositories.playback.Player, PlayerEvent) -> Unit,
 ) : LocalPlayer(onPlayerEvent) {
@@ -210,6 +212,7 @@ class SimplePlayer(
             .setSeekBackIncrementMs(settings.skipBackInSecs.value * 1000L)
             .build()
         player.addListener(WearUnsuitableOutputPlaybackSuppressionResolverListener(context))
+        player.addListener(PlayPauseListener(playbackStatsCollector))
         player.addAnalyticsListener(renderer)
 
         handleStop()
@@ -340,5 +343,17 @@ class SimplePlayer(
             it.setBoostVolume(playbackEffects.isVolumeBoosted)
         }
         player.playbackParameters = PlaybackParameters(playbackEffects.playbackSpeed.toFloat(), 1f)
+    }
+}
+
+private class PlayPauseListener(
+    private val statsCollector: PlaybackStatsCollector,
+) : Player.Listener {
+    override fun onEvents(player: Player, events: Player.Events) {
+        if (player.isPlaying) {
+            statsCollector.onStart()
+        } else {
+            statsCollector.onStop()
+        }
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/stats/PlaybackStatsCollector.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/stats/PlaybackStatsCollector.kt
@@ -1,0 +1,142 @@
+package au.com.shiftyjelly.pocketcasts.repositories.stats
+
+import androidx.collection.LruCache
+import au.com.shiftyjelly.pocketcasts.coroutines.di.ApplicationScope
+import au.com.shiftyjelly.pocketcasts.models.db.dao.PlaybackStatsDao
+import au.com.shiftyjelly.pocketcasts.models.db.dao.PodcastDao
+import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaybackStatsEvent
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
+import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
+import au.com.shiftyjelly.pocketcasts.utils.UUIDProvider
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import java.util.UUID
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
+
+interface PlaybackStatsCollector {
+    fun onStart()
+    fun onStop()
+}
+
+@Singleton
+class PersistentPlaybackStatsCollector @Inject constructor(
+    private val queue: UpNextQueue,
+    private val podcastDao: PodcastDao,
+    private val playbackStatsDao: PlaybackStatsDao,
+    private val clock: Clock,
+    private val uuidProvider: UUIDProvider,
+    @ApplicationScope private val scope: CoroutineScope,
+) : PlaybackStatsCollector {
+    private val stateLock = Any()
+    private val podcastCache = LruCache<String, Podcast>(maxSize = 20)
+
+    private var isPlaying = false
+    private var deferredPartialEvent: Deferred<PartialStatsEvent?>? = null
+
+    override fun onStart() {
+        val startedAt = clock.instant()
+        synchronized(stateLock) {
+            val episode = queue.currentEpisode ?: return
+            if (isPlaying) {
+                return
+            }
+            isPlaying = true
+
+            deferredPartialEvent = scope.async {
+                val podcast = podcastCache[episode.podcastOrSubstituteUuid] ?: findPodcast(episode)
+                podcast?.let {
+                    podcastCache.put(podcast.uuid, podcast)
+                    PartialStatsEvent(episode, podcast, startedAt)
+                }
+            }
+        }
+    }
+
+    override fun onStop() {
+        val endedAt = clock.instant()
+        val partialEvent = synchronized(stateLock) {
+            if (!isPlaying) {
+                return
+            }
+            isPlaying = false
+
+            deferredPartialEvent.also { deferredPartialEvent = null }
+        }
+
+        scope.launch {
+            val events = partialEvent?.await()?.toEvents(endedAt, clock, uuidProvider).orEmpty()
+            if (events.isNotEmpty()) {
+                playbackStatsDao.insertOrIgnore(events)
+            }
+        }
+    }
+
+    private suspend fun findPodcast(episode: BaseEpisode): Podcast? {
+        return when (episode) {
+            is PodcastEpisode -> podcastDao.findPodcastByUuid(episode.podcastUuid)
+            is UserEpisode -> Podcast.userPodcast
+        }
+    }
+}
+
+private class PartialStatsEvent(
+    val episode: BaseEpisode,
+    val podcast: Podcast,
+    val createdAt: Instant,
+) {
+    fun toEvents(endedAt: Instant, clock: Clock, uuidProvider: UUIDProvider): List<PlaybackStatsEvent> {
+        if (endedAt <= createdAt) {
+            return emptyList()
+        }
+        return split(createdAt, endedAt, clock.zone, uuidProvider)
+    }
+
+    private tailrec fun split(
+        startedAt: Instant,
+        endedAt: Instant,
+        zone: ZoneId,
+        uuidProvider: UUIDProvider,
+        events: MutableList<PlaybackStatsEvent> = mutableListOf(),
+    ): List<PlaybackStatsEvent> {
+        val segmentEnd = minOf(endedAt, startedAt.nextDayStart(zone))
+        events += createEvent(uuidProvider.generateUUID(), startedAt, segmentEnd)
+        return if (segmentEnd >= endedAt) {
+            events
+        } else {
+            split(segmentEnd, endedAt, zone, uuidProvider, events)
+        }
+    }
+
+    private fun createEvent(
+        uuid: UUID,
+        startedAt: Instant,
+        endedAt: Instant,
+    ) = PlaybackStatsEvent(
+        uuid = uuid.toString(),
+        episodeUuid = episode.uuid,
+        podcastUuid = podcast.uuid,
+        episodeTitle = episode.title,
+        podcastTitle = podcast.title,
+        podcastCategory = podcast.getFirstCategoryUnlocalised(),
+        startedAtMs = startedAt.toEpochMilli(),
+        durationMs = endedAt.toEpochMilli() - startedAt.toEpochMilli(),
+        isSynced = false,
+    )
+
+    private fun Instant.nextDayStart(zone: ZoneId): Instant {
+        return this.atZone(zone)
+            .toLocalDate()
+            .plusDays(1)
+            .atStartOfDay(zone)
+            .toInstant()
+    }
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/stats/PlaybackStatsCollector.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/stats/PlaybackStatsCollector.kt
@@ -1,14 +1,9 @@
 package au.com.shiftyjelly.pocketcasts.repositories.stats
 
-import androidx.collection.LruCache
 import au.com.shiftyjelly.pocketcasts.coroutines.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.models.db.dao.PlaybackStatsDao
-import au.com.shiftyjelly.pocketcasts.models.db.dao.PodcastDao
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PlaybackStatsEvent
-import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
-import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
-import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.utils.UUIDProvider
 import java.time.Clock
@@ -18,8 +13,6 @@ import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 
 interface PlaybackStatsCollector {
@@ -30,67 +23,48 @@ interface PlaybackStatsCollector {
 @Singleton
 class PersistentPlaybackStatsCollector @Inject constructor(
     private val queue: UpNextQueue,
-    private val podcastDao: PodcastDao,
     private val playbackStatsDao: PlaybackStatsDao,
     private val clock: Clock,
     private val uuidProvider: UUIDProvider,
     @ApplicationScope private val scope: CoroutineScope,
 ) : PlaybackStatsCollector {
     private val stateLock = Any()
-    private val podcastCache = LruCache<String, Podcast>(maxSize = 20)
-
     private var isPlaying = false
-    private var deferredPartialEvent: Deferred<PartialStatsEvent?>? = null
+    private var partialEvent: PartialStatsEvent? = null
 
     override fun onStart() {
         val startedAt = clock.instant()
+        val episode = queue.currentEpisode ?: return
         synchronized(stateLock) {
-            val episode = queue.currentEpisode ?: return
             if (isPlaying) {
                 return
             }
             isPlaying = true
 
-            deferredPartialEvent = scope.async {
-                val podcast = podcastCache[episode.podcastOrSubstituteUuid] ?: findPodcast(episode)
-                podcast?.let {
-                    podcastCache.put(podcast.uuid, podcast)
-                    PartialStatsEvent(episode, podcast, startedAt)
-                }
-            }
+            partialEvent = PartialStatsEvent(episode, startedAt)
         }
     }
 
     override fun onStop() {
         val endedAt = clock.instant()
-        val partialEvent = synchronized(stateLock) {
+        val events = synchronized(stateLock) {
             if (!isPlaying) {
                 return
             }
             isPlaying = false
 
-            deferredPartialEvent.also { deferredPartialEvent = null }
+            partialEvent?.toEvents(endedAt, clock, uuidProvider).also { partialEvent = null }
         }
-
-        scope.launch {
-            val events = partialEvent?.await()?.toEvents(endedAt, clock, uuidProvider).orEmpty()
-            if (events.isNotEmpty()) {
+        if (!events.isNullOrEmpty()) {
+            scope.launch {
                 playbackStatsDao.insertOrIgnore(events)
             }
-        }
-    }
-
-    private suspend fun findPodcast(episode: BaseEpisode): Podcast? {
-        return when (episode) {
-            is PodcastEpisode -> podcastDao.findPodcastByUuid(episode.podcastUuid)
-            is UserEpisode -> Podcast.userPodcast
         }
     }
 }
 
 private class PartialStatsEvent(
     val episode: BaseEpisode,
-    val podcast: Podcast,
     val createdAt: Instant,
 ) {
     fun toEvents(endedAt: Instant, clock: Clock, uuidProvider: UUIDProvider): List<PlaybackStatsEvent> {
@@ -123,13 +97,9 @@ private class PartialStatsEvent(
     ) = PlaybackStatsEvent(
         uuid = uuid.toString(),
         episodeUuid = episode.uuid,
-        podcastUuid = podcast.uuid,
-        episodeTitle = episode.title,
-        podcastTitle = podcast.title,
-        podcastCategory = podcast.getFirstCategoryUnlocalised(),
+        podcastUuid = episode.podcastOrSubstituteUuid,
         startedAtMs = startedAt.toEpochMilli(),
         durationMs = endedAt.toEpochMilli() - startedAt.toEpochMilli(),
-        isSynced = false,
     )
 
     private fun Instant.nextDayStart(zone: ZoneId): Instant {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/stats/PlaybackStatsCollector.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/stats/PlaybackStatsCollector.kt
@@ -74,19 +74,27 @@ private class PartialStatsEvent(
         return split(createdAt, endedAt, clock.zone, uuidProvider)
     }
 
-    private tailrec fun split(
+    /**
+     * Splits a session into one event per UTC based calendar day, cutting each
+     * segment at the next midnight until the play session ends
+     */
+    private fun split(
         startedAt: Instant,
         endedAt: Instant,
         zone: ZoneId,
         uuidProvider: UUIDProvider,
-        events: MutableList<PlaybackStatsEvent> = mutableListOf(),
     ): List<PlaybackStatsEvent> {
-        val segmentEnd = minOf(endedAt, startedAt.nextDayStart(zone))
-        events += createEvent(uuidProvider.generateUUID(), startedAt, segmentEnd)
-        return if (segmentEnd >= endedAt) {
-            events
-        } else {
-            split(segmentEnd, endedAt, zone, uuidProvider, events)
+        return buildList {
+            var segmentStart = startedAt
+            while (true) {
+                val segmentEnd = minOf(endedAt, segmentStart.nextDayStart(zone))
+                add(createEvent(uuidProvider.generateUUID(), segmentStart, segmentEnd))
+
+                if (segmentEnd >= endedAt) {
+                    break
+                }
+                segmentStart = segmentEnd
+            }
         }
     }
 

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/stats/PlaybackStatsCollectorTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/stats/PlaybackStatsCollectorTest.kt
@@ -1,7 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.repositories.stats
 
 import au.com.shiftyjelly.pocketcasts.models.db.dao.PlaybackStatsDao
-import au.com.shiftyjelly.pocketcasts.models.db.dao.PodcastDao
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PlaybackStatsEvent
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/stats/PlaybackStatsCollectorTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/stats/PlaybackStatsCollectorTest.kt
@@ -52,9 +52,6 @@ class PlaybackStatsCollectorTest {
         queue = mock<UpNextQueue> {
             on { currentEpisode } doAnswer { episode }
         },
-        podcastDao = mock<PodcastDao> {
-            on { findPodcastByUuid(any()) } doAnswer { podcast }
-        },
         playbackStatsDao = mock<PlaybackStatsDao> {
             on { insertOrIgnore(any()) } doAnswer { invocation ->
                 @Suppress("UNCHECKED_CAST")
@@ -112,9 +109,6 @@ class PlaybackStatsCollectorTest {
                     durationMs = 10.minutes.inWholeMilliseconds,
                     episodeUuid = "user-episode-id",
                     podcastUuid = Podcast.userPodcast.uuid,
-                    episodeTitle = "User episode title",
-                    podcastTitle = Podcast.userPodcast.title,
-                    podcastCategory = Podcast.userPodcast.getFirstCategoryUnlocalised(),
                 ),
             ),
             storedEvents,
@@ -145,48 +139,6 @@ class PlaybackStatsCollectorTest {
                     uuidIndex = 1,
                     startedAtMs = 24.hours.inWholeMilliseconds,
                     durationMs = 1.seconds.inWholeMilliseconds,
-                ),
-            ),
-            storedEvents,
-        )
-    }
-
-    @Test
-    fun `reuse cached podcast across playback sessions`() = testScope.runTest {
-        episode = createPodcastEpisode()
-        podcast = createPodcast()
-
-        collector.onStart()
-        runCurrent()
-
-        clock += 10.seconds
-        collector.onStop()
-        runCurrent()
-
-        episode = createPodcastEpisode(uuid = "episode-id-2", title = "Episode title 2")
-        podcast = null
-
-        clock += 5.seconds
-        collector.onStart()
-        runCurrent()
-
-        clock += 20.seconds
-        collector.onStop()
-        runCurrent()
-
-        assertEquals(
-            listOf(
-                expectedEvent(
-                    uuidIndex = 0,
-                    startedAtMs = 0,
-                    durationMs = 10.seconds.inWholeMilliseconds,
-                ),
-                expectedEvent(
-                    uuidIndex = 1,
-                    episodeUuid = "episode-id-2",
-                    episodeTitle = "Episode title 2",
-                    startedAtMs = 15.seconds.inWholeMilliseconds,
-                    durationMs = 20.seconds.inWholeMilliseconds,
                 ),
             ),
             storedEvents,
@@ -251,32 +203,24 @@ class PlaybackStatsCollectorTest {
 
     private fun createPodcastEpisode(
         uuid: String = "episode-id",
-        title: String = "Episode title",
         podcastUuid: String = "podcast-id",
     ) = PodcastEpisode(
         uuid = uuid,
-        title = title,
         podcastUuid = podcastUuid,
         publishedDate = Date(),
     )
 
     private fun createUserEpisode(
         uuid: String = "user-episode-id",
-        title: String = "User episode title",
     ) = UserEpisode(
         uuid = uuid,
-        title = title,
         publishedDate = Date(),
     )
 
     private fun createPodcast(
         uuid: String = "podcast-id",
-        title: String = "Podcast title",
-        category: String = "Podcast category",
     ) = Podcast(
         uuid = uuid,
-        title = title,
-        podcastCategory = category,
     )
 
     private fun expectedEvent(
@@ -285,18 +229,11 @@ class PlaybackStatsCollectorTest {
         durationMs: Long,
         episodeUuid: String = "episode-id",
         podcastUuid: String = "podcast-id",
-        episodeTitle: String = "Episode title",
-        podcastTitle: String = "Podcast title",
-        podcastCategory: String = "Podcast category",
     ) = PlaybackStatsEvent(
         uuid = uuidProvider.uuids[uuidIndex].toString(),
         episodeUuid = episodeUuid,
         podcastUuid = podcastUuid,
-        episodeTitle = episodeTitle,
-        podcastTitle = podcastTitle,
-        podcastCategory = podcastCategory,
         startedAtMs = startedAtMs,
         durationMs = durationMs,
-        isSynced = false,
     )
 }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/stats/PlaybackStatsCollectorTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/stats/PlaybackStatsCollectorTest.kt
@@ -30,8 +30,6 @@ import org.mockito.kotlin.mock
 class PlaybackStatsCollectorTest {
     private var episode: BaseEpisode? = null
 
-    private var podcast: Podcast? = null
-
     private val storedEvents = mutableListOf<PlaybackStatsEvent>()
 
     private val clock = MutableClock()
@@ -68,7 +66,6 @@ class PlaybackStatsCollectorTest {
     @Test
     fun `track podcast event`() = testScope.runTest {
         episode = createPodcastEpisode()
-        podcast = createPodcast()
 
         clock += 34.seconds
         collector.onStart()
@@ -117,7 +114,6 @@ class PlaybackStatsCollectorTest {
     @Test
     fun `save startedAtMs as epoch millis when clock zone is not UTC`() = testScope.runTest {
         episode = createPodcastEpisode()
-        podcast = createPodcast()
 
         val startedAt = Instant.parse("2026-01-01T13:14:15Z")
         clock.setInstant(startedAt)
@@ -144,7 +140,6 @@ class PlaybackStatsCollectorTest {
     @Test
     fun `split played event at midnight UTC`() = testScope.runTest {
         episode = createPodcastEpisode()
-        podcast = createPodcast()
 
         clock += 23.hours + 59.minutes + 59.seconds
         collector.onStart()
@@ -173,7 +168,6 @@ class PlaybackStatsCollectorTest {
     @Test
     fun `ignore repeated onStart while already playing`() = testScope.runTest {
         episode = createPodcastEpisode()
-        podcast = createPodcast()
 
         clock += 34.seconds
         collector.onStart()
@@ -200,7 +194,6 @@ class PlaybackStatsCollectorTest {
     @Test
     fun `ignore repeated onStop after playback ends`() = testScope.runTest {
         episode = createPodcastEpisode()
-        podcast = createPodcast()
 
         clock += 34.seconds
         collector.onStart()
@@ -239,12 +232,6 @@ class PlaybackStatsCollectorTest {
     ) = UserEpisode(
         uuid = uuid,
         publishedDate = Date(),
-    )
-
-    private fun createPodcast(
-        uuid: String = "podcast-id",
-    ) = Podcast(
-        uuid = uuid,
     )
 
     private fun expectedEvent(

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/stats/PlaybackStatsCollectorTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/stats/PlaybackStatsCollectorTest.kt
@@ -10,6 +10,8 @@ import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.sharedtest.MutableClock
 import au.com.shiftyjelly.pocketcasts.utils.UUIDProvider
+import java.time.Instant
+import java.time.ZoneId
 import java.util.Date
 import java.util.UUID
 import kotlin.time.Duration.Companion.hours
@@ -107,6 +109,33 @@ class PlaybackStatsCollectorTest {
                     durationMs = 10.minutes.inWholeMilliseconds,
                     episodeUuid = "user-episode-id",
                     podcastUuid = Podcast.userPodcast.uuid,
+                ),
+            ),
+            storedEvents,
+        )
+    }
+
+    @Test
+    fun `save startedAtMs as epoch millis when clock zone is not UTC`() = testScope.runTest {
+        episode = createPodcastEpisode()
+        podcast = createPodcast()
+
+        val startedAt = Instant.parse("2026-01-01T13:14:15Z")
+        clock.setInstant(startedAt)
+        clock.setZone(ZoneId.of("Australia/Sydney"))
+
+        collector.onStart()
+
+        clock += 10.minutes
+        collector.onStop()
+        runCurrent()
+
+        assertEquals(
+            listOf(
+                expectedEvent(
+                    uuidIndex = 0,
+                    startedAtMs = startedAt.toEpochMilli(),
+                    durationMs = 10.minutes.inWholeMilliseconds,
                 ),
             ),
             storedEvents,

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/stats/PlaybackStatsCollectorTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/stats/PlaybackStatsCollectorTest.kt
@@ -1,0 +1,302 @@
+package au.com.shiftyjelly.pocketcasts.repositories.stats
+
+import au.com.shiftyjelly.pocketcasts.models.db.dao.PlaybackStatsDao
+import au.com.shiftyjelly.pocketcasts.models.db.dao.PodcastDao
+import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaybackStatsEvent
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
+import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
+import au.com.shiftyjelly.pocketcasts.sharedtest.MutableClock
+import au.com.shiftyjelly.pocketcasts.utils.UUIDProvider
+import java.util.Date
+import java.util.UUID
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.mock
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PlaybackStatsCollectorTest {
+    private var episode: BaseEpisode? = null
+
+    private var podcast: Podcast? = null
+
+    private val storedEvents = mutableListOf<PlaybackStatsEvent>()
+
+    private val clock = MutableClock()
+
+    private val uuidProvider = object : UUIDProvider {
+        private val _uuids = mutableListOf<UUID>()
+        val uuids get() = _uuids.toList()
+
+        override fun generateUUID(): UUID {
+            val uuid = UUID.randomUUID()
+            _uuids.add(uuid)
+            return uuid
+        }
+    }
+
+    private val testScope = TestScope()
+
+    private val collector = PersistentPlaybackStatsCollector(
+        queue = mock<UpNextQueue> {
+            on { currentEpisode } doAnswer { episode }
+        },
+        podcastDao = mock<PodcastDao> {
+            on { findPodcastByUuid(any()) } doAnswer { podcast }
+        },
+        playbackStatsDao = mock<PlaybackStatsDao> {
+            on { insertOrIgnore(any()) } doAnswer { invocation ->
+                @Suppress("UNCHECKED_CAST")
+                storedEvents.addAll(invocation.arguments[0] as List<PlaybackStatsEvent>)
+                Unit
+            }
+        },
+        clock = clock,
+        uuidProvider = uuidProvider,
+        scope = testScope,
+    )
+
+    @Test
+    fun `track podcast event`() = testScope.runTest {
+        episode = createPodcastEpisode()
+        podcast = createPodcast()
+
+        clock += 34.seconds
+        collector.onStart()
+        runCurrent()
+
+        clock += 10.minutes
+        collector.onStop()
+        runCurrent()
+
+        assertEquals(
+            listOf(
+                expectedEvent(
+                    uuidIndex = 0,
+                    startedAtMs = 34.seconds.inWholeMilliseconds,
+                    durationMs = 10.minutes.inWholeMilliseconds,
+                ),
+            ),
+            storedEvents,
+        )
+    }
+
+    @Test
+    fun `track user event`() = testScope.runTest {
+        episode = createUserEpisode()
+
+        clock += 34.seconds
+        collector.onStart()
+        runCurrent()
+
+        clock += 10.minutes
+        collector.onStop()
+        runCurrent()
+
+        assertEquals(
+            listOf(
+                expectedEvent(
+                    uuidIndex = 0,
+                    startedAtMs = 34.seconds.inWholeMilliseconds,
+                    durationMs = 10.minutes.inWholeMilliseconds,
+                    episodeUuid = "user-episode-id",
+                    podcastUuid = Podcast.userPodcast.uuid,
+                    episodeTitle = "User episode title",
+                    podcastTitle = Podcast.userPodcast.title,
+                    podcastCategory = Podcast.userPodcast.getFirstCategoryUnlocalised(),
+                ),
+            ),
+            storedEvents,
+        )
+    }
+
+    @Test
+    fun `split played event at midnight UTC`() = testScope.runTest {
+        episode = createPodcastEpisode()
+        podcast = createPodcast()
+
+        clock += 23.hours + 59.minutes + 59.seconds
+        collector.onStart()
+        runCurrent()
+
+        clock += 2.seconds
+        collector.onStop()
+        runCurrent()
+
+        assertEquals(
+            listOf(
+                expectedEvent(
+                    uuidIndex = 0,
+                    startedAtMs = (23.hours + 59.minutes + 59.seconds).inWholeMilliseconds,
+                    durationMs = 1.seconds.inWholeMilliseconds,
+                ),
+                expectedEvent(
+                    uuidIndex = 1,
+                    startedAtMs = 24.hours.inWholeMilliseconds,
+                    durationMs = 1.seconds.inWholeMilliseconds,
+                ),
+            ),
+            storedEvents,
+        )
+    }
+
+    @Test
+    fun `reuse cached podcast across playback sessions`() = testScope.runTest {
+        episode = createPodcastEpisode()
+        podcast = createPodcast()
+
+        collector.onStart()
+        runCurrent()
+
+        clock += 10.seconds
+        collector.onStop()
+        runCurrent()
+
+        episode = createPodcastEpisode(uuid = "episode-id-2", title = "Episode title 2")
+        podcast = null
+
+        clock += 5.seconds
+        collector.onStart()
+        runCurrent()
+
+        clock += 20.seconds
+        collector.onStop()
+        runCurrent()
+
+        assertEquals(
+            listOf(
+                expectedEvent(
+                    uuidIndex = 0,
+                    startedAtMs = 0,
+                    durationMs = 10.seconds.inWholeMilliseconds,
+                ),
+                expectedEvent(
+                    uuidIndex = 1,
+                    episodeUuid = "episode-id-2",
+                    episodeTitle = "Episode title 2",
+                    startedAtMs = 15.seconds.inWholeMilliseconds,
+                    durationMs = 20.seconds.inWholeMilliseconds,
+                ),
+            ),
+            storedEvents,
+        )
+    }
+
+    @Test
+    fun `ignore repeated onStart while already playing`() = testScope.runTest {
+        episode = createPodcastEpisode()
+        podcast = createPodcast()
+
+        clock += 34.seconds
+        collector.onStart()
+
+        clock += 10.minutes
+        collector.onStart()
+        runCurrent()
+
+        clock += 5.minutes
+        collector.onStop()
+        runCurrent()
+
+        assertEquals(
+            listOf(
+                expectedEvent(
+                    uuidIndex = 0,
+                    startedAtMs = 34.seconds.inWholeMilliseconds,
+                    durationMs = 15.minutes.inWholeMilliseconds,
+                ),
+            ),
+            storedEvents,
+        )
+    }
+
+    @Test
+    fun `ignore repeated onStop after playback ends`() = testScope.runTest {
+        episode = createPodcastEpisode()
+        podcast = createPodcast()
+
+        clock += 34.seconds
+        collector.onStart()
+        runCurrent()
+
+        clock += 10.minutes
+        collector.onStop()
+
+        clock += 5.minutes
+        collector.onStop()
+        runCurrent()
+
+        assertEquals(
+            listOf(
+                expectedEvent(
+                    uuidIndex = 0,
+                    startedAtMs = 34.seconds.inWholeMilliseconds,
+                    durationMs = 10.minutes.inWholeMilliseconds,
+                ),
+            ),
+            storedEvents,
+        )
+    }
+
+    private fun createPodcastEpisode(
+        uuid: String = "episode-id",
+        title: String = "Episode title",
+        podcastUuid: String = "podcast-id",
+    ) = PodcastEpisode(
+        uuid = uuid,
+        title = title,
+        podcastUuid = podcastUuid,
+        publishedDate = Date(),
+    )
+
+    private fun createUserEpisode(
+        uuid: String = "user-episode-id",
+        title: String = "User episode title",
+    ) = UserEpisode(
+        uuid = uuid,
+        title = title,
+        publishedDate = Date(),
+    )
+
+    private fun createPodcast(
+        uuid: String = "podcast-id",
+        title: String = "Podcast title",
+        category: String = "Podcast category",
+    ) = Podcast(
+        uuid = uuid,
+        title = title,
+        podcastCategory = category,
+    )
+
+    private fun expectedEvent(
+        uuidIndex: Int,
+        startedAtMs: Long,
+        durationMs: Long,
+        episodeUuid: String = "episode-id",
+        podcastUuid: String = "podcast-id",
+        episodeTitle: String = "Episode title",
+        podcastTitle: String = "Podcast title",
+        podcastCategory: String = "Podcast category",
+    ) = PlaybackStatsEvent(
+        uuid = uuidProvider.uuids[uuidIndex].toString(),
+        episodeUuid = episodeUuid,
+        podcastUuid = podcastUuid,
+        episodeTitle = episodeTitle,
+        podcastTitle = podcastTitle,
+        podcastCategory = podcastCategory,
+        startedAtMs = startedAtMs,
+        durationMs = durationMs,
+        isSynced = false,
+    )
+}

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/stats/PlaybackStatsCollectorTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/stats/PlaybackStatsCollectorTest.kt
@@ -71,7 +71,6 @@ class PlaybackStatsCollectorTest {
 
         clock += 34.seconds
         collector.onStart()
-        runCurrent()
 
         clock += 10.minutes
         collector.onStop()
@@ -95,7 +94,6 @@ class PlaybackStatsCollectorTest {
 
         clock += 34.seconds
         collector.onStart()
-        runCurrent()
 
         clock += 10.minutes
         collector.onStop()
@@ -122,7 +120,6 @@ class PlaybackStatsCollectorTest {
 
         clock += 23.hours + 59.minutes + 59.seconds
         collector.onStart()
-        runCurrent()
 
         clock += 2.seconds
         collector.onStop()
@@ -155,7 +152,6 @@ class PlaybackStatsCollectorTest {
 
         clock += 10.minutes
         collector.onStart()
-        runCurrent()
 
         clock += 5.minutes
         collector.onStop()
@@ -180,10 +176,10 @@ class PlaybackStatsCollectorTest {
 
         clock += 34.seconds
         collector.onStart()
-        runCurrent()
 
         clock += 10.minutes
         collector.onStop()
+        runCurrent()
 
         clock += 5.minutes
         collector.onStop()

--- a/modules/services/sharedtest/src/main/java/au/com/shiftyjelly/pocketcasts/sharedtest/MutableClock.kt
+++ b/modules/services/sharedtest/src/main/java/au/com/shiftyjelly/pocketcasts/sharedtest/MutableClock.kt
@@ -7,13 +7,21 @@ import kotlin.time.Duration
 
 class MutableClock(
     private var instant: Instant = Instant.EPOCH,
-    private val zoneId: ZoneId = ZoneId.of("UTC"),
+    private var zoneId: ZoneId = ZoneId.of("UTC"),
 ) : Clock() {
     override fun instant() = instant
 
     override fun getZone() = zoneId
 
     override fun withZone(zone: ZoneId) = MutableClock(instant, zone)
+
+    fun setInstant(instant: Instant) {
+        this.instant = instant
+    }
+
+    fun setZone(zoneId: ZoneId) {
+        this.zoneId = zoneId
+    }
 
     operator fun plusAssign(duration: Duration) {
         instant = instant.plusMillis(duration.inWholeMilliseconds)


### PR DESCRIPTION
## Description

This change adds playback event tracking. The app stores listening as a series of playback events A session starts when an episode is actively playing, and it ends as soon as playback is no longer actively playing.

Behavior:
- It only counts time while playback is truly playing.
- Pausing, buffering, stopping, finishing, or otherwise leaving the playing state ends the current session.
- If playback starts again later, that becomes a new session.
- If listening crosses into a new day, it is split into separate daily sessions.
- This applies to both normal device playback and cast playback.

## Testing Instructions

1. Playing different episodes.
2. Using the App Inspection query the `playback_stats_events` table and verify that your playback data in there.
```sql
SELECT * FROM playback_stats_events ORDER BY started_at_ms ASC
```
3. Verify that it works with Chrome Cast as well.

## Screenshots or Screencast 

N/A

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack