### PR TITLE
Reduce transcript banner drop shadow elevation

### DIFF
--- a/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptExcerptBanner.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptExcerptBanner.kt
@@ -38,7 +38,7 @@ fun TranscriptExcerptBanner(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp),
         modifier = Modifier
-            .shadow(elevation = 2.dp, shape = BackgroundShape)
+            .shadow(elevation = 1.dp, shape = BackgroundShape)
             .background(MaterialTheme.theme.colors.primaryUi04, BackgroundShape)
             .then(modifier)
             .padding(vertical = 12.dp, horizontal = 12.dp),


### PR DESCRIPTION
## Description

Fixes #PCDROID-398

Reduces the drop shadow on the \"View Transcript\" banner from `2.dp` to `1.dp` to make it less visually heavy, consistent with other small card elements in the app.

## Testing Instructions
1. Open an episode that has a transcript available
2. Verify the \"View Transcript\" banner has a lighter, more subtle drop shadow

## Screenshots or Screencast
<!-- if applicable -->

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

#### I have tested any UI changes...
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack