### PR TITLE
Updated Blogs icon and improve podcast page link colours

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.statusBars
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.text.AnnotatedString
@@ -407,6 +408,7 @@ class PodcastAdapter(
             text = episodeHeader.searchTerm
         }
         holder.binding.btnArchived.setText(if (episodeHeader.showingArchived) LR.string.podcast_hide_archived else LR.string.podcast_show_archived)
+        holder.binding.btnArchived.setTextColor(ThemeColor.podcastText02(theme.activeTheme, tintColor))
         holder.binding.btnArchived.setOnClickListener { onShowArchivedClicked() }
     }
 
@@ -422,6 +424,7 @@ class PodcastAdapter(
             isSelected = multiSelectEpisodesHelper.isSelected(episode),
             useEpisodeArtwork = settings.artworkConfiguration.value.useEpisodeArtwork(Element.Podcasts),
             streamByDefault = settings.streamingMode.value,
+            tint = tintColor,
             animateMultiSelection = animateMultiSelection,
         )
     }
@@ -467,7 +470,9 @@ class PodcastAdapter(
     }
 
     fun setTint(tintColor: Int) {
+        if (this.tintColor == tintColor) return
         this.tintColor = tintColor
+        notifyDataSetChanged()
     }
 
     fun setSignInState(signInState: SignInState) {
@@ -832,6 +837,7 @@ class PodcastAdapter(
                             schedule = podcast.displayableFrequency(context.resources),
                             next = podcast.displayableNextEpisodeDate(context),
                         ),
+                        linkColor = Color(ThemeColor.podcastText02(theme.activeTheme, tintColor)),
                         rating = ratingState,
                         isFollowed = podcast.isSubscribed,
                         areNotificationsEnabled = podcast.isShowNotifications,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -57,6 +57,7 @@ import au.com.shiftyjelly.pocketcasts.preferences.model.ArtworkConfiguration.Ele
 import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeRowDataProvider
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverPodcast
+import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
 import au.com.shiftyjelly.pocketcasts.ui.extensions.themed
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
@@ -236,7 +237,7 @@ class PodcastAdapter(
 
     private var headerExpanded: Boolean = false
     private var isDescriptionExpanded = false
-    private var tintColor: Int = 0x000000
+    private var tintColor: Int = context.getThemeColor(UR.attr.primary_icon_01)
     private var signInState: SignInState = SignInState.SignedOut
     private var ratingState: RatingState = RatingState.Loading
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastHeader.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastHeader.kt
@@ -132,6 +132,7 @@ internal fun PodcastHeader(
     explicit: Boolean,
     description: AnnotatedString,
     podcastInfoState: PodcastInfoState,
+    linkColor: Color,
     rating: RatingState,
     isFollowed: Boolean,
     areNotificationsEnabled: Boolean,
@@ -225,6 +226,7 @@ internal fun PodcastHeader(
                 PodcastDetails(
                     description = description,
                     podcastInfoState = podcastInfoState,
+                    linkColor = linkColor,
                     isDescriptionExpanded = isDescriptionExpanded,
                     onClickShowNotes = onToggleDescription,
                     onClickWebsiteLink = onClickWebsiteLink,
@@ -729,36 +731,40 @@ private fun ActionButton(
 private fun PodcastDetails(
     description: AnnotatedString,
     podcastInfoState: PodcastInfoState,
+    linkColor: Color,
     isDescriptionExpanded: Boolean,
     onClickShowNotes: () -> Unit,
     onClickWebsiteLink: () -> Unit,
 ) {
     Column {
-        Spacer(
-            modifier = Modifier.height(16.dp),
-        )
-        ExpandableText(
-            text = description,
-            overflowText = stringResource(LR.string.see_more),
-            isExpanded = isDescriptionExpanded,
-            style = detailsInfoTextStyle.copy(
-                color = MaterialTheme.theme.colors.primaryText01,
-            ),
-            maxLines = 4,
-            modifier = Modifier
-                .fillMaxWidth()
-                .clickable(
-                    indication = null,
-                    interactionSource = null,
-                    onClick = onClickShowNotes,
+        if (description.isNotEmpty()) {
+            Spacer(
+                modifier = Modifier.height(16.dp),
+            )
+            ExpandableText(
+                text = description,
+                overflowText = stringResource(LR.string.see_more),
+                isExpanded = isDescriptionExpanded,
+                style = detailsInfoTextStyle.copy(
+                    color = MaterialTheme.theme.colors.primaryText01,
                 ),
-        )
+                maxLines = 4,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable(
+                        indication = null,
+                        interactionSource = null,
+                        onClick = onClickShowNotes,
+                    ),
+            )
+        }
         Spacer(
             modifier = Modifier.height(16.dp),
         )
         PodcastInfoView(
             state = podcastInfoState,
             onWebsiteLinkClick = onClickWebsiteLink,
+            linkColor = linkColor,
         )
     }
 }
@@ -982,6 +988,7 @@ private fun PodcastHeaderPreview(
                     schedule = "Every two weeks",
                     next = "Meaning of life",
                 ),
+                linkColor = MaterialTheme.theme.colors.primaryIcon01,
                 rating = RatingState.Loaded(
                     ratings = PodcastRatings(
                         podcastUuid = "uuid",

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastInfoView.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastInfoView.kt
@@ -15,6 +15,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
@@ -33,6 +34,7 @@ fun PodcastInfoView(
     state: PodcastInfoState,
     onWebsiteLinkClick: () -> Unit,
     modifier: Modifier = Modifier,
+    linkColor: Color = MaterialTheme.theme.colors.primaryIcon01,
 ) {
     Card(
         shape = RoundedCornerShape(8.dp),
@@ -50,16 +52,19 @@ fun PodcastInfoView(
             verticalArrangement = Arrangement.spacedBy(12.dp),
             modifier = Modifier.padding(16.dp),
         ) {
-            PodcastInfoItem(
-                state.author,
-                IR.drawable.ic_author,
-            )
+            if (state.author.isNotEmpty()) {
+                PodcastInfoItem(
+                    state.author,
+                    IR.drawable.ic_author,
+                )
+            }
 
             if (!state.link.isNullOrEmpty()) {
                 PodcastInfoItem(
                     text = state.link,
                     icon = IR.drawable.ic_link,
                     isLink = true,
+                    linkColor = linkColor,
                     onWebsiteLinkClick = onWebsiteLinkClick,
                 )
             }
@@ -87,6 +92,7 @@ private fun PodcastInfoItem(
     icon: Int,
     modifier: Modifier = Modifier,
     isLink: Boolean = false,
+    linkColor: Color = MaterialTheme.theme.colors.primaryIcon01,
     onWebsiteLinkClick: () -> Unit = {},
 ) {
     Row(
@@ -107,7 +113,7 @@ private fun PodcastInfoItem(
             TextP40(
                 text = text,
                 maxLines = 3,
-                color = MaterialTheme.theme.colors.support05,
+                color = linkColor,
                 fontWeight = FontWeight.W400,
                 modifier = Modifier.clickable {
                     onWebsiteLinkClick.invoke()

--- a/modules/services/images/src/main/res/drawable/ic_blogs.xml
+++ b/modules/services/images/src/main/res/drawable/ic_blogs.xml
@@ -19,10 +19,27 @@
     android:viewportWidth="24"
     android:viewportHeight="24">
   <path
-      android:pathData="M4,21C3.45,21 2.979,20.804 2.588,20.413C2.196,20.021 2,19.55 2,19V5C2,4.45 2.196,3.979 2.588,3.588C2.979,3.196 3.45,3 4,3H20C20.55,3 21.021,3.196 21.413,3.588C21.804,3.979 22,4.45 22,5V19C22,19.55 21.804,20.021 21.413,20.413C21.021,20.804 20.55,21 20,21H4ZM4,19H20V5H4V19ZM6,13H10V7H6V13Z"
-      android:fillColor="#E3E3E3"/>
-  <path
-      android:pathData="M6,17H18V15H6V17ZM12,13H18V11H12V13ZM12,9H18V7H12V9Z"
-      android:fillColor="#E3E3E3"
+      android:pathData="M10.071,5H21.071C21.623,5 22.071,5.448 22.071,6C22.071,6.552 21.623,7 21.071,7H10.071V5Z"
+      android:strokeAlpha="0.5"
+      android:fillColor="#000000"
       android:fillAlpha="0.5"/>
+  <path
+      android:pathData="M10.071,9H21.071C21.623,9 22.071,9.448 22.071,10C22.071,10.552 21.623,11 21.071,11H10.071V9Z"
+      android:strokeAlpha="0.5"
+      android:fillColor="#000000"
+      android:fillAlpha="0.5"/>
+  <path
+      android:pathData="M22.071,14C22.071,13.448 21.623,13 21.071,13H10.071V15H21.071C21.623,15 22.071,14.552 22.071,14Z"
+      android:strokeAlpha="0.5"
+      android:fillColor="#000000"
+      android:fillAlpha="0.5"/>
+  <path
+      android:pathData="M10.071,17H17.071C17.623,17 18.071,17.448 18.071,18C18.071,18.552 17.623,19 17.071,19H10.071V17Z"
+      android:strokeAlpha="0.5"
+      android:fillColor="#000000"
+      android:fillAlpha="0.5"/>
+  <path
+      android:pathData="M2,6.657L2,7.657L2,8.657L2,18.971L3.647,20.596L5.071,22L6.476,20.576L8.065,18.965L8.071,8.657L8.071,7.657V6.657V6.036C8.071,4.359 6.712,3 5.036,3C3.359,3 2,4.359 2,6.036L2,6.657ZM6.071,8.657L6.066,18.144L5.052,19.172L4,18.134L4,8.657L6.071,8.657ZM4,6.657L6.071,6.657V6.036C6.071,5.464 5.607,5 5.036,5C4.464,5 4,5.464 4,6.036L4,6.657Z"
+      android:fillColor="#000000"
+      android:fillType="evenOdd"/>
 </vector>


### PR DESCRIPTION
## Description

This makes the following changes:

- Updates the Blogs icon to match the Web Player
- Fixes the episode row play button not using the podcast colour anymore
- Set the other links on the page to the same podcast colour
- Removed the author and description if they aren't in the podcast, useful for the blog podcasts

Fixes https://linear.app/a8c/issue/POC-601/android-update-the-blogs-icon-to-match-the-web-player
Fixes https://linear.app/a8c/issue/POC-602/android-remove-the-podcast-page-author-if-its-blank

## Testing Instructions

1. Use the `debug` variant
2. Use the Blogs section on the Profile tab
3. Follow the blog https://android-developers.googleblog.com/
4. ✅ Verify on the podcast page the author is hidden and there is no padding for the description
5. ✅ Verify the podcast colour is working on the podcast page

## Screenshots 

| Before | After |
| --- | --- |
| <img width="1080" height="2424" alt="Screenshot_20260511_163411" src="https://github.com/user-attachments/assets/ba30472f-bfad-4a20-9eb4-6e9e70b56da8" /> | <img width="1080" height="2424" alt="Screenshot_20260511_163456" src="https://github.com/user-attachments/assets/102ed31a-ec22-4c50-b5f0-2357ec24fa35" /> |
| <img width="1080" height="2424" alt="Screenshot_20260511_163214" src="https://github.com/user-attachments/assets/9412348c-dda7-44b0-aac8-cee138601837" /> | <img width="1080" height="2424" alt="Screenshot_20260511_163039" src="https://github.com/user-attachments/assets/8f17b682-9c75-452c-90d1-c124cb962778" /> | 
| <img width="1080" height="2424" alt="Screenshot_20260511_163220" src="https://github.com/user-attachments/assets/2a158dca-42a8-4c78-be72-4af3570d0d80" /> | <img width="1080" height="2424" alt="Screenshot_20260511_163047" src="https://github.com/user-attachments/assets/7136b4d9-3359-43f4-abc8-0f4465df87b5" /> | 
| <img width="1080" height="2424" alt="Screenshot_20260511_163229" src="https://github.com/user-attachments/assets/4d734943-ebcc-4876-a43d-968d0442c8b7" /> | <img width="1080" height="2424" alt="Screenshot_20260511_163106" src="https://github.com/user-attachments/assets/b660b3b4-2d5a-4b47-b278-522d83bc07c3" /> | 
| <img width="1080" height="2424" alt="Screenshot_20260511_163235" src="https://github.com/user-attachments/assets/92819462-b11c-4139-b005-e585af009a4b" /> | <img width="1080" height="2424" alt="Screenshot_20260511_163113" src="https://github.com/user-attachments/assets/5d21e343-b76f-4990-a0a3-0020154e56d0" /> | 

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
