### PR TITLE
[RSM] Send JWT bearer token with episode chat requests

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/chat/ChatManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/chat/ChatManagerImpl.kt
@@ -8,6 +8,7 @@ import au.com.shiftyjelly.pocketcasts.servers.podcast.ConversationMessage
 import au.com.shiftyjelly.pocketcasts.servers.podcast.EpisodeChatQuote
 import au.com.shiftyjelly.pocketcasts.servers.podcast.EpisodeChatRequest
 import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServiceManager
+import au.com.shiftyjelly.pocketcasts.servers.sync.TokenHandler
 import com.squareup.moshi.Moshi
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -20,6 +21,7 @@ class ChatManagerImpl @Inject constructor(
     private val episodeChatDao: EpisodeChatDao,
     private val transcriptDao: TranscriptDao,
     private val podcastCacheServiceManager: PodcastCacheServiceManager,
+    private val tokenHandler: TokenHandler,
     moshi: Moshi,
 ) : ChatManager {
     private val quoteMetadataAdapter = moshi.adapter(QuoteMetadata::class.java)
@@ -62,7 +64,13 @@ class ChatManagerImpl @Inject constructor(
             conversationHistory = history,
         )
 
-        val response = podcastCacheServiceManager.episodeChat(request)
+        val accessToken = checkNotNull(tokenHandler.getAccessToken()) {
+            "Access token is required to send episode chat messages"
+        }
+        val response = podcastCacheServiceManager.episodeChat(
+            authorization = "Bearer ${accessToken.value}",
+            request = request,
+        )
 
         val aiReply = ChatMessage.Assistant(text = response.reply)
         episodeChatDao.insertMessage(aiReply.toEntity(episodeUuid, quoteMetadataAdapter))

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/chat/ChatManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/chat/ChatManagerImplTest.kt
@@ -5,11 +5,13 @@ import au.com.shiftyjelly.pocketcasts.models.db.dao.TranscriptDao
 import au.com.shiftyjelly.pocketcasts.models.entity.EpisodeChat
 import au.com.shiftyjelly.pocketcasts.models.entity.EpisodeChatMessage
 import au.com.shiftyjelly.pocketcasts.models.entity.Transcript
+import au.com.shiftyjelly.pocketcasts.preferences.AccessToken
 import au.com.shiftyjelly.pocketcasts.servers.podcast.ConversationMessage
 import au.com.shiftyjelly.pocketcasts.servers.podcast.EpisodeChatQuote
 import au.com.shiftyjelly.pocketcasts.servers.podcast.EpisodeChatRequest
 import au.com.shiftyjelly.pocketcasts.servers.podcast.EpisodeChatResponse
 import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServiceManager
+import au.com.shiftyjelly.pocketcasts.servers.sync.TokenHandler
 import com.squareup.moshi.Moshi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -31,10 +33,12 @@ class ChatManagerImplTest {
         on { observeTranscripts(any()) } doReturn transcripts
     }
     private val podcastCacheServiceManager = mock<PodcastCacheServiceManager>()
+    private val tokenHandler = TestTokenHandler()
     private val manager = ChatManagerImpl(
         episodeChatDao = episodeChatDao,
         transcriptDao = transcriptDao,
         podcastCacheServiceManager = podcastCacheServiceManager,
+        tokenHandler = tokenHandler,
         moshi = Moshi.Builder().build(),
     )
 
@@ -66,7 +70,7 @@ class ChatManagerImplTest {
             createTranscript(type = "text/vtt", isGenerated = true, url = "generated-url"),
             createTranscript(type = "application/json", isGenerated = false, url = "author-url"),
         )
-        whenever(podcastCacheServiceManager.episodeChat(any())).thenReturn(
+        whenever(podcastCacheServiceManager.episodeChat(any(), any())).thenReturn(
             EpisodeChatResponse(
                 reply = "Assistant reply",
                 quote = EpisodeChatQuote(
@@ -89,7 +93,9 @@ class ChatManagerImplTest {
         )
 
         val requestCaptor = argumentCaptor<EpisodeChatRequest>()
-        verify(podcastCacheServiceManager).episodeChat(requestCaptor.capture())
+        val authorizationCaptor = argumentCaptor<String>()
+        verify(podcastCacheServiceManager).episodeChat(authorizationCaptor.capture(), requestCaptor.capture())
+        assertEquals("Bearer access-token", authorizationCaptor.firstValue)
         assertEquals(
             EpisodeChatRequest(
                 transcriptUrl = "author-url",
@@ -120,7 +126,9 @@ class ChatManagerImplTest {
     @Test
     fun `send retry skips storing user message`() = runTest {
         transcripts.value = listOf(createTranscript())
-        whenever(podcastCacheServiceManager.episodeChat(any())).thenReturn(EpisodeChatResponse(reply = "Assistant reply", quote = null))
+        whenever(podcastCacheServiceManager.episodeChat(any(), any())).thenReturn(
+            EpisodeChatResponse(reply = "Assistant reply", quote = null),
+        )
 
         manager.sendMessage(
             episodeUuid = EPISODE_UUID,
@@ -168,7 +176,7 @@ class ChatManagerImplTest {
     @Test
     fun `blank quote text is ignored`() = runTest {
         transcripts.value = listOf(createTranscript())
-        whenever(podcastCacheServiceManager.episodeChat(any())).thenReturn(
+        whenever(podcastCacheServiceManager.episodeChat(any(), any())).thenReturn(
             EpisodeChatResponse(
                 reply = "Assistant reply",
                 quote = EpisodeChatQuote(text = " ", start = "00:01", end = "00:03"),
@@ -187,6 +195,12 @@ class ChatManagerImplTest {
     }
 
     private fun quoteAdapter() = Moshi.Builder().build().adapter(QuoteMetadata::class.java)
+
+    private class TestTokenHandler : TokenHandler {
+        override suspend fun getAccessToken() = AccessToken("access-token")
+
+        override fun invalidateAccessToken() = Unit
+    }
 
     private class TestEpisodeChatDao : EpisodeChatDao() {
         val chats = mutableListOf<EpisodeChat>()

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheService.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheService.kt
@@ -127,6 +127,9 @@ interface PodcastCacheService {
         @Body request: CombinedSearchRequest,
     ): CombinedSearchResponse
 
-    @POST("/mobile/episode/chat")
-    suspend fun episodeChat(@Body request: EpisodeChatRequest): EpisodeChatResponse
+    @POST("mobile/episode/chat")
+    suspend fun episodeChat(
+        @Header("Authorization") authorization: String,
+        @Body request: EpisodeChatRequest,
+    ): EpisodeChatResponse
 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheService.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheService.kt
@@ -12,6 +12,7 @@ import okhttp3.ResponseBody
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.Header
 import retrofit2.http.Headers
 import retrofit2.http.POST
 import retrofit2.http.Path

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServiceManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServiceManager.kt
@@ -20,5 +20,5 @@ interface PodcastCacheServiceManager {
     suspend fun getShowNotesCache(podcastUuid: String): ShowNotesResponse?
     suspend fun getEpisodeUrl(episode: PodcastEpisode): String?
     suspend fun suggestedFolders(request: SuggestedFoldersRequest): List<SuggestedFolder>
-    suspend fun episodeChat(request: EpisodeChatRequest): EpisodeChatResponse
+    suspend fun episodeChat(authorization: String, request: EpisodeChatRequest): EpisodeChatResponse
 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServiceManagerImpl.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServiceManagerImpl.kt
@@ -88,8 +88,11 @@ class PodcastCacheServiceManagerImpl @Inject constructor(
         return service.suggestedFolders(request).toSuggestedFolders()
     }
 
-    override suspend fun episodeChat(request: EpisodeChatRequest): EpisodeChatResponse {
-        return service.episodeChat(request)
+    override suspend fun episodeChat(authorization: String, request: EpisodeChatRequest): EpisodeChatResponse {
+        return service.episodeChat(
+            authorization = authorization,
+            request = request,
+        )
     }
 
     private fun Map<String, List<String>>.toSuggestedFolders(): List<SuggestedFolder> {


### PR DESCRIPTION
## Description
Send the current JWT access token as a Bearer Authorization header when submitting episode chat requests. The episode chat endpoint now receives the header through the podcast cache service and manager layers, so authenticated chat requests can be accepted by the backend.

Fixes # N/A

## Testing Instructions
1. Sign in to an account that can access episode chat.
2. Open an episode with chat available.
3. Send a chat message.
4. Confirm the request succeeds and the assistant response is shown.
5. Confirm the `mobile/episode/chat` request includes an `Authorization: Bearer ...` header.

## Screenshots or Screencast 
Not applicable. This PR changes request authentication only.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack