### PR TITLE
Update error message on spotty network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 *   Updates
     *   Make sure archived episode status is preserved across sync
         ([#5227](https://github.com/Automattic/pocket-casts-android/pull/5227))
+    *   Display dedicated error message for retryable playback errors
+        ([#5244](https://github.com/Automattic/pocket-casts-android/pull/5244))
 
 8.10
 -----

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1875,6 +1875,7 @@
     <string name="error_check_your_internet_connection">Check your internet connection.</string>
     <string name="error_playback_offline">You\'re offline</string>
     <string name="error_playback_connected">You\'re connected</string>
+    <string name="error_playback_failed_try_again">Playback failed, please try again.</string>
     <string name="error_episode_not_available">Episode not available</string>
     <string name="error_download_missing_episode">Unable to find the episode data on this device. Please contact support.</string>
     <string name="error_download_no_episode_file">Unable to create a download file for the episode. Please check that you have enough storage space on your device.</string>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1313,13 +1313,15 @@ open class PlaybackManager @Inject constructor(
             playbackStateRelay.blockingFirst().let { playbackState ->
                 val cause = event.error?.cause
                 val playbackIssue = when {
+                    stuckException != null && isBufferingStuck(stuckException) -> PlaybackIssue.TransientFailure
                     stuckException != null -> PlaybackIssue.StuckPlayer(errorClassifier.classifyErrorStringId(event))
                     cause is HttpDataSource.InvalidResponseCodeException -> PlaybackIssue.HttpError(cause.responseCode)
-                    cause is HttpDataSource.HttpDataSourceException -> PlaybackIssue.ConnectionError
+                    cause is HttpDataSource.HttpDataSourceException -> PlaybackIssue.TransientFailure
                     else -> null
                 }
                 val errorMessage = when (playbackIssue) {
                     is PlaybackIssue.ConnectionError -> application.getString(LR.string.player_play_failed_check_internet)
+                    is PlaybackIssue.TransientFailure -> application.getString(LR.string.error_playback_failed_try_again)
                     is PlaybackIssue.StuckPlayer -> application.getString(playbackIssue.messageResId)
                     else -> event.message
                 }
@@ -1369,6 +1371,12 @@ open class PlaybackManager @Inject constructor(
     @OptIn(UnstableApi::class)
     private fun mapPlaybackErrorToUserMessage(event: PlayerEvent.PlayerError): String {
         return application.getString(errorClassifier.classifyErrorStringId(event))
+    }
+
+    @OptIn(UnstableApi::class)
+    private fun isBufferingStuck(exception: StuckPlayerException): Boolean {
+        return exception.stuckType == StuckPlayerException.STUCK_BUFFERING_NOT_LOADING ||
+            exception.stuckType == StuckPlayerException.STUCK_BUFFERING_NO_PROGRESS
     }
 
     @OptIn(UnstableApi::class)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackNoticeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackNoticeManager.kt
@@ -125,8 +125,15 @@ class PlaybackNoticeManager @Inject constructor(
                         type = PlaybackNoticeType.CONNECTION_LOST,
                     )
 
+                    playbackState.playbackIssue is PlaybackIssue.TransientFailure -> PlaybackNoticeInfo(
+                        message = context.getString(LR.string.error_playback_failed_try_again),
+                        type = PlaybackNoticeType.PLAYBACK,
+                        supportUrl = Settings.INFO_DOWNLOAD_AND_PLAYBACK_URL,
+                        linkText = context.getString(LR.string.settings_battery_learn_more),
+                    )
+
                     playbackState.playbackIssue is PlaybackIssue.StuckPlayer -> PlaybackNoticeInfo(
-                        message = context.getString(LR.string.error_streaming_access_denied),
+                        message = context.getString(playbackState.playbackIssue.messageResId),
                         type = PlaybackNoticeType.PLAYBACK,
                         supportUrl = Settings.INFO_DOWNLOAD_AND_PLAYBACK_URL,
                         linkText = context.getString(LR.string.settings_battery_learn_more),

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackState.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackState.kt
@@ -90,6 +90,7 @@ data class PlaybackState(
 
 sealed class PlaybackIssue {
     data object ConnectionError : PlaybackIssue()
+    data object TransientFailure : PlaybackIssue()
     data class HttpError(val statusCode: Int) : PlaybackIssue()
     data class StuckPlayer(@StringRes val messageResId: Int) : PlaybackIssue()
 }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackNoticeManagerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackNoticeManagerTest.kt
@@ -38,6 +38,7 @@ class PlaybackNoticeManagerTest {
     private val episodeNotAvailableMessage = "Episode not available"
     private val unableToPlayMessage = "Unable to play"
     private val accessDeniedMessage = "This episode can't be played."
+    private val playbackFailedMessage = "Playback failed, please try again."
     private val accessDeniedAction = "Learn more"
 
     private val context: Context = mock {
@@ -46,6 +47,7 @@ class PlaybackNoticeManagerTest {
         on { getString(au.com.shiftyjelly.pocketcasts.localization.R.string.error_episode_not_available) } doReturn episodeNotAvailableMessage
         on { getString(au.com.shiftyjelly.pocketcasts.localization.R.string.error_unable_to_play) } doReturn unableToPlayMessage
         on { getString(au.com.shiftyjelly.pocketcasts.localization.R.string.error_streaming_access_denied) } doReturn accessDeniedMessage
+        on { getString(au.com.shiftyjelly.pocketcasts.localization.R.string.error_playback_failed_try_again) } doReturn playbackFailedMessage
         on { getString(au.com.shiftyjelly.pocketcasts.localization.R.string.settings_battery_learn_more) } doReturn accessDeniedAction
     }
 
@@ -595,9 +597,35 @@ class PlaybackNoticeManagerTest {
             )
             val notice = awaitItem()
             assertEquals(PlaybackNoticeType.PLAYBACK, notice?.type)
-            assertEquals(accessDeniedMessage, notice?.message)
+            assertEquals(unableToPlayMessage, notice?.message)
             assertEquals(accessDeniedAction, notice?.linkText)
             assertEquals(Settings.INFO_DOWNLOAD_AND_PLAYBACK_URL, notice?.supportUrl)
+        }
+    }
+
+    @Test
+    fun `transient failure shown with playback failed message`() = runTest {
+        FeatureFlag.setEnabled(Feature.PLAYBACK_ERROR_INFO_BAR, true)
+        networkCapabilities.value = onlineCapabilities()
+        val manager = createManager(backgroundScope)
+        runCurrent()
+
+        manager.playbackNotice.test {
+            assertNull(awaitItem())
+
+            playbackStateFlow.value = PlaybackState(
+                state = PlaybackState.State.ERROR,
+                playbackIssue = PlaybackIssue.TransientFailure,
+            )
+            val notice = awaitItem()
+            assertEquals(PlaybackNoticeType.PLAYBACK, notice?.type)
+            assertEquals(playbackFailedMessage, notice?.message)
+            assertEquals(accessDeniedAction, notice?.linkText)
+            assertEquals(Settings.INFO_DOWNLOAD_AND_PLAYBACK_URL, notice?.supportUrl)
+
+            advanceTimeBy(PlaybackNoticeManager.AUTO_DISMISS_DURATION)
+            runCurrent()
+            assertNull(awaitItem())
         }
     }
 


### PR DESCRIPTION
## Description
This PR adds a new error text "Playback failed, please try again" to be displayed in certain situations when the issue is transient, a retry might solve it. Typically when the user's network is spotty.

internal discussion: p1776766685943309-slack-C0AJ0GPFYLF

## Testing Instructions
It's hard to test, but in my case this scenario worked:
1. Start playing a long episode
2. Go airplane mode
3. Seek towards the end of the episode and trigger buffering
4. Wait until Exo gives up 
5. Verify that you're seeing the new text

## Screenshots or Screencast 
<img width="1080" height="2400" alt="Screenshot_20260423_145554" src="https://github.com/user-attachments/assets/33ae5dd2-6348-4721-9c88-878ee9c3f592" />


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 