### PR TITLE
Fix missing episode duration when RSS feed lacks length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 8.12
 -----
+*   Bug Fixes
+    *   Restore episode duration after download for feeds without an RSS length attribute
+        ([#5258](https://github.com/Automattic/pocket-casts-android/pull/5258))
 
 
 8.11

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/RepositoryModule.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/RepositoryModule.kt
@@ -23,6 +23,8 @@ import au.com.shiftyjelly.pocketcasts.repositories.chromecast.CastManagerImpl
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadQueue
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadStatusObserver
+import au.com.shiftyjelly.pocketcasts.repositories.download.MediaDurationExtractor
+import au.com.shiftyjelly.pocketcasts.repositories.download.MediaDurationExtractorImpl
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.EndOfYearManager
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.EndOfYearManagerImpl
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.EndOfYearSync
@@ -204,6 +206,9 @@ abstract class RepositoryModule {
 
     @Binds
     abstract fun provideExternalDataManager(externalDataManagerImpl: ExternalDataManagerImpl): ExternalDataManager
+
+    @Binds
+    abstract fun provideMediaDurationExtractor(mediaDurationExtractorImpl: MediaDurationExtractorImpl): MediaDurationExtractor
 
     @Binds
     abstract fun provideReferralManager(referralManagerImpl: ReferralManagerImpl): ReferralManager

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadEpisodeWorker.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadEpisodeWorker.kt
@@ -337,6 +337,9 @@ class DownloadEpisodeWorker @AssistedInject constructor(
     private fun fixMissingDuration(episodeUuid: String, file: File) {
         try {
             val episode = runBlocking { episodeManager.findEpisodeByUuid(episodeUuid) } ?: return
+            if (episode.duration > 0) {
+                return
+            }
             val extractor = MediaExtractor()
             try {
                 extractor.setDataSource(file.path)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadEpisodeWorker.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadEpisodeWorker.kt
@@ -4,8 +4,6 @@ import android.app.ForegroundServiceStartNotAllowedException
 import android.app.Notification
 import android.content.Context
 import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
-import android.media.MediaExtractor
-import android.media.MediaFormat
 import android.os.Build
 import android.system.ErrnoException
 import android.system.OsConstants
@@ -93,6 +91,7 @@ class DownloadEpisodeWorker @AssistedInject constructor(
     private val fileStorage: FileStorage,
     private val progressCache: DownloadProgressCache,
     private val notificationObserver: DownloadNotificationObserver,
+    private val episodeDurationFixer: EpisodeDurationFixer,
 ) : Worker(context, params) {
     private val args = inputData.toArgs()
 
@@ -128,6 +127,7 @@ class DownloadEpisodeWorker @AssistedInject constructor(
         if (!isStopped) {
             LogBuffer.i(LogBuffer.TAG_DOWNLOAD, "Download started. Episode: ${args.episodeUuid}")
         }
+        var resolvedEpisode: BaseEpisode? = null
         val timedValue = measureTimedValue {
             try {
                 // Block the work until the state is dispatched to keep it consistent
@@ -137,6 +137,7 @@ class DownloadEpisodeWorker @AssistedInject constructor(
                 prepareForegroundNotification(episode)
 
                 episode = refreshDownloadUrlOrThrow(episode)
+                resolvedEpisode = episode
                 val downloadFile = getDownloadFileOrThrow(episode)
                 val tempFile = fileStorage.getOrCreatePodcastEpisodeTempFile(episode)
 
@@ -157,7 +158,7 @@ class DownloadEpisodeWorker @AssistedInject constructor(
 
         return when (val result = timedValue.value) {
             is DownloadResult.Success -> {
-                fixMissingDuration(args.episodeUuid, result.file)
+                resolvedEpisode?.let { episodeDurationFixer.fixMissingDuration(it, result.file) }
                 val data = Data.Builder()
                     .putString(DOWNLOAD_FILE_PATH_KEY, result.file.path)
                     .build()
@@ -332,36 +333,6 @@ class DownloadEpisodeWorker @AssistedInject constructor(
             throwable = throwable.cause
         }
         return false
-    }
-
-    private fun fixMissingDuration(episodeUuid: String, file: File) {
-        try {
-            val episode = runBlocking { episodeManager.findEpisodeByUuid(episodeUuid) } ?: return
-            if (episode.duration > 0) {
-                return
-            }
-            val extractor = MediaExtractor()
-            try {
-                extractor.setDataSource(file.path)
-                for (i in 0 until extractor.trackCount) {
-                    val format = extractor.getTrackFormat(i)
-                    if (!format.containsKey(MediaFormat.KEY_DURATION)) {
-                        continue
-                    }
-                    val durationUs = format.getLong(MediaFormat.KEY_DURATION)
-                    if (durationUs <= 0) {
-                        continue
-                    }
-                    val durationInSecs = durationUs / 1_000_000.0
-                    episodeManager.updateDurationBlocking(episode, durationInSecs, syncChanges = true)
-                    return
-                }
-            } finally {
-                extractor.release()
-            }
-        } catch (e: Exception) {
-            LogBuffer.i(LogBuffer.TAG_DOWNLOAD, e, "Failed to fix missing duration for episode: $episodeUuid")
-        }
     }
 
     private fun prepareForegroundNotification(episode: BaseEpisode) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadEpisodeWorker.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadEpisodeWorker.kt
@@ -4,6 +4,8 @@ import android.app.ForegroundServiceStartNotAllowedException
 import android.app.Notification
 import android.content.Context
 import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+import android.media.MediaExtractor
+import android.media.MediaFormat
 import android.os.Build
 import android.system.ErrnoException
 import android.system.OsConstants
@@ -155,6 +157,7 @@ class DownloadEpisodeWorker @AssistedInject constructor(
 
         return when (val result = timedValue.value) {
             is DownloadResult.Success -> {
+                fixMissingDuration(args.episodeUuid, result.file)
                 val data = Data.Builder()
                     .putString(DOWNLOAD_FILE_PATH_KEY, result.file.path)
                     .build()
@@ -329,6 +332,33 @@ class DownloadEpisodeWorker @AssistedInject constructor(
             throwable = throwable.cause
         }
         return false
+    }
+
+    private fun fixMissingDuration(episodeUuid: String, file: File) {
+        try {
+            val episode = runBlocking { episodeManager.findEpisodeByUuid(episodeUuid) } ?: return
+            val extractor = MediaExtractor()
+            try {
+                extractor.setDataSource(file.path)
+                for (i in 0 until extractor.trackCount) {
+                    val format = extractor.getTrackFormat(i)
+                    if (!format.containsKey(MediaFormat.KEY_DURATION)) {
+                        continue
+                    }
+                    val durationUs = format.getLong(MediaFormat.KEY_DURATION)
+                    if (durationUs <= 0) {
+                        continue
+                    }
+                    val durationInSecs = durationUs / 1_000_000.0
+                    episodeManager.updateDurationBlocking(episode, durationInSecs, syncChanges = true)
+                    return
+                }
+            } finally {
+                extractor.release()
+            }
+        } catch (e: Exception) {
+            LogBuffer.i(LogBuffer.TAG_DOWNLOAD, e, "Failed to fix missing duration for episode: $episodeUuid")
+        }
     }
 
     private fun prepareForegroundNotification(episode: BaseEpisode) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/EpisodeDurationFixer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/EpisodeDurationFixer.kt
@@ -1,0 +1,24 @@
+package au.com.shiftyjelly.pocketcasts.repositories.download
+
+import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import java.io.File
+import javax.inject.Inject
+
+/**
+ * Backfills `episode.duration` after a successful download when the RSS feed
+ * did not provide a usable duration. No-op when the stored duration is already
+ * populated, so it never overwrites a value supplied by the feed.
+ */
+class EpisodeDurationFixer @Inject constructor(
+    private val episodeManager: EpisodeManager,
+    private val mediaDurationExtractor: MediaDurationExtractor,
+) {
+    fun fixMissingDuration(episode: BaseEpisode, file: File) {
+        if (episode.duration > 0) {
+            return
+        }
+        val durationInSecs = mediaDurationExtractor.extractDurationInSeconds(file) ?: return
+        episodeManager.updateDurationBlocking(episode, durationInSecs, syncChanges = true)
+    }
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/MediaDurationExtractor.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/MediaDurationExtractor.kt
@@ -1,0 +1,37 @@
+package au.com.shiftyjelly.pocketcasts.repositories.download
+
+import android.media.MediaExtractor
+import android.media.MediaFormat
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
+import java.io.File
+import javax.inject.Inject
+
+interface MediaDurationExtractor {
+    fun extractDurationInSeconds(file: File): Double?
+}
+
+class MediaDurationExtractorImpl @Inject constructor() : MediaDurationExtractor {
+    override fun extractDurationInSeconds(file: File): Double? {
+        val extractor = MediaExtractor()
+        return try {
+            extractor.setDataSource(file.path)
+            for (i in 0 until extractor.trackCount) {
+                val format = extractor.getTrackFormat(i)
+                if (!format.containsKey(MediaFormat.KEY_DURATION)) {
+                    continue
+                }
+                val durationUs = format.getLong(MediaFormat.KEY_DURATION)
+                if (durationUs <= 0) {
+                    continue
+                }
+                return durationUs / 1_000_000.0
+            }
+            null
+        } catch (e: Exception) {
+            LogBuffer.i(LogBuffer.TAG_DOWNLOAD, e, "Failed to extract media duration from ${file.path}")
+            null
+        } finally {
+            extractor.release()
+        }
+    }
+}

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/download/EpisodeDurationFixerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/download/EpisodeDurationFixerTest.kt
@@ -1,0 +1,76 @@
+package au.com.shiftyjelly.pocketcasts.repositories.download
+
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import java.io.File
+import java.util.Date
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.whenever
+
+@RunWith(MockitoJUnitRunner::class)
+class EpisodeDurationFixerTest {
+    @Mock
+    private lateinit var episodeManager: EpisodeManager
+
+    @Mock
+    private lateinit var mediaDurationExtractor: MediaDurationExtractor
+
+    private val downloadFile = File("episode.mp3")
+
+    private lateinit var fixer: EpisodeDurationFixer
+
+    @Before
+    fun setUp() {
+        fixer = EpisodeDurationFixer(episodeManager, mediaDurationExtractor)
+    }
+
+    @Test
+    fun `skips extraction when episode duration is already populated`() {
+        val episode = PodcastEpisode(uuid = "abc", duration = 300.0, publishedDate = Date())
+
+        fixer.fixMissingDuration(episode, downloadFile)
+
+        verifyNoInteractions(mediaDurationExtractor)
+        verify(episodeManager, never()).updateDurationBlocking(any(), any(), any())
+    }
+
+    @Test
+    fun `skips update when extractor returns null`() {
+        val episode = PodcastEpisode(uuid = "abc", duration = 0.0, publishedDate = Date())
+        whenever(mediaDurationExtractor.extractDurationInSeconds(downloadFile)).thenReturn(null)
+
+        fixer.fixMissingDuration(episode, downloadFile)
+
+        verify(episodeManager, never()).updateDurationBlocking(any(), any(), any())
+    }
+
+    @Test
+    fun `updates duration when extractor returns valid value`() {
+        val episode = PodcastEpisode(uuid = "abc", duration = 0.0, publishedDate = Date())
+        whenever(mediaDurationExtractor.extractDurationInSeconds(downloadFile)).thenReturn(123.45)
+
+        fixer.fixMissingDuration(episode, downloadFile)
+
+        verify(episodeManager).updateDurationBlocking(eq(episode), eq(123.45), eq(true))
+    }
+
+    @Test
+    fun `updates duration for user episodes too`() {
+        val episode = UserEpisode(uuid = "user-abc", duration = 0.0, publishedDate = Date())
+        whenever(mediaDurationExtractor.extractDurationInSeconds(downloadFile)).thenReturn(99.0)
+
+        fixer.fixMissingDuration(episode, downloadFile)
+
+        verify(episodeManager).updateDurationBlocking(eq(episode), eq(99.0), eq(true))
+    }
+}


### PR DESCRIPTION
## Description

Fixes #5228

The downloads rewrite in #5017 removed the post-download `MediaExtractor`
pass that populated `episode.duration` when the RSS `<enclosure length>`
attribute was missing or empty. As a result, episodes from feeds that
omit the length (e.g. `<enclosure url="..." length="" type="audio/mpeg"/>`)
show no playtime even after they finish downloading, and they don't
contribute to the Up Next "time left" total. Last working version: 8.6.

### Changes
- Re-add a `fixMissingDuration` helper in `DownloadEpisodeWorker` that
  reads `MediaFormat.KEY_DURATION` from the downloaded file via
  `MediaExtractor` and persists it through
  `EpisodeManager.updateDurationBlocking`.
- Call it on every successful download. `updateDurationBlocking`
  already short-circuits when the extracted value is invalid, matching
  the pre-rewrite behavior.
- Wrap extraction in try/finally and a top-level catch so a malformed
  file never propagates an exception out of the worker.

## Testing Instructions

1. Subscribe to a feed whose `<enclosure>` element has an empty
   `length` attribute. The reporter's example:
   `https://archive.org/download/rss_vfbaxxdzgi/vfbaxxdzgi`
2. Download an episode.
3. Verify that once the download finishes, the episode shows a real
   playtime (e.g. `12m`, `1h 23m`) on the podcast list, episode card,
   and Up Next, instead of a blank duration.
4. Add the episode to Up Next and verify the bottom-bar "time left"
   total includes its duration.
5. As a regression check: download a normal episode (RSS includes a
   valid `length` and/or `<itunes:duration>`) and verify the playtime
   displayed matches what was shown before download (no flicker /
   regression to wrong value).
6. Force a download to fail (airplane mode mid-download) and confirm
   the failure path still works — duration extraction should not run.

## Screenshots or Screencast

_To be added — repro on emulator with the linked archive.org feed._

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

#### I have tested any UI changes...

- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
