### PR TITLE
Hide expiration label for auto-renewing subscribers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 *   Bug Fixes
     *   Restore episode duration after download for feeds without an RSS length attribute
         ([#5258](https://github.com/Automattic/pocket-casts-android/pull/5258))
+    *   Hide the "Plus expires in X days" label on the profile for auto-renewing subscribers
+        ([#5263](https://github.com/Automattic/pocket-casts-android/pull/5263))
 
 
 8.11

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsFragment.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsFragment.kt
@@ -115,7 +115,7 @@ class AutomotiveSettingsFragment : BaseFragment() {
                     imageUrl = Gravatar.getUrl(state.email),
                     subscriptionTier = state.subscription?.tier,
                     email = state.email,
-                    expiresIn = state.subscription?.expiryDate?.toDurationFromNow(),
+                    expiresIn = state.subscription?.takeIf { it.isExpiring }?.expiryDate?.toDurationFromNow(),
                 )
 
                 is SignInState.SignedOut -> ProfileHeaderState(

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileViewModel.kt
@@ -68,7 +68,7 @@ class ProfileViewModel @Inject constructor(
                 imageUrl = Gravatar.getUrl(state.email),
                 subscriptionTier = state.subscription?.tier,
                 email = state.email,
-                expiresIn = state.subscription?.expiryDate?.toDurationFromNow(),
+                expiresIn = state.subscription?.takeIf { it.isExpiring }?.expiryDate?.toDurationFromNow(),
             )
 
             is SignInState.SignedOut -> ProfileHeaderState(


### PR DESCRIPTION
## Description

Fixes #3323

The profile and automotive screens gate the "Plus expires in X days" label only on whether the remaining duration is under 30 days, without checking whether the subscription is set to auto-renew. Monthly subscribers always have an expiry date within ~30 days of "now" (the next renewal), so the expiration label was being shown every single day of an active monthly subscription — leading users to believe their subscription had been cancelled.

This wires up the existing (but previously unused) `Subscription.isExpiring` property — `!isAutoRenewing && expiryDate < now + 30 days` — as the gate. The semantics match how `AccountDetailsViewModel` already distinguishes between "Next Payment" (auto-renewing) and "Plus expires on …" (cancelled) on the account details screen, so behavior is consistent across the two screens.

The fix applies uniformly to Google Play and Paddle (Web) subscribers — both populate `isAutoRenewing` from the same server `autoRenewing` boolean with no platform-specific branching.

### Changes
- `ProfileViewModel.profileHeaderState`: only set `expiresIn` when `subscription.isExpiring == true`.
- `AutomotiveSettingsFragment` header state: same gate.

## Testing Instructions

1. Sign in as a **monthly Plus** subscriber whose subscription is actively auto-renewing.
2. Open the profile screen.
   - [ ] Verify the "Plus expires in X days" label is **not shown**.
   - [ ] Verify the Plus badge / tier indicator still renders.
3. Sign in as a **yearly Plus** subscriber more than 30 days from renewal.
   - [ ] Verify no expiration label.
4. Sign in as a **cancelled** Plus subscriber whose access still has < 30 days remaining (e.g., test via a dev override of the subscription state if no live test account is available).
   - [ ] Verify "Plus expires in X days" **is** shown — this is the legitimate use of the label.
5. Sign in as a Patron (any cycle) and repeat steps 1–4.
   - [ ] Verify the Patron variant of the label respects the same rules.
6. Repeat step 1 in the Automotive build (`./gradlew :automotive:installDebug`) and open the settings screen.
   - [ ] Verify no expiration label for an auto-renewing monthly subscriber there either.

## Screenshots or Screencast

_To be added — repro on emulator with a monthly auto-renew test account._

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml` (no string changes)
- [x] Any jetpack compose components I added or changed are covered by compose previews (no compose changes)
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics. (no analytics changes)

#### I have tested any UI changes...
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
