### PR TITLE
Fix AAOS double playback caused by re-entrant loadCurrentEpisode

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -227,6 +227,17 @@ open class PlaybackManager @Inject constructor(
     @Volatile
     private var lastPrefetchedEpisodeUuid: String? = null
 
+    // PCDROID-569: Re-entrancy guard for [loadCurrentEpisode]. Set to the in-progress
+    // episode UUID; concurrent calls for the same UUID are skipped. AAOS dispatches both
+    // `Media3SessionCallback.onAddMediaItems → playNowSuspend` and
+    // `Player.play → playQueueSuspend` for a single user gesture, and without this guard
+    // both paths reach `resetPlayer()` and create separate ExoPlayer instances. The first
+    // is orphaned, keeps playing, and keeps holding audio focus — the "phantom" stream
+    // users hear mixed in after they leave the app.
+    @Volatile
+    private var loadingEpisodeUuid: String? = null
+    private val loadCurrentEpisodeGuardMutex = Mutex()
+
     private val resumptionHelper = ResumptionHelper(settings)
 
     private val errorClassifier = PlaybackErrorClassifier()
@@ -1572,7 +1583,8 @@ open class PlaybackManager @Inject constructor(
             nextEpisode = autoLoadEpisode(autoPlay)
             if (nextEpisode == null) {
                 lastTrackedAutoPlaySource = null
-                stop()
+                // PCDROID-569: shutdown() already calls stop() — calling both produced
+                // duplicate "Stopping playback" log lines at episode hand-off.
                 shutdown()
             }
         } else {
@@ -1886,6 +1898,42 @@ open class PlaybackManager @Inject constructor(
             return
         }
 
+        // PCDROID-569: Skip if a concurrent call is already loading the same episode.
+        // The mutex guards the read-modify-write so two concurrent callers can't both
+        // observe a null `loadingEpisodeUuid` and both proceed. The heavy work below
+        // intentionally runs outside the mutex so loads for *different* episodes are
+        // not serialised against each other.
+        val acquiredLoad = loadCurrentEpisodeGuardMutex.withLock {
+            if (loadingEpisodeUuid == episode.uuid) {
+                false
+            } else {
+                loadingEpisodeUuid = episode.uuid
+                true
+            }
+        }
+        if (!acquiredLoad) {
+            LogBuffer.i(LogBuffer.TAG_PLAYBACK, "loadCurrentEpisode skipped — already loading ${episode.uuid}")
+            return
+        }
+
+        try {
+            loadCurrentEpisodeInternal(episode, play, showedStreamWarning, forceStream, sourceView)
+        } finally {
+            loadCurrentEpisodeGuardMutex.withLock {
+                if (loadingEpisodeUuid == episode.uuid) {
+                    loadingEpisodeUuid = null
+                }
+            }
+        }
+    }
+
+    private suspend fun loadCurrentEpisodeInternal(
+        episode: BaseEpisode,
+        play: Boolean,
+        showedStreamWarning: Boolean,
+        forceStream: Boolean,
+        sourceView: SourceView,
+    ) {
         val podcast = findPodcastByEpisode(episode)
 
         cancelPauseTimer()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -236,6 +236,13 @@ open class PlaybackManager @Inject constructor(
     // users hear mixed in after they leave the app.
     @Volatile
     private var loadingEpisodeUuid: String? = null
+
+    // Tracks the `play` intent of the in-flight load. A concurrent caller that
+    // arrives with `play=true` while the in-flight load is `play=false` upgrades
+    // this flag, and the in-flight call honours it once the load finishes — so a
+    // user-initiated play is never silently dropped by the re-entrancy guard.
+    @Volatile
+    private var loadingEpisodePlay: Boolean? = null
     private val loadCurrentEpisodeGuardMutex = Mutex()
 
     private val resumptionHelper = ResumptionHelper(settings)
@@ -1903,11 +1910,21 @@ open class PlaybackManager @Inject constructor(
         // observe a null `loadingEpisodeUuid` and both proceed. The heavy work below
         // intentionally runs outside the mutex so loads for *different* episodes are
         // not serialised against each other.
+        //
+        // If a skipped call requested `play=true` while the in-flight load was
+        // `play=false`, upgrade `loadingEpisodePlay` so the in-flight call starts
+        // playback once it finishes — otherwise the user-initiated play would be
+        // silently dropped (e.g. an internal `play=false` reload racing with an
+        // AAOS `play=true` for the same episode).
         val acquiredLoad = loadCurrentEpisodeGuardMutex.withLock {
             if (loadingEpisodeUuid == episode.uuid) {
+                if (play && loadingEpisodePlay == false) {
+                    loadingEpisodePlay = true
+                }
                 false
             } else {
                 loadingEpisodeUuid = episode.uuid
+                loadingEpisodePlay = play
                 true
             }
         }
@@ -1918,10 +1935,18 @@ open class PlaybackManager @Inject constructor(
 
         try {
             loadCurrentEpisodeInternal(episode, play, showedStreamWarning, forceStream, sourceView)
+            val upgradedToPlay = loadCurrentEpisodeGuardMutex.withLock {
+                !play && loadingEpisodePlay == true
+            }
+            if (upgradedToPlay) {
+                LogBuffer.i(LogBuffer.TAG_PLAYBACK, "loadCurrentEpisode play upgraded by concurrent caller — starting playback for ${episode.uuid}")
+                play(sourceView)
+            }
         } finally {
             loadCurrentEpisodeGuardMutex.withLock {
                 if (loadingEpisodeUuid == episode.uuid) {
                     loadingEpisodeUuid = null
+                    loadingEpisodePlay = null
                 }
             }
         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -213,6 +213,8 @@ open class PlaybackManager @Inject constructor(
     val playbackStateFlow: Flow<PlaybackState> = playbackStateRelay.asFlow()
 
     private var updateCount = 0
+
+    @Volatile
     private var resettingPlayer = false
     private var episodeLastBufferStatus: EpisodeBufferStatus? = null
     private var focusWasPlaying: Date? = null

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -113,6 +113,7 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -1935,18 +1936,26 @@ open class PlaybackManager @Inject constructor(
 
         try {
             loadCurrentEpisodeInternal(episode, play, showedStreamWarning, forceStream, sourceView)
+            // Both fields must be read under the same lock and gated on the UUID still
+            // matching — otherwise a different-UUID load that overwrote `loadingEpisodePlay`
+            // could be misread here as an upgrade for *this* episode.
             val upgradedToPlay = loadCurrentEpisodeGuardMutex.withLock {
-                !play && loadingEpisodePlay == true
+                !play && loadingEpisodeUuid == episode.uuid && loadingEpisodePlay == true
             }
             if (upgradedToPlay) {
                 LogBuffer.i(LogBuffer.TAG_PLAYBACK, "loadCurrentEpisode play upgraded by concurrent caller — starting playback for ${episode.uuid}")
                 play(sourceView)
             }
         } finally {
-            loadCurrentEpisodeGuardMutex.withLock {
-                if (loadingEpisodeUuid == episode.uuid) {
-                    loadingEpisodeUuid = null
-                    loadingEpisodePlay = null
+            // Cleanup must run even if this coroutine is cancelled while acquiring the
+            // mutex — otherwise the guard fields stay set and every future load for this
+            // UUID gets skipped forever.
+            withContext(NonCancellable) {
+                loadCurrentEpisodeGuardMutex.withLock {
+                    if (loadingEpisodeUuid == episode.uuid) {
+                        loadingEpisodeUuid = null
+                        loadingEpisodePlay = null
+                    }
                 }
             }
         }


### PR DESCRIPTION
## References

Fixes [PCDROID-569](https://linear.app/a8c/issue/PCDROID-569/aaos-pocket-casts-plays-two-simultaneous-audio-streams-and-retains).

Reported via Zendesk ticket [11240696](https://a8c.zendesk.com/agent/tickets/11240696) on a Volvo head unit running AAOS / Android 13, build `TAG2.241130.001.ARTINFO.TAB.0-9033-gf2cb292fa9`.

## What it does

Adds a re-entrancy guard to `PlaybackManager.loadCurrentEpisode` so a single AAOS user gesture cannot spin up two `SimplePlayer` (ExoPlayer) instances and leave one running as an unkillable "phantom" stream.

## Changes

- `PlaybackManager.loadCurrentEpisode`: after resolving the target episode, atomically test-and-set `loadingEpisodeUuid` under `loadCurrentEpisodeGuardMutex`. Concurrent calls for the same UUID log `loadCurrentEpisode skipped — already loading <uuid>` and return early. The heavy work runs **outside** the mutex so legitimate concurrent loads for *different* episodes still proceed.
- Extracted the long body into `loadCurrentEpisodeInternal(...)` so the guard wrapper stays readable.
- `PlaybackManager.onCompletion`: collapsed `stop(); shutdown()` to just `shutdown()`. `shutdown()` already calls `stop()`, so the bare call was producing the duplicate `Stopping playback` log entries visible in the same user's traces at episode hand-off.

### Root cause (short version)

On AAOS, a single "play this episode" gesture drives two playback chains against the session:

1. `Media3SessionCallback.onAddMediaItems` resolves the item and directly calls `playbackManager.playNowSuspend(...)` → `loadCurrentEpisode` → `resetPlayer()` → new ExoPlayer.
2. Media3 then continues the standard controller flow: `setMediaItem` → `prepare` → `Player.play()`. `PocketCastsForwardingPlayer.play` routes through `onPlay`, wired in `MediaSessionManager.createSession` to `playbackManager.playQueueSuspend(MEDIA_BUTTON_BROADCAST_ACTION)` → another `loadCurrentEpisode` → another `resetPlayer()`.

`resetPlayer` has an internal `resettingPlayer` flag but it is a plain (non-`@Volatile`, unsynchronised) `Boolean`; two coroutines on different dispatchers can both pass the check. The result is two `SimplePlayer` instances; the second assignment overwrites the `player` field but leaves the first ExoPlayer playing and holding audio focus. That orphan cannot be paused from the Pocket Casts UI (`pause()` acts only on `PlaybackManager.player`), and it keeps mixing in over Spotify/radio after the user leaves the app, until a process kill or head-unit reset. Logs show the two start chains 100–300 ms apart, with the second focus request reporting `We already had audio focus`.

The proper fix would untangle the two chains in `Media3SessionCallback.onAddMediaItems` (so it no longer starts playback itself, leaving that to `Player.play() → onPlay`). That is a larger refactor; this PR is the smaller-blast-radius hotfix that prevents `resetPlayer` from being entered twice, matching the lower-risk option requested for this triage.

## Checklist

- [x] I have reviewed my own changes
- [x] This PR adds fewer than 500 lines of code

## Testing

### How to test

#### Automated

- `./gradlew :modules:services:repositories:testDebugUnitTest`
- [ ] Verify existing `PlaybackManager`-touching tests still pass (no `PlaybackManagerTest` exists today, so this is a regression check only).

#### Manual — AAOS (primary target)

- Install the `automotive` build (`./gradlew :automotive:installDebug`) on an AAOS emulator or vehicle.
- Open Pocket Casts, browse to any podcast, and tap an episode to play.
- [ ] Verify only **one** audio stream is heard.
- [ ] Verify the playback log shows exactly one `Opening episode`, one `Trying to gain audio focus` + `Audio focus gained`, and one `Play <position> System Player` per user-initiated play. If the duplicate path is exercised you will see a single new line `loadCurrentEpisode skipped — already loading <uuid>` between them.
- Press Pause from the Pocket Casts UI.
- [ ] Verify audio stops completely (no second stream continues).
- Switch to Spotify (or the radio) and start playback there.
- [ ] Verify Pocket Casts releases audio focus cleanly — no Pocket Casts audio mixes in.
- Play a short episode through to its end, letting it transition to the next queued episode.
- [ ] Verify only one `Stopping playback` log line per episode hand-off (was previously two).
- [ ] Verify the next episode starts cleanly with a single `Opening episode` / `Play` pair.

#### Manual — mobile regression

- Run the mobile `debug` variant.
- Play, pause, skip, and queue several episodes; reload an episode that's currently playing.
- [ ] Verify single-stream playback behaves exactly as before — the guard only prevents *concurrent* duplicate loads of the same UUID; sequential loads (the normal path) are unaffected.
- Connect Bluetooth headphones with multi-tap (e.g. Pixel Buds), trigger double-tap (skip forward) and triple-tap (skip back).
- [ ] Verify multi-tap headphone controls still resolve as expected.

---
*Cherry-picked from #5319*