### PR TITLE
Add `web_feed` column to Podcast database table

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabaseTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabaseTest.kt
@@ -196,6 +196,7 @@ class AppDatabaseTest {
                 AppDatabase.MIGRATION_124_125,
                 AppDatabase.MIGRATION_125_126,
                 AppDatabase.MIGRATION_126_127,
+                AppDatabase.MIGRATION_127_128,
             )
             .build()
         // close the database and release any stream resources when the test finishes

--- a/modules/services/model/schemas/au.com.shiftyjelly.pocketcasts.models.db.AppDatabase/128.json
+++ b/modules/services/model/schemas/au.com.shiftyjelly.pocketcasts.models.db.AppDatabase/128.json
@@ -1,0 +1,2110 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 128,
+    "identityHash": "9e5810e29835ac246ce574bc4e42d8ff",
+    "entities": [
+      {
+        "tableName": "bump_stats",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `event_time` INTEGER NOT NULL, `custom_event_props` TEXT NOT NULL, PRIMARY KEY(`name`, `event_time`, `custom_event_props`))",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventTime",
+            "columnName": "event_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customEventProps",
+            "columnName": "custom_event_props",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "name",
+            "event_time",
+            "custom_event_props"
+          ]
+        }
+      },
+      {
+        "tableName": "bookmarks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `podcast_uuid` TEXT NOT NULL, `episode_uuid` TEXT NOT NULL, `time` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, `title` TEXT NOT NULL, `title_modified` INTEGER, `deleted` INTEGER NOT NULL, `deleted_modified` INTEGER, `sync_status` INTEGER NOT NULL, `clean_title` TEXT NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcast_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeUuid",
+            "columnName": "episode_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timeSecs",
+            "columnName": "time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "titleModified",
+            "columnName": "title_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedModified",
+            "columnName": "deleted_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "sync_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cleanTitle",
+            "columnName": "clean_title",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "bookmarks_podcast_uuid",
+            "unique": false,
+            "columnNames": [
+              "podcast_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `bookmarks_podcast_uuid` ON `${TABLE_NAME}` (`podcast_uuid`)"
+          }
+        ]
+      },
+      {
+        "tableName": "podcast_episodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `episode_description` TEXT NOT NULL, `published_date` INTEGER NOT NULL, `title` TEXT NOT NULL, `size_in_bytes` INTEGER NOT NULL, `episode_status` INTEGER NOT NULL, `file_type` TEXT, `duration` REAL NOT NULL, `download_url` TEXT, `downloaded_file_path` TEXT, `downloaded_error_details` TEXT, `play_error_details` TEXT, `played_up_to` REAL NOT NULL, `playing_status` INTEGER NOT NULL, `podcast_id` TEXT NOT NULL, `added_date` INTEGER NOT NULL, `auto_download_status` INTEGER NOT NULL, `starred` INTEGER NOT NULL, `thumbnail_status` INTEGER NOT NULL, `last_download_attempt_date` INTEGER, `playing_status_modified` INTEGER, `played_up_to_modified` INTEGER, `duration_modified` INTEGER, `starred_modified` INTEGER, `last_starred_date` INTEGER, `archived` INTEGER NOT NULL, `archived_modified` INTEGER, `season` INTEGER, `number` INTEGER, `type` TEXT, `last_playback_interaction_date` INTEGER, `last_playback_interaction_sync_status` INTEGER NOT NULL, `exclude_from_episode_limit` INTEGER NOT NULL, `download_task_id` TEXT, `last_archive_interaction_date` INTEGER, `image_url` TEXT, `deselected_chapters` TEXT NOT NULL, `deselected_chapters_modified` INTEGER, `slug` TEXT NOT NULL, `has_generated_transcript` INTEGER NOT NULL, `cleanTitle` TEXT, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeDescription",
+            "columnName": "episode_description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publishedDate",
+            "columnName": "published_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeInBytes",
+            "columnName": "size_in_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadStatus",
+            "columnName": "episode_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileType",
+            "columnName": "file_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadUrl",
+            "columnName": "download_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadedFilePath",
+            "columnName": "downloaded_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadErrorDetails",
+            "columnName": "downloaded_error_details",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playErrorDetails",
+            "columnName": "play_error_details",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playedUpTo",
+            "columnName": "played_up_to",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playingStatus",
+            "columnName": "playing_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcast_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedDate",
+            "columnName": "added_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoDownloadStatus",
+            "columnName": "auto_download_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isStarred",
+            "columnName": "starred",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailStatus",
+            "columnName": "thumbnail_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDownloadAttemptDate",
+            "columnName": "last_download_attempt_date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "playingStatusModified",
+            "columnName": "playing_status_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "playedUpToModified",
+            "columnName": "played_up_to_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "durationModified",
+            "columnName": "duration_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "starredModified",
+            "columnName": "starred_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastStarredDate",
+            "columnName": "last_starred_date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isArchived",
+            "columnName": "archived",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "archivedModified",
+            "columnName": "archived_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "season",
+            "columnName": "season",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "number",
+            "columnName": "number",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastPlaybackInteraction",
+            "columnName": "last_playback_interaction_date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastPlaybackInteractionSyncStatus",
+            "columnName": "last_playback_interaction_sync_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "excludeFromEpisodeLimit",
+            "columnName": "exclude_from_episode_limit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadTaskId",
+            "columnName": "download_task_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastArchiveInteraction",
+            "columnName": "last_archive_interaction_date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "image_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "deselectedChapters",
+            "columnName": "deselected_chapters",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deselectedChaptersModified",
+            "columnName": "deselected_chapters_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "slug",
+            "columnName": "slug",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasGeneratedTranscript",
+            "columnName": "has_generated_transcript",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cleanTitle",
+            "columnName": "cleanTitle",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "episode_last_download_attempt_date",
+            "unique": false,
+            "columnNames": [
+              "last_download_attempt_date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `episode_last_download_attempt_date` ON `${TABLE_NAME}` (`last_download_attempt_date`)"
+          },
+          {
+            "name": "episode_podcast_id",
+            "unique": false,
+            "columnNames": [
+              "podcast_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `episode_podcast_id` ON `${TABLE_NAME}` (`podcast_id`)"
+          },
+          {
+            "name": "episode_published_date",
+            "unique": false,
+            "columnNames": [
+              "published_date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `episode_published_date` ON `${TABLE_NAME}` (`published_date`)"
+          }
+        ]
+      },
+      {
+        "tableName": "folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `name` TEXT NOT NULL, `color` INTEGER NOT NULL, `added_date` INTEGER NOT NULL, `sort_position` INTEGER NOT NULL, `podcasts_sort_type` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, `sync_modified` INTEGER NOT NULL, `clean_name` TEXT NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedDate",
+            "columnName": "added_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortPosition",
+            "columnName": "sort_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastsSortType",
+            "columnName": "podcasts_sort_type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncModified",
+            "columnName": "sync_modified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cleanName",
+            "columnName": "clean_name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        }
+      },
+      {
+        "tableName": "suggested_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`folder_name` TEXT NOT NULL, `podcast_uuid` TEXT NOT NULL, PRIMARY KEY(`folder_name`, `podcast_uuid`))",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "folder_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcast_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "folder_name",
+            "podcast_uuid"
+          ]
+        }
+      },
+      {
+        "tableName": "playlists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `title` TEXT NOT NULL, `iconId` INTEGER NOT NULL, `sortPosition` INTEGER, `sortId` INTEGER NOT NULL, `manual` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, `syncStatus` INTEGER NOT NULL, `autoDownload` INTEGER NOT NULL, `autoDownloadLimit` INTEGER NOT NULL, `unplayed` INTEGER NOT NULL, `partiallyPlayed` INTEGER NOT NULL, `finished` INTEGER NOT NULL, `downloaded` INTEGER NOT NULL, `notDownloaded` INTEGER NOT NULL, `audioVideo` INTEGER NOT NULL, `filterHours` INTEGER NOT NULL, `starred` INTEGER NOT NULL, `allPodcasts` INTEGER NOT NULL, `podcastUuids` TEXT, `filterDuration` INTEGER NOT NULL, `longerThan` INTEGER NOT NULL, `shorterThan` INTEGER NOT NULL, `showArchivedEpisodes` INTEGER NOT NULL, `clean_title` TEXT NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iconId",
+            "columnName": "iconId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortPosition",
+            "columnName": "sortPosition",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "sortType",
+            "columnName": "sortId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "manual",
+            "columnName": "manual",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "syncStatus",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoDownload",
+            "columnName": "autoDownload",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autodownloadLimit",
+            "columnName": "autoDownloadLimit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unplayed",
+            "columnName": "unplayed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "partiallyPlayed",
+            "columnName": "partiallyPlayed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "finished",
+            "columnName": "finished",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloaded",
+            "columnName": "downloaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notDownloaded",
+            "columnName": "notDownloaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioVideo",
+            "columnName": "audioVideo",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filterHours",
+            "columnName": "filterHours",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "starred",
+            "columnName": "starred",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "allPodcasts",
+            "columnName": "allPodcasts",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastUuids",
+            "columnName": "podcastUuids",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "filterDuration",
+            "columnName": "filterDuration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longerThan",
+            "columnName": "longerThan",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shorterThan",
+            "columnName": "shorterThan",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showArchivedEpisodes",
+            "columnName": "showArchivedEpisodes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cleanTitle",
+            "columnName": "clean_title",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        }
+      },
+      {
+        "tableName": "podcasts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `added_date` INTEGER, `thumbnail_url` TEXT, `title` TEXT NOT NULL, `podcast_url` TEXT, `podcast_description` TEXT NOT NULL, `podcast_html_description` TEXT NOT NULL, `podcast_category` TEXT NOT NULL, `podcast_language` TEXT NOT NULL, `media_type` TEXT, `latest_episode_uuid` TEXT, `author` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, `episodes_sort_order` INTEGER NOT NULL, `episodes_sort_order_modified` INTEGER, `latest_episode_date` INTEGER, `episodes_to_keep` INTEGER NOT NULL, `override_global_settings` INTEGER NOT NULL, `override_global_effects` INTEGER NOT NULL, `override_global_effects_modified` INTEGER, `start_from` INTEGER NOT NULL, `start_from_modified` INTEGER, `playback_speed` REAL NOT NULL, `playback_speed_modified` INTEGER, `volume_boosted` INTEGER NOT NULL, `volume_boosted_modified` INTEGER, `is_folder` INTEGER NOT NULL, `subscribed` INTEGER NOT NULL, `show_notifications` INTEGER NOT NULL, `show_notifications_modified` INTEGER, `auto_download_status` INTEGER NOT NULL, `auto_add_to_up_next` INTEGER NOT NULL, `auto_add_to_up_next_modified` INTEGER, `most_popular_color` INTEGER NOT NULL, `primary_color` INTEGER NOT NULL, `secondary_color` INTEGER NOT NULL, `light_overlay_color` INTEGER NOT NULL, `fab_for_light_bg` INTEGER NOT NULL, `link_for_dark_bg` INTEGER NOT NULL, `link_for_light_bg` INTEGER NOT NULL, `color_version` INTEGER NOT NULL, `color_last_downloaded` INTEGER NOT NULL, `sync_status` INTEGER NOT NULL, `exclude_from_auto_archive` INTEGER NOT NULL, `override_global_archive` INTEGER NOT NULL, `override_global_archive_modified` INTEGER, `auto_archive_played_after` INTEGER NOT NULL, `auto_archive_played_after_modified` INTEGER, `auto_archive_inactive_after` INTEGER NOT NULL, `auto_archive_inactive_after_modified` INTEGER, `auto_archive_episode_limit` INTEGER NOT NULL, `auto_archive_episode_limit_modified` INTEGER, `estimated_next_episode` INTEGER, `episode_frequency` TEXT, `grouping` INTEGER NOT NULL, `grouping_modified` INTEGER, `skip_last` INTEGER NOT NULL, `skip_last_modified` INTEGER, `show_archived` INTEGER NOT NULL, `show_archived_modified` INTEGER, `trim_silence_level` INTEGER NOT NULL, `trim_silence_level_modified` INTEGER, `refresh_available` INTEGER NOT NULL, `folder_uuid` TEXT, `licensing` INTEGER NOT NULL, `isPaid` INTEGER NOT NULL, `is_private` INTEGER NOT NULL, `is_header_expanded` INTEGER NOT NULL DEFAULT 1, `funding_url` TEXT, `slug` TEXT NOT NULL, `explicit` INTEGER, `web_feed` INTEGER NOT NULL DEFAULT 0, `clean_title` TEXT NOT NULL, `bundleuuid` TEXT, `bundlebundleUrl` TEXT, `bundlepaymentUrl` TEXT, `bundledescription` TEXT, `bundlepodcastUuid` TEXT, `bundlepaidType` TEXT, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedDate",
+            "columnName": "added_date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnail_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastUrl",
+            "columnName": "podcast_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "podcastDescription",
+            "columnName": "podcast_description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastHtmlDescription",
+            "columnName": "podcast_html_description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastCategory",
+            "columnName": "podcast_category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastLanguage",
+            "columnName": "podcast_language",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "media_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latestEpisodeUuid",
+            "columnName": "latest_episode_uuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortPosition",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodesSortType",
+            "columnName": "episodes_sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodesSortTypeModified",
+            "columnName": "episodes_sort_order_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "latestEpisodeDate",
+            "columnName": "latest_episode_date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "episodesToKeep",
+            "columnName": "episodes_to_keep",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "overrideGlobalSettings",
+            "columnName": "override_global_settings",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "overrideGlobalEffects",
+            "columnName": "override_global_effects",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "overrideGlobalEffectsModified",
+            "columnName": "override_global_effects_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "startFromSecs",
+            "columnName": "start_from",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startFromModified",
+            "columnName": "start_from_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "playbackSpeed",
+            "columnName": "playback_speed",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playbackSpeedModified",
+            "columnName": "playback_speed_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isVolumeBoosted",
+            "columnName": "volume_boosted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "volumeBoostedModified",
+            "columnName": "volume_boosted_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isFolder",
+            "columnName": "is_folder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSubscribed",
+            "columnName": "subscribed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isShowNotifications",
+            "columnName": "show_notifications",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showNotificationsModified",
+            "columnName": "show_notifications_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "autoDownloadStatus",
+            "columnName": "auto_download_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoAddToUpNext",
+            "columnName": "auto_add_to_up_next",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoAddToUpNextModified",
+            "columnName": "auto_add_to_up_next_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "backgroundColor",
+            "columnName": "most_popular_color",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tintColorForLightBg",
+            "columnName": "primary_color",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tintColorForDarkBg",
+            "columnName": "secondary_color",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fabColorForDarkBg",
+            "columnName": "light_overlay_color",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fabColorForLightBg",
+            "columnName": "fab_for_light_bg",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "linkColorForLightBg",
+            "columnName": "link_for_dark_bg",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "linkColorForDarkBg",
+            "columnName": "link_for_light_bg",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "colorVersion",
+            "columnName": "color_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "colorLastDownloaded",
+            "columnName": "color_last_downloaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "sync_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "excludeFromAutoArchive",
+            "columnName": "exclude_from_auto_archive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "overrideGlobalArchive",
+            "columnName": "override_global_archive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "overrideGlobalArchiveModified",
+            "columnName": "override_global_archive_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "rawAutoArchiveAfterPlaying",
+            "columnName": "auto_archive_played_after",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoArchiveAfterPlayingModified",
+            "columnName": "auto_archive_played_after_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "rawAutoArchiveInactive",
+            "columnName": "auto_archive_inactive_after",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoArchiveInactiveModified",
+            "columnName": "auto_archive_inactive_after_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "rawAutoArchiveEpisodeLimit",
+            "columnName": "auto_archive_episode_limit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoArchiveEpisodeLimitModified",
+            "columnName": "auto_archive_episode_limit_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "estimatedNextEpisode",
+            "columnName": "estimated_next_episode",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "episodeFrequency",
+            "columnName": "episode_frequency",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "grouping",
+            "columnName": "grouping",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "groupingModified",
+            "columnName": "grouping_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "skipLastSecs",
+            "columnName": "skip_last",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skipLastModified",
+            "columnName": "skip_last_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showArchived",
+            "columnName": "show_archived",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showArchivedModified",
+            "columnName": "show_archived_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "trimMode",
+            "columnName": "trim_silence_level",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trimModeModified",
+            "columnName": "trim_silence_level_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "refreshAvailable",
+            "columnName": "refresh_available",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rawFolderUuid",
+            "columnName": "folder_uuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "licensing",
+            "columnName": "licensing",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPaid",
+            "columnName": "isPaid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPrivate",
+            "columnName": "is_private",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isHeaderExpanded",
+            "columnName": "is_header_expanded",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "fundingUrl",
+            "columnName": "funding_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "slug",
+            "columnName": "slug",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "explicit",
+            "columnName": "explicit",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "webFeed",
+            "columnName": "web_feed",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "cleanTitle",
+            "columnName": "clean_title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "singleBundle.uuid",
+            "columnName": "bundleuuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "singleBundle.bundleUrl",
+            "columnName": "bundlebundleUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "singleBundle.paymentUrl",
+            "columnName": "bundlepaymentUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "singleBundle.description",
+            "columnName": "bundledescription",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "singleBundle.podcastUuid",
+            "columnName": "bundlepodcastUuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "singleBundle.paidType",
+            "columnName": "bundlepaidType",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        }
+      },
+      {
+        "tableName": "search_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT, `modified` INTEGER NOT NULL, `term` TEXT, `podcast_uuid` TEXT, `podcast_title` TEXT, `podcast_author` TEXT, `folder_uuid` TEXT, `folder_title` TEXT, `folder_color` INTEGER, `folder_podcastIds` TEXT, `episode_uuid` TEXT, `episode_title` TEXT, `episode_duration` REAL, `episode_podcastUuid` TEXT, `episode_podcastTitle` TEXT, `episode_artworkUrl` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "modified",
+            "columnName": "modified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "term",
+            "columnName": "term",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "podcast.uuid",
+            "columnName": "podcast_uuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "podcast.title",
+            "columnName": "podcast_title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "podcast.author",
+            "columnName": "podcast_author",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "folder.uuid",
+            "columnName": "folder_uuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "folder.title",
+            "columnName": "folder_title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "folder.color",
+            "columnName": "folder_color",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "folder.podcastIds",
+            "columnName": "folder_podcastIds",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "episode.uuid",
+            "columnName": "episode_uuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "episode.title",
+            "columnName": "episode_title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "episode.duration",
+            "columnName": "episode_duration",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "episode.podcastUuid",
+            "columnName": "episode_podcastUuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "episode.podcastTitle",
+            "columnName": "episode_podcastTitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "episode.artworkUrl",
+            "columnName": "episode_artworkUrl",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_search_history_term",
+            "unique": true,
+            "columnNames": [
+              "term"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_search_history_term` ON `${TABLE_NAME}` (`term`)"
+          },
+          {
+            "name": "index_search_history_podcast_uuid",
+            "unique": true,
+            "columnNames": [
+              "podcast_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_search_history_podcast_uuid` ON `${TABLE_NAME}` (`podcast_uuid`)"
+          },
+          {
+            "name": "index_search_history_folder_uuid",
+            "unique": true,
+            "columnNames": [
+              "folder_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_search_history_folder_uuid` ON `${TABLE_NAME}` (`folder_uuid`)"
+          },
+          {
+            "name": "index_search_history_episode_uuid",
+            "unique": true,
+            "columnNames": [
+              "episode_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_search_history_episode_uuid` ON `${TABLE_NAME}` (`episode_uuid`)"
+          }
+        ]
+      },
+      {
+        "tableName": "up_next_changes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT, `type` INTEGER NOT NULL, `uuid` TEXT, `uuids` TEXT, `modified` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "uuids",
+            "columnName": "uuids",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "modified",
+            "columnName": "modified",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        }
+      },
+      {
+        "tableName": "up_next_episodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT, `episodeUuid` TEXT NOT NULL, `position` INTEGER NOT NULL, `playlistId` INTEGER, `title` TEXT NOT NULL, `publishedDate` INTEGER, `downloadUrl` TEXT, `podcastUuid` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "episodeUuid",
+            "columnName": "episodeUuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publishedDate",
+            "columnName": "publishedDate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "downloadUrl",
+            "columnName": "downloadUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcastUuid",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "up_next_episode_episodeUuid",
+            "unique": false,
+            "columnNames": [
+              "episodeUuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `up_next_episode_episodeUuid` ON `${TABLE_NAME}` (`episodeUuid`)"
+          }
+        ]
+      },
+      {
+        "tableName": "user_episodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `published_date` INTEGER NOT NULL, `episode_description` TEXT NOT NULL, `title` TEXT NOT NULL, `size_in_bytes` INTEGER NOT NULL, `episode_status` INTEGER NOT NULL, `file_type` TEXT, `duration` REAL NOT NULL, `download_url` TEXT, `played_up_to` REAL NOT NULL, `playing_status` INTEGER NOT NULL, `added_date` INTEGER NOT NULL, `auto_download_status` INTEGER NOT NULL, `last_download_attempt_date` INTEGER, `archived` INTEGER NOT NULL, `download_task_id` TEXT, `downloaded_file_path` TEXT, `playing_status_modified` INTEGER, `played_up_to_modified` INTEGER, `artwork_url` TEXT, `play_error_details` TEXT, `server_status` INTEGER NOT NULL, `upload_error_details` TEXT, `downloaded_error_details` TEXT, `tint_color_index` INTEGER NOT NULL, `has_custom_image` INTEGER NOT NULL, `upload_task_id` TEXT, `deselected_chapters` TEXT NOT NULL, `deselected_chapters_modified` INTEGER, `clean_title` TEXT NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publishedDate",
+            "columnName": "published_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeDescription",
+            "columnName": "episode_description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeInBytes",
+            "columnName": "size_in_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadStatus",
+            "columnName": "episode_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileType",
+            "columnName": "file_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadUrl",
+            "columnName": "download_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playedUpTo",
+            "columnName": "played_up_to",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playingStatus",
+            "columnName": "playing_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedDate",
+            "columnName": "added_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoDownloadStatus",
+            "columnName": "auto_download_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDownloadAttemptDate",
+            "columnName": "last_download_attempt_date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isArchived",
+            "columnName": "archived",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadTaskId",
+            "columnName": "download_task_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadedFilePath",
+            "columnName": "downloaded_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playingStatusModified",
+            "columnName": "playing_status_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "playedUpToModified",
+            "columnName": "played_up_to_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "artworkUrl",
+            "columnName": "artwork_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playErrorDetails",
+            "columnName": "play_error_details",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "serverStatus",
+            "columnName": "server_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uploadErrorDetails",
+            "columnName": "upload_error_details",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadErrorDetails",
+            "columnName": "downloaded_error_details",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tintColorIndex",
+            "columnName": "tint_color_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasCustomImage",
+            "columnName": "has_custom_image",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uploadTaskId",
+            "columnName": "upload_task_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "deselectedChapters",
+            "columnName": "deselected_chapters",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deselectedChaptersModified",
+            "columnName": "deselected_chapters_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "cleanTitle",
+            "columnName": "clean_title",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "user_episode_last_download_attempt_date",
+            "unique": false,
+            "columnNames": [
+              "last_download_attempt_date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `user_episode_last_download_attempt_date` ON `${TABLE_NAME}` (`last_download_attempt_date`)"
+          },
+          {
+            "name": "user_episode_published_date",
+            "unique": false,
+            "columnNames": [
+              "published_date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `user_episode_published_date` ON `${TABLE_NAME}` (`published_date`)"
+          }
+        ]
+      },
+      {
+        "tableName": "podcast_ratings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`podcast_uuid` TEXT NOT NULL, `average` REAL, `total` INTEGER, PRIMARY KEY(`podcast_uuid`))",
+        "fields": [
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcast_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "average",
+            "columnName": "average",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "total",
+            "columnName": "total",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "podcast_uuid"
+          ]
+        }
+      },
+      {
+        "tableName": "episode_chapters",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`chapter_index` INTEGER NOT NULL, `episode_uuid` TEXT NOT NULL, `start_time` INTEGER NOT NULL, `end_time` INTEGER, `title` TEXT, `image_url` TEXT, `url` TEXT, `is_embedded` INTEGER NOT NULL, PRIMARY KEY(`episode_uuid`, `chapter_index`))",
+        "fields": [
+          {
+            "fieldPath": "index",
+            "columnName": "chapter_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeUuid",
+            "columnName": "episode_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTimeMs",
+            "columnName": "start_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endTimeMs",
+            "columnName": "end_time",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "image_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isEmbedded",
+            "columnName": "is_embedded",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "episode_uuid",
+            "chapter_index"
+          ]
+        },
+        "indices": [
+          {
+            "name": "chapter_episode_uuid_index",
+            "unique": false,
+            "columnNames": [
+              "episode_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `chapter_episode_uuid_index` ON `${TABLE_NAME}` (`episode_uuid`)"
+          }
+        ]
+      },
+      {
+        "tableName": "curated_podcasts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`list_id` TEXT NOT NULL, `list_title` TEXT NOT NULL, `podcast_id` TEXT NOT NULL, `podcast_title` TEXT NOT NULL, `podcast_description` TEXT, PRIMARY KEY(`list_id`, `podcast_id`))",
+        "fields": [
+          {
+            "fieldPath": "listId",
+            "columnName": "list_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listTitle",
+            "columnName": "list_title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastId",
+            "columnName": "podcast_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastTitle",
+            "columnName": "podcast_title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastDescription",
+            "columnName": "podcast_description",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "list_id",
+            "podcast_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "curated_podcasts_list_id_index",
+            "unique": false,
+            "columnNames": [
+              "list_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `curated_podcasts_list_id_index` ON `${TABLE_NAME}` (`list_id`)"
+          },
+          {
+            "name": "curated_podcasts_podcast_id_index",
+            "unique": false,
+            "columnNames": [
+              "podcast_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `curated_podcasts_podcast_id_index` ON `${TABLE_NAME}` (`podcast_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "episode_transcript",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`episode_uuid` TEXT NOT NULL, `url` TEXT NOT NULL, `type` TEXT NOT NULL, `is_generated` INTEGER NOT NULL, `language` TEXT, PRIMARY KEY(`episode_uuid`, `url`))",
+        "fields": [
+          {
+            "fieldPath": "episodeUuid",
+            "columnName": "episode_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isGenerated",
+            "columnName": "is_generated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "episode_uuid",
+            "url"
+          ]
+        }
+      },
+      {
+        "tableName": "user_podcast_ratings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`podcast_uuid` TEXT NOT NULL, `rating` INTEGER NOT NULL, `modified_at` INTEGER NOT NULL, PRIMARY KEY(`podcast_uuid`))",
+        "fields": [
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcast_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "podcast_uuid"
+          ]
+        }
+      },
+      {
+        "tableName": "up_next_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`episodeUuid` TEXT NOT NULL, `position` INTEGER NOT NULL, `playlistId` INTEGER, `title` TEXT NOT NULL, `publishedDate` INTEGER, `downloadUrl` TEXT, `podcastUuid` TEXT, `addedDate` INTEGER NOT NULL, PRIMARY KEY(`episodeUuid`, `addedDate`))",
+        "fields": [
+          {
+            "fieldPath": "episodeUuid",
+            "columnName": "episodeUuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publishedDate",
+            "columnName": "publishedDate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "downloadUrl",
+            "columnName": "downloadUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcastUuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addedDate",
+            "columnName": "addedDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "episodeUuid",
+            "addedDate"
+          ]
+        }
+      },
+      {
+        "tableName": "user_notifications",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`notification_id` INTEGER NOT NULL, `sent_this_week` INTEGER NOT NULL, `last_sent_at` INTEGER NOT NULL, `interacted_at` INTEGER, PRIMARY KEY(`notification_id`))",
+        "fields": [
+          {
+            "fieldPath": "notificationId",
+            "columnName": "notification_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sentThisWeek",
+            "columnName": "sent_this_week",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSentAt",
+            "columnName": "last_sent_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "interactedAt",
+            "columnName": "interacted_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "notification_id"
+          ]
+        }
+      },
+      {
+        "tableName": "user_category_visits",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`category_id` INTEGER NOT NULL, `total_visits` INTEGER NOT NULL, PRIMARY KEY(`category_id`))",
+        "fields": [
+          {
+            "fieldPath": "categoryId",
+            "columnName": "category_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalVisits",
+            "columnName": "total_visits",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "category_id"
+          ]
+        }
+      },
+      {
+        "tableName": "manual_playlist_episodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_uuid` TEXT NOT NULL, `episode_uuid` TEXT NOT NULL, `podcast_uuid` TEXT NOT NULL, `title` TEXT NOT NULL, `added_at` INTEGER NOT NULL, `published_at` INTEGER NOT NULL, `download_url` TEXT, `episode_slug` TEXT NOT NULL, `podcast_slug` TEXT NOT NULL, `sort_position` INTEGER NOT NULL, `is_synced` INTEGER NOT NULL, `clean_title` TEXT NOT NULL, PRIMARY KEY(`playlist_uuid`, `episode_uuid`))",
+        "fields": [
+          {
+            "fieldPath": "playlistUuid",
+            "columnName": "playlist_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeUuid",
+            "columnName": "episode_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcast_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publishedAt",
+            "columnName": "published_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadUrl",
+            "columnName": "download_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "episodeSlug",
+            "columnName": "episode_slug",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastSlug",
+            "columnName": "podcast_slug",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortPosition",
+            "columnName": "sort_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSynced",
+            "columnName": "is_synced",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cleanTitle",
+            "columnName": "clean_title",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_uuid",
+            "episode_uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "manual_playlist_episodes_playlist_uuid_index",
+            "unique": false,
+            "columnNames": [
+              "playlist_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `manual_playlist_episodes_playlist_uuid_index` ON `${TABLE_NAME}` (`playlist_uuid`)"
+          },
+          {
+            "name": "manual_playlist_episodes_episode_uuid_index",
+            "unique": false,
+            "columnNames": [
+              "episode_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `manual_playlist_episodes_episode_uuid_index` ON `${TABLE_NAME}` (`episode_uuid`)"
+          },
+          {
+            "name": "manual_playlist_episodes_podcast_uuid_index",
+            "unique": false,
+            "columnNames": [
+              "podcast_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `manual_playlist_episodes_podcast_uuid_index` ON `${TABLE_NAME}` (`podcast_uuid`)"
+          },
+          {
+            "name": "manual_playlist_episodes_playlist_uuid_is_synced_index",
+            "unique": false,
+            "columnNames": [
+              "playlist_uuid",
+              "is_synced"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `manual_playlist_episodes_playlist_uuid_is_synced_index` ON `${TABLE_NAME}` (`playlist_uuid`, `is_synced`)"
+          }
+        ]
+      },
+      {
+        "tableName": "blaze_ads",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `text` TEXT NOT NULL, `image_url` TEXT NOT NULL, `url_title` TEXT NOT NULL, `url` TEXT NOT NULL, `location` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "image_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "urlTitle",
+            "columnName": "url_title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "location",
+            "columnName": "location",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "playback_stats_events",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `episode_uuid` TEXT NOT NULL, `podcast_uuid` TEXT NOT NULL, `started_at_ms` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeUuid",
+            "columnName": "episode_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcast_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAtMs",
+            "columnName": "started_at_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "playback_stats_events_started_at_ms",
+            "unique": false,
+            "columnNames": [
+              "started_at_ms"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `playback_stats_events_started_at_ms` ON `${TABLE_NAME}` (`started_at_ms`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '9e5810e29835ac246ce574bc4e42d8ff')"
+    ]
+  }
+}

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabase.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabase.kt
@@ -110,7 +110,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
         BlazeAd::class,
         PlaybackStatsEvent::class,
     ],
-    version = 127,
+    version = 128,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 81, to = 82, spec = AppDatabase.Companion.DeleteSilenceRemovedMigration::class),
@@ -1436,6 +1436,10 @@ abstract class AppDatabase : RoomDatabase() {
             database.execSQL("ALTER TABLE podcasts ADD COLUMN explicit INTEGER")
         }
 
+        val MIGRATION_127_128 = addMigration(127, 128) { database ->
+            database.execSQL("ALTER TABLE podcasts ADD COLUMN web_feed INTEGER NOT NULL DEFAULT 0")
+        }
+
         fun addMigrations(databaseBuilder: Builder<AppDatabase>, context: Context) {
             databaseBuilder.addMigrations(
                 addMigration(1, 2) { },
@@ -1853,6 +1857,7 @@ abstract class AppDatabase : RoomDatabase() {
                 MIGRATION_124_125,
                 MIGRATION_125_126,
                 MIGRATION_126_127,
+                MIGRATION_127_128,
             )
         }
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
@@ -288,8 +288,8 @@ abstract class PodcastDao {
     @Update
     abstract suspend fun updateSuspend(podcast: Podcast)
 
-    @Query("UPDATE podcasts SET title = :title, author = :author, podcast_category = :podcastCategory, podcast_description = :podcastDescription, estimated_next_episode = :estimatedNextEpisode, episode_frequency = :episodeFrequency, refresh_available = :refreshAvailable, funding_url = :fundingUrl, explicit = :explicit WHERE uuid = :uuid")
-    abstract suspend fun updateRefresh(uuid: String, title: String, author: String, podcastCategory: String, podcastDescription: String, estimatedNextEpisode: Date?, episodeFrequency: String?, refreshAvailable: Boolean, fundingUrl: String?, explicit: Boolean?)
+    @Query("UPDATE podcasts SET title = :title, author = :author, podcast_category = :podcastCategory, podcast_description = :podcastDescription, estimated_next_episode = :estimatedNextEpisode, episode_frequency = :episodeFrequency, refresh_available = :refreshAvailable, funding_url = :fundingUrl, explicit = :explicit, web_feed = :webFeed WHERE uuid = :uuid")
+    abstract suspend fun updateRefresh(uuid: String, title: String, author: String, podcastCategory: String, podcastDescription: String, estimatedNextEpisode: Date?, episodeFrequency: String?, refreshAvailable: Boolean, fundingUrl: String?, explicit: Boolean?, webFeed: Boolean)
 
     @Query("DELETE FROM podcasts WHERE uuid = :uuid")
     abstract fun deleteByUuidBlocking(uuid: String)

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/Podcast.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/Podcast.kt
@@ -102,6 +102,7 @@ data class Podcast(
     @ColumnInfo(name = "funding_url") var fundingUrl: String? = null,
     @ColumnInfo(name = "slug") var slug: String = "",
     @ColumnInfo(name = "explicit") var explicit: Boolean? = null,
+    @ColumnInfo(name = "web_feed", defaultValue = "0") var webFeed: Boolean = false,
     @Embedded(prefix = "bundle") var singleBundle: Bundle? = null,
     @Ignore val episodes: MutableList<PodcastEpisode> = mutableListOf(),
 ) : Serializable {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastRefresherImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastRefresherImpl.kt
@@ -129,7 +129,8 @@ class PodcastRefresherImpl @Inject constructor(
             existingPodcast.episodeFrequency != updatedPodcast.episodeFrequency ||
             existingPodcast.refreshAvailable != updatedPodcast.refreshAvailable ||
             existingPodcast.fundingUrl != updatedPodcast.fundingUrl ||
-            existingPodcast.explicit != updatedPodcast.explicit
+            existingPodcast.explicit != updatedPodcast.explicit ||
+            existingPodcast.webFeed != updatedPodcast.webFeed
         ) {
             LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Refresh required update for podcast ${existingPodcast.uuid}")
             appDatabase.podcastDao().updateRefresh(
@@ -143,6 +144,7 @@ class PodcastRefresherImpl @Inject constructor(
                 refreshAvailable = updatedPodcast.refreshAvailable,
                 fundingUrl = updatedPodcast.fundingUrl,
                 explicit = updatedPodcast.explicit,
+                webFeed = updatedPodcast.webFeed,
             )
         }
     }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastRefresherImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastRefresherImplTest.kt
@@ -73,6 +73,7 @@ class PodcastRefresherImplTest {
             refreshAvailable = podcast.refreshAvailable,
             fundingUrl = podcast.fundingUrl,
             explicit = podcast.explicit,
+            webFeed = podcast.webFeed,
         )
     }
 
@@ -94,6 +95,7 @@ class PodcastRefresherImplTest {
             refreshAvailable = existingPodcast.refreshAvailable,
             fundingUrl = existingPodcast.fundingUrl,
             explicit = existingPodcast.explicit,
+            webFeed = existingPodcast.webFeed,
         )
     }
 
@@ -115,6 +117,7 @@ class PodcastRefresherImplTest {
             refreshAvailable = existingPodcast.refreshAvailable,
             fundingUrl = existingPodcast.fundingUrl,
             explicit = existingPodcast.explicit,
+            webFeed = existingPodcast.webFeed,
         )
     }
 
@@ -136,6 +139,7 @@ class PodcastRefresherImplTest {
             refreshAvailable = existingPodcast.refreshAvailable,
             fundingUrl = existingPodcast.fundingUrl,
             explicit = existingPodcast.explicit,
+            webFeed = existingPodcast.webFeed,
         )
     }
 
@@ -157,6 +161,7 @@ class PodcastRefresherImplTest {
             refreshAvailable = existingPodcast.refreshAvailable,
             fundingUrl = existingPodcast.fundingUrl,
             explicit = existingPodcast.explicit,
+            webFeed = existingPodcast.webFeed,
         )
     }
 
@@ -180,6 +185,7 @@ class PodcastRefresherImplTest {
             refreshAvailable = existingPodcast.refreshAvailable,
             fundingUrl = existingPodcast.fundingUrl,
             explicit = existingPodcast.explicit,
+            webFeed = existingPodcast.webFeed,
         )
     }
 
@@ -201,6 +207,7 @@ class PodcastRefresherImplTest {
             refreshAvailable = existingPodcast.refreshAvailable,
             fundingUrl = existingPodcast.fundingUrl,
             explicit = existingPodcast.explicit,
+            webFeed = existingPodcast.webFeed,
         )
     }
 
@@ -222,6 +229,7 @@ class PodcastRefresherImplTest {
             refreshAvailable = true,
             fundingUrl = existingPodcast.fundingUrl,
             explicit = existingPodcast.explicit,
+            webFeed = existingPodcast.webFeed,
         )
     }
 
@@ -243,6 +251,7 @@ class PodcastRefresherImplTest {
             refreshAvailable = existingPodcast.refreshAvailable,
             fundingUrl = "https://new.com",
             explicit = existingPodcast.explicit,
+            webFeed = existingPodcast.webFeed,
         )
     }
 
@@ -264,6 +273,7 @@ class PodcastRefresherImplTest {
             refreshAvailable = existingPodcast.refreshAvailable,
             fundingUrl = existingPodcast.fundingUrl,
             explicit = true,
+            webFeed = existingPodcast.webFeed,
         )
     }
 
@@ -285,6 +295,29 @@ class PodcastRefresherImplTest {
             refreshAvailable = existingPodcast.refreshAvailable,
             fundingUrl = existingPodcast.fundingUrl,
             explicit = true,
+            webFeed = existingPodcast.webFeed,
+        )
+    }
+
+    @Test
+    fun `updatePodcastIfRequired updates when the webFeed changes`() = runTest {
+        val existingPodcast = createPodcast(webFeed = false)
+        val updatedPodcast = existingPodcast.copy(webFeed = true)
+
+        podcastRefresher.updatePodcastIfRequired(existingPodcast, updatedPodcast)
+
+        verify(podcastDao).updateRefresh(
+            uuid = existingPodcast.uuid,
+            title = existingPodcast.title,
+            author = existingPodcast.author,
+            podcastCategory = existingPodcast.podcastCategory,
+            podcastDescription = existingPodcast.podcastDescription,
+            estimatedNextEpisode = existingPodcast.estimatedNextEpisode,
+            episodeFrequency = existingPodcast.episodeFrequency,
+            refreshAvailable = existingPodcast.refreshAvailable,
+            fundingUrl = existingPodcast.fundingUrl,
+            explicit = existingPodcast.explicit,
+            webFeed = true,
         )
     }
 
@@ -316,6 +349,7 @@ class PodcastRefresherImplTest {
             refreshAvailable = true,
             fundingUrl = existingPodcast.fundingUrl,
             explicit = existingPodcast.explicit,
+            webFeed = existingPodcast.webFeed,
         )
     }
 
@@ -341,6 +375,7 @@ class PodcastRefresherImplTest {
             refreshAvailable = existingPodcast.refreshAvailable,
             fundingUrl = existingPodcast.fundingUrl,
             explicit = existingPodcast.explicit,
+            webFeed = existingPodcast.webFeed,
         )
     }
 
@@ -355,6 +390,7 @@ class PodcastRefresherImplTest {
         refreshAvailable: Boolean = false,
         fundingUrl: String? = null,
         explicit: Boolean? = null,
+        webFeed: Boolean = false,
     ) = Podcast(
         uuid = uuid,
         title = title,
@@ -366,5 +402,6 @@ class PodcastRefresherImplTest {
         refreshAvailable = refreshAvailable,
         fundingUrl = fundingUrl,
         explicit = explicit,
+        webFeed = webFeed,
     )
 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastResponse.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastResponse.kt
@@ -48,6 +48,7 @@ data class PodcastInfo(
     @Json(name = "fundings") val fundings: List<Funding>?,
     @Json(name = "slug") val slug: String?,
     @Json(name = "explicit") val explicit: Boolean?,
+    @Json(name = "web_feed") val webFeed: Boolean?,
 ) {
 
     fun toPodcast(): Podcast {
@@ -67,6 +68,7 @@ data class PodcastInfo(
         podcast.fundingUrl = fundings?.firstOrNull()?.url
         podcast.slug = slug.orEmpty()
         podcast.explicit = explicit
+        podcast.webFeed = webFeed ?: false
         return podcast
     }
 }


### PR DESCRIPTION
## Description

For the Blogs feature we need to track which podcasts are blogs. There's a new field in the podcast JSON called `web_feed`. This change reads it from the JSON and puts it in the database. Another pull request will show them all in the blogs section.

## Testing Instructions

1. Sign into a Plus account
2. Go to the Profile tab -> Blogs
3. Add a blog using a website, such as https://android-developers.googleblog.com/
4. In Android Studio go to App Inspection, Database Inspector
5. Run the query `SELECT title FROM podcasts WHERE web_feed = TRUE;`
6. ✅ Confirm that the blog podcast is listed. 

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack