### PR TITLE
Trial: route CI to android-staging queue (AINFRA-2296)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,9 @@
 ---
 
 agents:
-  queue: "android"
+  # Temporary: trial the m8i.2xlarge-backed `android-staging` queue
+  # per AINFRA-2296. Revert once the prod `android` queue is flipped.
+  queue: "android-staging"
 
 steps:
   - label: Gradle Wrapper Validation


### PR DESCRIPTION
AINFRA-2296

Throwaway/trial PR to route this repo's CI onto the `android-staging` queue so we can validate the new `m8i.2xlarge` instance family ([Automattic/buildkite-ci#841](https://github.com/Automattic/buildkite-ci/pull/841)) against a representative build from this pipeline.

`android-staging` has the same AMI, 32 GiB RAM, and x86_64 shape as prod `android`, just on newer Intel silicon (Xeon 6 / Granite Rapids). No pipeline-level changes needed to run.

**Not to be merged.** Will be closed once the trial run is captured and the prod queue flip lands in `buildkite-ci`.