### PR TITLE
Fix Automotive double tap playing twice

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3SessionCallback.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3SessionCallback.kt
@@ -157,7 +157,7 @@ internal class Media3SessionCallback(
                     if (playbackManager.getCurrentEpisode()?.uuid == episode.uuid) {
                         playbackManager.playQueueSuspend(sourceView = source)
                     } else {
-                        playbackManager.playNowSuspend(episode = episode, sourceView = source)
+                        playbackManager.playNowSync(episode = episode, sourceView = source)
                     }
                 } catch (e: Exception) {
                     Timber.e(e, "Play from media ID failed")

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3SessionCallback.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3SessionCallback.kt
@@ -154,7 +154,11 @@ internal class Media3SessionCallback(
                     val resolvedItem = buildEpisodeMediaItem(episode, podcast, mediaId)
                     future.set(listOf(resolvedItem))
 
-                    playbackManager.playNowSuspend(episode = episode, sourceView = source)
+                    if (playbackManager.getCurrentEpisode()?.uuid == episode.uuid) {
+                        playbackManager.playQueueSuspend(sourceView = source)
+                    } else {
+                        playbackManager.playNowSuspend(episode = episode, sourceView = source)
+                    }
                 } catch (e: Exception) {
                     Timber.e(e, "Play from media ID failed")
                     future.set(emptyList())

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3SessionCallbackTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3SessionCallbackTest.kt
@@ -10,7 +10,6 @@ import androidx.media3.session.MediaSession
 import androidx.media3.session.SessionCommand
 import androidx.media3.session.SessionError
 import androidx.media3.session.SessionResult
-import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -521,7 +520,7 @@ class Media3SessionCallbackTest {
             sourceView = any(),
             showedStreamWarning = eq(false),
         )
-        verify(playbackManager, never()).playNowSuspend(
+        verify(playbackManager, never()).playNowSync(
             episode = any(),
             forceStream = any(),
             showedStreamWarning = any(),

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3SessionCallbackTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3SessionCallbackTest.kt
@@ -439,7 +439,7 @@ class Media3SessionCallbackTest {
     // --- onAddMediaItems resolved item tests ---
 
     @Test
-    fun `onAddMediaItems with valid mediaId returns resolved MediaItem and fires playNowSuspend`() = runTest {
+    fun `onAddMediaItems with valid mediaId returns resolved MediaItem and fires playNowSync`() = runTest {
         val episode = PodcastEpisode(
             uuid = "ep-uuid-1",
             title = "My Episode",
@@ -471,7 +471,7 @@ class Media3SessionCallbackTest {
         assertNotNull(resolved.mediaMetadata.artworkUri)
         assertTrue(resolved.mediaMetadata.isPlayable!!)
 
-        verify(playbackManager).playNowSuspend(
+        verify(playbackManager).playNowSync(
             episode = any(),
             forceStream = any(),
             showedStreamWarning = any(),
@@ -551,7 +551,7 @@ class Media3SessionCallbackTest {
         assertEquals("My Upload", resolved.mediaMetadata.title)
         assertTrue(resolved.mediaMetadata.isPlayable!!)
 
-        verify(playbackManager).playNowSuspend(
+        verify(playbackManager).playNowSync(
             episode = any(),
             forceStream = any(),
             showedStreamWarning = any(),

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3SessionCallbackTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3SessionCallbackTest.kt
@@ -34,6 +34,7 @@ import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
@@ -492,6 +493,40 @@ class Media3SessionCallbackTest {
 
         val result = future.get()
         assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `onAddMediaItems with current episode resumes queue instead of forcing player switch`() = runTest {
+        val episode = PodcastEpisode(
+            uuid = "ep-uuid-1",
+            title = "My Episode",
+            duration = 3600.0,
+            publishedDate = Date(),
+            podcastUuid = "pod-uuid-1",
+        )
+        whenever(episodeManager.findEpisodeByUuid("ep-uuid-1")).thenReturn(episode)
+        whenever(playbackManager.getCurrentEpisode()).thenReturn(episode)
+
+        val mediaItem = MediaItem.Builder()
+            .setMediaId("pod-uuid-1#ep-uuid-1")
+            .build()
+
+        val future = callback.onAddMediaItems(mockSession, mockController, listOf(mediaItem))
+        testScope.advanceUntilIdle()
+
+        val result = future.get()
+        assertEquals(1, result.size)
+
+        verify(playbackManager).playQueueSuspend(
+            sourceView = any(),
+            showedStreamWarning = eq(false),
+        )
+        verify(playbackManager, never()).playNowSuspend(
+            episode = any(),
+            forceStream = any(),
+            showedStreamWarning = any(),
+            sourceView = any(),
+        )
     }
 
     @Test


### PR DESCRIPTION
## Description

In the Automotive OS app, double tapping an episode row can cause two episodes to start playing at the same time. We could add locking around parts of the playback code, but given we want to ship this for review today, that felt a little risky.

Instead, this change checks what is currently loaded in the player and calls a method that does not reset the player state, which appears to resolve the issue.

Fixes [PCDROID-569](https://linear.app/a8c/issue/PCDROID-569/aaos-pocket-casts-plays-two-simultaneous-audio-streams-and-retains)

## Testing Instructions

1. Install the `Automotive` build.
2. Open a podcast.
3. Double tap the episode row to start playback.
4. Tap pause.
5. ✅ Verify playback stops. 
6. Tap a *different* episode row
7.  ✅ Verify playback starts. 

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack