### PR TITLE
Fix transcript banner overlapping episode description

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -16,6 +16,8 @@ import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.widget.Toast
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -575,6 +577,8 @@ class EpisodeFragment : BaseFragment() {
                 ) {
                     AnimatedNonNullVisibility(
                         item = transcript as? Transcript.Text,
+                        enter = fadeIn(),
+                        exit = fadeOut(),
                     ) { textTranscript ->
                         val episodeUuid = textTranscript.episodeUuid
                         val podcastUuid = textTranscript.podcastUuid


### PR DESCRIPTION
## Description

Fixes #PCDROID-326

The \"View Transcript\" banner was overlapping the episode description (show notes WebView) in the episode detail screen.

**Root cause**: `AnimatedNonNullVisibility` uses `expandVertically` by default, which animates the Compose layout height from 0 to full size. When embedded in a `ConstraintLayout`, the View system doesn't receive `requestLayout()` on every animation frame — so during the expand, `webViewShowNotes` stays positioned as if `episodeTranscript` has height 0, causing the overlap.

**Fix**: Override `enter`/`exit` transitions to `fadeIn()`/`fadeOut()` at the `EpisodeFragment` call site. This avoids height animation entirely; Compose reports the full height immediately, and `ConstraintLayout` positions the show notes correctly from the first frame.

## Testing Instructions
1. Open an episode that has a transcript available
2. Observe the episode detail screen — the \"View Transcript\" banner should appear above the episode description without overlapping it
3. Dismiss and reopen the episode to verify consistent behaviour

## Screenshots or Screencast
<!-- if applicable -->

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

#### I have tested any UI changes...
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack