### PR TITLE
Route Ask AI widget tickets through Help WebView log-attach flow

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HelpPage.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HelpPage.kt
@@ -114,9 +114,9 @@ fun HelpPage(
                     }
                 }
             },
-            onContactSupport = {
+            onContactSupport = { recipient ->
                 scope.launch {
-                    val intent = viewModel.getSupportIntent(activity)
+                    val intent = viewModel.getSupportIntent(activity, recipient)
                     try {
                         activity.startActivity(intent)
                     } catch (_: ActivityNotFoundException) {
@@ -167,7 +167,7 @@ fun HelpPage(
 private fun HelpPage(
     appBarInsets: WindowInsets,
     onSendFeedbackEmail: () -> Unit,
-    onContactSupport: () -> Unit,
+    onContactSupport: (String) -> Unit,
     onTapUri: (Uri) -> Unit,
     onShowLogs: () -> Unit,
     onShowStatusPage: () -> Unit,
@@ -343,7 +343,7 @@ private fun ActionRow(
 @Composable
 private fun HelpWebViewContainer(
     onSendFeedbackEmail: () -> Unit,
-    onContactSupport: () -> Unit,
+    onContactSupport: (String) -> Unit,
     onTapUri: (Uri) -> Unit,
     onWebViewCreate: (WebView) -> Unit,
     onWebViewDispose: (WebView) -> Unit,
@@ -405,7 +405,7 @@ private fun HelpWebViewContainer(
                 )
 
                 ContainerState.Error -> WebViewError(
-                    onContactSupport = onContactSupport,
+                    onContactSupport = { onContactSupport("support@pocketcasts.com") },
                     modifier = Modifier.fillMaxSize(),
                 )
 
@@ -469,7 +469,7 @@ private fun WebViewError(
 private fun HelpWebView(
     state: WebViewState,
     onSendFeedbackEmail: () -> Unit,
-    onContactSupport: () -> Unit,
+    onContactSupport: (String) -> Unit,
     onTapUri: (Uri) -> Unit,
     onLoadUrl: (String) -> Unit,
     onWebViewCreate: (WebView) -> Unit,
@@ -504,7 +504,7 @@ private fun HelpWebView(
 
 private class HelpWebViewClient(
     private val onSendFeedbackEmail: () -> Unit,
-    private val onContactSupport: () -> Unit,
+    private val onContactSupport: (String) -> Unit,
     private val onTapUri: (Uri) -> Unit,
     private val onLoadUrl: (String) -> Unit,
 ) : AccompanistWebViewClient() {
@@ -514,7 +514,14 @@ private class HelpWebViewClient(
         when {
             url.contains("feedback", ignoreCase = true) -> onSendFeedbackEmail()
 
-            contactSupportAction.any { url.startsWith(it) } -> onContactSupport()
+            url.startsWith("mailto:") -> {
+                val recipient = url.removePrefix("mailto:").substringBefore('?')
+                if (recipient in supportRecipients) {
+                    onContactSupport(recipient)
+                } else {
+                    onTapUri(request.url)
+                }
+            }
 
             url.startsWith("https://support.pocketcasts.com") -> {
                 val androidUrl = if ("device=android" !in url) {
@@ -537,7 +544,11 @@ private class HelpWebViewClient(
     }
 }
 
-private val contactSupportAction = listOf("mailto:support@shiftyjelly.com", "mailto:support@pocketcasts.com")
+private val supportRecipients = setOf(
+    "support@shiftyjelly.com",
+    "support@pocketcasts.com",
+    "chatbot-support@pocketcasts.com",
+)
 private val fadeAnimationSpec = spring<Float>(stiffness = Spring.StiffnessMedium, visibilityThreshold = 0.001f)
 private val expandAnimationSpec = spring<IntSize>(stiffness = Spring.StiffnessMedium, visibilityThreshold = IntSize.VisibilityThreshold)
 private val popupEnterTransition = fadeIn(fadeAnimationSpec) + expandIn(expandAnimationSpec, expandFrom = Alignment.TopEnd)

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/HelpViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/HelpViewModel.kt
@@ -32,13 +32,17 @@ class HelpViewModel @Inject constructor(
         )
     }
 
-    suspend fun getSupportIntent(activity: Activity): Intent {
+    suspend fun getSupportIntent(
+        activity: Activity,
+        recipient: String = "support@pocketcasts.com",
+    ): Intent {
         eventHorizon.track(SettingsGetSupportEvent)
         return support.shareLogs(
             subject = "Android support.",
             intro = "Hi there, just needed help with something…",
             emailSupport = true,
             context = activity,
+            recipient = recipient,
         )
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
@@ -72,7 +72,13 @@ class Support @Inject constructor(
         get() = Dispatchers.Default
 
     @Suppress("DEPRECATION")
-    suspend fun shareLogs(subject: String, intro: String, emailSupport: Boolean, context: Context): Intent {
+    suspend fun shareLogs(
+        subject: String,
+        intro: String,
+        emailSupport: Boolean,
+        context: Context,
+        recipient: String = "support@pocketcasts.com",
+    ): Intent {
         val dialog = withContext(Dispatchers.Main) {
             android.app.ProgressDialog.show(context, context.getString(R.string.loading), context.getString(R.string.settings_support_please_wait), true)
         }
@@ -81,7 +87,7 @@ class Support @Inject constructor(
         withContext(Dispatchers.IO) {
             intent.type = "message/rfc822"
             if (emailSupport) {
-                intent.putExtra(Intent.EXTRA_EMAIL, arrayOf("support@pocketcasts.com"))
+                intent.putExtra(Intent.EXTRA_EMAIL, arrayOf(recipient))
             }
             intent.putExtra(
                 Intent.EXTRA_SUBJECT,


### PR DESCRIPTION
## Summary

The Ask AI widget on the in-app help WebView is moving to a new dedicated support recipient so widget-originated tickets bypass the AI auto-reply loop.

Full context, motivation, and test plan: [PCDROID-557](https://linear.app/a8c/issue/PCDROID-557).

Today, when a user taps the widget's "contact us here" link inside the in-app Help WebView, [HelpWebViewClient][1] intercepts the `mailto:` and routes it through `Support.shareLogs()`, which builds an `Intent.ACTION_SEND` with `debug.txt` attached. The recipient list and outgoing address are hardcoded — so once the widget renders the new recipient, the WebView would stop recognising the link, fall through to `onTapUri()`, and the user would email the new inbox **without** debug logs attached.

This PR makes the recipient address configurable end-to-end while preserving existing behaviour for every other caller of `shareLogs()`.

## Changes

- **`HelpPage.kt`** — replaced the prefix-match allowlist with an exact-recipient `Set<String>` (`supportRecipients`) that now includes the new AI-assistant recipient. Parses the recipient from the matched mailto URL and passes it through. Falls back to `onTapUri()` for any mailto whose recipient isn't in the set. The `WebViewError` "Contact support" button (shown when the help page fails to load) explicitly uses the existing support recipient.
- **`HelpViewModel.getSupportIntent()`** — accepts an optional `recipient: String` (default: existing support recipient) and forwards it.
- **`Support.shareLogs()`** — adds an optional `recipient: String` parameter (default: existing support recipient) and uses it for `Intent.EXTRA_EMAIL` instead of the hardcoded address. Other callers (`LogsViewModel`, `StatusViewModel`, the `getFeedbackIntent` path, and `emailWearLogsToSupportIntent`) are unaffected via the default.

## Security note

The previous `contactSupportAction.any { url.startsWith(it) }` check matched by prefix, so a `mailto:` whose recipient was crafted as `<allowlisted>@example.com.attacker.com` would also match. This was harmless before because the to-address was hardcoded — but parsing the recipient from the URL would have made it exploitable. This PR tightens to exact-equality matching against the `supportRecipients` set.

## Test plan

Full test plan in [PCDROID-557](https://linear.app/a8c/issue/PCDROID-557). Highlights:

- [ ] Ask AI widget → "contact us here" link → email composer opens with the new recipient and `debug.txt` attached.
- [ ] Regular "Contact support" button on the Help page still uses the existing recipient and `debug.txt` (regression).
- [ ] Standalone Logs share flow still uses the existing recipient (regression).
- [ ] `WebViewError` "Contact support" button (airplane mode → help page fails) still uses the existing recipient (regression).
- [ ] A `mailto:` whose recipient isn't in `supportRecipients` falls through to the system email composer with no log attachment, no crash.

## Coordination

Draft until the widget HTML swap is timed.

iOS counterpart: [Automattic/pocket-casts-ios#4227](https://github.com/Automattic/pocket-casts-ios/pull/4227).

[1]: https://github.com/Automattic/pocket-casts-android/blob/main/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HelpPage.kt