### PR TITLE
Add a Blog post loading page

### DIFF
--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/blogs/AddBlogPage.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/blogs/AddBlogPage.kt
@@ -589,6 +589,12 @@ private fun DoneDot() {
     }
 }
 
+private val previewWebFeed = WebFeed(
+    title = "pocketcasts.com",
+    href = "https://pocketcasts.com/feed/",
+    type = "application/rss+xml",
+)
+
 @Preview
 @Composable
 private fun AddBlogPageStartPreview(
@@ -662,11 +668,7 @@ private fun AddBlogPageFoundEpisodesPreview(
     AppThemeWithBackground(themeType) {
         AddBlogPage(
             state = UiState.Found(
-                webFeed = WebFeed(
-                    title = "pocketcasts.com",
-                    href = "https://pocketcasts.com/feed/",
-                    type = "application/rss+xml",
-                ),
+                webFeed = previewWebFeed,
                 podcastUuid = "00000000-0000-0000-0000-000000000000",
                 episodeCount = 1,
             ),
@@ -690,11 +692,7 @@ private fun AddBlogPageFoundNoEpisodesPreview(
     AppThemeWithBackground(themeType) {
         AddBlogPage(
             state = UiState.Found(
-                webFeed = WebFeed(
-                    title = "pocketcasts.com",
-                    href = "https://pocketcasts.com/feed/",
-                    type = "application/rss+xml",
-                ),
+                webFeed = previewWebFeed,
                 podcastUuid = "00000000-0000-0000-0000-000000000000",
                 episodeCount = 0,
             ),

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/blogs/AddBlogPage.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/blogs/AddBlogPage.kt
@@ -4,6 +4,7 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -56,6 +57,8 @@ import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
+import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP50
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP60
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
@@ -76,6 +79,7 @@ internal fun AddBlogPage(
     onFindFeeds: (url: String) -> Unit,
     onRetry: (url: String) -> Unit,
     onFeedClick: (webFeed: WebFeed) -> Unit,
+    onGoToPodcast: (podcastUuid: String) -> Unit,
     onEditUrl: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -95,6 +99,7 @@ internal fun AddBlogPage(
             onFindFeeds = onFindFeeds,
             onRetry = onRetry,
             onFeedClick = onFeedClick,
+            onGoToPodcast = onGoToPodcast,
             onEditUrl = onEditUrl,
         )
     }
@@ -108,6 +113,7 @@ private fun AddBlogContent(
     onFindFeeds: (url: String) -> Unit,
     onRetry: (url: String) -> Unit,
     onFeedClick: (WebFeed) -> Unit,
+    onGoToPodcast: (String) -> Unit,
     onEditUrl: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -136,7 +142,7 @@ private fun AddBlogContent(
                     { LoadingDot() }
                 }
 
-                is UiState.Pick -> {
+                is UiState.Pick, is UiState.Found -> {
                     { DoneDot() }
                 }
 
@@ -151,8 +157,18 @@ private fun AddBlogContent(
 
         when (state) {
             is UiState.Start -> FormContent(onContinueClick = { onFindFeeds(url) })
+
             is UiState.Loading -> LoadingContent()
+
             is UiState.Pick -> PickContent(feeds = state.feeds, onFeedClick = onFeedClick)
+
+            is UiState.Found -> FoundContent(
+                webFeed = state.webFeed,
+                podcastUuid = state.podcastUuid,
+                episodeCount = state.episodeCount,
+                onGoToPodcastClick = { onGoToPodcast(state.podcastUuid) },
+            )
+
             is UiState.Error -> ErrorContent(reason = state.reason, onRetry = { onRetry(url) })
         }
     }
@@ -334,6 +350,146 @@ private fun FeedChoiceRow(
 }
 
 @Composable
+private fun FoundContent(
+    webFeed: WebFeed,
+    podcastUuid: String,
+    episodeCount: Int,
+    onGoToPodcastClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val colors = MaterialTheme.theme.colors
+
+    Column(modifier = modifier) {
+        TextP60(
+            text = stringResource(LR.string.blogs_found_feed_detected),
+            color = colors.support02,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 4.dp),
+        )
+
+        Spacer(Modifier.height(22.dp))
+
+        FoundFeedCard(
+            webFeed = webFeed,
+            podcastUuid = podcastUuid,
+            episodeCount = episodeCount,
+        )
+
+        Spacer(Modifier.height(18.dp))
+
+        RowButton(
+            text = stringResource(LR.string.blogs_found_go_to_podcast),
+            onClick = onGoToPodcastClick,
+            includePadding = false,
+            textColor = colors.primaryInteractive02,
+            colors = ButtonDefaults.buttonColors(backgroundColor = colors.primaryInteractive01),
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}
+
+@Composable
+private fun FoundFeedCard(
+    webFeed: WebFeed,
+    podcastUuid: String,
+    episodeCount: Int,
+    modifier: Modifier = Modifier,
+) {
+    val colors = MaterialTheme.theme.colors
+    val greenColor = colors.support02
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(14.dp))
+            .border(1.5.dp, greenColor, RoundedCornerShape(14.dp))
+            .background(greenColor.copy(alpha = 0.08f))
+            .padding(14.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier
+                    .size(16.dp)
+                    .background(greenColor, CircleShape),
+            ) {
+                Icon(
+                    painter = painterResource(IR.drawable.ic_check_black_24dp),
+                    contentDescription = null,
+                    tint = colors.primaryUi01,
+                    modifier = Modifier.size(10.dp),
+                )
+            }
+            Spacer(Modifier.width(8.dp))
+            Text(
+                text = stringResource(LR.string.blogs_found_followed_badge),
+                fontWeight = FontWeight.Bold,
+                fontSize = 11.sp,
+                color = greenColor,
+                letterSpacing = 1.1.sp,
+            )
+        }
+
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            PodcastImage(
+                uuid = podcastUuid,
+                imageSize = 56.dp,
+                cornerSize = 8.dp,
+            )
+            Spacer(Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                TextP50(
+                    text = webFeed.title,
+                    fontWeight = FontWeight.Bold,
+                    color = colors.primaryText01,
+                    lineHeight = 18.sp,
+                    maxLines = 1,
+                )
+                Spacer(Modifier.height(2.dp))
+                TextP60(
+                    text = webFeed.displayHref,
+                    color = colors.primaryText02,
+                    maxLines = 1,
+                )
+            }
+        }
+
+        if (episodeCount == 0) {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(1.dp)
+                        .background(greenColor.copy(alpha = 0.2f)),
+                )
+                Spacer(Modifier.height(4.dp))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(18.dp),
+                        strokeWidth = 2.dp,
+                        color = colors.primaryInteractive01,
+                    )
+                    Spacer(Modifier.width(12.dp))
+                    TextP40(
+                        text = stringResource(LR.string.blogs_found_headline),
+                        fontWeight = FontWeight.Bold,
+                        color = colors.primaryText01,
+                    )
+                }
+                TextP40(
+                    text = stringResource(LR.string.blogs_found_description),
+                    color = colors.primaryText02,
+                )
+            }
+        }
+    }
+}
+
+@Composable
 private fun ErrorContent(
     reason: AddBlogViewModel.ErrorReason,
     onRetry: () -> Unit,
@@ -446,6 +602,7 @@ private fun AddBlogPageStartPreview(
             onFindFeeds = { _ -> },
             onRetry = { _ -> },
             onFeedClick = { _ -> },
+            onGoToPodcast = { _ -> },
             onEditUrl = {},
             onUrlChange = {},
         )
@@ -465,6 +622,7 @@ private fun AddBlogPageLoadingPreview(
             onFindFeeds = { _ -> },
             onRetry = { _ -> },
             onFeedClick = { _ -> },
+            onGoToPodcast = { _ -> },
             onEditUrl = {},
             onUrlChange = {},
         )
@@ -489,6 +647,63 @@ private fun AddBlogPagePickPreview(
             onFindFeeds = { _ -> },
             onRetry = { _ -> },
             onFeedClick = { _ -> },
+            onGoToPodcast = { _ -> },
+            onEditUrl = {},
+            onUrlChange = {},
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun AddBlogPageFoundEpisodesPreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
+) {
+    AppThemeWithBackground(themeType) {
+        AddBlogPage(
+            state = UiState.Found(
+                webFeed = WebFeed(
+                    title = "pocketcasts.com",
+                    href = "https://pocketcasts.com/feed/",
+                    type = "application/rss+xml",
+                ),
+                podcastUuid = "00000000-0000-0000-0000-000000000000",
+                episodeCount = 1,
+            ),
+            url = "https://pocketcasts.com",
+            onBackPress = {},
+            onFindFeeds = { _ -> },
+            onRetry = { _ -> },
+            onFeedClick = { _ -> },
+            onGoToPodcast = { _ -> },
+            onEditUrl = {},
+            onUrlChange = {},
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun AddBlogPageFoundNoEpisodesPreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
+) {
+    AppThemeWithBackground(themeType) {
+        AddBlogPage(
+            state = UiState.Found(
+                webFeed = WebFeed(
+                    title = "pocketcasts.com",
+                    href = "https://pocketcasts.com/feed/",
+                    type = "application/rss+xml",
+                ),
+                podcastUuid = "00000000-0000-0000-0000-000000000000",
+                episodeCount = 0,
+            ),
+            url = "https://pocketcasts.com",
+            onBackPress = {},
+            onFindFeeds = { _ -> },
+            onRetry = { _ -> },
+            onFeedClick = { _ -> },
+            onGoToPodcast = { _ -> },
             onEditUrl = {},
             onUrlChange = {},
         )
@@ -508,6 +723,7 @@ private fun AddBlogPageErrorPreview(
             onFindFeeds = { _ -> },
             onRetry = { _ -> },
             onFeedClick = { _ -> },
+            onGoToPodcast = { _ -> },
             onEditUrl = {},
             onUrlChange = {},
         )

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/blogs/AddBlogViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/blogs/AddBlogViewModel.kt
@@ -224,8 +224,8 @@ class AddBlogViewModel @Inject constructor(
         Generic,
     }
 
-    companion object {
-        private const val POLL_FIRST_EPISODE_INTERVAL_MS = 20_000L
-        private const val POLL_FIRST_EPISODE_MAX_ATTEMPTS = 15
+    private companion object {
+        const val POLL_FIRST_EPISODE_INTERVAL_MS = 20_000L
+        const val POLL_FIRST_EPISODE_MAX_ATTEMPTS = 15
     }
 }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/blogs/AddBlogViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/blogs/AddBlogViewModel.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.profile.blogs
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.servers.webfeeds.WebFeed
@@ -20,9 +21,14 @@ import java.io.IOException
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -40,24 +46,28 @@ class AddBlogViewModel @Inject constructor(
     private val _url = MutableStateFlow("")
     val url: StateFlow<String> = _url.asStateFlow()
 
+    private val _podcastNavigationEvents = MutableSharedFlow<String>(extraBufferCapacity = 1)
+    val podcastNavigationEvents: SharedFlow<String> = _podcastNavigationEvents.asSharedFlow()
+
     private var findFeedsJob: Job? = null
     private var createFeedJob: Job? = null
+    private var pollEpisodesJob: Job? = null
 
     fun onUrlChange(url: String) {
         _url.value = url
     }
 
-    fun onFindFeedsTapped(url: String, onNavigateToPodcast: (String) -> Unit) {
+    fun onFindFeedsTapped(url: String) {
         eventHorizon.track(BlogsFindFeedsTappedEvent)
-        findFeeds(url = url, onNavigateToPodcast = onNavigateToPodcast)
+        findFeeds(url = url)
     }
 
-    fun onRetryTapped(url: String, onNavigateToPodcast: (String) -> Unit) {
+    fun onRetryTapped(url: String) {
         eventHorizon.track(BlogsRetryTappedEvent)
-        findFeeds(url = url, onNavigateToPodcast = onNavigateToPodcast)
+        findFeeds(url = url)
     }
 
-    private fun findFeeds(url: String, onNavigateToPodcast: (String) -> Unit) {
+    private fun findFeeds(url: String) {
         val cleanUrl = url.trim()
         if (cleanUrl.isEmpty()) {
             return
@@ -70,7 +80,7 @@ class AddBlogViewModel @Inject constructor(
                 eventHorizon.track(BlogsFeedsFoundEvent(feedCount = feeds.size.toLong()))
                 when {
                     feeds.isEmpty() -> _uiState.value = UiState.Error(ErrorReason.NoFeedsFound)
-                    feeds.size == 1 -> createFeed(webFeed = feeds.first(), onNavigateToPodcast = onNavigateToPodcast)
+                    feeds.size == 1 -> createFeed(webFeed = feeds.first())
                     else -> _uiState.value = UiState.Pick(feeds)
                 }
             } catch (e: CancellationException) {
@@ -87,12 +97,12 @@ class AddBlogViewModel @Inject constructor(
         }
     }
 
-    fun onFeedSelected(webFeed: WebFeed, onNavigateToPodcast: (String) -> Unit) {
+    fun onFeedSelected(webFeed: WebFeed) {
         eventHorizon.track(BlogsFeedSelectedEvent)
-        createFeed(webFeed = webFeed, onNavigateToPodcast = onNavigateToPodcast)
+        createFeed(webFeed = webFeed)
     }
 
-    fun createFeed(webFeed: WebFeed, onNavigateToPodcast: (String) -> Unit) {
+    fun createFeed(webFeed: WebFeed) {
         createFeedJob?.cancel()
         createFeedJob = viewModelScope.launch {
             _uiState.value = UiState.Loading
@@ -102,7 +112,21 @@ class AddBlogViewModel @Inject constructor(
                     val podcastUuid = response.podcast.uuid
                     podcastManager.subscribeToPodcast(podcastUuid = podcastUuid, sync = true)
                     eventHorizon.track(BlogsSubscribedEvent(uuid = podcastUuid))
-                    onNavigateToPodcast(podcastUuid)
+                    val podcast = awaitSubscribedPodcast(podcastUuid)
+                    // jump straight to the podcast page if the subscribe is slow or didn't work
+                    if (podcast == null) {
+                        _podcastNavigationEvents.tryEmit(podcastUuid)
+                    } else {
+                        val episodeCount = podcastManager.countEpisodesByPodcast(podcastUuid)
+                        _uiState.value = UiState.Found(
+                            webFeed = webFeed,
+                            podcastUuid = podcastUuid,
+                            episodeCount = episodeCount,
+                        )
+                        if (episodeCount == 0) {
+                            pollForFirstEpisode(podcast = podcast, webFeed = webFeed)
+                        }
+                    }
                 } else {
                     Timber.e("Timed out waiting for podcast creation for ${webFeed.href}")
                     eventHorizon.track(BlogsCreateFailedEvent)
@@ -129,9 +153,48 @@ class AddBlogViewModel @Inject constructor(
         _uiState.value = UiState.Start
     }
 
+    private suspend fun awaitSubscribedPodcast(podcastUuid: String): Podcast? {
+        repeat(10) {
+            val podcast = podcastManager.findPodcastByUuid(podcastUuid)
+            if (podcast != null) return podcast
+            delay(1000L)
+        }
+        return null
+    }
+
+    private fun pollForFirstEpisode(podcast: Podcast, webFeed: WebFeed) {
+        pollEpisodesJob?.cancel()
+        pollEpisodesJob = viewModelScope.launch {
+            repeat(POLL_FIRST_EPISODE_MAX_ATTEMPTS) {
+                if (!isActive) return@launch
+                delay(POLL_FIRST_EPISODE_INTERVAL_MS)
+                try {
+                    podcastManager.refreshPodcastFeed(podcast)
+                    val count = podcastManager.countEpisodesByPodcast(podcast.uuid)
+                    if (count > 0) {
+                        _uiState.value = UiState.Found(
+                            webFeed = webFeed,
+                            podcastUuid = podcast.uuid,
+                            episodeCount = count,
+                        )
+                        _podcastNavigationEvents.tryEmit(podcast.uuid)
+                        return@launch
+                    }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    Timber.e(e, "Polling for first episode failed for ${podcast.uuid}")
+                }
+            }
+            // when waiting for too long, take the user to the podcast page
+            _podcastNavigationEvents.tryEmit(podcast.uuid)
+        }
+    }
+
     private fun cancelJobs() {
         findFeedsJob?.cancel()
         createFeedJob?.cancel()
+        pollEpisodesJob?.cancel()
     }
 
     fun onBackPressed(): Boolean {
@@ -147,6 +210,11 @@ class AddBlogViewModel @Inject constructor(
         data object Start : UiState
         data object Loading : UiState
         data class Pick(val feeds: List<WebFeed>) : UiState
+        data class Found(
+            val webFeed: WebFeed,
+            val podcastUuid: String,
+            val episodeCount: Int,
+        ) : UiState
         data class Error(val reason: ErrorReason) : UiState
     }
 
@@ -154,5 +222,10 @@ class AddBlogViewModel @Inject constructor(
         NoInternet,
         NoFeedsFound,
         Generic,
+    }
+
+    companion object {
+        private const val POLL_FIRST_EPISODE_INTERVAL_MS = 20_000L
+        private const val POLL_FIRST_EPISODE_MAX_ATTEMPTS = 15
     }
 }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/blogs/BlogsFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/blogs/BlogsFragment.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.profile.blogs
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalDensity
@@ -99,6 +100,9 @@ class BlogsFragment : BaseFragment() {
                         navController.popBackStack(BlogsRoutes.PODCASTS, inclusive = false)
                         navigateToPodcast(uuid)
                     }
+                    LaunchedEffect(viewModel) {
+                        viewModel.podcastNavigationEvents.collect(onBlogAdded)
+                    }
                     AddBlogPage(
                         state = uiState,
                         url = url,
@@ -108,15 +112,10 @@ class BlogsFragment : BaseFragment() {
                                 navController.popBackStack()
                             }
                         },
-                        onFindFeeds = {
-                            viewModel.onFindFeedsTapped(url = it, onNavigateToPodcast = onBlogAdded)
-                        },
-                        onRetry = {
-                            viewModel.onRetryTapped(url = it, onNavigateToPodcast = onBlogAdded)
-                        },
-                        onFeedClick = { webFeed ->
-                            viewModel.onFeedSelected(webFeed = webFeed, onNavigateToPodcast = onBlogAdded)
-                        },
+                        onFindFeeds = { viewModel.onFindFeedsTapped(url = it) },
+                        onRetry = { viewModel.onRetryTapped(url = it) },
+                        onFeedClick = { webFeed -> viewModel.onFeedSelected(webFeed = webFeed) },
+                        onGoToPodcast = onBlogAdded,
                         onEditUrl = { viewModel.editUrl() },
                     )
                 }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/blogs/BlogsFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/blogs/BlogsFragment.kt
@@ -112,7 +112,7 @@ class BlogsFragment : BaseFragment() {
                                 navController.popBackStack()
                             }
                         },
-                        onFindFeeds = { viewModel.onFindFeedsTapped(url = it) },
+                        onFindFeeds = viewModel::onFindFeedsTapped,
                         onRetry = { viewModel.onRetryTapped(url = it) },
                         onFeedClick = { webFeed -> viewModel.onFeedSelected(webFeed = webFeed) },
                         onGoToPodcast = onBlogAdded,

--- a/modules/features/profile/src/test/kotlin/au/com/shiftyjelly/pocketcasts/profile/blogs/AddBlogViewModelTest.kt
+++ b/modules/features/profile/src/test/kotlin/au/com/shiftyjelly/pocketcasts/profile/blogs/AddBlogViewModelTest.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.profile.blogs
 
 import app.cash.turbine.test
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.servers.webfeeds.WebFeed
@@ -15,13 +16,16 @@ import com.automattic.eventhorizon.BlogsFindFeedsTappedEvent
 import com.automattic.eventhorizon.BlogsRetryTappedEvent
 import com.automattic.eventhorizon.BlogsSubscribedEvent
 import com.automattic.eventhorizon.EventHorizon
+import com.pocketcasts.service.api.ApiPodcastResponse
 import com.pocketcasts.service.api.WebFeedCreateResponse
 import java.io.IOException
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -30,9 +34,11 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class AddBlogViewModelTest {
     @get:Rule
     val coroutineRule = MainCoroutineRule()
@@ -64,16 +70,16 @@ class AddBlogViewModelTest {
 
     @Test
     fun `onFindFeeds with blank url is ignored`() = runTest {
-        viewModel.onFindFeedsTapped("   ") { }
+        viewModel.onFindFeedsTapped("   ")
 
         assertEquals(AddBlogViewModel.UiState.Start, viewModel.uiState.value)
     }
 
     @Test
-    fun `onFindFeeds with single feed creates the feed and navigates to the podcast`() = runTest {
+    fun `onFindFeeds with single feed creates the feed and lands on Found state`() = runTest(coroutineRule.testDispatcher.scheduler) {
         val feed = webFeed("Example", "https://example.com/feed")
         val podcastUuid = "uuid-123"
-        val podcastResponse = mock<com.pocketcasts.service.api.ApiPodcastResponse> {
+        val podcastResponse = mock<ApiPodcastResponse> {
             on { uuid } doReturn podcastUuid
         }
         val response = mock<WebFeedCreateResponse> {
@@ -82,12 +88,14 @@ class AddBlogViewModelTest {
         }
         whenever(webFeedsService.getFeeds("https://example.com")).doSuspendableAnswer { listOf(feed) }
         whenever(syncManager.createWebFeedPodcast(feed.href)).thenReturn(response)
+        whenever(podcastManager.findPodcastByUuid(podcastUuid)).thenReturn(Podcast(uuid = podcastUuid))
+        whenever(podcastManager.countEpisodesByPodcast(podcastUuid)).thenReturn(0)
 
-        var navigatedUuid: String? = null
-        viewModel.onFindFeedsTapped("https://example.com") { navigatedUuid = it }
+        viewModel.onFindFeedsTapped("https://example.com")
+        advanceUntilIdle()
 
         verify(syncManager).createWebFeedPodcast(feed.href)
-        assertEquals(podcastUuid, navigatedUuid)
+        assertEquals(AddBlogViewModel.UiState.Found(webFeed = feed, podcastUuid = podcastUuid, episodeCount = 0), viewModel.uiState.value)
         verify(eventHorizon).track(BlogsFindFeedsTappedEvent)
         verify(eventHorizon).track(BlogsFeedsFoundEvent(feedCount = 1))
         verify(eventHorizon).track(BlogsSubscribedEvent(uuid = podcastUuid))
@@ -105,7 +113,7 @@ class AddBlogViewModelTest {
         viewModel.uiState.test {
             assertEquals(AddBlogViewModel.UiState.Start, awaitItem())
 
-            viewModel.onFindFeedsTapped("https://example.com") { }
+            viewModel.onFindFeedsTapped("https://example.com")
             assertEquals(AddBlogViewModel.UiState.Loading, awaitItem())
 
             gate.complete(feeds)
@@ -122,7 +130,7 @@ class AddBlogViewModelTest {
         viewModel.uiState.test {
             assertEquals(AddBlogViewModel.UiState.Start, awaitItem())
 
-            viewModel.onFindFeedsTapped("https://example.com") { }
+            viewModel.onFindFeedsTapped("https://example.com")
             assertEquals(AddBlogViewModel.UiState.Loading, awaitItem())
 
             gate.complete(emptyList())
@@ -139,7 +147,7 @@ class AddBlogViewModelTest {
         viewModel.uiState.test {
             assertEquals(AddBlogViewModel.UiState.Start, awaitItem())
 
-            viewModel.onFindFeedsTapped("https://example.com") { }
+            viewModel.onFindFeedsTapped("https://example.com")
             assertEquals(AddBlogViewModel.UiState.Loading, awaitItem())
 
             gate.completeExceptionally(IOException("offline"))
@@ -156,7 +164,7 @@ class AddBlogViewModelTest {
         viewModel.uiState.test {
             assertEquals(AddBlogViewModel.UiState.Start, awaitItem())
 
-            viewModel.onFindFeedsTapped("https://example.com") { }
+            viewModel.onFindFeedsTapped("https://example.com")
             assertEquals(AddBlogViewModel.UiState.Loading, awaitItem())
 
             gate.completeExceptionally(RuntimeException("boom"))
@@ -174,7 +182,7 @@ class AddBlogViewModelTest {
         whenever(webFeedsService.getFeeds("https://example.com")).doSuspendableAnswer { feeds }
 
         viewModel.onUrlChange("https://example.com")
-        viewModel.onFindFeedsTapped("https://example.com") { }
+        viewModel.onFindFeedsTapped("https://example.com")
 
         assertEquals(AddBlogViewModel.UiState.Pick(feeds), viewModel.uiState.value)
 
@@ -193,7 +201,7 @@ class AddBlogViewModelTest {
         whenever(webFeedsService.getFeeds("https://example.com")).doSuspendableAnswer { feeds }
 
         viewModel.onUrlChange("https://example.com")
-        viewModel.onFindFeedsTapped("https://example.com") { }
+        viewModel.onFindFeedsTapped("https://example.com")
 
         assertEquals(AddBlogViewModel.UiState.Pick(feeds), viewModel.uiState.value)
 
@@ -218,7 +226,7 @@ class AddBlogViewModelTest {
         whenever(webFeedsService.getFeeds("https://example.com")).doSuspendableAnswer { feeds }
 
         viewModel.onUrlChange("https://example.com")
-        viewModel.onFindFeedsTapped("https://example.com") { }
+        viewModel.onFindFeedsTapped("https://example.com")
 
         assertEquals(AddBlogViewModel.UiState.Pick(feeds), viewModel.uiState.value)
 
@@ -228,10 +236,10 @@ class AddBlogViewModelTest {
     }
 
     @Test
-    fun `createFeed with success transitions Loading to success and calls onNavigateToPodcast`() = runTest {
+    fun `createFeed with success subscribes and transitions to Found state`() = runTest(coroutineRule.testDispatcher.scheduler) {
         val feed = webFeed("Example", "https://example.com/feed")
         val podcastUuid = "uuid-123"
-        val podcastResponse = mock<com.pocketcasts.service.api.ApiPodcastResponse> {
+        val podcastResponse = mock<ApiPodcastResponse> {
             on { uuid } doReturn podcastUuid
         }
         val response = mock<WebFeedCreateResponse> {
@@ -239,14 +247,18 @@ class AddBlogViewModelTest {
             on { podcast } doReturn podcastResponse
         }
         whenever(syncManager.createWebFeedPodcast(feed.href)).thenReturn(response)
+        whenever(podcastManager.findPodcastByUuid(podcastUuid)).thenReturn(Podcast(uuid = podcastUuid))
+        whenever(podcastManager.countEpisodesByPodcast(podcastUuid)).thenReturn(0)
 
-        var navigatedUuid: String? = null
-        viewModel.createFeed(feed) { navigatedUuid = it }
+        viewModel.createFeed(feed)
+        advanceUntilIdle()
 
-        assertEquals(AddBlogViewModel.UiState.Loading, viewModel.uiState.value)
         verify(syncManager).createWebFeedPodcast(feed.href)
         verify(podcastManager).subscribeToPodcast(podcastUuid = eq(podcastUuid), sync = eq(true), shouldAutoDownload = eq(true))
-        assertEquals(podcastUuid, navigatedUuid)
+        assertEquals(
+            AddBlogViewModel.UiState.Found(webFeed = feed, podcastUuid = podcastUuid, episodeCount = 0),
+            viewModel.uiState.value,
+        )
     }
 
     @Test
@@ -257,7 +269,7 @@ class AddBlogViewModelTest {
         }
         whenever(syncManager.createWebFeedPodcast(feed.href)).thenReturn(response)
 
-        viewModel.createFeed(feed) { }
+        viewModel.createFeed(feed)
 
         assertEquals(AddBlogViewModel.UiState.Error(AddBlogViewModel.ErrorReason.Generic), viewModel.uiState.value)
         verify(eventHorizon).track(BlogsCreateFailedEvent)
@@ -268,17 +280,17 @@ class AddBlogViewModelTest {
         val feed = webFeed("Example", "https://example.com/feed")
         whenever(syncManager.createWebFeedPodcast(feed.href)).thenThrow(RuntimeException("boom"))
 
-        viewModel.createFeed(feed) { }
+        viewModel.createFeed(feed)
 
         assertEquals(AddBlogViewModel.UiState.Error(AddBlogViewModel.ErrorReason.Generic), viewModel.uiState.value)
         verify(eventHorizon).track(BlogsCreateFailedEvent)
     }
 
     @Test
-    fun `onFeedSelected tracks feed-selected event then subscribes`() = runTest {
+    fun `onFeedSelected tracks feed-selected event then subscribes and lands on Found`() = runTest(coroutineRule.testDispatcher.scheduler) {
         val feed = webFeed("Example", "https://example.com/feed")
         val podcastUuid = "uuid-123"
-        val podcastResponse = mock<com.pocketcasts.service.api.ApiPodcastResponse> {
+        val podcastResponse = mock<ApiPodcastResponse> {
             on { uuid } doReturn podcastUuid
         }
         val response = mock<WebFeedCreateResponse> {
@@ -286,11 +298,16 @@ class AddBlogViewModelTest {
             on { podcast } doReturn podcastResponse
         }
         whenever(syncManager.createWebFeedPodcast(feed.href)).thenReturn(response)
+        whenever(podcastManager.findPodcastByUuid(podcastUuid)).thenReturn(Podcast(uuid = podcastUuid))
+        whenever(podcastManager.countEpisodesByPodcast(podcastUuid)).thenReturn(0)
 
-        var navigatedUuid: String? = null
-        viewModel.onFeedSelected(feed) { navigatedUuid = it }
+        viewModel.onFeedSelected(feed)
+        advanceUntilIdle()
 
-        assertEquals(podcastUuid, navigatedUuid)
+        assertEquals(
+            AddBlogViewModel.UiState.Found(webFeed = feed, podcastUuid = podcastUuid, episodeCount = 0),
+            viewModel.uiState.value,
+        )
         verify(eventHorizon).track(BlogsFeedSelectedEvent)
         verify(eventHorizon).track(BlogsSubscribedEvent(uuid = podcastUuid))
     }
@@ -303,7 +320,7 @@ class AddBlogViewModelTest {
         )
         whenever(webFeedsService.getFeeds("https://example.com")).doSuspendableAnswer { feeds }
 
-        viewModel.onRetryTapped("https://example.com") { }
+        viewModel.onRetryTapped("https://example.com")
 
         assertEquals(AddBlogViewModel.UiState.Pick(feeds), viewModel.uiState.value)
         verify(eventHorizon).track(BlogsRetryTappedEvent)
@@ -311,18 +328,17 @@ class AddBlogViewModelTest {
     }
 
     @Test
-    fun `resetToStart cancels in-flight createFeed and skips navigation`() = runTest {
+    fun `resetToStart cancels in-flight createFeed and skips Found state`() = runTest {
         val feed = webFeed("Example", "https://example.com/feed")
         val gate = CompletableDeferred<WebFeedCreateResponse>()
         whenever(syncManager.createWebFeedPodcast(feed.href)).doSuspendableAnswer { gate.await() }
 
-        var navigatedUuid: String? = null
-        viewModel.createFeed(feed) { navigatedUuid = it }
+        viewModel.createFeed(feed)
         assertEquals(AddBlogViewModel.UiState.Loading, viewModel.uiState.value)
 
         viewModel.resetToStart()
 
-        val podcastResponse = mock<com.pocketcasts.service.api.ApiPodcastResponse> {
+        val podcastResponse = mock<ApiPodcastResponse> {
             on { uuid } doReturn "uuid-123"
         }
         gate.complete(
@@ -333,22 +349,20 @@ class AddBlogViewModelTest {
         )
 
         assertEquals(AddBlogViewModel.UiState.Start, viewModel.uiState.value)
-        assertNull(navigatedUuid)
     }
 
     @Test
-    fun `editUrl cancels in-flight createFeed and skips navigation`() = runTest {
+    fun `editUrl cancels in-flight createFeed and skips Found state`() = runTest {
         val feed = webFeed("Example", "https://example.com/feed")
         val gate = CompletableDeferred<WebFeedCreateResponse>()
         whenever(syncManager.createWebFeedPodcast(feed.href)).doSuspendableAnswer { gate.await() }
 
         viewModel.onUrlChange("https://example.com")
-        var navigatedUuid: String? = null
-        viewModel.createFeed(feed) { navigatedUuid = it }
+        viewModel.createFeed(feed)
 
         viewModel.editUrl()
 
-        val podcastResponse = mock<com.pocketcasts.service.api.ApiPodcastResponse> {
+        val podcastResponse = mock<ApiPodcastResponse> {
             on { uuid } doReturn "uuid-123"
         }
         gate.complete(
@@ -360,7 +374,80 @@ class AddBlogViewModelTest {
 
         assertEquals(AddBlogViewModel.UiState.Start, viewModel.uiState.value)
         assertEquals("https://example.com", viewModel.url.value)
-        assertNull(navigatedUuid)
+    }
+
+    @Test
+    fun `createFeed includes episode count when subscribed podcast has episodes`() = runTest(coroutineRule.testDispatcher.scheduler) {
+        val feed = webFeed("Example", "https://example.com/feed")
+        val podcastUuid = "uuid-123"
+        val podcastResponse = mock<ApiPodcastResponse> {
+            on { uuid } doReturn podcastUuid
+        }
+        val response = mock<WebFeedCreateResponse> {
+            on { hasPodcast() } doReturn true
+            on { podcast } doReturn podcastResponse
+        }
+        val podcast = Podcast(uuid = podcastUuid)
+        whenever(syncManager.createWebFeedPodcast(feed.href)).thenReturn(response)
+        whenever(podcastManager.findPodcastByUuid(podcastUuid)).thenReturn(podcast)
+        whenever(podcastManager.countEpisodesByPodcast(podcastUuid)).thenReturn(3)
+
+        viewModel.createFeed(feed)
+        advanceUntilIdle()
+
+        assertEquals(
+            AddBlogViewModel.UiState.Found(webFeed = feed, podcastUuid = podcastUuid, episodeCount = 3),
+            viewModel.uiState.value,
+        )
+    }
+
+    @Test
+    fun `createFeed has zero episode count when subscribed podcast has no episodes`() = runTest(coroutineRule.testDispatcher.scheduler) {
+        val feed = webFeed("Example", "https://example.com/feed")
+        val podcastUuid = "uuid-123"
+        val podcastResponse = mock<ApiPodcastResponse> {
+            on { uuid } doReturn podcastUuid
+        }
+        val response = mock<WebFeedCreateResponse> {
+            on { hasPodcast() } doReturn true
+            on { podcast } doReturn podcastResponse
+        }
+        val podcast = Podcast(uuid = podcastUuid)
+        whenever(syncManager.createWebFeedPodcast(feed.href)).thenReturn(response)
+        whenever(podcastManager.findPodcastByUuid(podcastUuid)).thenReturn(podcast)
+        whenever(podcastManager.countEpisodesByPodcast(podcastUuid)).thenReturn(0)
+
+        viewModel.createFeed(feed)
+        runCurrent()
+
+        assertEquals(
+            AddBlogViewModel.UiState.Found(webFeed = feed, podcastUuid = podcastUuid, episodeCount = 0),
+            viewModel.uiState.value,
+        )
+        viewModel.resetToStart()
+    }
+
+    @Test
+    fun `createFeed polls for podcast up to ten times before emitting navigation event`() = runTest(coroutineRule.testDispatcher.scheduler) {
+        val feed = webFeed("Example", "https://example.com/feed")
+        val podcastUuid = "uuid-123"
+        val podcastResponse = mock<ApiPodcastResponse> {
+            on { uuid } doReturn podcastUuid
+        }
+        val response = mock<WebFeedCreateResponse> {
+            on { hasPodcast() } doReturn true
+            on { podcast } doReturn podcastResponse
+        }
+        whenever(syncManager.createWebFeedPodcast(feed.href)).thenReturn(response)
+        whenever(podcastManager.findPodcastByUuid(podcastUuid)).thenReturn(null)
+
+        viewModel.podcastNavigationEvents.test {
+            viewModel.createFeed(feed)
+            advanceUntilIdle()
+
+            assertEquals(podcastUuid, awaitItem())
+        }
+        verify(podcastManager, times(10)).findPodcastByUuid(podcastUuid)
     }
 
     private fun webFeed(title: String, href: String) = WebFeed(title = title, href = href, type = "rss")

--- a/modules/features/profile/src/test/kotlin/au/com/shiftyjelly/pocketcasts/profile/blogs/AddBlogViewModelTest.kt
+++ b/modules/features/profile/src/test/kotlin/au/com/shiftyjelly/pocketcasts/profile/blogs/AddBlogViewModelTest.kt
@@ -450,5 +450,62 @@ class AddBlogViewModelTest {
         verify(podcastManager, times(10)).findPodcastByUuid(podcastUuid)
     }
 
+    @Test
+    fun `pollForFirstEpisode emits navigation event and updates Found state when an episode is found`() = runTest(coroutineRule.testDispatcher.scheduler) {
+        val feed = webFeed("Example", "https://example.com/feed")
+        val podcastUuid = "uuid-123"
+        val podcastResponse = mock<ApiPodcastResponse> {
+            on { uuid } doReturn podcastUuid
+        }
+        val response = mock<WebFeedCreateResponse> {
+            on { hasPodcast() } doReturn true
+            on { podcast } doReturn podcastResponse
+        }
+        val podcast = Podcast(uuid = podcastUuid)
+        whenever(syncManager.createWebFeedPodcast(feed.href)).thenReturn(response)
+        whenever(podcastManager.findPodcastByUuid(podcastUuid)).thenReturn(podcast)
+        whenever(podcastManager.countEpisodesByPodcast(podcastUuid))
+            .thenReturn(0)
+            .thenReturn(0)
+            .thenReturn(3)
+
+        viewModel.podcastNavigationEvents.test {
+            viewModel.createFeed(feed)
+            advanceUntilIdle()
+
+            assertEquals(podcastUuid, awaitItem())
+        }
+        assertEquals(
+            AddBlogViewModel.UiState.Found(webFeed = feed, podcastUuid = podcastUuid, episodeCount = 3),
+            viewModel.uiState.value,
+        )
+        verify(podcastManager, times(2)).refreshPodcastFeed(podcast)
+    }
+
+    @Test
+    fun `pollForFirstEpisode emits navigation event after exhausting all attempts when no episodes are found`() = runTest(coroutineRule.testDispatcher.scheduler) {
+        val feed = webFeed("Example", "https://example.com/feed")
+        val podcastUuid = "uuid-123"
+        val podcastResponse = mock<ApiPodcastResponse> {
+            on { uuid } doReturn podcastUuid
+        }
+        val response = mock<WebFeedCreateResponse> {
+            on { hasPodcast() } doReturn true
+            on { podcast } doReturn podcastResponse
+        }
+        val podcast = Podcast(uuid = podcastUuid)
+        whenever(syncManager.createWebFeedPodcast(feed.href)).thenReturn(response)
+        whenever(podcastManager.findPodcastByUuid(podcastUuid)).thenReturn(podcast)
+        whenever(podcastManager.countEpisodesByPodcast(podcastUuid)).thenReturn(0)
+
+        viewModel.podcastNavigationEvents.test {
+            viewModel.createFeed(feed)
+            advanceUntilIdle()
+
+            assertEquals(podcastUuid, awaitItem())
+        }
+        verify(podcastManager, times(15)).refreshPodcastFeed(podcast)
+    }
+
     private fun webFeed(title: String, href: String) = WebFeed(title = title, href = href, type = "rss")
 }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2776,4 +2776,9 @@
     <string name="blogs_error_no_internet">Check your internet connection and try again.</string>
     <string name="blogs_error_no_feeds_found">We couldn\'t find any feeds at that URL. Please check the URL and try again.</string>
     <string name="blogs_error_generic">Something went wrong. Please try again.</string>
+    <string name="blogs_found_feed_detected">Feed found</string>
+    <string name="blogs_found_followed_badge">PODCAST FOLLOWED</string>
+    <string name="blogs_found_headline">Reading your blog out loud</string>
+    <string name="blogs_found_description">We\'re turning the latest posts into podcast episodes. We\'ll take you to the podcast page as soon as the first episode is ready, or come back to the podcast page anytime and pull down to refresh.</string>
+    <string name="blogs_found_go_to_podcast">Go to podcast</string>
 </resources>


### PR DESCRIPTION
## Description

This change adds a loading state while the blog is having the post text converted to audio. 

Fixes https://linear.app/a8c/issue/POC-621/android-add-a-loading-state-on-the-podcast-page

## Testing Instructions

1. Run the `debug` variant
2. Go to the Profile tab, tap Blogs
3. Enter a new blog such as from https://wordpress.com/discover/latest
4. ✅ Verify the loading page is shown
5. ✅ Verify the podcast page loads with an episode (The generation may take awhile but if you are lucky it will load in a minute or two)
6. Repeat the process with an exiting blog such as https://android-developers.googleblog.com/
7. ✅ Verify you aren't shown the loading an instead just the "Go to podcast" button

## Screenshots / Video

| Light | Dark |
| --- | --- |
| <img width="1080" height="2424" alt="Screenshot_20260518_141928" src="https://github.com/user-attachments/assets/01195397-1f19-44ad-b458-786d1e74acaa" /> | <img width="1080" height="2424" alt="Screenshot_20260518_142005" src="https://github.com/user-attachments/assets/23b06cf0-4af9-47bd-ba98-7a7689f21882" /> | 

https://github.com/user-attachments/assets/5ba774fe-da64-4f26-a12f-6511418ab31b

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
