### PR TITLE
Bump nokogiri to 1.19.3 (GHSA-c4rq-3m3g-8wgx)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -284,7 +284,7 @@ GEM
     nap (1.1.0)
     naturally (2.3.0)
     nkf (0.2.0)
-    nokogiri (1.19.2)
+    nokogiri (1.19.3)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     octokit (6.1.1)


### PR DESCRIPTION
## Description

Lockfile-only bump of `nokogiri` from `1.19.2` to `1.19.3` to close [Dependabot alert #125](https://github.com/Automattic/pocket-casts-android/security/dependabot/125): [GHSA-c4rq-3m3g-8wgx](https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-c4rq-3m3g-8wgx) — high-severity ReDoS in Nokogiri's CSS selector tokenizer.

`fastlane-plugin-wpmreleasetoolkit`'s `nokogiri ~> 1.11` constraint already permits `1.19.3`, so no Gemfile change is needed — `bundle update nokogiri --conservative` advances the lock alone.

## Testing Instructions

1. `bundle install` resolves `nokogiri 1.19.3`.
2. Diff is restricted to a single line in `Gemfile.lock` (`1.19.2` → `1.19.3`).

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md _(N/A — tooling/dependency bump, matches recent precedents like #5199, #5171, #5149, #5016.)_
- [x] Ensure the linter passes _(N/A — only `Gemfile.lock` changed.)_
- [x] I have considered whether it makes sense to add tests for my changes _(N/A — security patch from upstream gem.)_

---

*Posted by Claude Code (Opus 4.7) on behalf of @mokagio with approval.*