### PR TITLE
[RSM] Smart Bookmarks list UI

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarkViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarkViewModel.kt
@@ -113,9 +113,7 @@ class BookmarkViewModel
                 if (bookmark != null) {
                     onSaved(bookmark, isExistingBookmark)
                     if (!isExistingBookmark && FeatureFlag.isEnabled(Feature.SMART_BOOKMARKS)) {
-                        viewModelScope.launch(Dispatchers.IO) {
-                            bookmarkManager.enrichBookmark(bookmark)
-                        }
+                        bookmarkManager.enrichBookmark(bookmark)
                     }
                 }
             } catch (e: Exception) {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarkViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarkViewModel.kt
@@ -8,6 +8,8 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
 import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import com.automattic.eventhorizon.BookmarkEditFormDismissedEvent
 import com.automattic.eventhorizon.BookmarkEditFormShownEvent
 import com.automattic.eventhorizon.BookmarkEditFormSubmittedEvent
@@ -110,6 +112,11 @@ class BookmarkViewModel
                 }
                 if (bookmark != null) {
                     onSaved(bookmark, isExistingBookmark)
+                    if (!isExistingBookmark && FeatureFlag.isEnabled(Feature.SMART_BOOKMARKS)) {
+                        viewModelScope.launch(Dispatchers.IO) {
+                            bookmarkManager.enrichBookmark(bookmark)
+                        }
+                    }
                 }
             } catch (e: Exception) {
                 Timber.e(e)

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/bookmark/BookmarkRow.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/bookmark/BookmarkRow.kt
@@ -137,7 +137,7 @@ fun BookmarkRow(
                     TextH70(
                         text = bookmark.episodeTitle,
                         color = colors.bookmarkRow.secondaryText,
-                        maxLines = 2,
+                        maxLines = 1,
                         modifier = Modifier.padding(top = 8.dp),
                     )
                 }
@@ -153,18 +153,9 @@ fun BookmarkRow(
                 TextH40(
                     text = displayTitle,
                     color = colors.bookmarkRow.primaryText,
-                    maxLines = 2,
+                    maxLines = 1,
                     lineHeight = 18.sp,
                 )
-
-                if (!bookmark.aiSummary.isNullOrEmpty()) {
-                    TextH70(
-                        text = bookmark.aiSummary.orEmpty(),
-                        color = colors.bookmarkRow.secondaryText,
-                        maxLines = 2,
-                        modifier = Modifier.padding(top = 2.dp),
-                    )
-                }
 
                 TextH70(
                     text = createdAtText,

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/bookmark/BookmarkRow.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/bookmark/BookmarkRow.kt
@@ -118,7 +118,7 @@ fun BookmarkRow(
                     } else {
                         Image(
                             painter = painterResource(if (MaterialTheme.theme.isDark) IR.drawable.defaultartwork_dark else IR.drawable.defaultartwork),
-                            contentDescription = bookmark.title,
+                            contentDescription = bookmark.displayTitle,
                             modifier = Modifier
                                 .size(56.dp)
                                 .clip(RoundedCornerShape(8.dp)),

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/bookmark/BookmarkRow.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/bookmark/BookmarkRow.kt
@@ -148,12 +148,23 @@ fun BookmarkRow(
                     ),
                 )
 
+                val displayTitle = bookmark.displayTitle
+
                 TextH40(
-                    text = bookmark.title,
+                    text = displayTitle,
                     color = colors.bookmarkRow.primaryText,
                     maxLines = 2,
                     lineHeight = 18.sp,
                 )
+
+                if (!bookmark.aiSummary.isNullOrEmpty()) {
+                    TextH70(
+                        text = bookmark.aiSummary.orEmpty(),
+                        color = colors.bookmarkRow.secondaryText,
+                        maxLines = 2,
+                        modifier = Modifier.padding(top = 2.dp),
+                    )
+                }
 
                 TextH70(
                     text = createdAtText,

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/BookmarkDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/BookmarkDao.kt
@@ -211,10 +211,10 @@ abstract class BookmarkDao {
 
     @Query(
         """UPDATE bookmarks SET
-            ai_title = :aiTitle,
-            ai_summary = :aiSummary,
-            ai_title_modified = :aiTitleModified,
-            ai_summary_modified = :aiSummaryModified,
+            ai_title = COALESCE(:aiTitle, ai_title),
+            ai_summary = COALESCE(:aiSummary, ai_summary),
+            ai_title_modified = COALESCE(:aiTitleModified, ai_title_modified),
+            ai_summary_modified = COALESCE(:aiSummaryModified, ai_summary_modified),
             sync_status = :syncStatus
             WHERE uuid = :bookmarkUuid""",
     )

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/BookmarkDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/BookmarkDao.kt
@@ -32,7 +32,7 @@ abstract class BookmarkDao {
     @Transaction
     open suspend fun deleteAll(uuids: Collection<String>) {
         uuids.chunked(AppDatabase.SQLITE_BIND_ARG_LIMIT).forEach { chunk ->
-            deleteAllUnsafe(uuids)
+            deleteAllUnsafe(chunk)
         }
     }
 
@@ -239,7 +239,7 @@ abstract class BookmarkDao {
     @Transaction
     open suspend fun getAll(uuids: Collection<String>): List<Bookmark> {
         return uuids.chunked(999).flatMap { chunk ->
-            getAllUnsafe(uuids)
+            getAllUnsafe(chunk)
         }
     }
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/Bookmark.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/Bookmark.kt
@@ -48,11 +48,10 @@ data class Bookmark(
 
     val displayTitle: String
         get() {
-            val aiModified = aiTitleModified
-            val userModified = titleModified
+            val userEdited = titleModified != null && titleModified!! > createdAt.time
             return when {
                 aiTitle == null -> title
-                userModified != null && aiModified != null && userModified > aiModified -> title
+                userEdited -> title
                 else -> aiTitle ?: title
             }
         }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/Bookmark.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/Bookmark.kt
@@ -48,12 +48,9 @@ data class Bookmark(
 
     val displayTitle: String
         get() {
-            val userEdited = titleModified != null && titleModified!! > createdAt.time
-            return when {
-                aiTitle == null -> title
-                userEdited -> title
-                else -> aiTitle ?: title
-            }
+            val aiTitleValue = aiTitle ?: return title
+            val userEditedAt = titleModified ?: return aiTitleValue
+            return if (userEditedAt > createdAt.time) title else aiTitleValue
         }
 
     fun createdAtDatePattern(): String {

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/Bookmark.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/Bookmark.kt
@@ -46,6 +46,17 @@ data class Bookmark(
     val adapterId: Long
         get() = UUID.nameUUIDFromBytes(uuid.toByteArray()).mostSignificantBits
 
+    val displayTitle: String
+        get() {
+            val aiModified = aiTitleModified
+            val userModified = titleModified
+            return when {
+                aiTitle == null -> title
+                userModified != null && aiModified != null && userModified > aiModified -> title
+                else -> aiTitle ?: title
+            }
+        }
+
     fun createdAtDatePattern(): String {
         val calendar = Calendar.getInstance()
         val currentYear = calendar.get(Calendar.YEAR)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkHelper.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkHelper.kt
@@ -67,7 +67,6 @@ class BookmarkHelper(
             if (isNew && FeatureFlag.isEnabled(Feature.SMART_BOOKMARKS)) {
                 bookmarkManager.enrichBookmark(bookmark)
             }
-
             if (settings.headphoneControlsPlayBookmarkConfirmationSound.value) {
                 playbackManager.playBookmarkTone()
             }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkHelper.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkHelper.kt
@@ -19,6 +19,8 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.utils.AppPlatform
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.utils.extensions.isAppForeground
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import com.automattic.eventhorizon.BookmarkSourceType
 import au.com.shiftyjelly.pocketcasts.images.R as IR
@@ -52,6 +54,7 @@ class BookmarkHelper(
                 timeSecs = timeInSecs,
             )
 
+            val isNew = bookmark == null
             if (bookmark == null) {
                 bookmark = bookmarkManager.add(
                     episode = episode,
@@ -59,6 +62,10 @@ class BookmarkHelper(
                     title = context.getString(LR.string.bookmark),
                     creationSource = BookmarkSourceType.Headphones,
                 )
+            }
+
+            if (isNew && FeatureFlag.isEnabled(Feature.SMART_BOOKMARKS)) {
+                bookmarkManager.enrichBookmark(bookmark)
             }
 
             if (settings.headphoneControlsPlayBookmarkConfirmationSound.value) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManager.kt
@@ -40,7 +40,7 @@ interface BookmarkManager {
         sortType: BookmarksSortTypeForProfile,
     ): Flow<List<Bookmark>>
     fun hasBookmarksFlow(episodeUuid: String): Flow<Boolean>
-    suspend fun enrichBookmark(bookmark: Bookmark)
+    fun enrichBookmark(bookmark: Bookmark)
 
     var sourceView: SourceView
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerImpl.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
 import timber.log.Timber
 
 class BookmarkManagerImpl @Inject constructor(
@@ -233,34 +234,36 @@ class BookmarkManagerImpl @Inject constructor(
         return bookmarkDao.hasBookmarksFlow(episodeUuid)
     }
 
-    override suspend fun enrichBookmark(bookmark: Bookmark) {
-        try {
-            val snippet = transcriptWindowExtractor.extractWindow(
-                episodeUuid = bookmark.episodeUuid,
-                timeSecs = bookmark.timeSecs,
-            ) ?: return
+    override fun enrichBookmark(bookmark: Bookmark) {
+        launch {
+            try {
+                val snippet = transcriptWindowExtractor.extractWindow(
+                    episodeUuid = bookmark.episodeUuid,
+                    timeSecs = bookmark.timeSecs,
+                ) ?: return@launch
 
-            val response = syncManager.enrichBookmark(transcriptSnippet = snippet)
-            if (response.error != null) {
-                Timber.w("Smart bookmark enrichment returned error for ${bookmark.uuid}: ${response.error}")
+                val response = syncManager.enrichBookmark(transcriptSnippet = snippet)
+                if (response.error != null) {
+                    Timber.w("Smart bookmark enrichment returned error for ${bookmark.uuid}: ${response.error}")
+                }
+                val title = response.title
+                val summary = response.summary
+                if (title != null && summary != null) {
+                    val now = System.currentTimeMillis()
+                    bookmarkDao.updateAiData(
+                        bookmarkUuid = bookmark.uuid,
+                        aiTitle = title,
+                        aiSummary = summary,
+                        aiTitleModified = now,
+                        aiSummaryModified = now,
+                        syncStatus = SyncStatus.NOT_SYNCED,
+                    )
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Timber.e(e, "Smart bookmark enrichment failed for ${bookmark.uuid}")
             }
-            val title = response.title
-            val summary = response.summary
-            if (title != null && summary != null) {
-                val now = System.currentTimeMillis()
-                bookmarkDao.updateAiData(
-                    bookmarkUuid = bookmark.uuid,
-                    aiTitle = title,
-                    aiSummary = summary,
-                    aiTitleModified = now,
-                    aiSummaryModified = now,
-                    syncStatus = SyncStatus.NOT_SYNCED,
-                )
-            }
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            Timber.e(e, "Smart bookmark enrichment failed for ${bookmark.uuid}")
         }
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerImpl.kt
@@ -235,7 +235,7 @@ class BookmarkManagerImpl @Inject constructor(
     }
 
     override fun enrichBookmark(bookmark: Bookmark) {
-        launch {
+        launch(Dispatchers.IO) {
             try {
                 val snippet = transcriptWindowExtractor.extractWindow(
                     episodeUuid = bookmark.episodeUuid,
@@ -248,14 +248,14 @@ class BookmarkManagerImpl @Inject constructor(
                 }
                 val title = response.title
                 val summary = response.summary
-                if (title != null && summary != null) {
+                if (title != null || summary != null) {
                     val now = System.currentTimeMillis()
                     bookmarkDao.updateAiData(
                         bookmarkUuid = bookmark.uuid,
                         aiTitle = title,
                         aiSummary = summary,
-                        aiTitleModified = now,
-                        aiSummaryModified = now,
+                        aiTitleModified = now.takeIf { title != null },
+                        aiSummaryModified = now.takeIf { summary != null },
                         syncStatus = SyncStatus.NOT_SYNCED,
                     )
                 }


### PR DESCRIPTION
## Description
This is the last PR on the android-side of changes, where we hook up the enrichment flow and surface the results in the UI, on the bookmarks list. When a new bookmark is created, the app now fires off a background enrichment call if the Smart Bookmarks feature flag is enabled. The enrichment runs after the bookmark is saved, so the user sees no delay. 
On the display side, the bookmark row now shows the AI-generated title when the user hasn't manually edited it, with a `displayTitle` property that picks the right one based on timestamp priority. If an AI summary is available, it appears as a secondary line beneath the title.  
    
An upcoming PR will let us open the enhanced bookmarks to see its details.

## Testing Instructions
Since the backend changes are not yet deployed, the best way to test the new ui in action is to manually inject data into the database via Android Studio's Database inspector tool.
Select `pocketcasts` database then run these queries:
1- ` SELECT uuid, podcast_id FROM podcast_episodes ORDER BY published_date DESC LIMIT 1` -- remember these Ids!
2- 
```
INSERT INTO bookmarks (uuid, podcast_uuid, episode_uuid, time, created_at, title, title_modified, deleted, deleted_modified, ai_title, ai_summary, ai_title_modified, ai_summary_modified, sync_status, clean_title)                                                                                                      
  VALUES                                                                                                                                                                                                                                                                                                                    
    ('aaaa-0001-test-bookmark-01', '<PODCAST_UUID>', '<EPISODE_UUID>', 120, 1715100000000, 'Bookmark', 1715100000000, 0, 1715100000000, 'The future of open-source AI', 'Discussion about why open-weight models are becoming the default choice for enterprise adoption.', 1715100000001, 1715100000001, 0, 'bookmark'),
    ('aaaa-0002-test-bookmark-02', '<PODCAST_UUID>', '<EPISODE_UUID>', 340, 1715100000000, 'Bookmark', 1715100000000, 0, 1715100000000, 'Latency vs throughput tradeoff', 'Why optimizing for low latency often means sacrificing batch throughput, and when that tradeoff makes sense.', 1715100000001, 1715100000001, 0,  
  'bookmark'),                                                                                                                                                                                                                                                                                                              
    ('aaaa-0003-test-bookmark-03', '<PODCAST_UUID>', '<EPISODE_UUID>', 600, 1715100000000, 'Bookmark', 1715100000000, 0, 1715100000000, NULL, NULL, NULL, NULL, 0, 'bookmark');  
```

don't forget to overwrite the placeholders <PODCAST_UUID> and <EPISODE_UUID> with actual values from the previous query!

Then just navigate to the bookmarks list to see the results

design decision: p1778625860157799/1778602895.425639-slack-C05RR9P9RAT

## Screenshots or Screencast 
| designs | actual |
| --- | --- |
| <img width="235" height="486" alt="SCR-20260522-pbmt" src="https://github.com/user-attachments/assets/9e3d1f31-5a8f-4d0b-9def-c3379aaabe6e" /> | <img width="1080" height="2400" alt="Screenshot_20260522_163055" src="https://github.com/user-attachments/assets/d1c95aba-967c-4b36-9df9-ac3499c807dc" /> |



## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.