### PR TITLE
Allow unknown callers to interact with basic playback controls

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -625,6 +625,17 @@
             </intent-filter>
         </service>
 
+        <!-- Receives ACTION_MEDIA_BUTTON broadcasts from external apps (e.g. Tasker,
+             Automate) and forwards them to whichever MediaBrowserService is enabled.
+             Without this, only AudioManager.dispatchMediaKeyEvent() reaches the session;
+             broadcast-based media button events are silently dropped. -->
+        <receiver android:name="androidx.media.session.MediaButtonReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MEDIA_BUTTON"/>
+            </intent-filter>
+        </receiver>
+
         <service
             android:name=".PocketCastsWearListenerService"
             android:exported="true">

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3LibrarySessionCallback.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3LibrarySessionCallback.kt
@@ -12,6 +12,7 @@ import androidx.media3.session.LibraryResult
 import androidx.media3.session.MediaLibraryService
 import androidx.media3.session.MediaSession
 import androidx.media3.session.SessionCommand
+import androidx.media3.session.SessionCommands
 import androidx.media3.session.SessionError
 import androidx.media3.session.SessionResult
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
@@ -56,8 +57,15 @@ internal class Media3LibrarySessionCallback(
         controller: MediaSession.ControllerInfo,
     ): MediaSession.ConnectionResult {
         if (packageValidator != null && !packageValidator.isKnownCaller(controller.packageName, controller.uid)) {
-            Timber.e("Unknown caller trying to connect to Media3 session: ${controller.packageName} ${controller.uid}")
-            return MediaSession.ConnectionResult.reject()
+            // Unknown callers (e.g., Tasker, Automate) get transport controls only — no library
+            // browsing or custom commands. This matches the legacy MediaBrowserServiceCompat
+            // behavior where onGetRoot() returned null for unknown callers but transport
+            // controls via MediaControllerCompat still worked independently.
+            LogBuffer.i(
+                LogBuffer.TAG_PLAYBACK,
+                "Unknown caller connected with transport-only access: ${controller.packageName} uid=${controller.uid}",
+            )
+            return MediaSession.ConnectionResult.accept(SessionCommands.EMPTY, TRANSPORT_PLAYER_COMMANDS)
         }
         if (!controller.packageName.contains("au.com.shiftyjelly.pocketcasts")) {
             LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Client: ${controller.packageName} connected to media session")

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3SessionCallback.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3SessionCallback.kt
@@ -371,6 +371,8 @@ internal class Media3SessionCallback(
  * Player commands granted to all connected controllers (known and unknown).
  * Covers basic transport controls: play/pause, stop, seek, and metadata retrieval.
  */
+@OptIn(UnstableApi::class)
+@Suppress("UnsafeOptInUsageError")
 internal val TRANSPORT_PLAYER_COMMANDS: Player.Commands = Player.Commands.Builder()
     .addAll(
         Player.COMMAND_PLAY_PAUSE,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3SessionCallback.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3SessionCallback.kt
@@ -94,18 +94,7 @@ internal class Media3SessionCallback(
             .add(SessionCommand(SessionCommand.COMMAND_CODE_SESSION_SET_RATING))
             .build()
 
-        val playerCommands = Player.Commands.Builder()
-            .addAll(
-                Player.COMMAND_PLAY_PAUSE,
-                Player.COMMAND_SET_MEDIA_ITEM,
-                Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM,
-                Player.COMMAND_STOP,
-                Player.COMMAND_GET_CURRENT_MEDIA_ITEM,
-                Player.COMMAND_GET_METADATA,
-            )
-            .build()
-
-        return MediaSession.ConnectionResult.accept(sessionCommands, playerCommands)
+        return MediaSession.ConnectionResult.accept(sessionCommands, TRANSPORT_PLAYER_COMMANDS)
     }
 
     override fun onCustomCommand(
@@ -377,6 +366,21 @@ internal class Media3SessionCallback(
         }
     }
 }
+
+/**
+ * Player commands granted to all connected controllers (known and unknown).
+ * Covers basic transport controls: play/pause, stop, seek, and metadata retrieval.
+ */
+internal val TRANSPORT_PLAYER_COMMANDS: Player.Commands = Player.Commands.Builder()
+    .addAll(
+        Player.COMMAND_PLAY_PAUSE,
+        Player.COMMAND_SET_MEDIA_ITEM,
+        Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM,
+        Player.COMMAND_STOP,
+        Player.COMMAND_GET_CURRENT_MEDIA_ITEM,
+        Player.COMMAND_GET_METADATA,
+    )
+    .build()
 
 internal fun resolveArtworkUri(episode: BaseEpisode, podcast: Podcast?): Uri? {
     return when (episode) {

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3LibrarySessionCallbackTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3LibrarySessionCallbackTest.kt
@@ -6,9 +6,11 @@ import android.content.pm.PackageManager
 import android.os.Bundle
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
+import androidx.media3.common.Player
 import androidx.media3.session.MediaLibraryService
 import androidx.media3.session.MediaSession
 import androidx.media3.session.SessionCommand
+import androidx.media3.session.SessionCommands
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -219,7 +221,7 @@ class Media3LibrarySessionCallbackTest {
     }
 
     @Test
-    fun `onConnect rejects unknown caller when packageValidator rejects`() {
+    fun `onConnect accepts unknown caller with transport-only commands`() {
         val packageValidator: PackageValidator = mock()
         whenever(mockController.packageName).thenReturn("com.unknown.app")
         whenever(mockController.uid).thenReturn(12345)
@@ -239,7 +241,14 @@ class Media3LibrarySessionCallbackTest {
 
         val result = callbackWithValidator.onConnect(mockSession, mockController)
 
-        assertFalse(result.isAccepted)
+        assertTrue(result.isAccepted)
+        // Unknown callers get transport controls but no session commands
+        assertEquals(SessionCommands.EMPTY, result.availableSessionCommands)
+        val playerCommands = result.availablePlayerCommands
+        assertTrue(playerCommands.contains(Player.COMMAND_PLAY_PAUSE))
+        assertTrue(playerCommands.contains(Player.COMMAND_STOP))
+        assertTrue(playerCommands.contains(Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM))
+        // Should NOT delegate to sessionCallback (which adds full session commands)
         verify(sessionCallback, never()).onConnect(any(), any())
     }
 


### PR DESCRIPTION
## Description
A user has reported that in the latest beta `8.10.rc-2` Tasker no longer works with Pocket Casts. 
The reason was that we explicitly rejected interactions from unknown callers such as Tasker (uknown means outside our package and not whitelisted).
This PR restores the original behavior and allows unknown callers to access basic playback controls.
Plus, we have restored `androidx.media.session.MediaButtonReceiver` broadcast receiver in the manifest and added a nice reminder not to poke it in the future...

Fixes PCDROID-553 https://linear.app/a8c/issue/PCDROID-553/user-reports-simulated-media-button-commands-broken-in-v810-rc-2

## Screencap

https://github.com/user-attachments/assets/e88ed3e9-9495-4356-a087-04798c7c67ab



## Testing Instructions
1. Download [Automate](https://play.google.com/store/apps/details?id=com.llamalab.automate)  (it's free while Tasker is paid)
2. Setup a flow in automate: tap "+" FAB, + again, select "Audio player control" -- use search to find it, customize Audio Player control (see screenshot), finally connect the two boxes and create a shortcut on the home screen

| Final setup | Audio player control setup |
| --- | --- |
| <img width="1080" height="2400" alt="Screenshot_20260423_211957" src="https://github.com/user-attachments/assets/13d65e16-a6a6-4897-a983-c9e21649b757" /> | <img width="1080" height="2400" alt="Screenshot_20260423_212003" src="https://github.com/user-attachments/assets/f7e8abbe-9b31-46e5-a354-412e78d9d626" />  |

4. Build the app with A - media3_session defaultValue=false, then install it
5. Start playing an episode, then send the app to bg
6. Tap the Automate shortcut, notice playback pauses
7. Tap shortcut again, notice playback resumes
8. Do steps 4-7 with defaultValue=true, don't forget to uninstall the previous version to properly kill playback service

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 