### PR TITLE
Fix Up Next scroll-to-top crash on long queues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 -----
 *   Bug Fixes
     *   Fix crash when scrolling to the top of a long Up Next queue
-        ([#5315](https://github.com/Automattic/pocket-casts-android/pull/5315))
+        ([#5320](https://github.com/Automattic/pocket-casts-android/pull/5320))
 
 8.12
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 8.13
 -----
-
+*   Bug Fixes
+    *   Fix crash when scrolling to the top of a long Up Next queue
+        ([#5315](https://github.com/Automattic/pocket-casts-android/pull/5315))
 
 8.12
 -----

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/extensions/RecyclerView.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/extensions/RecyclerView.kt
@@ -38,21 +38,23 @@ fun RecyclerView.quickScrollToTop() {
         override fun getVerticalSnapPreference() = LinearSmoothScroller.SNAP_TO_START
 
         override fun calculateSpeedPerPixel(displayMetrics: DisplayMetrics): Float {
-            val scrollOffset = computeVerticalScrollOffset()
-            val scrollRange = computeVerticalScrollRange()
-
-            return if (scrollRange > 0 && scrollOffset > 0) {
-                // Float math + floor of 1 prevents a non-positive speed, which would yield a
-                // non-positive duration in LinearSmoothScroller and crash RecyclerView.
-                val pixelsInRange = scrollOffset.toFloat().coerceAtLeast(1f)
-                (MILLIS_PER_RANGE / pixelsInRange).coerceAtMost(MAX_MILLIS_PER_INCH / displayMetrics.densityDpi)
-            } else {
-                super.calculateSpeedPerPixel(displayMetrics)
-            }
+            return quickScrollSpeedPerPixel(
+                scrollOffset = computeVerticalScrollOffset(),
+                scrollRange = computeVerticalScrollRange(),
+                densityDpi = displayMetrics.densityDpi,
+            ) ?: super.calculateSpeedPerPixel(displayMetrics)
         }
     }
 
     layoutManager?.startSmoothScroll(smoothScroller)
+}
+
+internal fun quickScrollSpeedPerPixel(scrollOffset: Int, scrollRange: Int, densityDpi: Int): Float? {
+    if (scrollRange <= 0 || scrollOffset <= 0 || densityDpi <= 0) return null
+    // Float math + floor of 1 prevents a non-positive speed, which would yield a
+    // non-positive duration in LinearSmoothScroller and crash RecyclerView.
+    val pixelsInRange = scrollOffset.toFloat().coerceAtLeast(1f)
+    return (MILLIS_PER_RANGE / pixelsInRange).coerceAtMost(MAX_MILLIS_PER_INCH / densityDpi)
 }
 
 fun RecyclerView.ViewHolder.hideRow() {

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/extensions/RecyclerView.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/extensions/RecyclerView.kt
@@ -42,7 +42,9 @@ fun RecyclerView.quickScrollToTop() {
             val scrollRange = computeVerticalScrollRange()
 
             return if (scrollRange > 0 && scrollOffset > 0) {
-                val pixelsInRange = scrollRange * scrollOffset / scrollRange.toFloat()
+                // Float math + floor of 1 prevents a non-positive speed, which would yield a
+                // non-positive duration in LinearSmoothScroller and crash RecyclerView.
+                val pixelsInRange = scrollOffset.toFloat().coerceAtLeast(1f)
                 (MILLIS_PER_RANGE / pixelsInRange).coerceAtMost(MAX_MILLIS_PER_INCH / displayMetrics.densityDpi)
             } else {
                 super.calculateSpeedPerPixel(displayMetrics)

--- a/modules/services/views/src/test/java/au/com/shiftyjelly/pocketcasts/views/extensions/RecyclerViewTest.kt
+++ b/modules/services/views/src/test/java/au/com/shiftyjelly/pocketcasts/views/extensions/RecyclerViewTest.kt
@@ -1,0 +1,49 @@
+package au.com.shiftyjelly.pocketcasts.views.extensions
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RecyclerViewTest {
+    @Test
+    fun `quickScrollSpeedPerPixel returns null for non-positive scrollRange`() {
+        assertNull(quickScrollSpeedPerPixel(scrollOffset = 100, scrollRange = 0, densityDpi = 480))
+        assertNull(quickScrollSpeedPerPixel(scrollOffset = 100, scrollRange = -1, densityDpi = 480))
+    }
+
+    @Test
+    fun `quickScrollSpeedPerPixel returns null for non-positive scrollOffset`() {
+        assertNull(quickScrollSpeedPerPixel(scrollOffset = 0, scrollRange = 1000, densityDpi = 480))
+        assertNull(quickScrollSpeedPerPixel(scrollOffset = -1, scrollRange = 1000, densityDpi = 480))
+    }
+
+    @Test
+    fun `quickScrollSpeedPerPixel returns positive speed for typical values`() {
+        val speed = quickScrollSpeedPerPixel(scrollOffset = 500, scrollRange = 5000, densityDpi = 480)
+        assertNotNull(speed)
+        assertTrue("Speed should be positive but was $speed", speed!! > 0f)
+    }
+
+    @Test
+    fun `quickScrollSpeedPerPixel stays positive when scrollRange times scrollOffset overflows Int`() {
+        // The previous implementation computed scrollRange * scrollOffset as Int, which
+        // overflows when the product exceeds Int.MAX_VALUE (~2.1B). Verify the new
+        // implementation returns a positive speed even in that regime, since a
+        // non-positive speed leads to LinearSmoothScroller throwing
+        // IllegalStateException: "If you provide an interpolator, you must set a positive duration".
+        val speed = quickScrollSpeedPerPixel(scrollOffset = 60_000, scrollRange = 100_000, densityDpi = 480)
+        assertNotNull(speed)
+        assertTrue("Speed should be positive but was $speed", speed!! > 0f)
+    }
+
+    @Test
+    fun `quickScrollSpeedPerPixel caps speed at MAX_MILLIS_PER_INCH per densityDpi`() {
+        // Small scrollOffset would otherwise produce a very large millis-per-pixel value,
+        // but it should be capped at MAX_MILLIS_PER_INCH / densityDpi.
+        val densityDpi = 480
+        val speed = quickScrollSpeedPerPixel(scrollOffset = 1, scrollRange = 1000, densityDpi = densityDpi)
+        assertEquals(50f / densityDpi, speed!!, 0.0001f)
+    }
+}


### PR DESCRIPTION
## Description

The following crash is something I could replicate:


https://github.com/user-attachments/assets/f5e9cb71-9efb-4fd3-b68e-e43a91b0fe4d



The lower "Up Next" button calls `RecyclerView.quickScrollToTop()`, which installs a `LinearSmoothScroller` whose `calculateSpeedPerPixel` computed:

```kotlin
val pixelsInRange = scrollRange * scrollOffset / scrollRange.toFloat()
```

The leading `scrollRange * scrollOffset` is `Int * Int`, evaluated before the divide-by-float. On long Up Next queues both values can be tens of thousands and their product overflows `Int.MAX_VALUE`, producing a negative `pixelsInRange`. That cascades into a negative speed-per-pixel, a negative duration handed to `Action.update(…, duration, interpolator)`, and a fatal:

> `IllegalStateException: If you provide an interpolator, you must set a positive duration`

The reporter's debug log confirms this path — the crash trace ends in a `Choreographer` frame callback dispatching a `LinearSmoothScroller$Action.validate()`, and the user had 332 episodes in Up Next at the time.

This PR:
- Extracts the speed-per-pixel math into an `internal` top-level function so it can be unit-tested.
- Replaces `scrollRange * scrollOffset / scrollRange.toFloat()` (mathematically equivalent to `scrollOffset` ignoring overflow) with `scrollOffset.toFloat().coerceAtLeast(1f)`. The floor at `1f` guarantees a positive speed (and therefore a positive duration), even if some future input falls outside the early-return guards.
- Adds a unit test that exercises a `scrollOffset` × `scrollRange` combination that would have overflowed `Int.MAX_VALUE` under the old implementation.

Fixes PCDROID-417 (https://linear.app/a8c/issue/PCDROID-417/android-up-next-lower-button-causes-fatal-crash)

## Testing Instructions
1. Build and install the app.
2. Add ~20+ episodes to the Up Next queue (enough that the queue scrolls past a screenful).
3. Open the player, then open Up Next via the lower "Up Next" button (the one with the text label, not the badge button).
4. Scroll down through the queue for 5+ seconds so a large `scrollOffset` accumulates.
5. Tap the lower "Up Next" button again.
6. - [ ] Verify the queue smoothly scrolls back to the top with no crash.
7. - [ ] Repeat a few times to confirm the crash never reappears.
8. - [ ] Tap the lower "Up Next" button while already at the top — verify nothing breaks (regression check).

The new `RecyclerViewTest` also exercises the math directly:

```
./gradlew :modules:services:views:testDebugUnitTest --tests "au.com.shiftyjelly.pocketcasts.views.extensions.RecyclerViewTest"
```

## Screenshots or Screencast
N/A — bug fix, no UI changes.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml` (n/a)
- [x] Any jetpack compose components I added or changed are covered by compose previews (n/a)
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics. (n/a)
