### PR TITLE
Fix unknown caller crash on media3

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/auto/PackageValidator.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/auto/PackageValidator.kt
@@ -95,11 +95,20 @@ class PackageValidator(context: Context, @XmlRes xmlResId: Int) {
 
         // Build the caller info for the rest of the checks here.
         val callerPackageInfo = buildCallerInfo(callingPackage)
-            ?: throw IllegalStateException("Caller wasn't found in the system?")
+        if (callerPackageInfo == null) {
+            Timber.w("PackageValidator: package $callingPackage not found in the system. Treating as unknown caller.")
+            callerChecked[callingPackage] = Pair(callingUid, false)
+            return false
+        }
 
-        // Verify that things aren't ... broken. (This test should always pass.)
+        // Verify that the UID from PackageManager matches the Binder caller UID.
+        // This can legitimately fail for cross-profile controllers (work profile,
+        // Secure Folder) where getPackageInfo() returns the primary-user UID but the
+        // Binder caller has a different user-offset UID.
         if (callerPackageInfo.uid != callingUid) {
-            throw IllegalStateException("Caller's package UID doesn't match caller's actual UID?")
+            Timber.w("PackageValidator: UID mismatch for $callingPackage (package=${callerPackageInfo.uid}, caller=$callingUid). Treating as unknown caller.")
+            callerChecked[callingPackage] = Pair(callingUid, false)
+            return false
         }
 
         val callerSignature = callerPackageInfo.signature


### PR DESCRIPTION
## Description
`PackageValidator.kt` is unchanged since 2022 -- the two throw IllegalStateException lines have always been there. In pre-Media3 world it was only called from `onGetRoot()`, which the Android framework  exclusively invokes for `MediaBrowserCompat` browse connections -- transport-only controllers, system UI, and cross-profile callers never touched it. The Media3 migration replaced that with `onConnect()`, which fires for every connecting controller, exposing `PackageValidator` to caller types it was never designed to see. Cross-profile controllers (work profile, Secure Folder) have a Binder UID that includes a user-offset component, which will never match the primary-user UID returned by `PackageManager.getPackageInfo()` -- triggering the throw. The fix we applied replaces both throws with `return false`, which the downstream code already handles gracefully (transport-only access for Media3, denied browsing for legacy)

Fixes PCDROID-559 (https://linear.app/a8c/issue/PCDROID-559/media3-unknown-caller-crashes)

## Testing Instructions
Reviewing the code is fine.
If you want to make sure the issue's been fixed, I'd suggest these steps:
1. Install the android app ona  phone that has private / business profiles
2. On your private profile, make sure medai3_session is enabled
3. Start playing some episodes
4. Switch profile
5. Interact with the playback notification

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 