### PR TITLE
Fix intermittent episode artwork not updating on filters page

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1699,6 +1699,16 @@ open class PlaybackManager @Inject constructor(
                     )
                 }
                 chapterManager.updateChapters(playbackState.episodeUuid, dbChapters)
+
+                val episode = episodeManager.findEpisodeByUuid(playbackState.episodeUuid) as? PodcastEpisode
+                if (episode != null && episode.thumbnailStatus == PodcastEpisode.THUMBNAIL_STATUS_UNKNOWN) {
+                    episode.thumbnailStatus = if (episodeMetadata.embeddedArtworkPath != null) {
+                        PodcastEpisode.THUMBNAIL_STATUS_EMBEDDED_AVAILABLE
+                    } else {
+                        PodcastEpisode.THUMBNAIL_STATUS_EMBEDDED_NOT_AVAILABLE
+                    }
+                    episodeManager.update(episode)
+                }
             }
         }
     }


### PR DESCRIPTION
## Description

Fixes #PCDROID-79

**Root cause**: `PodcastEpisode.thumbnailStatus` has three constants — `THUMBNAIL_STATUS_UNKNOWN`, `THUMBNAIL_STATUS_EMBEDDED_AVAILABLE`, and `THUMBNAIL_STATUS_EMBEDDED_NOT_AVAILABLE` — but `PlaybackManager.onMetadataAvailable()` never set it. When embedded artwork is extracted from a downloaded audio file during playback and saved to the `artworkCacheFile` on disk, the episode's DB record was never updated. Because Room didn't re-emit, DiffUtil detected no changes, and the filters page ViewHolder was never rebound to show the newly extracted artwork.

**Fix**: After saving chapters in `onMetadataAvailable()`, fetch the episode and set `thumbnailStatus` to the appropriate value (only once, when still `THUMBNAIL_STATUS_UNKNOWN`). This DB write triggers Room → DiffUtil → `onBindViewHolder` → `bindArtwork()` → Coil loads from the local cache file.

## Testing Instructions
1. Find a podcast episode that has embedded artwork (common in many podcasts)
2. Open the filters page — note the episode shows podcast-level CDN artwork
3. Play the episode to completion or for a few seconds (allowing the player to read metadata)
4. Return to the filters page — the episode should now show its embedded artwork without needing to scroll

## Screenshots or Screencast
<!-- if applicable -->

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

#### I have tested any UI changes...
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack