### PR TITLE
Fix web feed creation polling and improve subscribed blog sorting

### DIFF
--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
@@ -71,7 +71,7 @@ abstract class PodcastDao {
     abstract suspend fun findSubscribedNoOrder(): List<Podcast>
 
     @Transaction
-    @Query("SELECT * FROM podcasts WHERE subscribed = 1 AND web_feed = 1 ORDER BY CASE WHEN latest_episode_date IS NULL THEN 1 ELSE 0 END, latest_episode_date DESC, LOWER(title) ASC")
+    @Query("SELECT * FROM podcasts WHERE subscribed = 1 AND web_feed = 1 ORDER BY CASE WHEN latest_episode_date IS NULL THEN 0 ELSE 1 END, latest_episode_date DESC, added_date DESC")
     abstract fun observeSubscribedWebFeedPodcasts(): Flow<List<Podcast>>
 
     @Transaction

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
@@ -71,7 +71,7 @@ abstract class PodcastDao {
     abstract suspend fun findSubscribedNoOrder(): List<Podcast>
 
     @Transaction
-    @Query("SELECT * FROM podcasts WHERE subscribed = 1 AND web_feed = 1 ORDER BY CASE WHEN latest_episode_date IS NULL THEN 0 ELSE 1 END, latest_episode_date DESC, added_date DESC")
+    @Query("SELECT * FROM podcasts WHERE subscribed = 1 AND web_feed = 1 ORDER BY CASE WHEN latest_episode_date IS NULL THEN 0 ELSE 1 END, latest_episode_date DESC, LOWER(title) ASC")
     abstract fun observeSubscribedWebFeedPodcasts(): Flow<List<Podcast>>
 
     @Transaction

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
@@ -410,7 +410,7 @@ class SyncManagerImpl @Inject constructor(
             delay((pollCount + 1) * 1_000L)
             val pollUuid = response.pollUuid
             response = getCacheTokenOrLogin { token ->
-                syncServiceManager.pollWebFeedPodcast(token, pollUuid)
+                syncServiceManager.pollWebFeedPodcast(token = token, pollUuid = pollUuid, url = url)
             }
             pollCount++
         }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServiceManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServiceManager.kt
@@ -310,9 +310,10 @@ open class SyncServiceManager @Inject constructor(
         return service.createWebFeedPodcast(addBearer(token), request)
     }
 
-    suspend fun pollWebFeedPodcast(token: AccessToken, pollUuid: String): WebFeedCreateResponse {
+    suspend fun pollWebFeedPodcast(token: AccessToken, pollUuid: String, url: String): WebFeedCreateResponse {
         val request = WebFeedCreateRequest.newBuilder()
             .setPollUuid(StringValue.of(pollUuid))
+            .setUrl(url)
             .build()
         return service.createWebFeedPodcast(addBearer(token), request)
     }


### PR DESCRIPTION
## Description

This change fixes two issues. When creating a podcast from a blog for the first time, an error was incorrectly shown because the polling call was broken. It also updates the ordering of new blogs so they appear above the podcasts with episodes until they receive their first episode, after which they are sorted by the latest episode date.

## Testing Instructions

1. Install the 'debug' variant
2. Go to the Profile tab -> Blogs
3. Add a new Blog that doesn't exist in staging, such as https://jindgi4.wordpress.com/
4. ✅ Verify there is no error displayed and that it is shown at the top of the Blogs podcast list

## Screenshots 

<img width="300" src="https://github.com/user-attachments/assets/93586520-d089-47fe-97a0-128c124a5df8" />

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
