### PR TITLE
[Synced Transcripts] Add fingerprint timing manager and supporting business logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+8.14
+-----
+*   New Features
+    *   Synced episode transcripts
+        ([#5324](https://github.com/Automattic/pocket-casts-android/pull/5324))
+
 8.13
 -----
 *   New Features

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -94,7 +94,6 @@ import au.com.shiftyjelly.pocketcasts.compose.components.rememberNestedScrollLoc
 import au.com.shiftyjelly.pocketcasts.compose.extensions.contentWithoutConsumedInsets
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.models.entity.BlazeAd
-import au.com.shiftyjelly.pocketcasts.models.to.Transcript
 import au.com.shiftyjelly.pocketcasts.player.R
 import au.com.shiftyjelly.pocketcasts.player.view.PlaybackIssuesBottomSheetFragment
 import au.com.shiftyjelly.pocketcasts.player.view.bookmark.BookmarkActivity
@@ -144,9 +143,7 @@ import com.automattic.eventhorizon.PlaybackErrorTappedEvent
 import com.automattic.eventhorizon.PlayerErrorBannerSource
 import com.automattic.eventhorizon.TranscriptDismissedEvent
 import com.automattic.eventhorizon.TranscriptGeneratedPaywallDismissedEvent
-import com.automattic.eventhorizon.TranscriptGeneratedPaywallShownEvent
 import com.automattic.eventhorizon.TranscriptGeneratedPaywallSubscribeTappedEvent
-import com.automattic.eventhorizon.TranscriptShownEvent
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
@@ -1016,6 +1013,9 @@ class PlayerHeaderFragment :
             val navigationBarPadding = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
             TranscriptPage(
                 uiState = state,
+                viewModel = transcriptViewModel,
+                fingerprintTimingManager = transcriptViewModel.fingerprintTimingManager,
+                playbackManager = transcriptViewModel.playbackManager,
                 toolbarPadding = PaddingValues(horizontal = 16.dp),
                 paywallPadding = PaddingValues(start = 16.dp, end = 16.dp, bottom = 16.dp),
                 transcriptPadding = PaddingValues(start = 16.dp, end = 16.dp, bottom = navigationBarPadding + if (isPortraitPlayer) 96.dp else 16.dp),
@@ -1039,26 +1039,6 @@ class PlayerHeaderFragment :
                         )
                     }
                     OnboardingLauncher.openOnboardingFlow(requireActivity(), OnboardingFlow.Upsell(OnboardingUpgradeSource.GENERATED_TRANSCRIPTS))
-                },
-                onShowTranscript = { transcript ->
-                    transcriptViewModel.track { source, podcastUuid, episodeUuid ->
-                        TranscriptShownEvent(
-                            type = transcript.type.analyticsValue,
-                            showAsWebpage = transcript is Transcript.Web,
-                            podcastUuid = podcastUuid,
-                            episodeUuid = episodeUuid,
-                            source = source,
-                        )
-                    }
-                },
-                onShowTranscriptPaywall = {
-                    transcriptViewModel.track { source, podcastUuid, episodeUuid ->
-                        TranscriptGeneratedPaywallShownEvent(
-                            podcastUuid = podcastUuid,
-                            episodeUuid = episodeUuid,
-                            source = source,
-                        )
-                    }
                 },
                 toolbarTrailingContent = { toolbarColors ->
                     if (state.isTextTranscriptLoaded && FeatureFlag.isEnabled(Feature.SHARE_TRANSCRIPTS)) {

--- a/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/TranscriptFragment.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/TranscriptFragment.kt
@@ -24,7 +24,6 @@ import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.compose.components.AnimatedPlayPauseButton
 import au.com.shiftyjelly.pocketcasts.compose.components.rememberViewInteropNestedScrollConnection
 import au.com.shiftyjelly.pocketcasts.compose.extensions.contentWithoutConsumedInsets
-import au.com.shiftyjelly.pocketcasts.models.to.Transcript
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
@@ -37,9 +36,7 @@ import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
 import com.automattic.eventhorizon.EpisodeTranscriptShownEvent
-import com.automattic.eventhorizon.TranscriptGeneratedPaywallShownEvent
 import com.automattic.eventhorizon.TranscriptGeneratedPaywallSubscribeTappedEvent
-import com.automattic.eventhorizon.TranscriptShownEvent
 import dagger.hilt.android.AndroidEntryPoint
 import dagger.hilt.android.lifecycle.withCreationCallback
 import javax.inject.Inject
@@ -99,6 +96,9 @@ class TranscriptFragment : BaseDialogFragment() {
 
             TranscriptPage(
                 uiState = uiState,
+                viewModel = viewModel,
+                fingerprintTimingManager = viewModel.fingerprintTimingManager,
+                playbackManager = viewModel.playbackManager,
                 toolbarPadding = PaddingValues(start = 20.dp, end = 20.dp, top = 16.dp),
                 paywallPadding = PaddingValues(start = 16.dp, end = 16.dp, bottom = 16.dp),
                 transcriptPadding = PaddingValues(start = 20.dp, end = 20.dp, bottom = 16.dp),
@@ -125,26 +125,6 @@ class TranscriptFragment : BaseDialogFragment() {
                         requireActivity(),
                         OnboardingFlow.Upsell(OnboardingUpgradeSource.GENERATED_TRANSCRIPTS),
                     )
-                },
-                onShowTranscript = { transcript ->
-                    viewModel.track { source, podcastUuid, episodeUuid ->
-                        TranscriptShownEvent(
-                            type = transcript.type.analyticsValue,
-                            showAsWebpage = transcript is Transcript.Web,
-                            podcastUuid = podcastUuid,
-                            episodeUuid = episodeUuid,
-                            source = source,
-                        )
-                    }
-                },
-                onShowTranscriptPaywall = {
-                    viewModel.track { source, podcastUuid, episodeUuid ->
-                        TranscriptGeneratedPaywallShownEvent(
-                            podcastUuid = podcastUuid,
-                            episodeUuid = episodeUuid,
-                            source = source,
-                        )
-                    }
                 },
                 toolbarTrailingContent = { toolbarColors ->
                     Row(

--- a/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/TranscriptViewModel.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/TranscriptViewModel.kt
@@ -11,6 +11,8 @@ import au.com.shiftyjelly.pocketcasts.payment.PaymentClient
 import au.com.shiftyjelly.pocketcasts.payment.SubscriptionOffer
 import au.com.shiftyjelly.pocketcasts.payment.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.payment.getOrNull
+import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.FingerprintTimingManager
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.transcript.TranscriptManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
@@ -21,9 +23,11 @@ import au.com.shiftyjelly.pocketcasts.utils.search.kmpSearch
 import com.automattic.eventhorizon.EventHorizon
 import com.automattic.eventhorizon.Trackable
 import com.automattic.eventhorizon.TranscriptErrorEvent
+import com.automattic.eventhorizon.TranscriptGeneratedPaywallShownEvent
 import com.automattic.eventhorizon.TranscriptSearchNextResultEvent
 import com.automattic.eventhorizon.TranscriptSearchPreviousResultEvent
 import com.automattic.eventhorizon.TranscriptSearchShownEvent
+import com.automattic.eventhorizon.TranscriptShownEvent
 import com.automattic.eventhorizon.TranscriptSourceType
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -48,6 +52,8 @@ class TranscriptViewModel @AssistedInject constructor(
     private val paymentClient: PaymentClient,
     private val eventHorizon: EventHorizon,
     private val sharingClient: TranscriptSharingClient,
+    val fingerprintTimingManager: FingerprintTimingManager,
+    val playbackManager: PlaybackManager,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(UiState.Empty)
@@ -68,6 +74,7 @@ class TranscriptViewModel @AssistedInject constructor(
                 }
             }
         }
+        observePlaybackState()
     }
 
     private var episodeUuid: String? = null
@@ -78,6 +85,7 @@ class TranscriptViewModel @AssistedInject constructor(
 
     fun loadTranscript(episodeUuid: String) {
         loadTranscriptJob?.cancel()
+        syncedStateJob?.cancel()
         loadTranscriptJob = viewModelScope.launch {
             searchJob?.cancelAndJoin()
 
@@ -85,6 +93,7 @@ class TranscriptViewModel @AssistedInject constructor(
                 state.copy(
                     transcriptState = TranscriptState.Loading,
                     searchState = SearchState.Empty,
+                    syncedState = FingerprintTimingManager.State.Idle,
                 )
             }
 
@@ -119,7 +128,58 @@ class TranscriptViewModel @AssistedInject constructor(
                 }
             }
             _uiState.update { state -> state.copy(transcriptState = transcriptState) }
+
+            if (transcriptState is TranscriptState.Loaded) {
+                trackTranscriptShown(transcriptState.transcript)
+            }
+
+            if (transcriptState is TranscriptState.Loaded && transcriptState.transcript is Transcript.Text) {
+                val currentPlayingUuid = playbackManager.getCurrentEpisode()?.uuid
+                if (currentPlayingUuid == episodeUuid) {
+                    fingerprintTimingManager.prepareForCurrentEpisode()
+                    _uiState.update { state -> state.copy(syncedState = fingerprintTimingManager.state) }
+                    observeSyncedState()
+                }
+            }
         }
+    }
+
+    private var syncedStateJob: Job? = null
+
+    private fun observeSyncedState() {
+        syncedStateJob?.cancel()
+        syncedStateJob = viewModelScope.launch {
+            fingerprintTimingManager.stateFlow.collect { syncedState ->
+                _uiState.update { state -> state.copy(syncedState = syncedState) }
+            }
+        }
+    }
+
+    private fun observePlaybackState() {
+        viewModelScope.launch {
+            playbackManager.playbackStateFlow.collect { playbackState ->
+                _uiState.update { state ->
+                    state.copy(playingEpisodeUuid = playbackState.episodeUuid.ifEmpty { null })
+                }
+            }
+        }
+    }
+
+    fun seekToTranscriptEntry(entry: TranscriptEntry) {
+        val textEntry = entry as? TranscriptEntry.Text ?: return
+        if (textEntry.startTimeMs < 0) return
+        val currentState = _uiState.value
+        if (!currentState.isSyncedActive) return
+
+        val refTimeSec = textEntry.startTimeMs / 1000.0
+        val seekTimeMs = fingerprintTimingManager.playbackTimeMs(forReferenceTime = refTimeSec) ?: return
+        playbackManager.seekToTimeMs(seekTimeMs)
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        loadTranscriptJob?.cancel()
+        syncedStateJob?.cancel()
     }
 
     fun reloadTranscript() {
@@ -259,6 +319,29 @@ class TranscriptViewModel @AssistedInject constructor(
         }
     }
 
+    private fun trackTranscriptShown(transcript: Transcript) {
+        val isPaywallVisible = !_uiState.value.isPlusUser && transcript.isGenerated
+        if (isPaywallVisible) {
+            track { source, podcastUuid, episodeUuid ->
+                TranscriptGeneratedPaywallShownEvent(
+                    podcastUuid = podcastUuid,
+                    episodeUuid = episodeUuid,
+                    source = source,
+                )
+            }
+        } else {
+            track { source, podcastUuid, episodeUuid ->
+                TranscriptShownEvent(
+                    type = transcript.type.analyticsValue,
+                    showAsWebpage = transcript is Transcript.Web,
+                    podcastUuid = podcastUuid,
+                    episodeUuid = episodeUuid,
+                    source = source,
+                )
+            }
+        }
+    }
+
     fun track(event: (TranscriptSourceType, podcastUuid: String, episodeUuid: String) -> Trackable) {
         val podcastUuid = podcastUuid ?: AnalyticsTracker.INVALID_OR_NULL_VALUE
         val episodeUuid = episodeUuid ?: AnalyticsTracker.INVALID_OR_NULL_VALUE
@@ -295,12 +378,18 @@ data class UiState(
     val searchState: SearchState,
     val isPlusUser: Boolean,
     val isFreeTrialAvailable: Boolean,
+    val syncedState: FingerprintTimingManager.State = FingerprintTimingManager.State.Idle,
+    val playingEpisodeUuid: String? = null,
 ) {
     val isPaywallVisible get() = !isPlusUser && (transcriptState as? TranscriptState.Loaded)?.transcript?.isGenerated == true
 
     val isTextTranscriptLoaded get() = (transcriptState as? TranscriptState.Loaded)?.transcript is Transcript.Text
 
     val transcriptEpisodeUuid get() = (transcriptState as? TranscriptState.Loaded)?.transcript?.episodeUuid
+
+    val isSyncedActive get() = syncedState is FingerprintTimingManager.State.Active &&
+        transcriptEpisodeUuid != null &&
+        transcriptEpisodeUuid == playingEpisodeUuid
 
     companion object {
         val Empty = UiState(

--- a/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptCueHelper.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptCueHelper.kt
@@ -1,0 +1,134 @@
+package au.com.shiftyjelly.pocketcasts.transcripts.ui
+
+import au.com.shiftyjelly.pocketcasts.models.to.TranscriptEntry
+import kotlin.math.abs
+
+internal object TranscriptCueHelper {
+
+    fun findCueIndex(
+        entries: List<TranscriptEntry>,
+        refTimeMs: Long,
+        cachedIndex: Int,
+    ): Int? {
+        if (entries.isEmpty()) return null
+        val cached = cachedIndex.coerceAtMost(entries.size - 1)
+
+        val cachedEntry = entries[cached]
+        if (cachedEntry is TranscriptEntry.Text && cachedEntry.startTimeMs >= 0 &&
+            refTimeMs >= cachedEntry.startTimeMs && refTimeMs <= cachedEntry.endTimeMs
+        ) {
+            return cached
+        }
+
+        val scanLimit = 10
+        val nearbyResult = findCueNearby(entries, refTimeMs, cached, scanLimit)
+        if (nearbyResult != null) return nearbyResult
+
+        return findCueBinarySearch(entries, refTimeMs)
+    }
+
+    fun findCueNearby(
+        entries: List<TranscriptEntry>,
+        refTimeMs: Long,
+        cached: Int,
+        scanLimit: Int,
+    ): Int? {
+        for (i in (cached + 1) until minOf(cached + 1 + scanLimit, entries.size)) {
+            val entry = entries[i]
+            if (entry is TranscriptEntry.Text && entry.startTimeMs >= 0) {
+                if (entry.startTimeMs > refTimeMs) break
+                if (refTimeMs >= entry.startTimeMs && refTimeMs <= entry.endTimeMs) return i
+            }
+        }
+        for (i in (cached - 1) downTo maxOf(cached - scanLimit, 0)) {
+            val entry = entries[i]
+            if (entry is TranscriptEntry.Text && entry.startTimeMs >= 0) {
+                if (refTimeMs >= entry.startTimeMs && refTimeMs <= entry.endTimeMs) return i
+            }
+        }
+        return null
+    }
+
+    fun findCueBinarySearch(
+        entries: List<TranscriptEntry>,
+        refTimeMs: Long,
+    ): Int? {
+        var lo = 0
+        var hi = entries.size - 1
+        while (lo <= hi) {
+            val mid = (lo + hi) / 2
+            val entry = entries[mid]
+            if (entry is TranscriptEntry.Text && entry.startTimeMs >= 0) {
+                when {
+                    refTimeMs < entry.startTimeMs -> hi = mid - 1
+                    refTimeMs > entry.endTimeMs -> lo = mid + 1
+                    else -> return mid
+                }
+            } else {
+                val timedIdx = findNearestTimedEntry(entries, mid, lo, hi)
+                if (timedIdx == null) {
+                    break
+                } else {
+                    val timed = entries[timedIdx] as TranscriptEntry.Text
+                    when {
+                        refTimeMs < timed.startTimeMs -> hi = timedIdx - 1
+                        refTimeMs > timed.endTimeMs -> lo = timedIdx + 1
+                        else -> return timedIdx
+                    }
+                }
+            }
+        }
+        return findClosestTimedEntry(entries, refTimeMs, lo.coerceIn(0, entries.size - 1))
+    }
+
+    fun findClosestTimedEntry(
+        entries: List<TranscriptEntry>,
+        refTimeMs: Long,
+        around: Int,
+    ): Int? {
+        var bestIndex: Int? = null
+        var bestDistance = Long.MAX_VALUE
+        val scanRadius = 5
+        val start = maxOf(0, around - scanRadius)
+        val end = minOf(entries.size - 1, around + scanRadius)
+        for (i in start..end) {
+            val entry = entries[i]
+            if (entry is TranscriptEntry.Text && entry.startTimeMs >= 0) {
+                val dist = minOf(
+                    abs(refTimeMs - entry.startTimeMs),
+                    abs(refTimeMs - entry.endTimeMs),
+                )
+                if (dist < bestDistance) {
+                    bestDistance = dist
+                    bestIndex = i
+                }
+            }
+        }
+        return if (bestDistance <= NEAREST_CUE_THRESHOLD_MS) bestIndex else null
+    }
+
+    fun findNearestTimedEntry(
+        entries: List<TranscriptEntry>,
+        mid: Int,
+        lo: Int,
+        hi: Int,
+    ): Int? {
+        var left = mid - 1
+        var right = mid + 1
+        while (left >= lo || right <= hi) {
+            if (right <= hi) {
+                val entry = entries[right]
+                if (entry is TranscriptEntry.Text && entry.startTimeMs >= 0) return right
+                right++
+            }
+            if (left >= lo) {
+                val entry = entries[left]
+                if (entry is TranscriptEntry.Text && entry.startTimeMs >= 0) return left
+                left--
+            }
+        }
+        return null
+    }
+
+    const val NEAREST_CUE_THRESHOLD_MS = 5000L
+}

--- a/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptLines.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptLines.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.transcripts.ui
 
 import android.os.Build
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -63,6 +64,8 @@ internal fun TranscriptLines(
     searchState: SearchState,
     modifier: Modifier = Modifier,
     isContentObscured: Boolean = false,
+    highlightIndex: Int? = null,
+    onEntryClick: ((TranscriptEntry, Int) -> Unit)? = null,
     state: LazyListState = rememberLazyListState(),
     theme: TranscriptTheme = TranscriptTheme.default(MaterialTheme.theme.colors),
 ) {
@@ -103,15 +106,23 @@ internal fun TranscriptLines(
                             Spacer(Modifier.height(8.dp))
                         }
                     }
-                    itemsIndexed(transcript.entries) { index, entry ->
+                    itemsIndexed(transcript.entries, key = { index, _ -> index }) { index, entry ->
                         TranscriptLine(
                             entryIndex = index,
                             entry = entry,
                             searchState = searchState,
+                            isHighlighted = index == highlightIndex,
                             theme = theme,
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .padding(entry.padding()),
+                                .padding(entry.padding())
+                                .then(
+                                    if (onEntryClick != null && entry is TranscriptEntry.Text && entry.startTimeMs >= 0) {
+                                        Modifier.clickable { onEntryClick(entry, index) }
+                                    } else {
+                                        Modifier
+                                    },
+                                ),
                         )
                     }
                     item {
@@ -156,6 +167,7 @@ private fun TranscriptLine(
     entryIndex: Int,
     entry: TranscriptEntry,
     searchState: SearchState,
+    isHighlighted: Boolean,
     theme: TranscriptTheme,
     modifier: Modifier = Modifier,
 ) {
@@ -169,6 +181,8 @@ private fun TranscriptLine(
             ?.filter { (start, end) -> isValidHighlightRange(start, end, entryText.length) }
             .orEmpty()
     }
+
+    val textColor = if (isHighlighted) theme.highlightText else theme.primaryText
 
     Text(
         text = buildAnnotatedString {
@@ -184,7 +198,7 @@ private fun TranscriptLine(
             }
         },
         style = entry.textStyle(),
-        color = theme.primaryText,
+        color = textColor,
         modifier = modifier,
     )
 }

--- a/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptPage.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptPage.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.transcripts.ui
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.interaction.DragInteraction
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -10,17 +11,34 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.loading.LoadingView
 import au.com.shiftyjelly.pocketcasts.models.to.Transcript
+import au.com.shiftyjelly.pocketcasts.models.to.TranscriptEntry
+import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.FingerprintTimingManager
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.transcripts.TranscriptState
+import au.com.shiftyjelly.pocketcasts.transcripts.TranscriptViewModel
 import au.com.shiftyjelly.pocketcasts.transcripts.UiState
 import au.com.shiftyjelly.pocketcasts.utils.search.SearchCoordinates
+import kotlin.math.roundToInt
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
@@ -35,9 +53,10 @@ fun TranscriptPage(
     onShowSearchBar: () -> Unit,
     onHideSearchBar: () -> Unit,
     onClickSubscribe: () -> Unit,
-    onShowTranscript: (Transcript) -> Unit,
-    onShowTranscriptPaywall: (Transcript) -> Unit,
     modifier: Modifier = Modifier,
+    viewModel: TranscriptViewModel? = null,
+    fingerprintTimingManager: FingerprintTimingManager? = null,
+    playbackManager: PlaybackManager? = null,
     toolbarPadding: PaddingValues = PaddingValues(0.dp),
     transcriptPadding: PaddingValues = PaddingValues(0.dp),
     paywallPadding: PaddingValues = PaddingValues(0.dp),
@@ -45,6 +64,14 @@ fun TranscriptPage(
 ) {
     val theme = rememberTranscriptTheme()
     val listState = rememberLazyListState()
+    var highlightIndex by remember { mutableStateOf<Int?>(null) }
+    var hasInitiallyScrolled by remember { mutableStateOf(false) }
+    var isAutoScrollSuppressed by remember { mutableStateOf(false) }
+    val playbackState by remember {
+        playbackManager?.playbackStateFlow ?: flowOf(null)
+    }.collectAsState(initial = null)
+    val isPlaying = playbackState?.isPlaying == true
+    val isSearching = uiState.searchState.isSearchOpen
 
     Column(
         modifier = modifier.background(theme.background),
@@ -71,11 +98,19 @@ fun TranscriptPage(
                 .weight(1f)
                 .fillMaxWidth(),
         ) {
+            val tapToSeekHandler: ((TranscriptEntry, Int) -> Unit)? = if (uiState.isSyncedActive && viewModel != null) {
+                { entry, _ -> viewModel.seekToTranscriptEntry(entry) }
+            } else {
+                null
+            }
+
             TranscriptContent(
                 uiState = uiState,
                 listState = listState,
                 theme = theme,
                 onClickReload = onClickReload,
+                highlightIndex = highlightIndex,
+                onEntryClick = tapToSeekHandler,
                 modifier = Modifier
                     .padding(top = 16.dp)
                     .padding(transcriptPadding),
@@ -97,11 +132,30 @@ fun TranscriptPage(
         listState = listState,
     )
 
-    ShowTranscriptEffect(
+    HighlightEffect(
         uiState = uiState,
-        onShowTranscript = onShowTranscript,
-        onShowTranscriptPaywall = onShowTranscriptPaywall,
+        fingerprintTimingManager = fingerprintTimingManager,
+        playbackManager = playbackManager,
+        onHighlightChange = { highlightIndex = it },
     )
+
+    AutoScrollEffect(
+        highlightIndex = highlightIndex,
+        listState = listState,
+        isSearching = isSearching,
+        isPlaying = isPlaying,
+        isAutoScrollSuppressed = isAutoScrollSuppressed,
+        animate = hasInitiallyScrolled,
+        onScroll = { hasInitiallyScrolled = true },
+    )
+
+    UserScrollDetectionEffect(
+        listState = listState,
+        onSuppressScroll = { isAutoScrollSuppressed = true },
+        onResumeScroll = { isAutoScrollSuppressed = false },
+    )
+
+    KeepScreenOnEffect(keepOn = uiState.isSyncedActive)
 }
 
 @Composable
@@ -111,6 +165,8 @@ private fun TranscriptContent(
     theme: TranscriptTheme,
     onClickReload: () -> Unit,
     modifier: Modifier = Modifier,
+    highlightIndex: Int? = null,
+    onEntryClick: ((TranscriptEntry, Int) -> Unit)? = null,
 ) {
     when (val transcriptState = uiState.transcriptState) {
         is TranscriptState.Loading -> {
@@ -126,6 +182,8 @@ private fun TranscriptContent(
                     transcript = transcript,
                     isContentObscured = uiState.isPaywallVisible,
                     searchState = uiState.searchState,
+                    highlightIndex = highlightIndex,
+                    onEntryClick = onEntryClick,
                     state = listState,
                     theme = theme,
                     modifier = modifier,
@@ -175,36 +233,108 @@ private fun ScrollToItemEffect(
 }
 
 @Composable
-private fun ShowTranscriptEffect(
+private fun HighlightEffect(
     uiState: UiState,
-    onShowTranscript: (Transcript) -> Unit,
-    onShowTranscriptPaywall: (Transcript) -> Unit,
+    fingerprintTimingManager: FingerprintTimingManager?,
+    playbackManager: PlaybackManager?,
+    onHighlightChange: (Int?) -> Unit,
 ) {
-    val transcript = (uiState.transcriptState as? TranscriptState.Loaded)?.transcript
-    if (transcript != null) {
-        val isPaywallVisible = uiState.isPaywallVisible
-        LaunchedEffect(transcript, isPaywallVisible, onShowTranscript, onShowTranscriptPaywall) {
-            // This delay is necessary due to how transcript loading works in the player.
-            //
-            // We trigger the page open animation and transcript loading at the same time.
-            // This means that the callbacks from this effect can be invoked with
-            // lingering state from the previously shown transcript, followed by
-            // the new incoming state. This can result in issues such as analytics overreporting.
-            //
-            // Since loading happens almost immediately when the page opens,
-            // adding a small delay prevents the situation described above,
-            // because the effect will be cancelled before it runs.
-            //
-            // We could potentially clear the transcript state after
-            // closing the page, but this would trigger animations,
-            // resulting in a flicker-like visual experience.
-            delay(100)
+    if (fingerprintTimingManager == null || playbackManager == null) return
 
-            if (isPaywallVisible) {
-                onShowTranscriptPaywall(transcript)
+    val transcript = (uiState.transcriptState as? TranscriptState.Loaded)?.transcript as? Transcript.Text ?: return
+    val isSyncedActive = uiState.isSyncedActive
+    val latestOnHighlightChanged by rememberUpdatedState(onHighlightChange)
+
+    val playbackState by remember {
+        playbackManager.playbackStateFlow
+    }.collectAsState(initial = null)
+    val isPlaying = playbackState?.isPlaying == true
+
+    if (isPlaying && isSyncedActive) {
+        LaunchedEffect(transcript.entries) {
+            var cachedIndex = 0
+            while (true) {
+                withFrameNanos { _ ->
+                    val posMs = playbackState?.positionMs ?: return@withFrameNanos
+                    val currentRefTime = fingerprintTimingManager.referenceTime(forPlaybackTimeMs = posMs) ?: return@withFrameNanos
+                    val currentRefTimeMs = (currentRefTime * 1000).toLong()
+                    val idx = TranscriptCueHelper.findCueIndex(transcript.entries, currentRefTimeMs, cachedIndex)
+                    if (idx != null) {
+                        cachedIndex = idx
+                        latestOnHighlightChanged(idx)
+                    }
+                }
+            }
+        }
+    } else if (!isSyncedActive) {
+        LaunchedEffect(Unit) { latestOnHighlightChanged(null) }
+    }
+}
+
+@Composable
+private fun AutoScrollEffect(
+    highlightIndex: Int?,
+    listState: LazyListState,
+    isSearching: Boolean,
+    isPlaying: Boolean,
+    isAutoScrollSuppressed: Boolean,
+    animate: Boolean,
+    onScroll: () -> Unit,
+) {
+    val latestOnScroll by rememberUpdatedState(onScroll)
+    if (highlightIndex != null && isPlaying && !isSearching && !isAutoScrollSuppressed) {
+        LaunchedEffect(highlightIndex) {
+            if (highlightIndex >= listState.layoutInfo.totalItemsCount) return@LaunchedEffect
+            val viewportHeight = listState.layoutInfo.viewportSize.height
+            val scrollOffset = (viewportHeight * 0.3f).roundToInt()
+            if (animate) {
+                listState.animateScrollToItem(highlightIndex, -scrollOffset)
             } else {
-                onShowTranscript(transcript)
+                listState.scrollToItem(highlightIndex, -scrollOffset)
+            }
+            latestOnScroll()
+        }
+    }
+}
+
+@Composable
+private fun UserScrollDetectionEffect(
+    listState: LazyListState,
+    onSuppressScroll: () -> Unit,
+    onResumeScroll: () -> Unit,
+) {
+    val latestOnSuppressScroll by rememberUpdatedState(onSuppressScroll)
+    val latestOnResumeScroll by rememberUpdatedState(onResumeScroll)
+    LaunchedEffect(listState) {
+        var resumeJob: Job? = null
+        listState.interactionSource.interactions.collect { interaction ->
+            when (interaction) {
+                is DragInteraction.Start -> {
+                    resumeJob?.cancel()
+                    latestOnSuppressScroll()
+                }
+
+                is DragInteraction.Stop, is DragInteraction.Cancel -> {
+                    resumeJob?.cancel()
+                    resumeJob = launch {
+                        delay(AUTO_SCROLL_BACK_DELAY_MS)
+                        latestOnResumeScroll()
+                    }
+                }
             }
         }
     }
 }
+
+@Composable
+private fun KeepScreenOnEffect(keepOn: Boolean) {
+    val view = LocalView.current
+    DisposableEffect(keepOn) {
+        view.keepScreenOn = keepOn
+        onDispose {
+            view.keepScreenOn = false
+        }
+    }
+}
+
+private const val AUTO_SCROLL_BACK_DELAY_MS = 5000L

--- a/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptTheme.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptTheme.kt
@@ -15,6 +15,7 @@ import au.com.shiftyjelly.pocketcasts.ui.R
 internal data class TranscriptTheme(
     val background: Color,
     val primaryText: Color,
+    val highlightText: Color,
     val secondaryText: Color,
     val secondaryElement: Color,
     val searchDefaultSpanStyle: SpanStyle,
@@ -28,6 +29,7 @@ internal data class TranscriptTheme(
         fun default(colors: ThemeColors) = TranscriptTheme(
             background = colors.primaryUi01,
             primaryText = colors.primaryText01,
+            highlightText = colors.primaryInteractive01,
             secondaryText = colors.primaryText02,
             secondaryElement = colors.primaryUi05,
             searchDefaultSpanStyle = SpanStyle(
@@ -45,6 +47,7 @@ internal data class TranscriptTheme(
         fun player(colors: PlayerColors) = TranscriptTheme(
             background = colors.background01,
             primaryText = colors.contrast02,
+            highlightText = colors.contrast01,
             secondaryText = colors.contrast04,
             secondaryElement = colors.contrast05,
             searchDefaultSpanStyle = SpanStyle(

--- a/modules/features/transcripts/src/test/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/TranscriptViewModelTest.kt
+++ b/modules/features/transcripts/src/test/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/TranscriptViewModelTest.kt
@@ -7,6 +7,8 @@ import au.com.shiftyjelly.pocketcasts.models.to.TranscriptEntry
 import au.com.shiftyjelly.pocketcasts.models.type.SignInState
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.payment.PaymentClient
+import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.FingerprintTimingManager
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
 import au.com.shiftyjelly.pocketcasts.repositories.transcript.TranscriptManager
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import au.com.shiftyjelly.pocketcasts.sharing.SharingRequest
@@ -38,6 +40,7 @@ class TranscriptViewModelTest {
 
     private val transcriptManager = TestTranscriptManager()
     private val signInStateFlow = MutableStateFlow<SignInState>(SignInState.SignedOut)
+    private val playbackStateFlow = MutableStateFlow(PlaybackState(episodeUuid = ""))
 
     lateinit var viewModel: TranscriptViewModel
 
@@ -57,6 +60,13 @@ class TranscriptViewModelTest {
                     Timber.i("Sharing transcript with request: $request")
                     return SharingResponse(isSuccessful = true, feedbackMessage = null, error = null)
                 }
+            },
+            fingerprintTimingManager = mock {
+                on { state } doReturn FingerprintTimingManager.State.Idle
+                on { stateFlow } doReturn MutableStateFlow(FingerprintTimingManager.State.Idle)
+            },
+            playbackManager = mock {
+                on { playbackStateFlow } doReturn playbackStateFlow
             },
         )
     }

--- a/modules/features/transcripts/src/test/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptCueHelperTest.kt
+++ b/modules/features/transcripts/src/test/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptCueHelperTest.kt
@@ -1,0 +1,224 @@
+package au.com.shiftyjelly.pocketcasts.transcripts.ui
+
+import au.com.shiftyjelly.pocketcasts.models.to.TranscriptEntry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class TranscriptCueHelperTest {
+
+    private fun text(start: Long, end: Long, value: String = "text") = TranscriptEntry.Text(value = value, startTimeMs = start, endTimeMs = end)
+
+    private fun speaker(name: String = "Speaker") = TranscriptEntry.Speaker(name = name)
+
+    // --- findCueIndex ---
+
+    @Test
+    fun `findCueIndex returns null for empty list`() {
+        assertNull(TranscriptCueHelper.findCueIndex(emptyList(), 1000, 0))
+    }
+
+    @Test
+    fun `findCueIndex returns cached index when refTime falls within cached entry`() {
+        val entries = listOf(
+            text(0, 1000),
+            text(1001, 2000),
+            text(2001, 3000),
+        )
+        assertEquals(1, TranscriptCueHelper.findCueIndex(entries, 1500, cachedIndex = 1))
+    }
+
+    @Test
+    fun `findCueIndex falls through to nearby scan when cache misses`() {
+        val entries = listOf(
+            text(0, 1000),
+            text(1001, 2000),
+            text(2001, 3000),
+            text(3001, 4000),
+        )
+        // Cached at 0, but refTime is in entry 2 — within nearby scan range
+        assertEquals(2, TranscriptCueHelper.findCueIndex(entries, 2500, cachedIndex = 0))
+    }
+
+    @Test
+    fun `findCueIndex falls through to binary search when nearby scan misses`() {
+        val entries = buildList {
+            for (i in 0 until 50) {
+                add(text(i * 1000L, (i + 1) * 1000L - 1))
+            }
+        }
+        // Cached at 0, target at index 40 — way beyond scan limit of 10
+        assertEquals(40, TranscriptCueHelper.findCueIndex(entries, 40_500, cachedIndex = 0))
+    }
+
+    @Test
+    fun `findCueIndex coerces cached index to list bounds`() {
+        val entries = listOf(text(0, 1000))
+        // cachedIndex far beyond list size — should not crash
+        assertEquals(0, TranscriptCueHelper.findCueIndex(entries, 500, cachedIndex = 100))
+    }
+
+    // --- findCueNearby ---
+
+    @Test
+    fun `findCueNearby finds entry scanning forward`() {
+        val entries = listOf(
+            text(0, 1000),
+            text(1001, 2000),
+            text(2001, 3000),
+        )
+        assertEquals(2, TranscriptCueHelper.findCueNearby(entries, 2500, cached = 0, scanLimit = 10))
+    }
+
+    @Test
+    fun `findCueNearby finds entry scanning backward`() {
+        val entries = listOf(
+            text(0, 1000),
+            text(1001, 2000),
+            text(2001, 3000),
+        )
+        assertEquals(0, TranscriptCueHelper.findCueNearby(entries, 500, cached = 2, scanLimit = 10))
+    }
+
+    @Test
+    fun `findCueNearby returns null when no match within scan limit`() {
+        val entries = buildList {
+            for (i in 0 until 30) {
+                add(text(i * 1000L, (i + 1) * 1000L - 1))
+            }
+        }
+        // Cached at 0, target at 25 — beyond scan limit of 10
+        assertNull(TranscriptCueHelper.findCueNearby(entries, 25_500, cached = 0, scanLimit = 10))
+    }
+
+    @Test
+    fun `findCueNearby skips Speaker entries`() {
+        val entries = listOf(
+            text(0, 1000),
+            speaker(),
+            speaker(),
+            text(2001, 3000),
+        )
+        assertEquals(3, TranscriptCueHelper.findCueNearby(entries, 2500, cached = 0, scanLimit = 10))
+    }
+
+    // --- findCueBinarySearch ---
+
+    @Test
+    fun `findCueBinarySearch finds entry at exact start time`() {
+        val entries = listOf(
+            text(0, 999),
+            text(1000, 1999),
+            text(2000, 2999),
+        )
+        assertEquals(1, TranscriptCueHelper.findCueBinarySearch(entries, 1000))
+    }
+
+    @Test
+    fun `findCueBinarySearch finds entry when refTime is mid-range`() {
+        val entries = listOf(
+            text(0, 999),
+            text(1000, 1999),
+            text(2000, 2999),
+            text(3000, 3999),
+            text(4000, 4999),
+        )
+        assertEquals(3, TranscriptCueHelper.findCueBinarySearch(entries, 3500))
+    }
+
+    @Test
+    fun `findCueBinarySearch handles interleaved Speaker entries`() {
+        val entries = listOf(
+            text(0, 999),
+            speaker("Alice"),
+            text(1000, 1999),
+            speaker("Bob"),
+            text(2000, 2999),
+        )
+        assertEquals(4, TranscriptCueHelper.findCueBinarySearch(entries, 2500))
+    }
+
+    @Test
+    fun `findCueBinarySearch falls back to closest entry when no exact range match`() {
+        val entries = listOf(
+            text(0, 1000),
+            text(5000, 6000),
+        )
+        // refTime 4500 is in a gap — should find closest entry within threshold
+        assertEquals(1, TranscriptCueHelper.findCueBinarySearch(entries, 4500))
+    }
+
+    @Test
+    fun `findCueBinarySearch returns null when refTime far beyond all entries`() {
+        val entries = listOf(
+            text(0, 1000),
+            text(1001, 2000),
+        )
+        assertNull(TranscriptCueHelper.findCueBinarySearch(entries, 100_000))
+    }
+
+    // --- findClosestTimedEntry ---
+
+    @Test
+    fun `findClosestTimedEntry returns closest entry within threshold`() {
+        val entries = listOf(
+            text(0, 1000),
+            text(2000, 3000),
+            text(5000, 6000),
+        )
+        // refTime 4500 is 1500ms from entry[1].end and 500ms from entry[2].start
+        assertEquals(2, TranscriptCueHelper.findClosestTimedEntry(entries, 4500, around = 1))
+    }
+
+    @Test
+    fun `findClosestTimedEntry returns null when all entries beyond threshold`() {
+        val entries = listOf(
+            text(0, 1000),
+        )
+        // refTime 20000 is 19000ms away — well beyond 5000ms threshold
+        assertNull(TranscriptCueHelper.findClosestTimedEntry(entries, 20_000, around = 0))
+    }
+
+    @Test
+    fun `findClosestTimedEntry skips Speaker entries`() {
+        val entries = listOf(
+            speaker(),
+            speaker(),
+            text(1000, 2000),
+            speaker(),
+        )
+        assertEquals(2, TranscriptCueHelper.findClosestTimedEntry(entries, 1500, around = 1))
+    }
+
+    // --- findNearestTimedEntry ---
+
+    @Test
+    fun `findNearestTimedEntry finds timed entry to the right`() {
+        val entries = listOf(
+            speaker(),
+            speaker(),
+            text(1000, 2000),
+        )
+        assertEquals(2, TranscriptCueHelper.findNearestTimedEntry(entries, mid = 1, lo = 0, hi = 2))
+    }
+
+    @Test
+    fun `findNearestTimedEntry finds timed entry to the left`() {
+        val entries = listOf(
+            text(0, 1000),
+            speaker(),
+            speaker(),
+        )
+        assertEquals(0, TranscriptCueHelper.findNearestTimedEntry(entries, mid = 1, lo = 0, hi = 2))
+    }
+
+    @Test
+    fun `findNearestTimedEntry returns null when no timed entries in range`() {
+        val entries = listOf(
+            speaker(),
+            speaker(),
+            speaker(),
+        )
+        assertNull(TranscriptCueHelper.findNearestTimedEntry(entries, mid = 1, lo = 0, hi = 2))
+    }
+}

--- a/modules/services/fingerprint/build.gradle.kts
+++ b/modules/services/fingerprint/build.gradle.kts
@@ -7,6 +7,9 @@ android {
     buildFeatures {
         buildConfig = true
     }
+    defaultConfig {
+        consumerProguardFiles("proguard-rules.pro")
+    }
 }
 
 dependencies {

--- a/modules/services/fingerprint/proguard-rules.pro
+++ b/modules/services/fingerprint/proguard-rules.pro
@@ -1,0 +1,11 @@
+# UniFFI generated bindings use JNA to dynamically map Kotlin interface methods
+# to native function symbols via reflection. R8 cannot trace this usage and will
+# remove these classes/methods as "unused" without explicit keep rules.
+
+# Keep all UniFFI generated classes and interfaces
+-keep class uniffi.fingerprint_uniffi.** { *; }
+-keep interface uniffi.fingerprint_uniffi.** { *; }
+
+# JNA core classes required for native library loading and FFI
+-keep class com.sun.jna.** { *; }
+-keep interface com.sun.jna.** { *; }

--- a/modules/services/fingerprint/src/main/java/uniffi/fingerprint_uniffi/fingerprint_uniffi.kt
+++ b/modules/services/fingerprint/src/main/java/uniffi/fingerprint_uniffi/fingerprint_uniffi.kt
@@ -1484,6 +1484,7 @@ private fun UniffiCleaner.Companion.create(): UniffiCleaner =
         UniffiJnaCleaner()
     }
 
+@android.annotation.SuppressLint("NewApi")
 private class JavaLangRefCleaner : UniffiCleaner {
     val cleaner = java.lang.ref.Cleaner.create()
 
@@ -1491,6 +1492,7 @@ private class JavaLangRefCleaner : UniffiCleaner {
         JavaLangRefCleanable(cleaner.register(value, cleanUpTask))
 }
 
+@android.annotation.SuppressLint("NewApi")
 private class JavaLangRefCleanable(
     val cleanable: java.lang.ref.Cleaner.Cleanable
 ) : UniffiCleaner.Cleanable {

--- a/modules/services/repositories/build.gradle.kts
+++ b/modules/services/repositories/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
     api(projects.modules.services.analytics)
     api(projects.modules.services.coroutines)
     api(projects.modules.services.crashlogging)
+    api(projects.modules.services.fingerprint)
     api(projects.modules.services.localization)
     api(projects.modules.services.model)
     api(projects.modules.services.payment)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadManager.kt
@@ -24,6 +24,8 @@ import au.com.shiftyjelly.pocketcasts.models.type.DownloadStatusUpdate
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeDownloadStatus
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.download.task.UpdateShowNotesTask
+import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.FingerprintMappingCache
+import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.FingerprintReferenceRetriever
 import au.com.shiftyjelly.pocketcasts.utils.FileUtil
 import au.com.shiftyjelly.pocketcasts.utils.Network
 import au.com.shiftyjelly.pocketcasts.utils.Power
@@ -259,7 +261,14 @@ private class DownloadQueueController(
             transcriptDao.deleteForEpisodes(episodes.keys)
             val deletedEpisodes = episodes.mapNotNull { (_, episode) ->
                 val deletedEpisode = runCatching {
-                    val isFileDeleted = episode.downloadedFilePath?.let(::File)?.delete() == true
+                    val isFileDeleted = episode.downloadedFilePath?.let { filePath ->
+                        val deleted = File(filePath).delete()
+                        if (deleted) {
+                            File(FingerprintMappingCache.mappingPath(filePath)).delete()
+                            File(FingerprintReferenceRetriever.referencePath(filePath)).delete()
+                        }
+                        deleted
+                    } == true
                     if (isFileDeleted) episode else null
                 }
                 if (episode is UserEpisode) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintConstants.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintConstants.kt
@@ -1,0 +1,60 @@
+package au.com.shiftyjelly.pocketcasts.repositories.fingerprint
+
+object FingerprintConstants {
+    /** If consecutive playback-progress updates differ by more than this, treat it as a seek/skip. */
+    const val RESTART_DELTA_SECONDS = 10.0
+
+    /** Slack window around the already-mapped range before playback is considered "outside". */
+    const val PLAYBACK_RANGE_MARGIN_SECONDS = 30.0
+
+    /** Minimum match score to accept a fingerprint match result. */
+    const val MATCH_SCORE_THRESHOLD = 0.5f
+
+    /** Duration of each windowed fingerprint during live matching, in milliseconds. */
+    const val WINDOW_DURATION_MS = 8000
+
+    /** Interval between windowed fingerprints during live matching, in milliseconds. */
+    const val WINDOW_INTERVAL_MS = 2000
+
+    /** Seconds of decoded PCM read per chunk during fingerprint generation. */
+    const val STREAM_CHUNK_SECONDS = 5.0
+
+    /** Seconds between polls when waiting for the streaming buffer to grow. */
+    const val BUFFER_GROW_POLL_CADENCE_SECONDS = 1.0
+
+    /** Give up the streaming grow-loop after this many consecutive seconds without new bytes. */
+    const val BUFFER_GROW_MAX_STALL_SECONDS = 60.0
+
+    /** Trailing audio the grow-loop refuses to read to avoid partial frame noise. */
+    const val BUFFER_GROW_TRAILING_MARGIN_SECONDS = 1.0
+
+    /** Minimum number of mapping entries before transitioning to Active. */
+    const val MINIMUM_COVERAGE_FOR_ACTIVE = 2
+
+    /** Residual tolerance, in seconds, on the rate-≈1 drift filter. */
+    const val DRIFT_TOLERANCE_SECONDS = 5.0
+
+    /** Consecutive rate-≈1 candidates required to establish a trusted anchor. */
+    const val DRIFT_BOOTSTRAP_COUNT = 3
+
+    /** Minimum matcher score for a match to reach the drift filter. */
+    const val DRIFT_ANCHOR_SCORE_THRESHOLD = 0.65f
+
+    /** Minimum score gap between top-1 and top-2 matcher candidates. */
+    const val DRIFT_SCORE_DOMINANCE_GAP = 0.05f
+
+    /** Distance ahead of current playback within which fingerprinting runs at full speed. */
+    const val LOOKAHEAD_SECONDS = 60.0
+
+    /** Sleep between chunks when fingerprinting ahead of the lookahead window. */
+    const val OUTSIDE_LOOKAHEAD_SLEEP_SECONDS = 0.5
+
+    /** Minimum fraction of reference timeline a cached mapping must cover. */
+    const val FULL_COVERAGE_THRESHOLD = 0.95
+
+    /** Persistent cache schema version. Bump when on-disk shape changes. */
+    const val MAPPING_CACHE_SCHEMA_VERSION = 3
+
+    /** Timeout for MediaCodec dequeue operations, in microseconds. */
+    const val CODEC_TIMEOUT_US = 10_000L
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintMappingCache.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintMappingCache.kt
@@ -1,0 +1,185 @@
+package au.com.shiftyjelly.pocketcasts.repositories.fingerprint
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import com.squareup.moshi.Moshi
+import java.io.File
+import java.io.FileInputStream
+import java.security.MessageDigest
+import timber.log.Timber
+
+object FingerprintMappingCache {
+
+    data class LoadResult(
+        val entries: List<FingerprintTimingManager.TimeMappingEntry>,
+        val referenceDuration: Double,
+    )
+
+    @JsonClass(generateAdapter = true)
+    internal data class CachedMapping(
+        val schemaVersion: Int,
+        val referenceHash: String,
+        val referenceByteSize: Long,
+        val referenceMTime: Long,
+        val audioByteSize: Long,
+        val audioMTime: Long,
+        val audioContentHash: String,
+        val referenceDuration: Double,
+        val entries: List<CachedEntry>,
+    )
+
+    @JsonClass(generateAdapter = true)
+    internal data class CachedEntry(
+        @Json(name = "p") val playbackTime: Double,
+        @Json(name = "r") val referenceTime: Double,
+        @Json(name = "s") val score: Float,
+    )
+
+    private val moshi = Moshi.Builder().build()
+    private val adapter = moshi.adapter(CachedMapping::class.java)
+
+    fun load(
+        audioFilePath: String,
+        referenceFilePath: String,
+        referenceData: ByteArray,
+    ): LoadResult? {
+        val path = mappingPath(audioFilePath)
+        val file = File(path)
+        if (!file.exists()) return null
+
+        val cached = try {
+            adapter.fromJson(file.readText())
+        } catch (e: Exception) {
+            Timber.w("FingerprintMappingCache: failed to decode cache at $path — discarding")
+            return null
+        } ?: return null
+
+        if (cached.schemaVersion != FingerprintConstants.MAPPING_CACHE_SCHEMA_VERSION) {
+            Timber.d("FingerprintMappingCache: schema version mismatch at $path — discarding")
+            return null
+        }
+
+        val refFile = File(referenceFilePath)
+        if (!refFile.exists() || refFile.length() != cached.referenceByteSize || refFile.lastModified() != cached.referenceMTime) {
+            Timber.d("FingerprintMappingCache: reference file changed at $referenceFilePath — discarding cache")
+            return null
+        }
+
+        if (cached.referenceHash != sha256(referenceData)) {
+            Timber.d("FingerprintMappingCache: reference hash mismatch at $path — discarding")
+            return null
+        }
+
+        val audioFile = File(audioFilePath)
+        if (!audioFile.exists() || audioFile.length() != cached.audioByteSize || audioFile.lastModified() != cached.audioMTime) {
+            Timber.d("FingerprintMappingCache: audio file changed at $audioFilePath — discarding cache")
+            return null
+        }
+
+        if (contentSampleHash(audioFilePath) != cached.audioContentHash) {
+            Timber.d("FingerprintMappingCache: audio content hash mismatch at $audioFilePath — discarding cache")
+            return null
+        }
+
+        val lastEntry = cached.entries.lastOrNull() ?: return null
+        if (cached.referenceDuration <= 0 || lastEntry.referenceTime / cached.referenceDuration < FingerprintConstants.FULL_COVERAGE_THRESHOLD) {
+            Timber.d("FingerprintMappingCache: partial coverage at $path — ignoring")
+            return null
+        }
+
+        Timber.d("FingerprintMappingCache: loaded ${cached.entries.size} cached mappings from $path")
+        return LoadResult(
+            entries = cached.entries.map {
+                FingerprintTimingManager.TimeMappingEntry(
+                    playbackTime = it.playbackTime,
+                    referenceTime = it.referenceTime,
+                    score = it.score,
+                )
+            },
+            referenceDuration = cached.referenceDuration,
+        )
+    }
+
+    fun save(
+        entries: List<FingerprintTimingManager.TimeMappingEntry>,
+        audioFilePath: String,
+        referenceFilePath: String,
+        referenceData: ByteArray,
+        referenceDuration: Double,
+    ) {
+        val lastEntry = entries.lastOrNull() ?: return
+        if (referenceDuration <= 0 || lastEntry.referenceTime / referenceDuration < FingerprintConstants.FULL_COVERAGE_THRESHOLD) {
+            return
+        }
+
+        val audioFile = File(audioFilePath)
+        if (!audioFile.exists()) {
+            Timber.w("FingerprintMappingCache: cannot stat audio at $audioFilePath — skipping save")
+            return
+        }
+
+        val refFile = File(referenceFilePath)
+        if (!refFile.exists()) {
+            Timber.w("FingerprintMappingCache: cannot stat reference at $referenceFilePath — skipping save")
+            return
+        }
+
+        val audioContentHash = contentSampleHash(audioFilePath)
+        if (audioContentHash == null) {
+            Timber.w("FingerprintMappingCache: cannot hash audio content at $audioFilePath — skipping save")
+            return
+        }
+
+        val cached = CachedMapping(
+            schemaVersion = FingerprintConstants.MAPPING_CACHE_SCHEMA_VERSION,
+            referenceHash = sha256(referenceData),
+            referenceByteSize = refFile.length(),
+            referenceMTime = refFile.lastModified(),
+            audioByteSize = audioFile.length(),
+            audioMTime = audioFile.lastModified(),
+            audioContentHash = audioContentHash,
+            referenceDuration = referenceDuration,
+            entries = entries.map { CachedEntry(it.playbackTime, it.referenceTime, it.score) },
+        )
+
+        val path = mappingPath(audioFilePath)
+        val tmpFile = File("$path.tmp")
+        try {
+            tmpFile.writeText(adapter.toJson(cached))
+            if (!tmpFile.renameTo(File(path))) {
+                Timber.w("FingerprintMappingCache: atomic rename failed for $path, falling back to direct write")
+                File(path).writeText(adapter.toJson(cached))
+            }
+            Timber.d("FingerprintMappingCache: saved ${entries.size} mappings to $path")
+        } catch (e: Exception) {
+            Timber.w(e, "FingerprintMappingCache: failed to save to $path")
+            tmpFile.delete()
+        }
+    }
+
+    fun mappingPath(audioFilePath: String): String {
+        val dotIndex = audioFilePath.lastIndexOf('.')
+        val base = if (dotIndex > 0) audioFilePath.substring(0, dotIndex) else audioFilePath
+        return "$base.map.fp.json"
+    }
+
+    private fun sha256(data: ByteArray): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        return digest.digest(data).joinToString("") { "%02x".format(it) }
+    }
+
+    private const val CONTENT_SAMPLE_SIZE = 65_536
+
+    private fun contentSampleHash(filePath: String): String? {
+        return try {
+            FileInputStream(filePath).use { stream ->
+                val buffer = ByteArray(CONTENT_SAMPLE_SIZE)
+                val bytesRead = stream.read(buffer)
+                if (bytesRead <= 0) return null
+                sha256(buffer.copyOf(bytesRead))
+            }
+        } catch (e: Exception) {
+            null
+        }
+    }
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintMappingCache.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintMappingCache.kt
@@ -149,6 +149,7 @@ object FingerprintMappingCache {
             if (!tmpFile.renameTo(File(path))) {
                 Timber.w("FingerprintMappingCache: atomic rename failed for $path, falling back to direct write")
                 File(path).writeText(adapter.toJson(cached))
+                tmpFile.delete()
             }
             Timber.d("FingerprintMappingCache: saved ${entries.size} mappings to $path")
         } catch (e: Exception) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintReferenceRetriever.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintReferenceRetriever.kt
@@ -1,0 +1,144 @@
+package au.com.shiftyjelly.pocketcasts.repositories.fingerprint
+
+import au.com.shiftyjelly.pocketcasts.servers.di.NoCache
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.util.zip.GZIPInputStream
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.coroutines.coroutineContext
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import timber.log.Timber
+
+@Singleton
+class FingerprintReferenceRetriever @Inject constructor(
+    @NoCache private val okHttpClient: OkHttpClient,
+) {
+    private val inFlightRequests = mutableMapOf<String, Deferred<ByteArray?>>()
+    private val requestMutex = Mutex()
+
+    suspend fun fetchReferenceData(
+        baseUrl: String,
+        podcastUuid: String,
+        episodeUuid: String,
+    ): ByteArray? = coroutineScope {
+        val key = "$podcastUuid/$episodeUuid"
+
+        val deferred = requestMutex.withLock {
+            val existing = inFlightRequests[key]
+            if (existing != null && existing.isActive) {
+                existing
+            } else {
+                async {
+                    try {
+                        performFetch(baseUrl, podcastUuid, episodeUuid)
+                    } finally {
+                        requestMutex.withLock { inFlightRequests.remove(key) }
+                    }
+                }.also { inFlightRequests[key] = it }
+            }
+        }
+        deferred.await()
+    }
+
+    private suspend fun performFetch(
+        baseUrl: String,
+        podcastUuid: String,
+        episodeUuid: String,
+    ): ByteArray? {
+        val url = "${baseUrl}$podcastUuid/$episodeUuid-fingerprints.json.gz"
+
+        for (attempt in 0 until MAX_RETRIES) {
+            coroutineContext.ensureActive()
+
+            if (attempt > 0) {
+                val delayMs = (1L shl attempt) * 1000L
+                kotlinx.coroutines.delay(delayMs)
+            }
+
+            try {
+                val request = Request.Builder().url(url).build()
+                okHttpClient.newCall(request).execute().use { response ->
+                    val statusCode = response.code
+
+                    if (statusCode == 404 || statusCode == 403) {
+                        Timber.d("FingerprintReferenceRetriever: no reference for $episodeUuid ($statusCode)")
+                        return null
+                    }
+
+                    if (statusCode != 200) {
+                        if (statusCode >= 500) {
+                            Timber.w("FingerprintReferenceRetriever: server error $statusCode for $episodeUuid, attempt ${attempt + 1}/$MAX_RETRIES")
+                            continue
+                        }
+                        Timber.w("FingerprintReferenceRetriever: unexpected status $statusCode for $episodeUuid")
+                        return null
+                    }
+
+                    val body = response.body.bytes()
+                    val jsonData = decompressGzipIfNeeded(body)
+
+                    Timber.d("FingerprintReferenceRetriever: reference fetched for $episodeUuid (${jsonData.size} bytes)")
+                    return jsonData
+                }
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                throw e
+            } catch (e: java.io.IOException) {
+                Timber.w("FingerprintReferenceRetriever: fetch failed for $episodeUuid, attempt ${attempt + 1}/$MAX_RETRIES — ${e.message}")
+                if (attempt == MAX_RETRIES - 1) return null
+            }
+        }
+
+        Timber.w("FingerprintReferenceRetriever: exhausted retries for $episodeUuid")
+        return null
+    }
+
+    fun saveReferenceData(data: ByteArray, audioFilePath: String) {
+        val path = referencePath(audioFilePath)
+        try {
+            File(path).writeBytes(data)
+            Timber.d("FingerprintReferenceRetriever: saved reference to $path")
+        } catch (e: Exception) {
+            Timber.w(e, "FingerprintReferenceRetriever: failed to save reference to $path")
+        }
+    }
+
+    fun loadReferenceData(audioFilePath: String): ByteArray? {
+        val path = referencePath(audioFilePath)
+        val file = File(path)
+        return if (file.exists()) file.readBytes() else null
+    }
+
+    companion object {
+        private const val MAX_RETRIES = 3
+
+        fun referencePath(audioFilePath: String): String {
+            val dotIndex = audioFilePath.lastIndexOf('.')
+            val base = if (dotIndex > 0) audioFilePath.substring(0, dotIndex) else audioFilePath
+            return "$base.ref.fp.json"
+        }
+
+        fun decompressGzipIfNeeded(data: ByteArray): ByteArray {
+            if (data.size < 2) return data
+            if (data[0] == 0x1f.toByte() && data[1] == 0x8b.toByte()) {
+                return decompressGzip(data)
+            }
+            return data
+        }
+
+        private fun decompressGzip(data: ByteArray): ByteArray {
+            return GZIPInputStream(data.inputStream()).use { gzip ->
+                val output = ByteArrayOutputStream()
+                gzip.copyTo(output)
+                output.toByteArray()
+            }
+        }
+    }
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintReferenceRetriever.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintReferenceRetriever.kt
@@ -8,11 +8,13 @@ import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.coroutines.coroutineContext
 import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import timber.log.Timber
@@ -52,7 +54,7 @@ class FingerprintReferenceRetriever @Inject constructor(
         baseUrl: String,
         podcastUuid: String,
         episodeUuid: String,
-    ): ByteArray? {
+    ): ByteArray? = withContext(Dispatchers.IO) {
         val url = "${baseUrl}$podcastUuid/$episodeUuid-fingerprints.json.gz"
 
         for (attempt in 0 until MAX_RETRIES) {
@@ -70,7 +72,7 @@ class FingerprintReferenceRetriever @Inject constructor(
 
                     if (statusCode == 404 || statusCode == 403) {
                         Timber.d("FingerprintReferenceRetriever: no reference for $episodeUuid ($statusCode)")
-                        return null
+                        return@withContext null
                     }
 
                     if (statusCode != 200) {
@@ -79,25 +81,25 @@ class FingerprintReferenceRetriever @Inject constructor(
                             continue
                         }
                         Timber.w("FingerprintReferenceRetriever: unexpected status $statusCode for $episodeUuid")
-                        return null
+                        return@withContext null
                     }
 
                     val body = response.body.bytes()
                     val jsonData = decompressGzipIfNeeded(body)
 
                     Timber.d("FingerprintReferenceRetriever: reference fetched for $episodeUuid (${jsonData.size} bytes)")
-                    return jsonData
+                    return@withContext jsonData
                 }
             } catch (e: kotlinx.coroutines.CancellationException) {
                 throw e
             } catch (e: java.io.IOException) {
                 Timber.w("FingerprintReferenceRetriever: fetch failed for $episodeUuid, attempt ${attempt + 1}/$MAX_RETRIES — ${e.message}")
-                if (attempt == MAX_RETRIES - 1) return null
+                if (attempt == MAX_RETRIES - 1) return@withContext null
             }
         }
 
         Timber.w("FingerprintReferenceRetriever: exhausted retries for $episodeUuid")
-        return null
+        null
     }
 
     fun saveReferenceData(data: ByteArray, audioFilePath: String) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintReferenceRetriever.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintReferenceRetriever.kt
@@ -3,15 +3,18 @@ package au.com.shiftyjelly.pocketcasts.repositories.fingerprint
 import au.com.shiftyjelly.pocketcasts.servers.di.NoCache
 import java.io.ByteArrayOutputStream
 import java.io.File
+import java.io.IOException
 import java.util.zip.GZIPInputStream
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.coroutines.coroutineContext
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -63,7 +66,7 @@ class FingerprintReferenceRetriever @Inject constructor(
 
             if (attempt > 0) {
                 val delayMs = (1L shl attempt) * 1000L
-                kotlinx.coroutines.delay(delayMs)
+                delay(delayMs)
             }
 
             try {
@@ -91,9 +94,9 @@ class FingerprintReferenceRetriever @Inject constructor(
                     Timber.d("FingerprintReferenceRetriever: reference fetched for $episodeUuid (${jsonData.size} bytes)")
                     return@withContext jsonData
                 }
-            } catch (e: kotlinx.coroutines.CancellationException) {
+            } catch (e: CancellationException) {
                 throw e
-            } catch (e: java.io.IOException) {
+            } catch (e: IOException) {
                 Timber.w("FingerprintReferenceRetriever: fetch failed for $episodeUuid, attempt ${attempt + 1}/$MAX_RETRIES — ${e.message}")
                 if (attempt == MAX_RETRIES - 1) return@withContext null
             }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintReferenceRetriever.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintReferenceRetriever.kt
@@ -9,6 +9,7 @@ import javax.inject.Singleton
 import kotlin.coroutines.coroutineContext
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.ensureActive
@@ -42,7 +43,7 @@ class FingerprintReferenceRetriever @Inject constructor(
                     try {
                         performFetch(baseUrl, podcastUuid, episodeUuid)
                     } finally {
-                        requestMutex.withLock { inFlightRequests.remove(key) }
+                        withContext(NonCancellable) { requestMutex.withLock { inFlightRequests.remove(key) } }
                     }
                 }.also { inFlightRequests[key] = it }
             }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
@@ -1,0 +1,813 @@
+package au.com.shiftyjelly.pocketcasts.repositories.fingerprint
+
+import android.media.MediaCodec
+import android.media.MediaExtractor
+import android.media.MediaFormat
+import androidx.annotation.VisibleForTesting
+import au.com.shiftyjelly.pocketcasts.repositories.BuildConfig
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
+import java.io.File
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.math.abs
+import kotlin.math.floor
+import kotlin.math.max
+import kotlin.math.min
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import timber.log.Timber
+import uniffi.fingerprint_uniffi.CheckpointMatcher
+import uniffi.fingerprint_uniffi.StreamingWindowedFingerprinter
+import uniffi.fingerprint_uniffi.WindowedFingerprint
+
+@Singleton
+class FingerprintTimingManager @Inject constructor(
+    private val playbackManager: PlaybackManager,
+    private val referenceRetriever: FingerprintReferenceRetriever,
+) {
+    // region Public Types
+
+    sealed interface State {
+        data object Idle : State
+        data object Preparing : State
+        data class Active(val coverage: Int) : State
+        data class Failed(val error: Throwable) : State
+        data object Unavailable : State
+    }
+
+    data class TimeMappingEntry(
+        val playbackTime: Double,
+        val referenceTime: Double,
+        val score: Float = 0f,
+    )
+
+    // endregion
+
+    // region Public State
+
+    private val _stateFlow = MutableStateFlow<State>(State.Idle)
+    val stateFlow: StateFlow<State> = _stateFlow.asStateFlow()
+    val state: State get() = _stateFlow.value
+
+    // endregion
+
+    // region Private State
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val mutex = Mutex()
+
+    // Mapping state: writers build new lists under mutex, then atomically publish via @Volatile.
+    // Readers access the snapshot without locking, safe for use from the UI thread.
+    private var mappingPlaybackToReference = mutableListOf<TimeMappingEntry>()
+    private var mappingReferenceToPlayback = mutableListOf<TimeMappingEntry>()
+
+    @Volatile
+    private var snapshotPlaybackToReference: List<TimeMappingEntry> = emptyList()
+
+    @Volatile
+    private var snapshotReferenceToPlayback: List<TimeMappingEntry> = emptyList()
+
+    private var lastProgressPositionMs = -1
+    private var generationJob: Job? = null
+    private var preparationJob: Job? = null
+    private var progressObserverJob: Job? = null
+    private var generation = 0L
+
+    // Drift filter state
+    private var filterLastTrusted: TimeMappingEntry? = null
+    private var filterCandidatePool = mutableListOf<TimeMappingEntry>()
+
+    // Context for current preparation
+    private var currentEpisodeUuid: String? = null
+    private var currentAudioFilePath: String? = null
+    private var currentReferenceData: ByteArray? = null
+    private var currentReferenceFilePath: String? = null
+    private var currentReferenceDuration: Double = 0.0
+    private var currentMatcher: CheckpointMatcher? = null
+    private var hasReachedActive = false
+
+    // endregion
+
+    // region Public API
+
+    fun prepareForCurrentEpisode() {
+        val episode = playbackManager.getCurrentEpisode() ?: run {
+            _stateFlow.value = State.Unavailable
+            return
+        }
+
+        val episodeUuid = episode.uuid
+        val podcastUuid = episode.podcastOrSubstituteUuid
+        val audioSource = episode.downloadedFilePath ?: episode.downloadUrl
+
+        scope.launch {
+            val gen: Long
+            mutex.withLock {
+                // Already prepared for this episode — reuse existing state.
+                if (currentEpisodeUuid == episodeUuid && state !is State.Idle) return@launch
+                resetState()
+                generation++
+                gen = generation
+            }
+            // Abort if a newer stop()/prepare() has started since we acquired the lock.
+            if (gen != generation) return@launch
+            prepareForEpisode(episodeUuid, podcastUuid, audioSource, episode.isDownloaded, episode.duration)
+        }
+
+        startPlaybackProgressObserver(episodeUuid)
+    }
+
+    private fun startPlaybackProgressObserver(episodeUuid: String) {
+        progressObserverJob?.cancel()
+        progressObserverJob = scope.launch {
+            playbackManager.playbackStateFlow.collect { state ->
+                if (state.episodeUuid == episodeUuid && state.isPlaying) {
+                    onPlaybackProgress(state.positionMs, state.episodeUuid)
+                }
+            }
+        }
+    }
+
+    fun stop() {
+        scope.launch {
+            mutex.withLock {
+                generation++
+                resetState()
+                _stateFlow.value = State.Idle
+            }
+        }
+        Timber.d("FingerprintTimingManager: stopped")
+    }
+
+    fun referenceTime(forPlaybackTimeMs: Int): Double? {
+        val playbackTimeSec = forPlaybackTimeMs / 1000.0
+        return interpolate(
+            time = playbackTimeSec,
+            entries = snapshotPlaybackToReference,
+            keySelector = { it.playbackTime },
+            valueSelector = { it.referenceTime },
+        )
+    }
+
+    fun playbackTimeMs(forReferenceTime: Double): Int? {
+        val result = interpolate(
+            time = forReferenceTime,
+            entries = snapshotReferenceToPlayback,
+            keySelector = { it.referenceTime },
+            valueSelector = { it.playbackTime },
+        ) ?: return null
+        return (result * 1000).toInt()
+    }
+
+    // endregion
+
+    // region State Management
+
+    private fun resetState() {
+        generationJob?.cancel()
+        generationJob = null
+        preparationJob?.cancel()
+        preparationJob = null
+        progressObserverJob?.cancel()
+        progressObserverJob = null
+        mappingPlaybackToReference.clear()
+        mappingReferenceToPlayback.clear()
+        publishSnapshot()
+        lastProgressPositionMs = -1
+        filterLastTrusted = null
+        filterCandidatePool.clear()
+        currentEpisodeUuid = null
+        currentAudioFilePath = null
+        currentReferenceData = null
+        currentReferenceFilePath = null
+        currentReferenceDuration = 0.0
+        currentMatcher?.close()
+        currentMatcher = null
+        hasReachedActive = false
+    }
+
+    // endregion
+
+    // region Preparation
+
+    private suspend fun prepareForEpisode(
+        episodeUuid: String,
+        podcastUuid: String,
+        audioSource: String?,
+        isDownloaded: Boolean,
+        durationSec: Double,
+    ) {
+        if (!FeatureFlag.isEnabled(Feature.SYNCED_TRANSCRIPTS)) {
+            _stateFlow.value = State.Unavailable
+            Timber.d("FingerprintTimingManager: feature disabled")
+            return
+        }
+
+        if (durationSec <= 0) {
+            _stateFlow.value = State.Unavailable
+            Timber.d("FingerprintTimingManager: invalid duration for $episodeUuid")
+            return
+        }
+
+        if (audioSource == null) {
+            _stateFlow.value = State.Unavailable
+            Timber.d("FingerprintTimingManager: no audio source for $episodeUuid")
+            return
+        }
+
+        currentEpisodeUuid = episodeUuid
+        currentAudioFilePath = audioSource
+
+        // Try loading cached reference from disk (only for downloaded episodes)
+        if (isDownloaded) {
+            val referenceData = referenceRetriever.loadReferenceData(audioSource)
+            if (referenceData != null) {
+                val reference = ReferenceFingerprint.decode(referenceData)
+                if (reference != null) {
+                    configureForReference(reference, referenceData, audioSource, episodeUuid)
+                    return
+                }
+            }
+        }
+
+        // Fetch from server
+        _stateFlow.value = State.Preparing
+        Timber.d("FingerprintTimingManager: fetching reference from server for $episodeUuid")
+
+        val baseUrl = "${BuildConfig.SERVER_SHOW_NOTES_URLS}/generated_transcripts/"
+        val referenceData = referenceRetriever.fetchReferenceData(baseUrl, podcastUuid, episodeUuid)
+
+        if (referenceData == null) {
+            _stateFlow.value = State.Unavailable
+            Timber.d("FingerprintTimingManager: no reference available for $episodeUuid")
+            return
+        }
+
+        val reference = ReferenceFingerprint.decode(referenceData)
+        if (reference == null) {
+            _stateFlow.value = State.Unavailable
+            Timber.d("FingerprintTimingManager: failed to decode reference for $episodeUuid")
+            return
+        }
+
+        if (isDownloaded) {
+            referenceRetriever.saveReferenceData(referenceData, audioSource)
+        }
+        configureForReference(reference, referenceData, audioSource, episodeUuid)
+    }
+
+    private suspend fun configureForReference(
+        reference: ReferenceFingerprint,
+        referenceData: ByteArray,
+        audioFilePath: String,
+        episodeUuid: String,
+    ) {
+        val libraryCheckpoints = reference.libraryCheckpoints()
+        if (libraryCheckpoints.isEmpty()) {
+            _stateFlow.value = State.Unavailable
+            Timber.d("FingerprintTimingManager: no usable checkpoints for $episodeUuid")
+            return
+        }
+
+        val refPath = FingerprintReferenceRetriever.referencePath(audioFilePath)
+        currentReferenceData = referenceData
+        currentReferenceFilePath = refPath
+        currentReferenceDuration = reference.totalDuration
+
+        _stateFlow.value = State.Preparing
+
+        Timber.d(
+            "FingerprintTimingManager: reference for $episodeUuid — " +
+                "totalDuration=${reference.totalDuration}s, " +
+                "${libraryCheckpoints.size} checkpoints",
+        )
+
+        // Create matcher and populate with reference checkpoints
+        val matcher = CheckpointMatcher()
+        for (checkpoint in libraryCheckpoints) {
+            matcher.add(
+                checkpoint.timestampSeconds,
+                checkpoint.hashes.map { it.toUInt() },
+                reference.checkpointDurationSeconds,
+            )
+        }
+        currentMatcher = matcher
+
+        // Try loading mapping cache (only for local files)
+        val isLocalFile = !audioFilePath.startsWith("http://") && !audioFilePath.startsWith("https://")
+        val cached = if (isLocalFile) FingerprintMappingCache.load(audioFilePath, refPath, referenceData) else null
+        if (cached != null) {
+            mutex.withLock {
+                mappingPlaybackToReference = cached.entries.toMutableList()
+                mappingReferenceToPlayback = cached.entries.sortedBy { it.referenceTime }.toMutableList()
+                publishSnapshot()
+                filterLastTrusted = cached.entries.lastOrNull()
+            }
+            val coverage = cached.entries.size
+            _stateFlow.value = State.Active(coverage)
+            Timber.d("FingerprintTimingManager: loaded mapping from cache for $episodeUuid ($coverage entries)")
+            return
+        }
+
+        // Start streaming fingerprint generation
+        val currentTime = playbackManager.playbackStateFlow.first().positionMs / 1000.0
+        startStream(audioFilePath, matcher, episodeUuid, startPosition = currentTime)
+    }
+
+    // endregion
+
+    // region Playback Progress Handling
+
+    private fun onPlaybackProgress(positionMs: Int, episodeUuid: String?) {
+        if (episodeUuid != currentEpisodeUuid) return
+
+        scope.launch {
+            mutex.withLock {
+                processProgress(positionMs)
+            }
+        }
+    }
+
+    private fun processProgress(positionMs: Int) {
+        if (lastProgressPositionMs >= 0) {
+            val deltaMs = abs(positionMs - lastProgressPositionMs)
+            if (deltaMs > FingerprintConstants.RESTART_DELTA_SECONDS * 1000) {
+                Timber.d("FingerprintTimingManager: playback jumped ${deltaMs}ms — restarting")
+                val matcher = currentMatcher
+                val audioPath = currentAudioFilePath
+                val uuid = currentEpisodeUuid
+                if (matcher != null && audioPath != null && uuid != null) {
+                    filterLastTrusted = null
+                    filterCandidatePool.clear()
+                    startStream(audioPath, matcher, uuid, startPosition = positionMs / 1000.0)
+                }
+                lastProgressPositionMs = positionMs
+                return
+            }
+        }
+        lastProgressPositionMs = positionMs
+
+        if (!isWithinMappedRange(positionMs / 1000.0) && mappingPlaybackToReference.isNotEmpty()) {
+            Timber.d("FingerprintTimingManager: playback outside mapped range — restarting")
+            val matcher = currentMatcher
+            val audioPath = currentAudioFilePath
+            val uuid = currentEpisodeUuid
+            if (matcher != null && audioPath != null && uuid != null) {
+                filterLastTrusted = null
+                filterCandidatePool.clear()
+                startStream(audioPath, matcher, uuid, startPosition = positionMs / 1000.0)
+            }
+        }
+    }
+
+    private fun isWithinMappedRange(playbackTimeSec: Double): Boolean {
+        val entries = mappingPlaybackToReference
+        val first = entries.firstOrNull() ?: return false
+        val last = entries.lastOrNull() ?: return false
+        val margin = FingerprintConstants.PLAYBACK_RANGE_MARGIN_SECONDS
+        return playbackTimeSec >= first.playbackTime - margin &&
+            playbackTimeSec <= last.playbackTime + margin
+    }
+
+    // endregion
+
+    // region Streaming Fingerprint Generation
+
+    private fun startStream(audioFilePath: String, matcher: CheckpointMatcher, episodeUuid: String, startPosition: Double) {
+        generationJob?.cancel()
+        generationJob = scope.launch {
+            val aligned = alignToWindowGrid(startPosition)
+            try {
+                streamFingerprint(audioFilePath, matcher, episodeUuid, startingAt = aligned)
+                persistMappingCacheIfFull()
+            } catch (_: CancellationException) {
+                Timber.d("FingerprintTimingManager: streaming fingerprint cancelled")
+            } catch (e: Exception) {
+                Timber.w(e, "FingerprintTimingManager: streaming fingerprint failed")
+                if (state !is State.Active) {
+                    _stateFlow.value = State.Failed(e)
+                }
+            }
+        }
+    }
+
+    private suspend fun streamFingerprint(
+        audioFilePath: String,
+        matcher: CheckpointMatcher,
+        episodeUuid: String,
+        startingAt: Double,
+    ) {
+        val isRemoteUrl = audioFilePath.startsWith("http://") || audioFilePath.startsWith("https://")
+        if (!isRemoteUrl && !File(audioFilePath).exists()) {
+            Timber.w("FingerprintTimingManager: audio file not found at $audioFilePath")
+            _stateFlow.value = State.Unavailable
+            return
+        }
+
+        val extractor = MediaExtractor()
+        try {
+            extractor.setDataSource(audioFilePath)
+        } catch (e: Exception) {
+            Timber.w(e, "FingerprintTimingManager: failed to open audio file")
+            _stateFlow.value = State.Failed(e)
+            return
+        }
+
+        // Find audio track
+        val audioTrackIndex = (0 until extractor.trackCount).firstOrNull { i ->
+            extractor.getTrackFormat(i).getString(MediaFormat.KEY_MIME)?.startsWith("audio/") == true
+        }
+        if (audioTrackIndex == null) {
+            extractor.release()
+            _stateFlow.value = State.Unavailable
+            Timber.w("FingerprintTimingManager: no audio track found")
+            return
+        }
+
+        extractor.selectTrack(audioTrackIndex)
+        val format = extractor.getTrackFormat(audioTrackIndex)
+        val sampleRate = format.getInteger(MediaFormat.KEY_SAMPLE_RATE)
+        val channelCount = format.getInteger(MediaFormat.KEY_CHANNEL_COUNT)
+        val mime = format.getString(MediaFormat.KEY_MIME) ?: "audio/mpeg"
+
+        // Seek to start position
+        if (startingAt > 0) {
+            extractor.seekTo((startingAt * 1_000_000).toLong(), MediaExtractor.SEEK_TO_CLOSEST_SYNC)
+        }
+
+        val codec = MediaCodec.createDecoderByType(mime)
+
+        // Request float PCM output. If the codec doesn't support it,
+        // it falls back to 16-bit; we detect the actual format below.
+        format.setInteger(MediaFormat.KEY_PCM_ENCODING, android.media.AudioFormat.ENCODING_PCM_FLOAT)
+        codec.configure(format, null, null, 0)
+        codec.start()
+
+        val streamer = StreamingWindowedFingerprinter(
+            sampleRate.toUInt(),
+            channelCount.toUShort(),
+            FingerprintConstants.WINDOW_DURATION_MS.toUInt(),
+            FingerprintConstants.WINDOW_INTERVAL_MS.toUInt(),
+        )
+
+        try {
+            decodeAndFingerprint(extractor, codec, streamer, matcher, episodeUuid, startingAt, sampleRate, channelCount)
+
+            // Flush remaining windows
+            val tail = streamer.flush()
+            if (tail.isNotEmpty()) {
+                mutex.withLock {
+                    processMatches(tail, matcher, startingAt)
+                }
+            }
+        } finally {
+            streamer.close()
+            codec.stop()
+            codec.release()
+            extractor.release()
+        }
+    }
+
+    private suspend fun decodeAndFingerprint(
+        extractor: MediaExtractor,
+        codec: MediaCodec,
+        streamer: StreamingWindowedFingerprinter,
+        matcher: CheckpointMatcher,
+        episodeUuid: String,
+        startOffset: Double,
+        sampleRate: Int,
+        channelCount: Int,
+    ) {
+        val bufferInfo = MediaCodec.BufferInfo()
+        var inputDone = false
+        val timeoutUs = FingerprintConstants.CODEC_TIMEOUT_US
+        // Default to 16-bit (safest assumption). Updated when the codec
+        // reports its actual format via INFO_OUTPUT_FORMAT_CHANGED.
+        var isOutputFloat = false
+
+        while (true) {
+            currentCoroutineContext().ensureActive()
+
+            // Feed input
+            if (!inputDone) {
+                val inputIndex = codec.dequeueInputBuffer(timeoutUs)
+                if (inputIndex >= 0) {
+                    val inputBuffer = codec.getInputBuffer(inputIndex)!!
+                    val bytesRead = extractor.readSampleData(inputBuffer, 0)
+                    if (bytesRead < 0) {
+                        codec.queueInputBuffer(inputIndex, 0, 0, 0, MediaCodec.BUFFER_FLAG_END_OF_STREAM)
+                        inputDone = true
+                    } else {
+                        codec.queueInputBuffer(inputIndex, 0, bytesRead, extractor.sampleTime, 0)
+                        extractor.advance()
+                    }
+                }
+            }
+
+            // Read decoded output
+            val outputIndex = codec.dequeueOutputBuffer(bufferInfo, timeoutUs)
+            when {
+                outputIndex == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED -> {
+                    val actualFormat = codec.outputFormat
+                    val encoding = if (actualFormat.containsKey(MediaFormat.KEY_PCM_ENCODING)) {
+                        actualFormat.getInteger(MediaFormat.KEY_PCM_ENCODING)
+                    } else {
+                        android.media.AudioFormat.ENCODING_PCM_16BIT
+                    }
+                    isOutputFloat = encoding == android.media.AudioFormat.ENCODING_PCM_FLOAT
+                    Timber.d("FingerprintTimingManager: codec output encoding=${if (isOutputFloat) "float" else "int16"}")
+                }
+
+                outputIndex >= 0 -> {
+                    if (bufferInfo.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM != 0) {
+                        codec.releaseOutputBuffer(outputIndex, false)
+                        break
+                    }
+
+                    val outputBuffer = codec.getOutputBuffer(outputIndex)
+                    if (outputBuffer != null && bufferInfo.size > 0) {
+                        val samples = extractFloatSamples(outputBuffer, bufferInfo, isOutputFloat)
+                        if (samples.isNotEmpty()) {
+                            val windows = streamer.pushSamplesF32(samples, channelCount.toUShort())
+                            if (windows.isNotEmpty()) {
+                                mutex.withLock {
+                                    processMatches(windows, matcher, startOffset)
+                                }
+                            }
+                        }
+
+                        // Throttle if we're far ahead of playback
+                        val decodedSeconds = startOffset + streamer.durationMs().toDouble() / 1000.0
+                        val lastKnownPositionMs = lastProgressPositionMs
+                        if (lastKnownPositionMs >= 0 && decodedSeconds - lastKnownPositionMs / 1000.0 > FingerprintConstants.LOOKAHEAD_SECONDS) {
+                            delay((FingerprintConstants.OUTSIDE_LOOKAHEAD_SLEEP_SECONDS * 1000).toLong())
+                        }
+                    }
+                    codec.releaseOutputBuffer(outputIndex, false)
+                }
+            }
+        }
+    }
+
+    private fun extractFloatSamples(
+        buffer: ByteBuffer,
+        info: MediaCodec.BufferInfo,
+        isFloatPcm: Boolean,
+    ): List<Float> {
+        buffer.position(info.offset)
+        buffer.limit(info.offset + info.size)
+
+        val byteOrder = buffer.order()
+        buffer.order(ByteOrder.nativeOrder())
+
+        return try {
+            if (isFloatPcm) {
+                val floatBuffer = buffer.asFloatBuffer()
+                val floatCount = floatBuffer.remaining()
+                if (floatCount == 0) return emptyList()
+                val result = FloatArray(floatCount)
+                floatBuffer.get(result)
+                result.toList()
+            } else {
+                // 16-bit PCM: convert to normalized float [-1.0, 1.0]
+                val shortBuffer = buffer.asShortBuffer()
+                val shortCount = shortBuffer.remaining()
+                if (shortCount == 0) return emptyList()
+                val result = FloatArray(shortCount)
+                for (i in 0 until shortCount) {
+                    result[i] = shortBuffer.get() / 32768f
+                }
+                result.toList()
+            }
+        } finally {
+            buffer.order(byteOrder)
+        }
+    }
+
+    private fun processMatches(
+        windows: List<WindowedFingerprint>,
+        matcher: CheckpointMatcher,
+        startOffset: Double,
+    ) {
+        var inserted = 0
+
+        for (window in windows) {
+            val matches = matcher.findTopMatches(window.hashes, 2u)
+            val best = matches.firstOrNull() ?: continue
+
+            if (best.score < FingerprintConstants.MATCH_SCORE_THRESHOLD) continue
+
+            val absolutePlaybackTime = startOffset + window.timestampMs.toDouble() / 1000.0
+            val candidate = TimeMappingEntry(
+                playbackTime = absolutePlaybackTime,
+                referenceTime = best.timestamp.toDouble(),
+                score = best.score,
+            )
+
+            if (best.score < FingerprintConstants.DRIFT_ANCHOR_SCORE_THRESHOLD) continue
+
+            val runnerUpScore = matches.getOrNull(1)?.score ?: 0f
+            val dominance = best.score - runnerUpScore
+            if (dominance < FingerprintConstants.DRIFT_SCORE_DOMINANCE_GAP) continue
+
+            inserted += consider(candidate)
+        }
+
+        publishSnapshot()
+        val coverage = mappingPlaybackToReference.size
+        if (coverage >= FingerprintConstants.MINIMUM_COVERAGE_FOR_ACTIVE) {
+            _stateFlow.value = State.Active(coverage)
+            if (!hasReachedActive) {
+                hasReachedActive = true
+                Timber.d("FingerprintTimingManager: reached active state with $coverage mappings")
+            }
+        }
+    }
+
+    private fun persistMappingCacheIfFull() {
+        val audioPath = currentAudioFilePath ?: return
+        if (audioPath.startsWith("http://") || audioPath.startsWith("https://")) return
+        val refPath = currentReferenceFilePath ?: return
+        val refData = currentReferenceData ?: return
+        val refDuration = currentReferenceDuration
+
+        val entries = mappingPlaybackToReference.toList()
+        FingerprintMappingCache.save(entries, audioPath, refPath, refData, refDuration)
+    }
+
+    // endregion
+
+    // region Drift Filter
+
+    internal fun consider(candidate: TimeMappingEntry): Int {
+        val trusted = filterLastTrusted
+        if (trusted != null && isInTrend(candidate, trusted)) {
+            flushPoolAsRejected()
+            insertMapping(candidate)
+            filterLastTrusted = candidate
+            return 1
+        }
+
+        filterCandidatePool.add(candidate)
+        val n = FingerprintConstants.DRIFT_BOOTSTRAP_COUNT
+
+        if (filterCandidatePool.size < n) return 0
+
+        val recent = filterCandidatePool.takeLast(n)
+        if (formsConsistentSequence(recent)) {
+            val keepStart = filterCandidatePool.size - n
+            for (i in 0 until keepStart) {
+                Timber.d("FingerprintTimingManager: drift filter evicted candidate at playback ${filterCandidatePool[i].playbackTime}s")
+            }
+            for (entry in recent) {
+                insertMapping(entry)
+            }
+            filterLastTrusted = recent.last()
+            filterCandidatePool.clear()
+            return n
+        }
+
+        val evicted = filterCandidatePool.removeFirst()
+        Timber.d("FingerprintTimingManager: drift filter evicted candidate at playback ${evicted.playbackTime}s")
+        return 0
+    }
+
+    private fun flushPoolAsRejected() {
+        filterCandidatePool.clear()
+    }
+
+    private fun isInTrend(candidate: TimeMappingEntry, anchor: TimeMappingEntry): Boolean {
+        val deltaPlayback = candidate.playbackTime - anchor.playbackTime
+        val deltaReference = candidate.referenceTime - anchor.referenceTime
+        return abs(deltaReference - deltaPlayback) <= FingerprintConstants.DRIFT_TOLERANCE_SECONDS
+    }
+
+    private fun formsConsistentSequence(entries: List<TimeMappingEntry>): Boolean {
+        if (entries.size < 2) return true
+        for (i in 1 until entries.size) {
+            if (!isInTrend(entries[i], entries[i - 1])) return false
+        }
+        return true
+    }
+
+    // endregion
+
+    // region Time Mapping
+
+    internal fun insertMapping(entry: TimeMappingEntry) {
+        val pbIdx = mappingPlaybackToReference.sortedInsertionIndex { it.playbackTime < entry.playbackTime }
+        mappingPlaybackToReference.add(pbIdx, entry)
+
+        val refIdx = mappingReferenceToPlayback.sortedInsertionIndex { it.referenceTime < entry.referenceTime }
+        mappingReferenceToPlayback.add(refIdx, entry)
+    }
+
+    /** Publish an immutable snapshot of the mapping lists for lock-free reads. */
+    private fun publishSnapshot() {
+        snapshotPlaybackToReference = mappingPlaybackToReference.toList()
+        snapshotReferenceToPlayback = mappingReferenceToPlayback.toList()
+    }
+
+    /** Test seam: insert a mapping directly. Must only be called from single-threaded tests. */
+    @VisibleForTesting
+    fun insert(mapping: TimeMappingEntry) {
+        insertMapping(mapping)
+        publishSnapshot()
+    }
+
+    /** Test seam: route candidates through the drift filter. Must only be called from single-threaded tests. */
+    @VisibleForTesting
+    fun stubMatches(entries: List<TimeMappingEntry>) {
+        for (entry in entries) {
+            consider(entry)
+        }
+        publishSnapshot()
+    }
+
+    // endregion
+
+    // region Interpolation
+
+    companion object {
+        fun interpolate(
+            time: Double,
+            entries: List<TimeMappingEntry>,
+            keySelector: (TimeMappingEntry) -> Double,
+            valueSelector: (TimeMappingEntry) -> Double,
+        ): Double? {
+            if (entries.isEmpty()) return null
+
+            val last = entries.size - 1
+
+            if (time <= keySelector(entries[0])) {
+                val offset = time - keySelector(entries[0])
+                return valueSelector(entries[0]) + offset
+            }
+
+            if (time >= keySelector(entries[last])) {
+                val offset = time - keySelector(entries[last])
+                return valueSelector(entries[last]) + offset
+            }
+
+            var lo = 0
+            var hi = last
+            while (lo < hi - 1) {
+                val mid = (lo + hi) / 2
+                if (keySelector(entries[mid]) <= time) {
+                    lo = mid
+                } else {
+                    hi = mid
+                }
+            }
+
+            val t0 = keySelector(entries[lo])
+            val t1 = keySelector(entries[hi])
+            val v0 = valueSelector(entries[lo])
+            val v1 = valueSelector(entries[hi])
+
+            val fraction = if (t1 > t0) (time - t0) / (t1 - t0) else 0.0
+            return v0 + fraction * (v1 - v0)
+        }
+
+        fun alignToWindowGrid(time: Double): Double {
+            val stride = FingerprintConstants.WINDOW_INTERVAL_MS / 1000.0
+            if (stride <= 0) return max(0.0, time)
+            return max(0.0, floor(time / stride) * stride)
+        }
+    }
+
+    // endregion
+}
+
+private inline fun <T> MutableList<T>.sortedInsertionIndex(crossinline predicate: (T) -> Boolean): Int {
+    var lo = 0
+    var hi = size
+    while (lo < hi) {
+        val mid = (lo + hi) / 2
+        if (predicate(this[mid])) {
+            lo = mid + 1
+        } else {
+            hi = mid
+        }
+    }
+    return lo
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
@@ -680,7 +680,7 @@ class FingerprintTimingManager @Inject constructor(
             return n
         }
 
-        val evicted = filterCandidatePool.removeFirst()
+        val evicted = filterCandidatePool.removeAt(0)
         Timber.d("FingerprintTimingManager: drift filter evicted candidate at playback ${evicted.playbackTime}s")
         return 0
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
@@ -451,32 +451,34 @@ class FingerprintTimingManager @Inject constructor(
         }
 
         val codec = MediaCodec.createDecoderByType(mime)
-
-        // Request float PCM output. If the codec doesn't support it,
-        // it falls back to 16-bit; we detect the actual format below.
-        format.setInteger(MediaFormat.KEY_PCM_ENCODING, android.media.AudioFormat.ENCODING_PCM_FLOAT)
-        codec.configure(format, null, null, 0)
-        codec.start()
-
-        val streamer = StreamingWindowedFingerprinter(
-            sampleRate.toUInt(),
-            channelCount.toUShort(),
-            FingerprintConstants.WINDOW_DURATION_MS.toUInt(),
-            FingerprintConstants.WINDOW_INTERVAL_MS.toUInt(),
-        )
-
         try {
-            decodeAndFingerprint(extractor, codec, streamer, matcher, episodeUuid, startingAt, sampleRate, channelCount)
+            // Request float PCM output. If the codec doesn't support it,
+            // it falls back to 16-bit; we detect the actual format below.
+            format.setInteger(MediaFormat.KEY_PCM_ENCODING, android.media.AudioFormat.ENCODING_PCM_FLOAT)
+            codec.configure(format, null, null, 0)
+            codec.start()
 
-            // Flush remaining windows
-            val tail = streamer.flush()
-            if (tail.isNotEmpty()) {
-                mutex.withLock {
-                    processMatches(tail, matcher, startingAt)
+            val streamer = StreamingWindowedFingerprinter(
+                sampleRate.toUInt(),
+                channelCount.toUShort(),
+                FingerprintConstants.WINDOW_DURATION_MS.toUInt(),
+                FingerprintConstants.WINDOW_INTERVAL_MS.toUInt(),
+            )
+
+            try {
+                decodeAndFingerprint(extractor, codec, streamer, matcher, episodeUuid, startingAt, sampleRate, channelCount)
+
+                // Flush remaining windows
+                val tail = streamer.flush()
+                if (tail.isNotEmpty()) {
+                    mutex.withLock {
+                        processMatches(tail, matcher, startingAt)
+                    }
                 }
+            } finally {
+                streamer.close()
             }
         } finally {
-            streamer.close()
             codec.stop()
             codec.release()
             extractor.release()
@@ -602,8 +604,6 @@ class FingerprintTimingManager @Inject constructor(
         matcher: CheckpointMatcher,
         startOffset: Double,
     ) {
-        var inserted = 0
-
         for (window in windows) {
             val matches = matcher.findTopMatches(window.hashes, 2u)
             val best = matches.firstOrNull() ?: continue
@@ -623,7 +623,7 @@ class FingerprintTimingManager @Inject constructor(
             val dominance = best.score - runnerUpScore
             if (dominance < FingerprintConstants.DRIFT_SCORE_DOMINANCE_GAP) continue
 
-            inserted += consider(candidate)
+            consider(candidate)
         }
 
         publishSnapshot()
@@ -644,7 +644,7 @@ class FingerprintTimingManager @Inject constructor(
         val refData = currentReferenceData ?: return
         val refDuration = currentReferenceDuration
 
-        val entries = mappingPlaybackToReference.toList()
+        val entries = snapshotPlaybackToReference
         FingerprintMappingCache.save(entries, audioPath, refPath, refData, refDuration)
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
@@ -41,7 +41,6 @@ class FingerprintTimingManager @Inject constructor(
     private val playbackManager: PlaybackManager,
     private val referenceRetriever: FingerprintReferenceRetriever,
 ) {
-    // region Public Types
 
     sealed interface State {
         data object Idle : State
@@ -57,17 +56,9 @@ class FingerprintTimingManager @Inject constructor(
         val score: Float = 0f,
     )
 
-    // endregion
-
-    // region Public State
-
     private val _stateFlow = MutableStateFlow<State>(State.Idle)
     val stateFlow: StateFlow<State> = _stateFlow.asStateFlow()
     val state: State get() = _stateFlow.value
-
-    // endregion
-
-    // region Private State
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     private val mutex = Mutex()
@@ -103,9 +94,23 @@ class FingerprintTimingManager @Inject constructor(
     private var currentMatcher: CheckpointMatcher? = null
     private var hasReachedActive = false
 
-    // endregion
+    init {
+        observePlaybackForProactivePreparation()
+    }
 
-    // region Public API
+    private fun observePlaybackForProactivePreparation() {
+        scope.launch {
+            var lastEpisodeUuid: String? = null
+            playbackManager.playbackStateFlow.collect { state ->
+                if (!FeatureFlag.isEnabled(Feature.SYNCED_TRANSCRIPTS)) return@collect
+                val uuid = state.episodeUuid
+                if (state.isPlaying && !uuid.isNullOrEmpty() && uuid != lastEpisodeUuid) {
+                    lastEpisodeUuid = uuid
+                    prepareForCurrentEpisode()
+                }
+            }
+        }
+    }
 
     fun prepareForCurrentEpisode() {
         val episode = playbackManager.getCurrentEpisode() ?: run {
@@ -175,10 +180,6 @@ class FingerprintTimingManager @Inject constructor(
         return (result * 1000).toInt()
     }
 
-    // endregion
-
-    // region State Management
-
     private fun resetState() {
         generationJob?.cancel()
         generationJob = null
@@ -199,10 +200,6 @@ class FingerprintTimingManager @Inject constructor(
         currentMatcher = null
         hasReachedActive = false
     }
-
-    // endregion
-
-    // region Preparation
 
     private suspend fun prepareForEpisode(
         episodeUuid: String,
@@ -328,10 +325,6 @@ class FingerprintTimingManager @Inject constructor(
         startStream(audioFilePath, matcher, episodeUuid, startPosition = currentTime)
     }
 
-    // endregion
-
-    // region Playback Progress Handling
-
     private fun onPlaybackProgress(positionMs: Int, episodeUuid: String?) {
         if (episodeUuid != currentEpisodeUuid) return
 
@@ -382,10 +375,6 @@ class FingerprintTimingManager @Inject constructor(
         return playbackTimeSec >= first.playbackTime - margin &&
             playbackTimeSec <= last.playbackTime + margin
     }
-
-    // endregion
-
-    // region Streaming Fingerprint Generation
 
     private fun startStream(audioFilePath: String, matcher: CheckpointMatcher, episodeUuid: String, startPosition: Double) {
         generationJob?.cancel()
@@ -648,10 +637,6 @@ class FingerprintTimingManager @Inject constructor(
         FingerprintMappingCache.save(entries, audioPath, refPath, refData, refDuration)
     }
 
-    // endregion
-
-    // region Drift Filter
-
     internal fun consider(candidate: TimeMappingEntry): Int {
         val trusted = filterLastTrusted
         if (trusted != null && isInTrend(candidate, trusted)) {
@@ -703,10 +688,6 @@ class FingerprintTimingManager @Inject constructor(
         return true
     }
 
-    // endregion
-
-    // region Time Mapping
-
     internal fun insertMapping(entry: TimeMappingEntry) {
         val pbIdx = mappingPlaybackToReference.sortedInsertionIndex { it.playbackTime < entry.playbackTime }
         mappingPlaybackToReference.add(pbIdx, entry)
@@ -736,10 +717,6 @@ class FingerprintTimingManager @Inject constructor(
         }
         publishSnapshot()
     }
-
-    // endregion
-
-    // region Interpolation
 
     companion object {
         fun interpolate(
@@ -788,8 +765,6 @@ class FingerprintTimingManager @Inject constructor(
             return max(0.0, floor(time / stride) * stride)
         }
     }
-
-    // endregion
 }
 
 private inline fun <T> MutableList<T>.sortedInsertionIndex(crossinline predicate: (T) -> Boolean): Int {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
@@ -128,10 +128,9 @@ class FingerprintTimingManager @Inject constructor(
             }
             // Abort if a newer stop()/prepare() has started since we acquired the lock.
             if (gen != generation) return@launch
+            startPlaybackProgressObserver(episodeUuid)
             prepareForEpisode(episodeUuid, podcastUuid, audioSource, episode.isDownloaded, episode.duration)
         }
-
-        startPlaybackProgressObserver(episodeUuid)
     }
 
     private fun startPlaybackProgressObserver(episodeUuid: String) {
@@ -423,6 +422,7 @@ class FingerprintTimingManager @Inject constructor(
         try {
             extractor.setDataSource(audioFilePath)
         } catch (e: Exception) {
+            extractor.release()
             Timber.w(e, "FingerprintTimingManager: failed to open audio file")
             _stateFlow.value = State.Failed(e)
             return
@@ -479,7 +479,7 @@ class FingerprintTimingManager @Inject constructor(
                 streamer.close()
             }
         } finally {
-            codec.stop()
+            runCatching { codec.stop() }
             codec.release()
             extractor.release()
         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
@@ -16,13 +16,11 @@ import javax.inject.Singleton
 import kotlin.math.abs
 import kotlin.math.floor
 import kotlin.math.max
-import kotlin.math.min
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
@@ -30,7 +28,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -88,8 +85,9 @@ class FingerprintTimingManager @Inject constructor(
 
     private var lastProgressPositionMs = -1
     private var generationJob: Job? = null
-    private var preparationJob: Job? = null
     private var progressObserverJob: Job? = null
+
+    @Volatile
     private var generation = 0L
 
     // Drift filter state
@@ -185,8 +183,6 @@ class FingerprintTimingManager @Inject constructor(
     private fun resetState() {
         generationJob?.cancel()
         generationJob = null
-        preparationJob?.cancel()
-        preparationJob = null
         progressObserverJob?.cancel()
         progressObserverJob = null
         mappingPlaybackToReference.clear()
@@ -538,10 +534,7 @@ class FingerprintTimingManager @Inject constructor(
                 }
 
                 outputIndex >= 0 -> {
-                    if (bufferInfo.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM != 0) {
-                        codec.releaseOutputBuffer(outputIndex, false)
-                        break
-                    }
+                    val isEos = bufferInfo.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM != 0
 
                     val outputBuffer = codec.getOutputBuffer(outputIndex)
                     if (outputBuffer != null && bufferInfo.size > 0) {
@@ -563,6 +556,7 @@ class FingerprintTimingManager @Inject constructor(
                         }
                     }
                     codec.releaseOutputBuffer(outputIndex, false)
+                    if (isEos) break
                 }
             }
         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/ReferenceFingerprint.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/ReferenceFingerprint.kt
@@ -1,0 +1,84 @@
+package au.com.shiftyjelly.pocketcasts.repositories.fingerprint
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import com.squareup.moshi.Moshi
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.util.Base64
+import timber.log.Timber
+
+@JsonClass(generateAdapter = true)
+data class ReferenceFingerprint(
+    val format: String,
+    @Json(name = "total_duration") val totalDuration: Double,
+    @Json(name = "checkpoint_interval") val checkpointInterval: Int,
+    @Json(name = "checkpoint_duration") val checkpointDuration: Int,
+    @Json(name = "timestamp_quantum") val timestampQuantum: Int,
+    val checkpoints: List<List<Any>>,
+) {
+    data class LibraryCheckpoint(
+        val timestampSeconds: Float,
+        val hashes: IntArray,
+    ) {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is LibraryCheckpoint) return false
+            return timestampSeconds == other.timestampSeconds && hashes.contentEquals(other.hashes)
+        }
+
+        override fun hashCode(): Int {
+            return 31 * timestampSeconds.hashCode() + hashes.contentHashCode()
+        }
+    }
+
+    val checkpointDurationSeconds: Float get() = checkpointDuration.toFloat()
+
+    fun libraryCheckpoints(): List<LibraryCheckpoint> {
+        var accumulated = 0
+        return checkpoints.mapNotNull { checkpoint ->
+            if (checkpoint.size < 2) return@mapNotNull null
+            val delta = (checkpoint[0] as? Number)?.toInt() ?: return@mapNotNull null
+            val data = checkpoint[1] as? String ?: return@mapNotNull null
+
+            accumulated += delta
+
+            val payload = try {
+                Base64.getDecoder().decode(data)
+            } catch (e: IllegalArgumentException) {
+                return@mapNotNull null
+            }
+            if (payload.size % 4 != 0) return@mapNotNull null
+
+            val count = payload.size / 4
+            val buffer = ByteBuffer.wrap(payload).order(ByteOrder.LITTLE_ENDIAN)
+            val hashes = IntArray(count) { buffer.getInt() }
+
+            val timestamp = accumulated.toFloat() * timestampQuantum.toFloat()
+            LibraryCheckpoint(timestampSeconds = timestamp, hashes = hashes)
+        }
+    }
+
+    companion object {
+        const val SUPPORTED_FORMAT = "fingerprint-compact-v2"
+
+        private val moshi = Moshi.Builder().build()
+        private val adapter = moshi.adapter(ReferenceFingerprint::class.java)
+
+        fun decode(data: ByteArray): ReferenceFingerprint? {
+            return try {
+                val fingerprint = adapter.fromJson(String(data)) ?: return null
+
+                if (fingerprint.format != SUPPORTED_FORMAT) {
+                    Timber.w("ReferenceFingerprint: unknown format '${fingerprint.format}', expected '$SUPPORTED_FORMAT'")
+                    return null
+                }
+
+                fingerprint
+            } catch (e: Exception) {
+                Timber.w(e, "ReferenceFingerprint: failed to decode JSON")
+                null
+            }
+        }
+    }
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/ReferenceFingerprint.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/ReferenceFingerprint.kt
@@ -2,10 +2,10 @@ package au.com.shiftyjelly.pocketcasts.repositories.fingerprint
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
-import kotlin.io.encoding.Base64
 import com.squareup.moshi.Moshi
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
+import kotlin.io.encoding.Base64
 import timber.log.Timber
 
 @JsonClass(generateAdapter = true)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/ReferenceFingerprint.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/ReferenceFingerprint.kt
@@ -1,8 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.repositories.fingerprint
 
-import android.util.Base64
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import kotlin.io.encoding.Base64
 import com.squareup.moshi.Moshi
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
@@ -44,7 +44,7 @@ data class ReferenceFingerprint(
             accumulated += delta
 
             val payload = try {
-                Base64.decode(data, Base64.DEFAULT)
+                Base64.Default.decode(data)
             } catch (e: IllegalArgumentException) {
                 return@mapNotNull null
             }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/ReferenceFingerprint.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/ReferenceFingerprint.kt
@@ -1,11 +1,11 @@
 package au.com.shiftyjelly.pocketcasts.repositories.fingerprint
 
+import android.util.Base64
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import com.squareup.moshi.Moshi
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
-import java.util.Base64
 import timber.log.Timber
 
 @JsonClass(generateAdapter = true)
@@ -44,7 +44,7 @@ data class ReferenceFingerprint(
             accumulated += delta
 
             val payload = try {
-                Base64.getDecoder().decode(data)
+                Base64.decode(data, Base64.DEFAULT)
             } catch (e: IllegalArgumentException) {
                 return@mapNotNull null
             }
@@ -67,7 +67,7 @@ data class ReferenceFingerprint(
 
         fun decode(data: ByteArray): ReferenceFingerprint? {
             return try {
-                val fingerprint = adapter.fromJson(String(data)) ?: return null
+                val fingerprint = adapter.fromJson(String(data, Charsets.UTF_8)) ?: return null
 
                 if (fingerprint.format != SUPPORTED_FORMAT) {
                     Timber.w("ReferenceFingerprint: unknown format '${fingerprint.format}', expected '$SUPPORTED_FORMAT'")

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/DriftFilterTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/DriftFilterTest.kt
@@ -2,12 +2,15 @@ package au.com.shiftyjelly.pocketcasts.repositories.fingerprint
 
 import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.FingerprintTimingManager.TimeMappingEntry
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
+import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito.mock
+import org.mockito.kotlin.whenever
 
 class DriftFilterTest {
 
@@ -15,8 +18,10 @@ class DriftFilterTest {
 
     @Before
     fun setUp() {
+        val playbackManager = mock(PlaybackManager::class.java)
+        whenever(playbackManager.playbackStateFlow).thenReturn(MutableStateFlow(PlaybackState()))
         manager = FingerprintTimingManager(
-            playbackManager = mock(PlaybackManager::class.java),
+            playbackManager = playbackManager,
             referenceRetriever = mock(FingerprintReferenceRetriever::class.java),
         )
     }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/DriftFilterTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/DriftFilterTest.kt
@@ -1,0 +1,102 @@
+package au.com.shiftyjelly.pocketcasts.repositories.fingerprint
+
+import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.FingerprintTimingManager.TimeMappingEntry
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mock
+
+class DriftFilterTest {
+
+    private lateinit var manager: FingerprintTimingManager
+
+    @Before
+    fun setUp() {
+        manager = FingerprintTimingManager(
+            playbackManager = mock(PlaybackManager::class.java),
+            referenceRetriever = mock(FingerprintReferenceRetriever::class.java),
+        )
+    }
+
+    @Test
+    fun `insert maintains sorted order by playback time`() {
+        manager.insert(TimeMappingEntry(playbackTime = 10.0, referenceTime = 10.0))
+        manager.insert(TimeMappingEntry(playbackTime = 5.0, referenceTime = 5.0))
+        manager.insert(TimeMappingEntry(playbackTime = 15.0, referenceTime = 15.0))
+
+        assertEquals(10.0, manager.referenceTime(forPlaybackTimeMs = 10_000)!!, 0.001)
+        assertEquals(5.0, manager.referenceTime(forPlaybackTimeMs = 5_000)!!, 0.001)
+        assertEquals(15.0, manager.referenceTime(forPlaybackTimeMs = 15_000)!!, 0.001)
+    }
+
+    @Test
+    fun `insert maintains sorted order by reference time for reverse lookup`() {
+        manager.insert(TimeMappingEntry(playbackTime = 10.0, referenceTime = 20.0))
+        manager.insert(TimeMappingEntry(playbackTime = 5.0, referenceTime = 10.0))
+        manager.insert(TimeMappingEntry(playbackTime = 15.0, referenceTime = 30.0))
+
+        assertEquals(10_000, manager.playbackTimeMs(forReferenceTime = 20.0)!!)
+        assertEquals(5_000, manager.playbackTimeMs(forReferenceTime = 10.0)!!)
+        assertEquals(15_000, manager.playbackTimeMs(forReferenceTime = 30.0)!!)
+    }
+
+    @Test
+    fun `referenceTime returns null with no mappings`() {
+        assertNull(manager.referenceTime(forPlaybackTimeMs = 5_000))
+    }
+
+    @Test
+    fun `playbackTimeMs returns null with no mappings`() {
+        assertNull(manager.playbackTimeMs(forReferenceTime = 5.0))
+    }
+
+    @Test
+    fun `consider accepts consistent sequence after bootstrap count`() {
+        val entries = listOf(
+            TimeMappingEntry(playbackTime = 10.0, referenceTime = 10.0, score = 0.9f),
+            TimeMappingEntry(playbackTime = 12.0, referenceTime = 12.0, score = 0.9f),
+            TimeMappingEntry(playbackTime = 14.0, referenceTime = 14.0, score = 0.9f),
+        )
+        manager.stubMatches(entries)
+
+        assertNotNull(manager.referenceTime(forPlaybackTimeMs = 10_000))
+        assertNotNull(manager.referenceTime(forPlaybackTimeMs = 12_000))
+        assertNotNull(manager.referenceTime(forPlaybackTimeMs = 14_000))
+    }
+
+    @Test
+    fun `consider rejects inconsistent candidates`() {
+        val inserted1 = manager.consider(
+            TimeMappingEntry(playbackTime = 10.0, referenceTime = 10.0, score = 0.9f),
+        )
+        assertEquals(0, inserted1)
+
+        val inserted2 = manager.consider(
+            TimeMappingEntry(playbackTime = 12.0, referenceTime = 100.0, score = 0.9f),
+        )
+        assertEquals(0, inserted2)
+
+        val inserted3 = manager.consider(
+            TimeMappingEntry(playbackTime = 14.0, referenceTime = 102.0, score = 0.9f),
+        )
+        assertEquals(0, inserted3)
+    }
+
+    @Test
+    fun `consider fast-paths entries consistent with trusted anchor`() {
+        val bootstrap = listOf(
+            TimeMappingEntry(playbackTime = 10.0, referenceTime = 10.0, score = 0.9f),
+            TimeMappingEntry(playbackTime = 12.0, referenceTime = 12.0, score = 0.9f),
+            TimeMappingEntry(playbackTime = 14.0, referenceTime = 14.0, score = 0.9f),
+        )
+        manager.stubMatches(bootstrap)
+
+        val inserted = manager.consider(
+            TimeMappingEntry(playbackTime = 16.0, referenceTime = 16.0, score = 0.9f),
+        )
+        assertEquals(1, inserted)
+    }
+}

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManagerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManagerTest.kt
@@ -1,0 +1,124 @@
+package au.com.shiftyjelly.pocketcasts.repositories.fingerprint
+
+import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.FingerprintTimingManager.TimeMappingEntry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class FingerprintTimingManagerTest {
+
+    @Test
+    fun `interpolate returns null for empty list`() {
+        val result = FingerprintTimingManager.interpolate(
+            time = 5.0,
+            entries = emptyList(),
+            keySelector = { it.playbackTime },
+            valueSelector = { it.referenceTime },
+        )
+        assertNull(result)
+    }
+
+    @Test
+    fun `interpolate extrapolates before first entry`() {
+        val entries = listOf(
+            TimeMappingEntry(playbackTime = 10.0, referenceTime = 20.0),
+        )
+        val result = FingerprintTimingManager.interpolate(
+            time = 5.0,
+            entries = entries,
+            keySelector = { it.playbackTime },
+            valueSelector = { it.referenceTime },
+        )
+        assertEquals(15.0, result!!, 0.001)
+    }
+
+    @Test
+    fun `interpolate extrapolates after last entry`() {
+        val entries = listOf(
+            TimeMappingEntry(playbackTime = 10.0, referenceTime = 20.0),
+        )
+        val result = FingerprintTimingManager.interpolate(
+            time = 15.0,
+            entries = entries,
+            keySelector = { it.playbackTime },
+            valueSelector = { it.referenceTime },
+        )
+        assertEquals(25.0, result!!, 0.001)
+    }
+
+    @Test
+    fun `interpolate returns exact value at entry`() {
+        val entries = listOf(
+            TimeMappingEntry(playbackTime = 10.0, referenceTime = 20.0),
+            TimeMappingEntry(playbackTime = 20.0, referenceTime = 40.0),
+        )
+        val result = FingerprintTimingManager.interpolate(
+            time = 10.0,
+            entries = entries,
+            keySelector = { it.playbackTime },
+            valueSelector = { it.referenceTime },
+        )
+        assertEquals(20.0, result!!, 0.001)
+    }
+
+    @Test
+    fun `interpolate linearly between two entries`() {
+        val entries = listOf(
+            TimeMappingEntry(playbackTime = 10.0, referenceTime = 20.0),
+            TimeMappingEntry(playbackTime = 20.0, referenceTime = 40.0),
+        )
+        val result = FingerprintTimingManager.interpolate(
+            time = 15.0,
+            entries = entries,
+            keySelector = { it.playbackTime },
+            valueSelector = { it.referenceTime },
+        )
+        assertEquals(30.0, result!!, 0.001)
+    }
+
+    @Test
+    fun `interpolate handles single entry`() {
+        val entries = listOf(
+            TimeMappingEntry(playbackTime = 10.0, referenceTime = 20.0),
+        )
+        val result = FingerprintTimingManager.interpolate(
+            time = 10.0,
+            entries = entries,
+            keySelector = { it.playbackTime },
+            valueSelector = { it.referenceTime },
+        )
+        assertEquals(20.0, result!!, 0.001)
+    }
+
+    @Test
+    fun `interpolate uses binary search for many entries`() {
+        val entries = (0..100).map {
+            TimeMappingEntry(playbackTime = it.toDouble(), referenceTime = it * 2.0)
+        }
+        val result = FingerprintTimingManager.interpolate(
+            time = 50.5,
+            entries = entries,
+            keySelector = { it.playbackTime },
+            valueSelector = { it.referenceTime },
+        )
+        assertEquals(101.0, result!!, 0.001)
+    }
+
+    @Test
+    fun `alignToWindowGrid aligns to stride boundary`() {
+        val aligned = FingerprintTimingManager.alignToWindowGrid(5.7)
+        assertEquals(4.0, aligned, 0.001)
+    }
+
+    @Test
+    fun `alignToWindowGrid clamps negative to zero`() {
+        val aligned = FingerprintTimingManager.alignToWindowGrid(-1.0)
+        assertEquals(0.0, aligned, 0.001)
+    }
+
+    @Test
+    fun `alignToWindowGrid zero stays zero`() {
+        val aligned = FingerprintTimingManager.alignToWindowGrid(0.0)
+        assertEquals(0.0, aligned, 0.001)
+    }
+}

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/ReferenceFingerprintTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/ReferenceFingerprintTest.kt
@@ -1,0 +1,120 @@
+package au.com.shiftyjelly.pocketcasts.repositories.fingerprint
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ReferenceFingerprintTest {
+
+    @Test
+    fun `decode returns null for invalid JSON`() {
+        val result = ReferenceFingerprint.decode("not json".toByteArray())
+        assertNull(result)
+    }
+
+    @Test
+    fun `decode returns null for empty data`() {
+        val result = ReferenceFingerprint.decode(ByteArray(0))
+        assertNull(result)
+    }
+
+    @Test
+    fun `decode returns null for unsupported format`() {
+        val json = """
+            {
+                "format": "unsupported-format",
+                "total_duration": 100.0,
+                "checkpoint_interval": 10,
+                "checkpoint_duration": 8,
+                "timestamp_quantum": 1,
+                "checkpoints": []
+            }
+        """.trimIndent()
+        val result = ReferenceFingerprint.decode(json.toByteArray())
+        assertNull(result)
+    }
+
+    @Test
+    fun `decode returns fingerprint for valid JSON`() {
+        val json = """
+            {
+                "format": "fingerprint-compact-v2",
+                "total_duration": 100.0,
+                "checkpoint_interval": 10,
+                "checkpoint_duration": 8,
+                "timestamp_quantum": 1,
+                "checkpoints": []
+            }
+        """.trimIndent()
+        val result = ReferenceFingerprint.decode(json.toByteArray())
+        assertNotNull(result)
+        assertEquals("fingerprint-compact-v2", result!!.format)
+        assertEquals(100.0, result.totalDuration, 0.001)
+        assertEquals(10, result.checkpointInterval)
+        assertEquals(8, result.checkpointDuration)
+        assertEquals(1, result.timestampQuantum)
+    }
+
+    @Test
+    fun `libraryCheckpoints returns empty for no checkpoints`() {
+        val fp = ReferenceFingerprint(
+            format = "fingerprint-compact-v2",
+            totalDuration = 100.0,
+            checkpointInterval = 10,
+            checkpointDuration = 8,
+            timestampQuantum = 1,
+            checkpoints = emptyList(),
+        )
+        assertEquals(emptyList<ReferenceFingerprint.LibraryCheckpoint>(), fp.libraryCheckpoints())
+    }
+
+    @Test
+    fun `libraryCheckpoints skips malformed entries`() {
+        val fp = ReferenceFingerprint(
+            format = "fingerprint-compact-v2",
+            totalDuration = 100.0,
+            checkpointInterval = 10,
+            checkpointDuration = 8,
+            timestampQuantum = 1,
+            checkpoints = listOf(
+                listOf<Any>(),
+                listOf<Any>(1.0),
+                listOf<Any>("not a number", "AQIDBA=="),
+            ),
+        )
+        assertEquals(0, fp.libraryCheckpoints().size)
+    }
+
+    @Test
+    fun `libraryCheckpoints accumulates timestamps correctly`() {
+        val fp = ReferenceFingerprint(
+            format = "fingerprint-compact-v2",
+            totalDuration = 100.0,
+            checkpointInterval = 10,
+            checkpointDuration = 8,
+            timestampQuantum = 2,
+            checkpoints = listOf(
+                listOf<Any>(5.0, "AQIDBA=="),
+                listOf<Any>(3.0, "BQYHCA=="),
+            ),
+        )
+        val checkpoints = fp.libraryCheckpoints()
+        assertEquals(2, checkpoints.size)
+        assertEquals(10.0f, checkpoints[0].timestampSeconds)
+        assertEquals(16.0f, checkpoints[1].timestampSeconds)
+    }
+
+    @Test
+    fun `checkpointDurationSeconds converts int to float`() {
+        val fp = ReferenceFingerprint(
+            format = "fingerprint-compact-v2",
+            totalDuration = 100.0,
+            checkpointInterval = 10,
+            checkpointDuration = 8,
+            timestampQuantum = 1,
+            checkpoints = emptyList(),
+        )
+        assertEquals(8.0f, fp.checkpointDurationSeconds)
+    }
+}

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/history/upnext/UpNextHistoryManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/history/upnext/UpNextHistoryManagerImplTest.kt
@@ -4,15 +4,13 @@ import au.com.shiftyjelly.pocketcasts.models.db.dao.UpNextHistoryDao
 import java.time.Duration
 import java.time.Instant
 import java.util.Date
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 
-@ExperimentalCoroutinesApi
 class UpNextHistoryManagerImplTest {
     private lateinit var upNextHistoryDao: UpNextHistoryDao
     private lateinit var upNextHistoryManager: UpNextHistoryManagerImpl
@@ -25,7 +23,7 @@ class UpNextHistoryManagerImplTest {
     }
 
     @Test
-    fun `snapshot up next - insertion and deletion dates are correct`() = runTest {
+    fun `snapshot up next - insertion and deletion dates are correct`() = runBlocking {
         val now = Instant.now()
         val expectedDate = Date.from(now)
         val expectedDeletionDate = Date.from(now.minus(periodOfSnapshot))


### PR DESCRIPTION
## Description
This PR is part of the Radical Speed Month initiative.
Implements the audio fingerprinting pipeline that powers synced transcripts. The core component is
`FingerprintTimingManager`, a `@Singleton` orchestrator that:                                                                                                                                                         - Fetches gzip-compressed reference fingerprints from S3 (via `FingerprintReferenceRetriever`)
- Decodes episode audio using `MediaExtractor`/`MediaCodec` and generates streaming fingerprints via the UniFFI native library                                                                                                                                                                                          
- Matches local fingerprints against the reference using a `CheckpointMatcher`                                                                                                                                                                                                                                        
- Filters matches through a drift-tolerant algorithm that rejects outliers                                                                                                                                                                                                                                              
- Maintains bidirectional time mapping (playback time <-> reference time) with linear interpolation                                                                                                                                                                                                                     
- Caches completed mappings to disk (via `FingerprintMappingCache` with SHA-256 validation) to avoid recomputation                                                                                                                                                                                                      
The manager exposes a `StateFlow` (Idle/Preparing/Active/Failed/Unavailable) and two public query methods: `referenceTime(forPlaybackTimeMs)` and `playbackTimeMs(forReferenceTime)`.                                                                                                                                   
Gated behind the `SYNCED_TRANSCRIPTS` feature flag.

## Testing Instructions
Review the code please, the next PR will connect the dots, making the entire flow testable

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
