### PR TITLE
Fix AAOS steering-wheel skip buttons after Android 14 update

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3SessionCallback.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3SessionCallback.kt
@@ -69,6 +69,8 @@ internal class Media3SessionCallback(
 
     private val mediaEventQueue = MediaEventQueue(scopeProvider = scopeProvider)
 
+    private val isAutomotive: Boolean by lazy { Util.isAutomotive(contextProvider()) }
+
     override fun onConnect(
         session: MediaSession,
         controller: MediaSession.ControllerInfo,
@@ -209,9 +211,12 @@ internal class Media3SessionCallback(
                 return true
             }
 
-            // PiP skip buttons use dedicated key codes that always skip forward/back,
-            // bypassing headphone control settings.
-            KeyEvent.KEYCODE_MEDIA_SKIP_FORWARD -> {
+            // PiP skip buttons and the FAST_FORWARD/REWIND media keys (used by some
+            // AAOS steering-wheel implementations) always skip forward/back, bypassing
+            // headphone control settings. See PCDROID-560.
+            KeyEvent.KEYCODE_MEDIA_SKIP_FORWARD,
+            KeyEvent.KEYCODE_MEDIA_FAST_FORWARD,
+            -> {
                 scope.launch {
                     try {
                         playbackManager.skipForwardSuspend(
@@ -219,13 +224,15 @@ internal class Media3SessionCallback(
                             jumpAmountSeconds = settings.skipForwardInSecs.value,
                         )
                     } catch (e: Exception) {
-                        Timber.e(e, "PiP skip forward failed")
+                        Timber.e(e, "Skip forward failed")
                     }
                 }
                 return true
             }
 
-            KeyEvent.KEYCODE_MEDIA_SKIP_BACKWARD -> {
+            KeyEvent.KEYCODE_MEDIA_SKIP_BACKWARD,
+            KeyEvent.KEYCODE_MEDIA_REWIND,
+            -> {
                 scope.launch {
                     try {
                         playbackManager.skipBackwardSuspend(
@@ -233,10 +240,46 @@ internal class Media3SessionCallback(
                             jumpAmountSeconds = settings.skipBackInSecs.value,
                         )
                     } catch (e: Exception) {
-                        Timber.e(e, "PiP skip backward failed")
+                        Timber.e(e, "Skip backward failed")
                     }
                 }
                 return true
+            }
+        }
+
+        // On Android Automotive OS the user controls are hardware buttons (e.g. the
+        // steering wheel) that send a single key event per press. Multi-tap detection
+        // adds a 250 ms response delay and never resolves to a higher tap count, so
+        // route NEXT/PREVIOUS straight to skip forward/back. See PCDROID-560.
+        if (isAutomotive) {
+            when (keyEvent.keyCode) {
+                KeyEvent.KEYCODE_MEDIA_NEXT -> {
+                    scope.launch {
+                        try {
+                            playbackManager.skipForwardSuspend(
+                                sourceView = source,
+                                jumpAmountSeconds = settings.skipForwardInSecs.value,
+                            )
+                        } catch (e: Exception) {
+                            Timber.e(e, "Skip forward failed")
+                        }
+                    }
+                    return true
+                }
+
+                KeyEvent.KEYCODE_MEDIA_PREVIOUS -> {
+                    scope.launch {
+                        try {
+                            playbackManager.skipBackwardSuspend(
+                                sourceView = source,
+                                jumpAmountSeconds = settings.skipBackInSecs.value,
+                            )
+                        } catch (e: Exception) {
+                            Timber.e(e, "Skip backward failed")
+                        }
+                    }
+                    return true
+                }
             }
         }
 
@@ -378,6 +421,11 @@ internal val TRANSPORT_PLAYER_COMMANDS: Player.Commands = Player.Commands.Builde
         Player.COMMAND_PLAY_PAUSE,
         Player.COMMAND_SET_MEDIA_ITEM,
         Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM,
+        // Advertise skip-to-next/previous so AAOS steering-wheel skip buttons (and
+        // other Media3 controllers) route through seekToNext()/seekToPrevious().
+        // See PCDROID-560.
+        Player.COMMAND_SEEK_TO_NEXT,
+        Player.COMMAND_SEEK_TO_PREVIOUS,
         Player.COMMAND_STOP,
         Player.COMMAND_GET_CURRENT_MEDIA_ITEM,
         Player.COMMAND_GET_METADATA,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsForwardingPlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsForwardingPlayer.kt
@@ -164,6 +164,11 @@ class PocketCastsForwardingPlayer(
                 Player.COMMAND_PLAY_PAUSE,
                 Player.COMMAND_SET_MEDIA_ITEM,
                 Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM,
+                // Advertise skip-to-next/previous so external controllers (notably AAOS
+                // steering-wheel buttons) route through seekToNext()/seekToPrevious()
+                // instead of falling back to STOP. See PCDROID-560.
+                Player.COMMAND_SEEK_TO_NEXT,
+                Player.COMMAND_SEEK_TO_PREVIOUS,
                 Player.COMMAND_STOP,
                 Player.COMMAND_GET_CURRENT_MEDIA_ITEM,
                 Player.COMMAND_GET_METADATA,

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3SessionCallbackTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3SessionCallbackTest.kt
@@ -1,6 +1,9 @@
 package au.com.shiftyjelly.pocketcasts.repositories.playback
 
+import android.content.Context
 import android.content.Intent
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageManager
 import android.os.Bundle
 import android.view.KeyEvent
 import androidx.media3.common.HeartRating
@@ -106,8 +109,10 @@ class Media3SessionCallbackTest {
         assertTrue(playerCommands.contains(Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM))
         assertFalse(playerCommands.contains(Player.COMMAND_SEEK_FORWARD))
         assertFalse(playerCommands.contains(Player.COMMAND_SEEK_BACK))
-        assertFalse(playerCommands.contains(Player.COMMAND_SEEK_TO_NEXT))
-        assertFalse(playerCommands.contains(Player.COMMAND_SEEK_TO_PREVIOUS))
+        // SEEK_TO_NEXT / SEEK_TO_PREVIOUS are advertised so AAOS steering-wheel skip
+        // buttons route through seekToNext()/seekToPrevious(). See PCDROID-560.
+        assertTrue(playerCommands.contains(Player.COMMAND_SEEK_TO_NEXT))
+        assertTrue(playerCommands.contains(Player.COMMAND_SEEK_TO_PREVIOUS))
         assertTrue(playerCommands.contains(Player.COMMAND_STOP))
         assertTrue(playerCommands.contains(Player.COMMAND_GET_CURRENT_MEDIA_ITEM))
         assertTrue(playerCommands.contains(Player.COMMAND_GET_METADATA))
@@ -436,6 +441,72 @@ class Media3SessionCallbackTest {
         )
     }
 
+    // --- FAST_FORWARD / REWIND keycode tests (PCDROID-560) ---
+
+    @Test
+    fun `KEYCODE_MEDIA_FAST_FORWARD calls skipForwardSuspend directly`() = runTest {
+        mockSkipSettings()
+
+        sendMediaButtonEvent(KeyEvent.KEYCODE_MEDIA_FAST_FORWARD)
+        testScope.advanceUntilIdle()
+
+        verify(playbackManager).skipForwardSuspend(
+            sourceView = any(),
+            jumpAmountSeconds = eq(30),
+        )
+    }
+
+    @Test
+    fun `KEYCODE_MEDIA_REWIND calls skipBackwardSuspend directly`() = runTest {
+        mockSkipSettings()
+
+        sendMediaButtonEvent(KeyEvent.KEYCODE_MEDIA_REWIND)
+        testScope.advanceUntilIdle()
+
+        verify(playbackManager).skipBackwardSuspend(
+            sourceView = any(),
+            jumpAmountSeconds = eq(10),
+        )
+    }
+
+    // --- Automotive bypass tests (PCDROID-560) ---
+
+    @Test
+    fun `on automotive, KEYCODE_MEDIA_NEXT skips forward immediately`() = runTest {
+        mockSkipSettings()
+        val automotiveCallback = createCallbackWithAutomotiveContext()
+
+        val keyEvent = KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_MEDIA_NEXT)
+        val intent = Intent(Intent.ACTION_MEDIA_BUTTON).apply {
+            putExtra(Intent.EXTRA_KEY_EVENT, keyEvent)
+        }
+        automotiveCallback.onMediaButtonEvent(mockSession, mockController, intent)
+        testScope.advanceUntilIdle()
+
+        verify(playbackManager).skipForwardSuspend(
+            sourceView = any(),
+            jumpAmountSeconds = eq(30),
+        )
+    }
+
+    @Test
+    fun `on automotive, KEYCODE_MEDIA_PREVIOUS skips backward immediately`() = runTest {
+        mockSkipSettings()
+        val automotiveCallback = createCallbackWithAutomotiveContext()
+
+        val keyEvent = KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_MEDIA_PREVIOUS)
+        val intent = Intent(Intent.ACTION_MEDIA_BUTTON).apply {
+            putExtra(Intent.EXTRA_KEY_EVENT, keyEvent)
+        }
+        automotiveCallback.onMediaButtonEvent(mockSession, mockController, intent)
+        testScope.advanceUntilIdle()
+
+        verify(playbackManager).skipBackwardSuspend(
+            sourceView = any(),
+            jumpAmountSeconds = eq(10),
+        )
+    }
+
     // --- onAddMediaItems resolved item tests ---
 
     @Test
@@ -545,6 +616,27 @@ class Media3SessionCallbackTest {
         val setting = mock<au.com.shiftyjelly.pocketcasts.preferences.UserSetting<HeadphoneAction>>()
         whenever(setting.value).thenReturn(action)
         whenever(settings.headphoneControlsPreviousAction).thenReturn(setting)
+    }
+
+    private fun createCallbackWithAutomotiveContext(): Media3SessionCallback {
+        val automotiveContext: Context = mock()
+        val automotivePackageManager: PackageManager = mock()
+        val metaData = Bundle().apply { putBoolean("pocketcasts_automotive", true) }
+        val appInfo = ApplicationInfo().apply { this.metaData = metaData }
+        whenever(automotivePackageManager.getApplicationInfo(any<String>(), any<Int>())).thenReturn(appInfo)
+        whenever(automotiveContext.packageManager).thenReturn(automotivePackageManager)
+        whenever(automotiveContext.packageName).thenReturn("au.com.shiftyjelly.pocketcasts.debug")
+
+        return Media3SessionCallback(
+            playbackManager = playbackManager,
+            episodeManager = episodeManager,
+            podcastManager = podcastManager,
+            settings = settings,
+            actions = actions,
+            bookmarkHelper = bookmarkHelper,
+            scopeProvider = { testScope },
+            contextProvider = { automotiveContext },
+        )
     }
 
     private fun mockSkipSettings() {

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsForwardingPlayerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsForwardingPlayerTest.kt
@@ -163,7 +163,7 @@ class PocketCastsForwardingPlayerTest {
     }
 
     @Test
-    fun `available commands expose only core controls`() {
+    fun `available commands expose core controls and skip-to-next-previous`() {
         val commands = forwardingPlayer.availableCommands
 
         assertTrue(commands.contains(Player.COMMAND_PLAY_PAUSE))
@@ -174,8 +174,11 @@ class PocketCastsForwardingPlayerTest {
         assertTrue(commands.contains(Player.COMMAND_GET_METADATA))
         assertFalse(commands.contains(Player.COMMAND_SEEK_FORWARD))
         assertFalse(commands.contains(Player.COMMAND_SEEK_BACK))
-        assertFalse(commands.contains(Player.COMMAND_SEEK_TO_NEXT))
-        assertFalse(commands.contains(Player.COMMAND_SEEK_TO_PREVIOUS))
+        // SEEK_TO_NEXT / SEEK_TO_PREVIOUS are advertised so AAOS steering-wheel skip
+        // buttons (and other Media3 controllers) route through seekToNext()/
+        // seekToPrevious() instead of falling back to STOP. See PCDROID-560.
+        assertTrue(commands.contains(Player.COMMAND_SEEK_TO_NEXT))
+        assertTrue(commands.contains(Player.COMMAND_SEEK_TO_PREVIOUS))
     }
 
     @Test
@@ -595,7 +598,7 @@ class PocketCastsForwardingPlayerTest {
     }
 
     @Test
-    fun `swapPlayer excludes seek to next and previous`() {
+    fun `swapPlayer preserves seek to next and previous`() {
         val player = PocketCastsForwardingPlayer(mockPlayer)
 
         val newWrappedPlayer = mock<Player> {
@@ -603,8 +606,11 @@ class PocketCastsForwardingPlayerTest {
         }
         val swapped = player.swapPlayer(newWrappedPlayer)
 
-        assertFalse(swapped.availableCommands.contains(Player.COMMAND_SEEK_TO_NEXT))
-        assertFalse(swapped.availableCommands.contains(Player.COMMAND_SEEK_TO_PREVIOUS))
+        // SEEK_TO_NEXT / SEEK_TO_PREVIOUS are always advertised (PCDROID-560) so AAOS
+        // continues to route steering-wheel skip buttons after a player swap (e.g.
+        // local ↔ cast).
+        assertTrue(swapped.availableCommands.contains(Player.COMMAND_SEEK_TO_NEXT))
+        assertTrue(swapped.availableCommands.contains(Player.COMMAND_SEEK_TO_PREVIOUS))
     }
 
     // --- setMediaItems / addMediaItems / prepare interception tests ---


### PR DESCRIPTION
## Description

Fixes https://linear.app/a8c/issue/PCDROID-560/aaos-steering-wheel-skip-forwardback-buttons-unresponsive-in-pocket

After the Media3 migration, the AAOS Pocket Casts session stopped advertising `COMMAND_SEEK_TO_NEXT` / `COMMAND_SEEK_TO_PREVIOUS`, and the `onMediaButtonEvent` handler didn't recognise `KEYCODE_MEDIA_FAST_FORWARD`, `KEYCODE_MEDIA_REWIND`, or the fallback `KEYCODE_MEDIA_STOP` that GM's car-media service sends when no skip action is reachable. After the Android 14 vehicle-OS rollout on Chevrolet Equinox EV (and likely other AAOS platforms), the steering-wheel skip-forward / skip-back buttons became completely unresponsive — the user reported `Media3 media button event: keyCode=86` (KEYCODE_MEDIA_STOP) in their log when pressing skip. Spotify and Amazon Music kept working because they advertise the skip commands.

### Changes

- **`PocketCastsForwardingPlayer.getAvailableCommands()`** — expose `COMMAND_SEEK_TO_NEXT` and `COMMAND_SEEK_TO_PREVIOUS`. The existing `seekToNext()` / `seekToPrevious()` overrides already route to `onSkipForward` / `onSkipBack` (→ `PlaybackManager.skipForwardSuspend` / `skipBackwardSuspend`), so no wiring change is needed.
- **`Media3SessionCallback.TRANSPORT_PLAYER_COMMANDS`** — same two commands added so connecting Media3 controllers (AAOS, MediaController test clients) see skip support.
- **`Media3SessionCallback.onMediaButtonEvent`** — handle `KEYCODE_MEDIA_FAST_FORWARD` and `KEYCODE_MEDIA_REWIND` as direct skip-forward / skip-back (defence-in-depth for controllers that still dispatch raw key events).
- **`Media3SessionCallback.onMediaButtonEvent`** — on Android Automotive OS, bypass the headphone multi-tap queue for `KEYCODE_MEDIA_NEXT` and `KEYCODE_MEDIA_PREVIOUS`. The 250 ms multi-tap window is correct for Pixel Buds but wrong for a steering-wheel button, which fires once per press.

## Testing Instructions

### Automated tests
1. `./gradlew :modules:services:repositories:testDebugUnitTest --tests "au.com.shiftyjelly.pocketcasts.repositories.playback.Media3SessionCallbackTest"`
2. `./gradlew :modules:services:repositories:testDebugUnitTest --tests "au.com.shiftyjelly.pocketcasts.repositories.playback.PocketCastsForwardingPlayerTest"`
3. ✅ Verify the new tests pass:
   - `KEYCODE_MEDIA_FAST_FORWARD calls skipForwardSuspend directly`
   - `KEYCODE_MEDIA_REWIND calls skipBackwardSuspend directly`
   - `on automotive, KEYCODE_MEDIA_NEXT skips forward immediately`
   - `on automotive, KEYCODE_MEDIA_PREVIOUS skips backward immediately`
4. ✅ Verify the updated commands-exposure tests still pass on both the session callback and the forwarding player.

### Manual — AAOS emulator
1. Build the automotive variant: `./gradlew :automotive:assembleDebug`.
2. Install and launch Pocket Casts on the AAOS emulator (or a physical Android 14 AAOS vehicle if available).
3. Start playback of any episode.
4. Send a `KEYCODE_MEDIA_NEXT` key event via `adb shell input keyevent 87` (and `88` for previous, `90` for fast-forward, `89` for rewind).
5. ✅ Verify each invocation triggers a skip forward / skip backward in the playback position immediately (no 250 ms delay), and that no `Media3: stop → pause` log line is emitted.
6. ✅ Verify on-screen playback controls within the app still work normally.

### Manual — mobile regression check
1. Run the mobile `debug` variant.
2. Connect Pixel Buds (or any BT headset with multi-tap), play an episode, and use double-tap / triple-tap.
3. ✅ Verify multi-tap still resolves to the user's configured `headphoneControlsNextAction` / `headphoneControlsPreviousAction` after the 250 ms window — the automotive bypass only applies when `Util.isAutomotive(context)` is true.

## Checklist
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml` *(no string changes)*
- [ ] Any jetpack compose components I added or changed are covered by compose previews *(no Compose changes)*
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics. *(no analytics changes)*

> [!NOTE]
> Tests were not executed locally — the current `main` branch pulls in a `crashlogging:6.0.8` dependency compiled to Java 21 class files, but `libs.versions.toml` still pins `java = "17"`. Without a local JDK 21 install, `:modules:services:crashlogging:compileDebugJavaWithJavac` fails before any test code runs. Pre-existing issue, not caused by this PR — relying on CI for verification.