### PR TITLE
Add Blogs experiment Banner

### DIFF
--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/blogs/EmptyBlogsPage.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/blogs/EmptyBlogsPage.kt
@@ -91,13 +91,12 @@ private fun ExperimentBanner(modifier: Modifier = Modifier) {
         append(' ')
         append(stringResource(LR.string.blogs_experiment_banner_body))
     }
-    Row(
+    Box(
         modifier = modifier
             .clip(RoundedCornerShape(12.dp))
             .background(MaterialTheme.theme.colors.support10.copy(alpha = 0.1f))
             .border(width = 1.dp, color = MaterialTheme.theme.colors.support10, shape = RoundedCornerShape(12.dp))
             .padding(horizontal = 18.dp, vertical = 12.dp),
-        horizontalArrangement = Arrangement.spacedBy(10.dp),
     ) {
         TextP40(text = text)
     }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/blogs/EmptyBlogsPage.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/blogs/EmptyBlogsPage.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.profile.blogs
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -34,8 +35,11 @@ import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
@@ -79,6 +83,27 @@ internal fun EmptyBlogsPage(
 }
 
 @Composable
+private fun ExperimentBanner(modifier: Modifier = Modifier) {
+    val text = buildAnnotatedString {
+        withStyle(SpanStyle(fontWeight = FontWeight.Bold)) {
+            append(stringResource(LR.string.blogs_experiment_banner_lead))
+        }
+        append(' ')
+        append(stringResource(LR.string.blogs_experiment_banner_body))
+    }
+    Row(
+        modifier = modifier
+            .clip(RoundedCornerShape(12.dp))
+            .background(MaterialTheme.theme.colors.support10.copy(alpha = 0.1f))
+            .border(width = 1.dp, color = MaterialTheme.theme.colors.support10, shape = RoundedCornerShape(12.dp))
+            .padding(horizontal = 18.dp, vertical = 12.dp),
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        TextP40(text = text)
+    }
+}
+
+@Composable
 private fun BlogsEmptyContent(
     onAddBlogClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -93,6 +118,10 @@ private fun BlogsEmptyContent(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
+        ExperimentBanner()
+
+        Spacer(Modifier.weight(1f))
+
         BlogsIllustration()
 
         Spacer(Modifier.height(24.dp))
@@ -124,6 +153,10 @@ private fun BlogsEmptyContent(
             ),
             modifier = Modifier.fillMaxWidth(),
         )
+
+        Spacer(Modifier.height(60.dp))
+
+        Spacer(Modifier.weight(1f))
     }
 }
 

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2765,6 +2765,8 @@
     <string name="blogs_empty_title">Turn any blog into a podcast</string>
     <string name="blogs_empty_description">Paste a blog or RSS URL. We\'ll narrate every post and add new episodes automatically as the site publishes.</string>
     <string name="blogs_add_button">Add a blog</string>
+    <string name="blogs_experiment_banner_lead">This is an experiment.</string>
+    <string name="blogs_experiment_banner_body">Blogs is something we\'re trying out. It might stick around, get reworked, or quietly go away.</string>
     <string name="blogs_empty_url_label">Blog or RSS URL</string>
     <string name="blogs_empty_url_placeholder" translatable="false">https://</string>
     <string name="blogs_add_url_hint">Paste a blog or RSS URL and we\'ll find the feed for you.</string>


### PR DESCRIPTION
## Description

This change adds a banner to the empty blogs page explaining the experiment. 

Fixes https://linear.app/a8c/issue/POC-623/android-add-an-experiment-banner

## Testing Instructions

1. Go to the Profile tab -> Blogs
2. ✅ Verify you see the banner

## Screenshots 

| Light | Dark |
| --- | --- |
| <img width="1080" height="2400" alt="Screenshot_20260514_065920" src="https://github.com/user-attachments/assets/f3436c0b-d7a7-48e4-8359-81c0a1d64625" /> | <img width="1080" height="2400" alt="Screenshot_20260514_065933" src="https://github.com/user-attachments/assets/bd35fda5-79f5-4f8c-93af-9e4fe53d89f9" /> | 

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
