### PR TITLE
[RSM] Show episode summary on the fullscreen player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 *   New Features
     *   Show episode summaries where possible
         ([#5276](https://github.com/Automattic/pocket-casts-android/pull/5276))
+    *   Show episode summary on fullscreen player
+        ([#5278](https://github.com/Automattic/pocket-casts-android/pull/5278))
 
 8.12
 -----

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
@@ -40,6 +40,8 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextSource
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.helper.NavigationBarColor
 import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarIconColor
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import au.com.shiftyjelly.pocketcasts.views.helper.HasBackstack
 import au.com.shiftyjelly.pocketcasts.views.helper.OffsettingBottomSheetCallback
@@ -239,7 +241,7 @@ class PlayerContainerFragment :
 
         viewModel.listDataLive.observe(viewLifecycleOwner) {
             adapter.updateNotes(addNotes = !it.podcastHeader.isUserEpisode)
-            if (!it.podcastHeader.isUserEpisode) {
+            if (FeatureFlag.isEnabled(Feature.AI_SUMMARIES) && !it.podcastHeader.isUserEpisode) {
                 summaryViewModel.loadSummary(it.podcastHeader.episodeUuid)
             } else {
                 summaryViewModel.clearSummary()

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.player.view
 
+import android.annotation.SuppressLint
 import android.graphics.drawable.Drawable
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -241,7 +242,7 @@ class PlayerContainerFragment :
             if (!it.podcastHeader.isUserEpisode) {
                 summaryViewModel.loadSummary(it.podcastHeader.episodeUuid)
             } else {
-                adapter.updateSummary(addSummary = false)
+                summaryViewModel.clearSummary()
             }
             val upNextCount = it.upNextEpisodes.size
             val drawableId = when {
@@ -449,6 +450,8 @@ private class ViewPagerAdapter(fragmentManager: FragmentManager, lifecycle: Life
         updateSections(hasChapters = addChapters)
     }
 
+    // Stable IDs via getItemId/containsItem allow FragmentStateAdapter to efficiently diff fragments
+    @SuppressLint("NotifyDataSetChanged")
     private fun updateSections(
         hasNotes: Boolean = sections.contains(Section.Notes),
         hasSummary: Boolean = sections.contains(Section.Summary),

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
@@ -33,6 +33,7 @@ import au.com.shiftyjelly.pocketcasts.player.view.chapters.ChaptersViewModel.Mod
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.BookmarksViewModel
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.PlayerViewModel
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.ShelfSharedViewModel
+import au.com.shiftyjelly.pocketcasts.player.viewmodel.SummaryViewModel
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextSource
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
@@ -70,6 +71,7 @@ class PlayerContainerFragment :
     lateinit var eventHorizon: EventHorizon
 
     private val bookmarksViewModel: BookmarksViewModel by viewModels()
+    private val summaryViewModel: SummaryViewModel by viewModels()
 
     var upNextBottomSheetBehavior: BottomSheetBehavior<View>? = null
 
@@ -206,6 +208,11 @@ class PlayerContainerFragment :
                         PlayerTabType.Chapters
                     }
 
+                    adapter.isSummaryTab(position) -> {
+                        // TODO: Add PlayerTabType.Summary when EventHorizon is updated
+                        null
+                    }
+
                     else -> {
                         Timber.e("Invalid tab selected")
                         null
@@ -231,6 +238,11 @@ class PlayerContainerFragment :
 
         viewModel.listDataLive.observe(viewLifecycleOwner) {
             adapter.updateNotes(addNotes = !it.podcastHeader.isUserEpisode)
+            if (!it.podcastHeader.isUserEpisode) {
+                summaryViewModel.loadSummary(it.podcastHeader.episodeUuid)
+            } else {
+                adapter.updateSummary(addSummary = false)
+            }
             val upNextCount = it.upNextEpisodes.size
             val drawableId = when {
                 upNextCount == 0 -> R.drawable.mini_player_upnext
@@ -259,6 +271,14 @@ class PlayerContainerFragment :
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 chaptersViewModel.uiState.collect {
                     adapter.updateChapters(addChapters = it.chaptersCount > 0)
+                }
+            }
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                summaryViewModel.state.collect { state ->
+                    adapter.updateSummary(addSummary = state is SummaryViewModel.SummaryState.Loaded)
                 }
             }
         }
@@ -401,6 +421,7 @@ private class ViewPagerAdapter(fragmentManager: FragmentManager, lifecycle: Life
     private sealed class Section(@StringRes val titleRes: Int) {
         data object Player : Section(LR.string.player_tab_playing)
         data object Notes : Section(LR.string.player_tab_notes)
+        data object Summary : Section(LR.string.player_tab_summary)
         data object Bookmarks : Section(LR.string.player_tab_bookmarks)
         data object Chapters : Section(LR.string.player_tab_chapters)
     }
@@ -417,55 +438,33 @@ private class ViewPagerAdapter(fragmentManager: FragmentManager, lifecycle: Life
         get() = sections.indexOf(Section.Bookmarks)
 
     fun updateNotes(addNotes: Boolean) {
-        val currentSections = sections
-        val hasChapters = sections.contains(Section.Chapters)
+        updateSections(hasNotes = addNotes)
+    }
 
-        val newSections = buildList {
-            add(Section.Player)
-            if (addNotes) {
-                add(Section.Notes)
-            }
-
-            if (hasChapters) {
-                add(Section.Chapters)
-            }
-            add(Section.Bookmarks)
-        }
-
-        if (currentSections != newSections) {
-            sections = newSections
-            if (addNotes) {
-                notifyItemInserted(1)
-            } else {
-                notifyItemRemoved(1)
-            }
-        }
+    fun updateSummary(addSummary: Boolean) {
+        updateSections(hasSummary = addSummary)
     }
 
     fun updateChapters(addChapters: Boolean) {
-        val currentSections = sections
-        val hasNotes = sections.contains(Section.Notes)
+        updateSections(hasChapters = addChapters)
+    }
 
+    private fun updateSections(
+        hasNotes: Boolean = sections.contains(Section.Notes),
+        hasSummary: Boolean = sections.contains(Section.Summary),
+        hasChapters: Boolean = sections.contains(Section.Chapters),
+    ) {
+        val currentSections = sections
         val newSections = buildList {
             add(Section.Player)
-            if (hasNotes) {
-                add(Section.Notes)
-            }
-
-            if (addChapters) {
-                add(Section.Chapters)
-            }
+            if (hasNotes) add(Section.Notes)
+            if (hasSummary) add(Section.Summary)
+            if (hasChapters) add(Section.Chapters)
             add(Section.Bookmarks)
         }
-
         if (currentSections != newSections) {
             sections = newSections
-            val position = if (hasNotes) 2 else 1
-            if (addChapters) {
-                notifyItemInserted(position)
-            } else {
-                notifyItemRemoved(position)
-            }
+            notifyDataSetChanged()
         }
     }
 
@@ -485,6 +484,7 @@ private class ViewPagerAdapter(fragmentManager: FragmentManager, lifecycle: Life
         return when (sections[position]) {
             is Section.Player -> PlayerHeaderFragment()
             is Section.Notes -> NotesFragment()
+            is Section.Summary -> SummaryFragment()
             is Section.Bookmarks -> BookmarksFragment.newInstance(SourceView.PLAYER)
             is Section.Chapters -> ChaptersFragment.forPlayer()
         }
@@ -497,6 +497,7 @@ private class ViewPagerAdapter(fragmentManager: FragmentManager, lifecycle: Life
 
     fun isPlayerTab(position: Int) = sections[position] is Section.Player
     fun isNotesTab(position: Int) = sections[position] is Section.Notes
+    fun isSummaryTab(position: Int) = sections[position] is Section.Summary
     fun isBookmarksTab(position: Int) = sections[position] is Section.Bookmarks
     fun isChaptersTab(position: Int) = sections[position] is Section.Chapters
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/SummaryFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/SummaryFragment.kt
@@ -1,0 +1,75 @@
+package au.com.shiftyjelly.pocketcasts.player.view
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
+import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.viewModels
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.extensions.contentWithoutConsumedInsets
+import au.com.shiftyjelly.pocketcasts.compose.summary.SummaryContent
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.player.viewmodel.PlayerViewModel
+import au.com.shiftyjelly.pocketcasts.player.viewmodel.SummaryViewModel
+import au.com.shiftyjelly.pocketcasts.player.viewmodel.SummaryViewModel.SummaryState
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class SummaryFragment : BaseFragment() {
+
+    private val playerViewModel: PlayerViewModel by activityViewModels()
+    private val summaryViewModel: SummaryViewModel by viewModels({ requireParentFragment() })
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ) = contentWithoutConsumedInsets {
+        val state by summaryViewModel.state.collectAsState()
+        val podcast by playerViewModel.podcastFlow.collectAsState()
+        val backgroundColor = Color(theme.playerBackgroundColor(podcast))
+
+        AppThemeWithBackground(Theme.ThemeType.DARK) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(backgroundColor),
+            ) {
+                when (val s = state) {
+                    is SummaryState.Loading -> {
+                        CircularProgressIndicator(
+                            color = MaterialTheme.theme.colors.playerContrast01,
+                            modifier = Modifier.align(Alignment.Center),
+                        )
+                    }
+
+                    is SummaryState.Loaded -> {
+                        SummaryContent(
+                            text = s.text,
+                            titleColor = MaterialTheme.theme.colors.playerContrast01,
+                            textColor = MaterialTheme.theme.colors.playerContrast02,
+                            scrollBarColor = MaterialTheme.theme.colors.playerContrast02,
+                            modifier = Modifier.nestedScroll(rememberNestedScrollInteropConnection()),
+                        )
+                    }
+
+                    is SummaryState.NotAvailable -> Unit
+                }
+            }
+        }
+    }
+}

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/SummaryFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/SummaryFragment.kt
@@ -61,7 +61,7 @@ class SummaryFragment : BaseFragment() {
                         SummaryContent(
                             text = s.text,
                             titleColor = MaterialTheme.theme.colors.playerContrast01,
-                            textColor = MaterialTheme.theme.colors.playerContrast02,
+                            textColor = MaterialTheme.theme.colors.playerContrast01,
                             scrollBarColor = MaterialTheme.theme.colors.playerContrast02,
                             modifier = Modifier.nestedScroll(rememberNestedScrollInteropConnection()),
                         )

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/SummaryFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/SummaryFragment.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.MaterialTheme
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -17,6 +16,7 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.extensions.contentWithoutConsumedInsets
 import au.com.shiftyjelly.pocketcasts.compose.summary.SummaryContent
@@ -39,8 +39,8 @@ class SummaryFragment : BaseFragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?,
     ) = contentWithoutConsumedInsets {
-        val state by summaryViewModel.state.collectAsState()
-        val podcast by playerViewModel.podcastFlow.collectAsState()
+        val state by summaryViewModel.state.collectAsStateWithLifecycle()
+        val podcast by playerViewModel.podcastFlow.collectAsStateWithLifecycle()
         val backgroundColor = Color(theme.playerBackgroundColor(podcast))
 
         AppThemeWithBackground(Theme.ThemeType.DARK) {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/SummaryViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/SummaryViewModel.kt
@@ -2,9 +2,11 @@ package au.com.shiftyjelly.pocketcasts.player.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.repositories.di.IoDispatcher
 import au.com.shiftyjelly.pocketcasts.repositories.transcript.TranscriptManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -14,6 +16,7 @@ import kotlinx.coroutines.launch
 @HiltViewModel
 class SummaryViewModel @Inject constructor(
     private val transcriptManager: TranscriptManager,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
 
     sealed interface SummaryState {
@@ -35,11 +38,11 @@ class SummaryViewModel @Inject constructor(
     }
 
     fun loadSummary(episodeUuid: String) {
-        if (currentEpisodeUuid == episodeUuid) return
+        if (currentEpisodeUuid == episodeUuid && _state.value is SummaryState.Loaded) return
         currentEpisodeUuid = episodeUuid
         loadJob?.cancel()
         _state.value = SummaryState.Loading
-        loadJob = viewModelScope.launch {
+        loadJob = viewModelScope.launch(ioDispatcher) {
             val text = transcriptManager.loadSummaryText(episodeUuid)
             _state.value = if (text != null) {
                 SummaryState.Loaded(text)

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/SummaryViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/SummaryViewModel.kt
@@ -1,0 +1,45 @@
+package au.com.shiftyjelly.pocketcasts.player.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.repositories.transcript.TranscriptManager
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class SummaryViewModel @Inject constructor(
+    private val transcriptManager: TranscriptManager,
+) : ViewModel() {
+
+    sealed interface SummaryState {
+        data object Loading : SummaryState
+        data class Loaded(val text: String) : SummaryState
+        data object NotAvailable : SummaryState
+    }
+
+    private val _state = MutableStateFlow<SummaryState>(SummaryState.Loading)
+    val state: StateFlow<SummaryState> = _state.asStateFlow()
+
+    private var currentEpisodeUuid: String? = null
+    private var loadJob: Job? = null
+
+    fun loadSummary(episodeUuid: String) {
+        if (currentEpisodeUuid == episodeUuid) return
+        currentEpisodeUuid = episodeUuid
+        loadJob?.cancel()
+        _state.value = SummaryState.Loading
+        loadJob = viewModelScope.launch {
+            val text = transcriptManager.loadSummaryText(episodeUuid)
+            _state.value = if (text != null) {
+                SummaryState.Loaded(text)
+            } else {
+                SummaryState.NotAvailable
+            }
+        }
+    }
+}

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/SummaryViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/SummaryViewModel.kt
@@ -28,6 +28,12 @@ class SummaryViewModel @Inject constructor(
     private var currentEpisodeUuid: String? = null
     private var loadJob: Job? = null
 
+    fun clearSummary() {
+        currentEpisodeUuid = null
+        loadJob?.cancel()
+        _state.value = SummaryState.NotAvailable
+    }
+
     fun loadSummary(episodeUuid: String) {
         if (currentEpisodeUuid == episodeUuid) return
         currentEpisodeUuid = episodeUuid

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/SummaryViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/SummaryViewModelTest.kt
@@ -79,16 +79,38 @@ class SummaryViewModelTest {
     }
 
     @Test
-    fun `state resets to Loading when switching episodes`() = runTest {
+    fun `state updates correctly when switching to episode without summary`() = runTest {
         whenever(transcriptManager.loadSummaryText("episode-1")).thenReturn("Summary 1")
         val viewModel = createViewModel()
         viewModel.loadSummary("episode-1")
         assertEquals(SummaryState.Loaded("Summary 1"), viewModel.state.value)
 
-        // When loading a new episode, state should reset before the result arrives
         whenever(transcriptManager.loadSummaryText("episode-2")).thenReturn(null)
         viewModel.loadSummary("episode-2")
         assertEquals(SummaryState.NotAvailable, viewModel.state.value)
+    }
+
+    @Test
+    fun `clearSummary resets state to NotAvailable`() = runTest {
+        whenever(transcriptManager.loadSummaryText("episode-1")).thenReturn("Summary 1")
+        val viewModel = createViewModel()
+        viewModel.loadSummary("episode-1")
+        assertEquals(SummaryState.Loaded("Summary 1"), viewModel.state.value)
+
+        viewModel.clearSummary()
+        assertEquals(SummaryState.NotAvailable, viewModel.state.value)
+    }
+
+    @Test
+    fun `clearSummary allows reloading same episode`() = runTest {
+        whenever(transcriptManager.loadSummaryText("episode-1")).thenReturn("Summary 1")
+        val viewModel = createViewModel()
+        viewModel.loadSummary("episode-1")
+        assertEquals(SummaryState.Loaded("Summary 1"), viewModel.state.value)
+
+        viewModel.clearSummary()
+        viewModel.loadSummary("episode-1")
+        assertEquals(SummaryState.Loaded("Summary 1"), viewModel.state.value)
     }
 
     @Test

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/SummaryViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/SummaryViewModelTest.kt
@@ -25,7 +25,7 @@ class SummaryViewModelTest {
     @Mock
     private lateinit var transcriptManager: TranscriptManager
 
-    private fun createViewModel() = SummaryViewModel(transcriptManager)
+    private fun createViewModel() = SummaryViewModel(transcriptManager, coroutineRule.testDispatcher)
 
     @Test
     fun `initial state is Loading`() {
@@ -55,7 +55,7 @@ class SummaryViewModelTest {
     }
 
     @Test
-    fun `loading same episode twice does not re-fetch`() = runTest {
+    fun `loading same episode twice does not re-fetch when already loaded`() = runTest {
         whenever(transcriptManager.loadSummaryText("episode-1")).thenReturn("Summary text")
         val viewModel = createViewModel()
 
@@ -63,6 +63,19 @@ class SummaryViewModelTest {
         viewModel.loadSummary("episode-1")
 
         verify(transcriptManager).loadSummaryText("episode-1")
+    }
+
+    @Test
+    fun `loading same episode retries when previous attempt returned NotAvailable`() = runTest {
+        whenever(transcriptManager.loadSummaryText("episode-1")).thenReturn(null)
+        val viewModel = createViewModel()
+
+        viewModel.loadSummary("episode-1")
+        assertEquals(SummaryState.NotAvailable, viewModel.state.value)
+
+        whenever(transcriptManager.loadSummaryText("episode-1")).thenReturn("Summary text")
+        viewModel.loadSummary("episode-1")
+        assertEquals(SummaryState.Loaded("Summary text"), viewModel.state.value)
     }
 
     @Test

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/SummaryViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/SummaryViewModelTest.kt
@@ -1,0 +1,100 @@
+package au.com.shiftyjelly.pocketcasts.player.viewmodel
+
+import au.com.shiftyjelly.pocketcasts.player.viewmodel.SummaryViewModel.SummaryState
+import au.com.shiftyjelly.pocketcasts.repositories.transcript.TranscriptManager
+import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+
+@ExperimentalCoroutinesApi
+@RunWith(MockitoJUnitRunner::class)
+class SummaryViewModelTest {
+
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
+
+    @Mock
+    private lateinit var transcriptManager: TranscriptManager
+
+    private fun createViewModel() = SummaryViewModel(transcriptManager)
+
+    @Test
+    fun `initial state is Loading`() {
+        val viewModel = createViewModel()
+
+        assertEquals(SummaryState.Loading, viewModel.state.value)
+    }
+
+    @Test
+    fun `state is Loaded when summary text is available`() = runTest {
+        whenever(transcriptManager.loadSummaryText("episode-1")).thenReturn("Summary text")
+        val viewModel = createViewModel()
+
+        viewModel.loadSummary("episode-1")
+
+        assertEquals(SummaryState.Loaded("Summary text"), viewModel.state.value)
+    }
+
+    @Test
+    fun `state is NotAvailable when summary text is null`() = runTest {
+        whenever(transcriptManager.loadSummaryText("episode-1")).thenReturn(null)
+        val viewModel = createViewModel()
+
+        viewModel.loadSummary("episode-1")
+
+        assertEquals(SummaryState.NotAvailable, viewModel.state.value)
+    }
+
+    @Test
+    fun `loading same episode twice does not re-fetch`() = runTest {
+        whenever(transcriptManager.loadSummaryText("episode-1")).thenReturn("Summary text")
+        val viewModel = createViewModel()
+
+        viewModel.loadSummary("episode-1")
+        viewModel.loadSummary("episode-1")
+
+        verify(transcriptManager).loadSummaryText("episode-1")
+    }
+
+    @Test
+    fun `loading different episode fetches new summary`() = runTest {
+        whenever(transcriptManager.loadSummaryText("episode-1")).thenReturn("Summary 1")
+        whenever(transcriptManager.loadSummaryText("episode-2")).thenReturn("Summary 2")
+        val viewModel = createViewModel()
+
+        viewModel.loadSummary("episode-1")
+        assertEquals(SummaryState.Loaded("Summary 1"), viewModel.state.value)
+
+        viewModel.loadSummary("episode-2")
+        assertEquals(SummaryState.Loaded("Summary 2"), viewModel.state.value)
+    }
+
+    @Test
+    fun `state resets to Loading when switching episodes`() = runTest {
+        whenever(transcriptManager.loadSummaryText("episode-1")).thenReturn("Summary 1")
+        val viewModel = createViewModel()
+        viewModel.loadSummary("episode-1")
+        assertEquals(SummaryState.Loaded("Summary 1"), viewModel.state.value)
+
+        // When loading a new episode, state should reset before the result arrives
+        whenever(transcriptManager.loadSummaryText("episode-2")).thenReturn(null)
+        viewModel.loadSummary("episode-2")
+        assertEquals(SummaryState.NotAvailable, viewModel.state.value)
+    }
+
+    @Test
+    fun `no interaction with transcript manager before loadSummary is called`() {
+        createViewModel()
+
+        verifyNoInteractions(transcriptManager)
+    }
+}

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -48,7 +48,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.graphics.BlendModeColorFilterCompat
 import androidx.core.graphics.BlendModeCompat
-import androidx.core.text.htmlEncode
 import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
 import androidx.core.widget.TextViewCompat
@@ -66,6 +65,7 @@ import au.com.shiftyjelly.pocketcasts.compose.buttons.ButtonTab
 import au.com.shiftyjelly.pocketcasts.compose.buttons.ButtonTabs
 import au.com.shiftyjelly.pocketcasts.compose.extensions.setContentWithViewCompositionStrategy
 import au.com.shiftyjelly.pocketcasts.compose.text.HtmlText
+import au.com.shiftyjelly.pocketcasts.compose.text.markdownToHtml
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.localization.helper.TimeHelper
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
@@ -993,19 +993,3 @@ class EpisodeFragment : BaseFragment() {
 
 private val BannerEnterTransition = fadeIn() + expandVertically()
 private val BannerExitTransition = fadeOut() + shrinkVertically()
-
-private fun markdownToHtml(markdown: String): String {
-    return markdown.lines()
-        .joinToString("\n") { line ->
-            when {
-                line.startsWith("### ") -> "<h3>${line.removePrefix("### ").htmlEncode()}</h3>"
-                line.startsWith("## ") -> "<h2>${line.removePrefix("## ").htmlEncode()}</h2>"
-                line.startsWith("# ") -> "<h1>${line.removePrefix("# ").htmlEncode()}</h1>"
-                line.startsWith("- ") -> "&#8226; ${line.removePrefix("- ").htmlEncode()}<br>"
-                line.startsWith("* ") -> "&#8226; ${line.removePrefix("* ").htmlEncode()}<br>"
-                line.isBlank() -> "<br>"
-                else -> "${line.htmlEncode()}<br>"
-            }
-        }
-        .replace(Regex("\\*\\*(.+?)\\*\\*"), "<b>$1</b>")
-}

--- a/modules/services/compose/build.gradle.kts
+++ b/modules/services/compose/build.gradle.kts
@@ -45,4 +45,7 @@ dependencies {
     implementation(projects.modules.services.images)
     implementation(projects.modules.services.localization)
     implementation(projects.modules.services.utils)
+
+    testImplementation(libs.junit)
+    testImplementation(libs.robolectric)
 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/summary/SummaryContent.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/summary/SummaryContent.kt
@@ -12,12 +12,17 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.text.htmlEncode
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.extensions.verticalScrollBar
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.text.HtmlText
 import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
@@ -55,6 +60,18 @@ fun SummaryContent(
                 textStyleResId = UR.style.P40,
             )
         }
+    }
+}
+
+@Preview
+@Composable
+private fun SummaryContentPreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
+) {
+    AppThemeWithBackground(themeType) {
+        SummaryContent(
+            text = "## Episode Highlights\n\n- First key point discussed\n- Second important topic\n- **Notable quote** from the guest\n\nThe hosts wrap up with final thoughts.",
+        )
     }
 }
 

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/summary/SummaryContent.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/summary/SummaryContent.kt
@@ -1,0 +1,73 @@
+package au.com.shiftyjelly.pocketcasts.compose.summary
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.core.text.htmlEncode
+import au.com.shiftyjelly.pocketcasts.compose.extensions.verticalScrollBar
+import au.com.shiftyjelly.pocketcasts.compose.text.HtmlText
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+import au.com.shiftyjelly.pocketcasts.ui.R as UR
+
+@Composable
+fun SummaryContent(
+    text: String,
+    modifier: Modifier = Modifier,
+    titleColor: Color = MaterialTheme.theme.colors.primaryText01,
+    textColor: Color = MaterialTheme.theme.colors.primaryText02,
+    scrollBarColor: Color = MaterialTheme.theme.colors.primaryIcon02,
+    contentPadding: PaddingValues = PaddingValues(horizontal = 24.dp, vertical = 24.dp),
+) {
+    val listState = rememberLazyListState()
+
+    LazyColumn(
+        state = listState,
+        contentPadding = contentPadding,
+        modifier = modifier
+            .verticalScrollBar(scrollState = listState, thumbColor = scrollBarColor),
+    ) {
+        item {
+            Text(
+                text = stringResource(LR.string.episode_summary),
+                color = titleColor,
+                fontSize = 20.sp,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(bottom = 16.dp),
+            )
+        }
+        item {
+            HtmlText(
+                html = markdownToHtml(text),
+                color = textColor,
+                textStyleResId = UR.style.P40,
+            )
+        }
+    }
+}
+
+fun markdownToHtml(markdown: String): String {
+    return markdown.lines()
+        .joinToString("\n") { line ->
+            when {
+                line.startsWith("### ") -> "<h3>${line.removePrefix("### ").htmlEncode()}</h3>"
+                line.startsWith("## ") -> "<h2>${line.removePrefix("## ").htmlEncode()}</h2>"
+                line.startsWith("# ") -> "<h1>${line.removePrefix("# ").htmlEncode()}</h1>"
+                line.startsWith("- ") -> "&#8226; ${line.removePrefix("- ").htmlEncode()}<br>"
+                line.startsWith("* ") -> "&#8226; ${line.removePrefix("* ").htmlEncode()}<br>"
+                line.isBlank() -> "<br>"
+                else -> "${line.htmlEncode()}<br>"
+            }
+        }
+        .replace(Regex("\\*\\*(.+?)\\*\\*"), "<b>$1</b>")
+}

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/summary/SummaryContent.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/summary/SummaryContent.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
@@ -35,7 +36,7 @@ fun SummaryContent(
         state = listState,
         contentPadding = contentPadding,
         modifier = modifier
-            .verticalScrollBar(scrollState = listState, thumbColor = scrollBarColor),
+            .verticalScrollBar(scrollState = listState, thumbColor = scrollBarColor, contentPadding = contentPadding),
     ) {
         item {
             Text(
@@ -47,8 +48,9 @@ fun SummaryContent(
             )
         }
         item {
+            val html = remember(text) { markdownToHtml(text) }
             HtmlText(
-                html = markdownToHtml(text),
+                html = html,
                 color = textColor,
                 textStyleResId = UR.style.P40,
             )
@@ -56,7 +58,7 @@ fun SummaryContent(
     }
 }
 
-fun markdownToHtml(markdown: String): String {
+internal fun markdownToHtml(markdown: String): String {
     return markdown.lines()
         .joinToString("\n") { line ->
             when {

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/summary/SummaryContent.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/summary/SummaryContent.kt
@@ -16,11 +16,11 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.core.text.htmlEncode
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.extensions.verticalScrollBar
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.text.HtmlText
+import au.com.shiftyjelly.pocketcasts.compose.text.markdownToHtml
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -73,20 +73,4 @@ private fun SummaryContentPreview(
             text = "## Episode Highlights\n\n- First key point discussed\n- Second important topic\n- **Notable quote** from the guest\n\nThe hosts wrap up with final thoughts.",
         )
     }
-}
-
-internal fun markdownToHtml(markdown: String): String {
-    return markdown.lines()
-        .joinToString("\n") { line ->
-            when {
-                line.startsWith("### ") -> "<h3>${line.removePrefix("### ").htmlEncode()}</h3>"
-                line.startsWith("## ") -> "<h2>${line.removePrefix("## ").htmlEncode()}</h2>"
-                line.startsWith("# ") -> "<h1>${line.removePrefix("# ").htmlEncode()}</h1>"
-                line.startsWith("- ") -> "&#8226; ${line.removePrefix("- ").htmlEncode()}<br>"
-                line.startsWith("* ") -> "&#8226; ${line.removePrefix("* ").htmlEncode()}<br>"
-                line.isBlank() -> "<br>"
-                else -> "${line.htmlEncode()}<br>"
-            }
-        }
-        .replace(Regex("\\*\\*(.+?)\\*\\*"), "<b>$1</b>")
 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/text/MarkdownUtils.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/text/MarkdownUtils.kt
@@ -1,0 +1,19 @@
+package au.com.shiftyjelly.pocketcasts.compose.text
+
+import androidx.core.text.htmlEncode
+
+fun markdownToHtml(markdown: String): String {
+    return markdown.lines()
+        .joinToString("\n") { line ->
+            when {
+                line.startsWith("### ") -> "<h3>${line.removePrefix("### ").htmlEncode()}</h3>"
+                line.startsWith("## ") -> "<h2>${line.removePrefix("## ").htmlEncode()}</h2>"
+                line.startsWith("# ") -> "<h1>${line.removePrefix("# ").htmlEncode()}</h1>"
+                line.startsWith("- ") -> "&#8226; ${line.removePrefix("- ").htmlEncode()}<br>"
+                line.startsWith("* ") -> "&#8226; ${line.removePrefix("* ").htmlEncode()}<br>"
+                line.isBlank() -> "<br>"
+                else -> "${line.htmlEncode()}<br>"
+            }
+        }
+        .replace(Regex("\\*\\*(.+?)\\*\\*"), "<b>$1</b>")
+}

--- a/modules/services/compose/src/test/java/au/com/shiftyjelly/pocketcasts/compose/text/MarkdownUtilsTest.kt
+++ b/modules/services/compose/src/test/java/au/com/shiftyjelly/pocketcasts/compose/text/MarkdownUtilsTest.kt
@@ -1,0 +1,74 @@
+package au.com.shiftyjelly.pocketcasts.compose.text
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class MarkdownUtilsTest {
+
+    @Test
+    fun `empty string returns empty html`() {
+        assertEquals("<br>", markdownToHtml(""))
+    }
+
+    @Test
+    fun `h1 header is converted`() {
+        assertEquals("<h1>Title</h1>", markdownToHtml("# Title"))
+    }
+
+    @Test
+    fun `h2 header is converted`() {
+        assertEquals("<h2>Section</h2>", markdownToHtml("## Section"))
+    }
+
+    @Test
+    fun `h3 header is converted`() {
+        assertEquals("<h3>Subsection</h3>", markdownToHtml("### Subsection"))
+    }
+
+    @Test
+    fun `dash list item is converted`() {
+        assertEquals("&#8226; Item one<br>", markdownToHtml("- Item one"))
+    }
+
+    @Test
+    fun `asterisk list item is converted`() {
+        assertEquals("&#8226; Item two<br>", markdownToHtml("* Item two"))
+    }
+
+    @Test
+    fun `bold text is converted`() {
+        assertEquals("This is <b>bold</b> text<br>", markdownToHtml("This is **bold** text"))
+    }
+
+    @Test
+    fun `blank line becomes br`() {
+        assertEquals("First<br>\n<br>\nSecond<br>", markdownToHtml("First\n\nSecond"))
+    }
+
+    @Test
+    fun `regular text gets br suffix`() {
+        assertEquals("Hello world<br>", markdownToHtml("Hello world"))
+    }
+
+    @Test
+    fun `special characters are html encoded`() {
+        val result = markdownToHtml("Use <div> & \"quotes\"")
+        assertEquals("Use &lt;div&gt; &amp; &quot;quotes&quot;<br>", result)
+    }
+
+    @Test
+    fun `mixed content is converted correctly`() {
+        val markdown = """
+            ## Episode Highlights
+
+            - First point
+            - **Key** takeaway
+        """.trimIndent()
+
+        val expected = "<h2>Episode Highlights</h2>\n<br>\n&#8226; First point<br>\n&#8226; <b>Key</b> takeaway<br>"
+        assertEquals(expected, markdownToHtml(markdown))
+    }
+}

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -438,6 +438,7 @@
     <string name="player_tab_chapters" translatable="false">@string/chapters</string>
     <string name="player_tab_notes">Details</string>
     <string name="player_tab_playing">Playing</string>
+    <string name="player_tab_summary">Summary</string>
     <string name="player_tab_playing_wide">Now Playing</string>
     <string name="player_time_saved_detail">In total you have saved %s using this feature.</string>
     <string name="player_time_saved_no_hour">Congrats! You\'re saving time and getting through more podcasts.</string>


### PR DESCRIPTION
## Description
This PR is part of the Radical Speed Month intiative. 
It builds upon the previous step where we added generated ai summary to the episode details page. This time we also display the summary on the full screen player, under a new dedicated tab 'Summary'.

internal comms: p1778169046180879/1778161670.744719-slack-C075WBQ9WKH

## Testing Instructions
1. Find a podcast that has generated transcripts (e.g. The American Life)
2. Open the podcast, start playing an episode
3. Tap miniplayer to enter fullscreen mode
4. Notice the new Summary tab
5. Scroll to Summary tab
6. Play with the summary

## Screenshots or Screencast

https://github.com/user-attachments/assets/e52cc4dd-9db9-48c4-92fb-b4605065bcc0

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack