### PR TITLE
Replace ActiveSupport's String#parameterize with a pure-Ruby helper

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -751,17 +751,24 @@ platform :android do
     { app: '📱 Mobile', wear: '⌚ Wear', automotive: '🚗 Automotive' }.fetch(key, '❔ Unknown')
   end
 
+  # Mimics the subset of ActiveSupport's `String#parameterize` we rely on.
+  # release-toolkit dropped its `activesupport` runtime dependency in v14.3.1,
+  # so `String#parameterize` is no longer available here.
+  def parameterize(string)
+    string.downcase.gsub(/[^a-z0-9\-_]+/, '-').squeeze('-').gsub(/\A-|-\z/, '')
+  end
+
   # This function is Buildkite-specific
   def generate_prototype_build_number
     if ENV['BUILDKITE']
       commit = ENV.fetch('BUILDKITE_COMMIT', nil)[0, 7]
-      branch = ENV['BUILDKITE_BRANCH'].parameterize
+      branch = parameterize(ENV['BUILDKITE_BRANCH'])
       pr_num = ENV.fetch('BUILDKITE_PULL_REQUEST', nil)
 
       pr_num == 'false' ? "#{branch}-#{commit}" : "pr#{pr_num}-#{commit}"
     else
       repo = Git.open(PROJECT_ROOT_FOLDER)
-      commit = repo.current_branch.parameterize
+      commit = parameterize(repo.current_branch)
       branch = repo.revparse('HEAD')[0, 7]
 
       "#{branch}-#{commit}"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -762,7 +762,7 @@ platform :android do
   def generate_prototype_build_number
     if ENV['BUILDKITE']
       commit = ENV.fetch('BUILDKITE_COMMIT', nil)[0, 7]
-      branch = parameterize(ENV['BUILDKITE_BRANCH'])
+      branch = parameterize(ENV.fetch('BUILDKITE_BRANCH', nil))
       pr_num = ENV.fetch('BUILDKITE_PULL_REQUEST', nil)
 
       pr_num == 'false' ? "#{branch}-#{commit}" : "pr#{pr_num}-#{commit}"


### PR DESCRIPTION
### Description

`release-toolkit` [v14.3.1](https://github.com/wordpress-mobile/release-toolkit/pull/709) dropped its `activesupport` runtime dependency, and #5286 just bumped this repo to `release-toolkit` 14.4.1. `generate_prototype_build_number` still uses `String#parameterize`, which now raises `NoMethodError`, breaking Prototype Builds.

This adds a tiny pure-Ruby `parameterize` helper (downcase, replace runs of non-`[a-z0-9_-]` with `-`, squeeze, strip leading/trailing `-`) and routes the two call sites through it. Output matches ActiveSupport's `String#parameterize` for the branch/commit names involved.

### Testing instructions

- CI: the Prototype Build step should succeed again.
- Locally: `ruby -c fastlane/Fastfile` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)