### PR TITLE
Episode summaries tweaks

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -684,7 +684,7 @@ class EpisodeFragment : BaseFragment() {
                                 )
                                 Text(
                                     text = stringResource(LR.string.ask_this_episode),
-                                    color = MaterialTheme.theme.colors.primaryText02,
+                                    color = MaterialTheme.theme.colors.primaryText01,
                                     fontSize = 16.sp,
                                 )
                             }
@@ -739,6 +739,7 @@ class EpisodeFragment : BaseFragment() {
                             ButtonTabs(
                                 tabs = tabs,
                                 selectedTab = selectedButtonTab,
+                                backgroundColor = MaterialTheme.theme.colors.primaryUi01,
                                 modifier = Modifier
                                     .fillMaxWidth()
                                     .padding(top = 4.dp),

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -298,9 +298,7 @@ class EpisodeFragment : BaseFragment() {
                         text = "$dateText \u00B7 $durationText",
                         color = MaterialTheme.theme.colors.primaryText02,
                         fontSize = 14.sp,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(top = 12.dp),
+                        modifier = Modifier.fillMaxWidth(),
                         textAlign = TextAlign.Center,
                     )
                 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -674,18 +674,20 @@ class EpisodeFragment : BaseFragment() {
                                         openChat(t.episodeUuid, t.podcastUuid, isPlusUser)
                                     }
                                     .fillMaxWidth()
-                                    .padding(horizontal = 16.dp, vertical = 14.dp),
+                                    .padding(horizontal = 14.dp, vertical = 12.dp),
                             ) {
                                 Image(
                                     painter = painterResource(IR.drawable.ic_ai),
                                     contentDescription = null,
-                                    colorFilter = ColorFilter.tint(MaterialTheme.theme.colors.primaryIcon03),
+                                    colorFilter = ColorFilter.tint(MaterialTheme.theme.colors.primaryIcon02),
                                     modifier = Modifier.size(18.dp),
                                 )
                                 Text(
                                     text = stringResource(LR.string.ask_this_episode),
-                                    color = MaterialTheme.theme.colors.primaryText01,
-                                    fontSize = 16.sp,
+                                    color = MaterialTheme.theme.colors.primaryText02,
+                                    fontSize = 15.sp,
+                                    fontWeight = FontWeight(500),
+                                    letterSpacing = 0.5.sp,
                                 )
                             }
                         }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -746,11 +746,7 @@ class EpisodeFragment : BaseFragment() {
                         }
 
                         // Inline summary content
-                        AnimatedVisibility(
-                            visible = selectedTab == EpisodeFragmentViewModel.EpisodeContentTab.SUMMARY && summaryText != null,
-                            enter = BannerEnterTransition,
-                            exit = BannerExitTransition,
-                        ) {
+                        if (selectedTab == EpisodeFragmentViewModel.EpisodeContentTab.SUMMARY && summaryText != null) {
                             Column(
                                 modifier = Modifier
                                     .fillMaxWidth()
@@ -765,7 +761,7 @@ class EpisodeFragment : BaseFragment() {
                                 )
                                 HtmlText(
                                     html = markdownToHtml(summaryText.orEmpty()),
-                                    color = MaterialTheme.theme.colors.primaryText02,
+                                    color = MaterialTheme.theme.colors.primaryText01,
                                     textStyleResId = UR.style.P40,
                                 )
                             }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -647,8 +647,9 @@ class EpisodeFragment : BaseFragment() {
                     // AI-enhanced layout: "Ask this episode" + simple tabs + inline summary
                     Column(modifier = Modifier.fillMaxWidth()) {
                         // "Ask this episode" input-style banner
+                        val askTheEpisodeVisible = FeatureFlag.isEnabled(Feature.EPISODE_CHAT) && transcript != null
                         AnimatedVisibility(
-                            visible = FeatureFlag.isEnabled(Feature.EPISODE_CHAT) && transcript != null,
+                            visible = askTheEpisodeVisible,
                             enter = BannerEnterTransition,
                             exit = BannerExitTransition,
                         ) {
@@ -744,7 +745,7 @@ class EpisodeFragment : BaseFragment() {
                                 backgroundColor = MaterialTheme.theme.colors.primaryUi01,
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .padding(top = 4.dp),
+                                    .padding(top = if (askTheEpisodeVisible) 4.dp else 16.dp),
                             )
                         }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -289,10 +289,11 @@ class EpisodeFragment : BaseFragment() {
         binding?.loadingGroup?.isInvisible = true
 
         binding?.episodeDateDuration?.setContentWithViewCompositionStrategy {
-            val info = viewModel.dateDurationInfo.collectAsState().value
-            if (info != null) {
-                val dateText = info.publishedDate?.let { DateUtil.toLocalizedFormatLongStyle(it) }.orEmpty()
-                val durationText = TimeHelper.getTimeDurationShortString(info.durationMs, context)
+            val pageState = viewModel.pageState.collectAsState().value
+            val durationMs = pageState.episodeDurationMs
+            if (durationMs != null) {
+                val dateText = pageState.episodePublishedDate?.let { DateUtil.toLocalizedFormatLongStyle(it) }.orEmpty()
+                val durationText = TimeHelper.getTimeDurationShortString(durationMs, context)
                 AppTheme(activeTheme) {
                     Text(
                         text = "$dateText \u00B7 $durationText",
@@ -340,7 +341,6 @@ class EpisodeFragment : BaseFragment() {
                         binding.lblDate.isVisible = !isAiEnabled
                         binding.lblTimeLeft.isVisible = !isAiEnabled
                         binding.episodeDateDuration.isVisible = isAiEnabled
-                        viewModel.updateDateDuration(state.episode.publishedDate, state.episode.durationMs.toLong())
 
                         binding.btnDownload.tintColor = iconColor
                         binding.btnAddEpisode.tintColor = iconColor
@@ -630,11 +630,12 @@ class EpisodeFragment : BaseFragment() {
         binding?.btnArchive?.setup(ToggleActionButton.State.On(LR.string.podcasts_unarchive, IR.drawable.ic_unarchive), ToggleActionButton.State.Off(LR.string.podcasts_archive, IR.drawable.ic_archive), false)
 
         binding?.episodeContentTabs?.setContentWithViewCompositionStrategy {
-            val summaryText = viewModel.summary.collectAsState().value
-            val transcript = viewModel.transcript.collectAsState().value as? Transcript.Text
+            val pageState = viewModel.pageState.collectAsState().value
+            val summaryText = pageState.summary
+            val transcript = pageState.transcript as? Transcript.Text
             val isSummaryEnabled = FeatureFlag.isEnabledFlow(Feature.AI_SUMMARIES).collectAsState().value
-            val isPlusUser = viewModel.isPlusUser.collectAsState().value
-            val selectedTab = viewModel.selectedContentTab.collectAsState().value
+            val isPlusUser = pageState.isPlusUser
+            val selectedTab = pageState.selectedContentTab
 
             val showDescription = !isSummaryEnabled || selectedTab == EpisodeFragmentViewModel.EpisodeContentTab.DESCRIPTION
             LaunchedEffect(showDescription) {
@@ -916,7 +917,7 @@ class EpisodeFragment : BaseFragment() {
 
                         override fun onPageFinished(view: WebView, url: String) {
                             binding?.webViewLoader?.hide()
-                            if (viewModel.selectedContentTab.value == EpisodeFragmentViewModel.EpisodeContentTab.DESCRIPTION) {
+                            if (viewModel.pageState.value.selectedContentTab == EpisodeFragmentViewModel.EpisodeContentTab.DESCRIPTION) {
                                 binding?.webViewShowNotes?.run {
                                     visibility = View.VISIBLE
                                 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
@@ -196,10 +196,19 @@ class EpisodeFragmentViewModel @Inject constructor(
                     episode = it.episode
                     podcast = it.podcast
                     _pageState.update { state ->
-                        state.copy(
-                            episodePublishedDate = it.episode.publishedDate,
-                            episodeDurationMs = it.episode.durationMs.toLong(),
-                        )
+                        val episodePublishedDate = it.episode.publishedDate
+                        val episodeDurationMs = it.episode.durationMs.toLong()
+                        if (
+                            state.episodePublishedDate == episodePublishedDate &&
+                            state.episodeDurationMs == episodeDurationMs
+                        ) {
+                            state
+                        } else {
+                            state.copy(
+                                episodePublishedDate = episodePublishedDate,
+                                episodeDurationMs = episodeDurationMs,
+                            )
+                        }
                     }
                 }
             }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
@@ -56,6 +56,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.rx2.asFlowable
@@ -95,40 +96,37 @@ class EpisodeFragmentViewModel @Inject constructor(
     private var autoDispatchPlay = false
 
     private var loadTranscriptJob: Job? = null
-    private val _transcript = MutableStateFlow<Transcript?>(null)
-    val transcript = _transcript.asStateFlow()
+    private var loadSummaryJob: Job? = null
+    private var lastSummaryEpisodeUuid: String? = null
 
-    private val _isPlusUser = MutableStateFlow(false)
-    val isPlusUser = _isPlusUser.asStateFlow()
+    enum class EpisodeContentTab { DESCRIPTION, SUMMARY }
+
+    data class EpisodePageState(
+        val transcript: Transcript? = null,
+        val isPlusUser: Boolean = false,
+        val summary: String? = null,
+        val selectedContentTab: EpisodeContentTab = EpisodeContentTab.DESCRIPTION,
+        val episodePublishedDate: Date? = null,
+        val episodeDurationMs: Long? = null,
+    )
+
+    private val _pageState = MutableStateFlow(EpisodePageState())
+    val pageState = _pageState.asStateFlow()
 
     init {
         viewModelScope.launch {
             userManager.getSignInState().asFlow().collect { signInState ->
-                _isPlusUser.value = signInState.isSignedInAsPlusOrPatron
+                _pageState.update { state ->
+                    state.copy(isPlusUser = signInState.isSignedInAsPlusOrPatron)
+                }
             }
         }
     }
 
-    private var loadSummaryJob: Job? = null
-    private var lastSummaryEpisodeUuid: String? = null
-    private val _summary = MutableStateFlow<String?>(null)
-    val summary = _summary.asStateFlow()
-
-    enum class EpisodeContentTab { DESCRIPTION, SUMMARY }
-
-    private val _selectedContentTab = MutableStateFlow(EpisodeContentTab.DESCRIPTION)
-    val selectedContentTab = _selectedContentTab.asStateFlow()
-
     fun selectContentTab(tab: EpisodeContentTab) {
-        _selectedContentTab.value = tab
-    }
-
-    data class DateDurationInfo(val publishedDate: java.util.Date?, val durationMs: Long)
-    private val _dateDurationInfo = MutableStateFlow<DateDurationInfo?>(null)
-    val dateDurationInfo = _dateDurationInfo.asStateFlow()
-
-    fun updateDateDuration(publishedDate: java.util.Date?, durationMs: Long) {
-        _dateDurationInfo.value = DateDurationInfo(publishedDate, durationMs)
+        _pageState.update { state ->
+            state.copy(selectedContentTab = tab)
+        }
     }
 
     fun setup(
@@ -197,6 +195,12 @@ class EpisodeFragmentViewModel @Inject constructor(
                     }
                     episode = it.episode
                     podcast = it.podcast
+                    _pageState.update { state ->
+                        state.copy(
+                            episodePublishedDate = it.episode.publishedDate,
+                            episodeDurationMs = it.episode.durationMs.toLong(),
+                        )
+                    }
                 }
             }
             .onErrorReturn { EpisodeFragmentState.Error(it) }
@@ -214,27 +218,36 @@ class EpisodeFragmentViewModel @Inject constructor(
             }
             .distinctUntilChanged()
 
-        if (transcript.value?.episodeUuid != episodeUuid) {
+        if (pageState.value.transcript?.episodeUuid != episodeUuid) {
             val oldJob = loadTranscriptJob
             loadTranscriptJob = launch {
                 oldJob?.cancelAndJoin()
-                _transcript.value = transcriptManager.loadTranscript(episodeUuid)
+                val transcript = transcriptManager.loadTranscript(episodeUuid)
+                _pageState.update { state ->
+                    state.copy(transcript = transcript)
+                }
             }
         }
 
         if (FeatureFlag.isEnabled(Feature.AI_SUMMARIES) && lastSummaryEpisodeUuid != episodeUuid) {
-            _summary.value = null
+            _pageState.update { state ->
+                state.copy(summary = null)
+            }
             val oldSummaryJob = loadSummaryJob
             loadSummaryJob = launch {
                 oldSummaryJob?.cancelAndJoin()
                 val result = transcriptManager.loadSummaryText(episodeUuid)
-                _summary.value = result
+                _pageState.update { state ->
+                    state.copy(summary = result)
+                }
                 if (result != null) {
                     lastSummaryEpisodeUuid = episodeUuid
                 }
             }
         } else if (!FeatureFlag.isEnabled(Feature.AI_SUMMARIES)) {
-            _summary.value = null
+            _pageState.update { state ->
+                state.copy(summary = null)
+            }
         }
     }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
@@ -108,7 +108,32 @@ class EpisodeFragmentViewModel @Inject constructor(
         val selectedContentTab: EpisodeContentTab = EpisodeContentTab.DESCRIPTION,
         val episodePublishedDate: Date? = null,
         val episodeDurationMs: Long? = null,
-    )
+    ) {
+        internal fun selectContentTab(tab: EpisodeContentTab): EpisodePageState {
+            val contentTab = when (tab) {
+                EpisodeContentTab.DESCRIPTION -> EpisodeContentTab.DESCRIPTION
+
+                EpisodeContentTab.SUMMARY -> if (summary == null) {
+                    EpisodeContentTab.DESCRIPTION
+                } else {
+                    EpisodeContentTab.SUMMARY
+                }
+            }
+            return copy(selectedContentTab = contentTab)
+        }
+
+        internal fun withSummary(summary: String?): EpisodePageState {
+            val contentTab = if (summary == null && selectedContentTab == EpisodeContentTab.SUMMARY) {
+                EpisodeContentTab.DESCRIPTION
+            } else {
+                selectedContentTab
+            }
+            return copy(
+                summary = summary,
+                selectedContentTab = contentTab,
+            )
+        }
+    }
 
     private val _pageState = MutableStateFlow(EpisodePageState())
     val pageState = _pageState.asStateFlow()
@@ -125,7 +150,7 @@ class EpisodeFragmentViewModel @Inject constructor(
 
     fun selectContentTab(tab: EpisodeContentTab) {
         _pageState.update { state ->
-            state.copy(selectedContentTab = tab)
+            state.selectContentTab(tab)
         }
     }
 
@@ -240,14 +265,14 @@ class EpisodeFragmentViewModel @Inject constructor(
 
         if (FeatureFlag.isEnabled(Feature.AI_SUMMARIES) && lastSummaryEpisodeUuid != episodeUuid) {
             _pageState.update { state ->
-                state.copy(summary = null)
+                state.withSummary(null)
             }
             val oldSummaryJob = loadSummaryJob
             loadSummaryJob = launch {
                 oldSummaryJob?.cancelAndJoin()
                 val result = transcriptManager.loadSummaryText(episodeUuid)
                 _pageState.update { state ->
-                    state.copy(summary = result)
+                    state.withSummary(result)
                 }
                 if (result != null) {
                     lastSummaryEpisodeUuid = episodeUuid
@@ -255,7 +280,7 @@ class EpisodeFragmentViewModel @Inject constructor(
             }
         } else if (!FeatureFlag.isEnabled(Feature.AI_SUMMARIES)) {
             _pageState.update { state ->
-                state.copy(summary = null)
+                state.withSummary(null)
             }
         }
     }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/adapter/TabsViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/adapter/TabsViewHolder.kt
@@ -1,15 +1,12 @@
 package au.com.shiftyjelly.pocketcasts.podcasts.view.podcast.adapter
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material.MaterialTheme
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
 import androidx.recyclerview.widget.RecyclerView
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.buttons.ButtonTab
 import au.com.shiftyjelly.pocketcasts.compose.buttons.ButtonTabs
-import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.podcasts.view.podcast.PodcastAdapter.TabsHeader
 import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.PodcastViewModel
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
@@ -31,10 +28,7 @@ class TabsViewHolder(
                 ButtonTabs(
                     tabs = tabs,
                     selectedTab = tabs[tabsHeader.selectedTab.ordinal],
-                    modifier = Modifier
-                        .background(color = MaterialTheme.theme.colors.primaryUi02)
-                        .fillMaxWidth(),
-
+                    modifier = Modifier.fillMaxWidth(),
                 )
             }
         }

--- a/modules/features/podcasts/src/main/res/layout/fragment_episode.xml
+++ b/modules/features/podcasts/src/main/res/layout/fragment_episode.xml
@@ -44,22 +44,37 @@
                 android:layout_height="192dp" />
         </androidx.cardview.widget.CardView>
 
+        <View
+            android:id="@+id/episodeDateDurationPadding"
+            android:layout_width="match_parent"
+            android:layout_height="16dp"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/episodeArt" />
+
         <androidx.compose.ui.platform.ComposeView
             android:id="@+id/episodeDateDuration"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:visibility="gone"
+            android:layout_marginTop="16dp"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintRight_toRightOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/episodeArt"
             tools:visibility="gone" />
+
+        <androidx.constraintlayout.widget.Barrier
+            android:id="@+id/episodeTitleTopBarrier"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:barrierDirection="bottom"
+            app:constraint_referenced_ids="episodeDateDuration,episodeDateDurationPadding" />
 
         <TextView
             android:id="@+id/lblTitle"
             style="?attr/textH2"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
             android:layout_marginStart="@dimen/episode_card_edge_padding"
             android:layout_marginEnd="@dimen/episode_card_edge_padding"
             android:gravity="center"
@@ -67,7 +82,7 @@
             app:layout_constraintHorizontal_bias="0.0"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/episodeDateDuration"
+            app:layout_constraintTop_toBottomOf="@+id/episodeTitleTopBarrier"
             tools:text="Vergecast 193: Encryption in the hype matrix" />
 
         <TextView

--- a/modules/features/podcasts/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModelTest.kt
+++ b/modules/features/podcasts/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModelTest.kt
@@ -1,0 +1,54 @@
+package au.com.shiftyjelly.pocketcasts.podcasts.view.episode
+
+import au.com.shiftyjelly.pocketcasts.podcasts.view.episode.EpisodeFragmentViewModel.EpisodeContentTab.DESCRIPTION
+import au.com.shiftyjelly.pocketcasts.podcasts.view.episode.EpisodeFragmentViewModel.EpisodeContentTab.SUMMARY
+import au.com.shiftyjelly.pocketcasts.podcasts.view.episode.EpisodeFragmentViewModel.EpisodePageState
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class EpisodeFragmentViewModelTest {
+    @Test
+    fun `clearing summary resets selected tab to description`() {
+        val state = EpisodePageState(
+            summary = "Episode summary",
+            selectedContentTab = SUMMARY,
+        )
+
+        val newState = state.withSummary(null)
+
+        assertNull(newState.summary)
+        assertEquals(DESCRIPTION, newState.selectedContentTab)
+    }
+
+    @Test
+    fun `clearing summary keeps description selected`() {
+        val state = EpisodePageState(
+            summary = "Episode summary",
+            selectedContentTab = DESCRIPTION,
+        )
+
+        val newState = state.withSummary(null)
+
+        assertNull(newState.summary)
+        assertEquals(DESCRIPTION, newState.selectedContentTab)
+    }
+
+    @Test
+    fun `summary tab cannot be selected without summary`() {
+        val state = EpisodePageState()
+
+        val newState = state.selectContentTab(SUMMARY)
+
+        assertEquals(DESCRIPTION, newState.selectedContentTab)
+    }
+
+    @Test
+    fun `summary tab can be selected when summary exists`() {
+        val state = EpisodePageState(summary = "Episode summary")
+
+        val newState = state.selectContentTab(SUMMARY)
+
+        assertEquals(SUMMARY, newState.selectedContentTab)
+    }
+}

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/ButtonTabs.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/ButtonTabs.kt
@@ -70,7 +70,7 @@ fun ButtonTabs(
             val pressed by interactionSource.collectIsPressedAsState()
             val focused by interactionSource.collectIsFocusedAsState()
             val selected = selectedTab == tab
-            val backgroundColor = if (selected) {
+            val tabBackgroundColor = if (selected) {
                 // make the button background the same color as the text, black on the light theme and white on the dark theme
                 buttonSelectedColor
             } else {
@@ -87,7 +87,7 @@ fun ButtonTabs(
                 onClick = { tab.onClick() },
                 shape = RoundedCornerShape(8.dp),
                 colors = ButtonDefaults.buttonColors(
-                    backgroundColor = backgroundColor,
+                    backgroundColor = tabBackgroundColor,
                 ),
                 contentPadding = ButtonPaddingValues,
                 elevation = ButtonDefaults.elevation(

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/ButtonTabs.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/ButtonTabs.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -66,48 +67,51 @@ fun ButtonTabs(
             .padding(start = 16.dp, end = 10.dp),
     ) {
         for (tab in tabs) {
-            val interactionSource = remember { MutableInteractionSource() }
-            val pressed by interactionSource.collectIsPressedAsState()
-            val focused by interactionSource.collectIsFocusedAsState()
-            val selected = selectedTab == tab
-            val tabBackgroundColor = if (selected) {
-                // make the button background the same color as the text, black on the light theme and white on the dark theme
-                buttonSelectedColor
-            } else {
-                if (pressed || focused) {
-                    // the press and focus state is a lighter version of the button background color
-                    buttonPressedColor
+            key(tab.labelResId) {
+                val interactionSource = remember { MutableInteractionSource() }
+                val pressed by interactionSource.collectIsPressedAsState()
+                val focused by interactionSource.collectIsFocusedAsState()
+                val selected = selectedTab == tab
+                val tabBackgroundColor = if (selected) {
+                    // make the button background the same color as the text,
+                    // black on the light theme and white on the dark theme
+                    buttonSelectedColor
                 } else {
-                    // the unselected button is the same color as the layout background
-                    backgroundColor
+                    if (pressed || focused) {
+                        // the press and focus state is a lighter version of the button background color
+                        buttonPressedColor
+                    } else {
+                        // the unselected button is the same color as the layout background
+                        backgroundColor
+                    }
                 }
+                val textColor = if (selected) textSelectedColor else textUnselectedColor
+                Button(
+                    onClick = { tab.onClick() },
+                    shape = RoundedCornerShape(8.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        backgroundColor = tabBackgroundColor,
+                    ),
+                    contentPadding = ButtonPaddingValues,
+                    elevation = ButtonDefaults.elevation(
+                        defaultElevation = 0.dp,
+                        pressedElevation = 0.dp,
+                        focusedElevation = 0.dp,
+                    ),
+                    interactionSource = interactionSource,
+                ) {
+                    Text(
+                        text = stringResource(tab.labelResId),
+                        fontSize = 15.sp,
+                        fontWeight = FontWeight(500),
+                        letterSpacing = 0.5.sp,
+                        color = textColor,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                Spacer(Modifier.width(6.dp))
             }
-            val textColor = if (selected) textSelectedColor else textUnselectedColor
-            Button(
-                onClick = { tab.onClick() },
-                shape = RoundedCornerShape(8.dp),
-                colors = ButtonDefaults.buttonColors(
-                    backgroundColor = tabBackgroundColor,
-                ),
-                contentPadding = ButtonPaddingValues,
-                elevation = ButtonDefaults.elevation(
-                    defaultElevation = 0.dp,
-                    pressedElevation = 0.dp,
-                    focusedElevation = 0.dp,
-                ),
-                interactionSource = interactionSource,
-            ) {
-                Text(
-                    text = stringResource(tab.labelResId),
-                    fontSize = 15.sp,
-                    fontWeight = FontWeight(500),
-                    letterSpacing = 0.5.sp,
-                    color = textColor,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            }
-            Spacer(Modifier.width(6.dp))
         }
     }
 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/ButtonTabs.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/ButtonTabs.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.compose.buttons
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsFocusedAsState
@@ -23,6 +24,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -56,9 +58,15 @@ fun ButtonTabs(
     tabs: List<ButtonTab>,
     selectedTab: ButtonTab,
     modifier: Modifier = Modifier,
+    buttonSelectedColor: Color = MaterialTheme.theme.colors.primaryText01,
+    buttonPressedColor: Color = MaterialTheme.theme.colors.primaryText01.copy(alpha = 0.1f),
+    backgroundColor: Color = MaterialTheme.theme.colors.primaryUi02,
+    textSelectedColor: Color = MaterialTheme.theme.colors.primaryUi02,
+    textUnselectedColor: Color = MaterialTheme.theme.colors.primaryText02,
 ) {
     Row(
         modifier = modifier
+            .background(color = backgroundColor)
             .horizontalScroll(rememberScrollState())
             .padding(start = 16.dp, end = 10.dp),
     ) {
@@ -69,17 +77,17 @@ fun ButtonTabs(
             val selected = selectedTab == tab
             val backgroundColor = if (selected) {
                 // make the button background the same color as the text, black on the light theme and white on the dark theme
-                MaterialTheme.theme.colors.primaryText01
+                buttonSelectedColor
             } else {
                 if (pressed || focused) {
                     // the press and focus state is a lighter version of the button background color
-                    MaterialTheme.theme.colors.primaryText01.copy(alpha = 0.1f)
+                    buttonPressedColor
                 } else {
                     // the unselected button is the same color as the layout background
-                    MaterialTheme.theme.colors.primaryUi02
+                    backgroundColor
                 }
             }
-            val textColor = if (selected) MaterialTheme.theme.colors.primaryUi02 else MaterialTheme.theme.colors.primaryText02
+            val textColor = if (selected) textSelectedColor else textUnselectedColor
             Button(
                 onClick = { tab.onClick() },
                 shape = RoundedCornerShape(8.dp),
@@ -129,7 +137,6 @@ private fun ButtonTabsPreview(themeType: Theme.ThemeType) {
         ButtonTabs(
             tabs = listOf(episodesTab, bookmarksTab),
             selectedTab = episodesTab,
-            modifier = Modifier.padding(horizontal = 8.dp),
         )
     }
 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/ButtonTabs.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/ButtonTabs.kt
@@ -1,8 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.compose.buttons
 
-import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -12,7 +10,6 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -25,8 +22,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/ButtonTabs.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/ButtonTabs.kt
@@ -49,8 +49,6 @@ private val ButtonPaddingValues = PaddingValues(
 data class ButtonTab(
     @StringRes val labelResId: Int,
     val onClick: () -> Unit,
-    @DrawableRes val iconResId: Int? = null,
-    @DrawableRes val trailingIconResId: Int? = null,
 )
 
 @Composable
@@ -96,15 +94,6 @@ fun ButtonTabs(
                 ),
                 interactionSource = interactionSource,
             ) {
-                if (tab.iconResId != null) {
-                    Image(
-                        painter = painterResource(tab.iconResId),
-                        contentDescription = null,
-                        colorFilter = ColorFilter.tint(textColor),
-                        modifier = Modifier.size(16.dp),
-                    )
-                    Spacer(Modifier.width(4.dp))
-                }
                 Text(
                     text = stringResource(tab.labelResId),
                     fontSize = 15.sp,
@@ -114,15 +103,6 @@ fun ButtonTabs(
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                 )
-                if (tab.trailingIconResId != null) {
-                    Spacer(Modifier.width(4.dp))
-                    Image(
-                        painter = painterResource(tab.trailingIconResId),
-                        contentDescription = null,
-                        colorFilter = ColorFilter.tint(textColor),
-                        modifier = Modifier.size(16.dp),
-                    )
-                }
             }
             Spacer(Modifier.width(6.dp))
         }


### PR DESCRIPTION
## Description

Tweaks the episode page UI and state handling for the PR https://github.com/Automattic/pocket-casts-android/pull/5276

This PR:
  - Consolidates episode summary, transcript, Plus status, selected tab, and date/duration data into a single
  `EpisodePageState`.
  - Alters the episode date/duration layout spacing.
  - Simplifies `ButtonTabs` unused attributes.
  - Removes the text animation when switching between Description and Summary.
  - Uses darker primary text for summary body content.
  - Changed the button tabs on the dark theme.

## Testing Instructions

1. Enable the AI Summaries feature flag in dev settings
2. Select a podcast that has generated transcripts (e.g. The American Life)
3. Select a podcast episode to open its details
4. Notice the tabbed UI: Description / Summary / Transcript tabs
5. Tap the "Summary" tab
6. Observe the summary rendered inline below the tabs

## Screenshots 

| Light | Dark |
| --- | --- |
| <img width="1080" height="2400" alt="Screenshot_20260524_224402" src="https://github.com/user-attachments/assets/e14bb718-1cf0-4cc7-9d4c-7b41a0f0fff0" /> | <img width="1080" height="2400" alt="Screenshot_20260524_224420" src="https://github.com/user-attachments/assets/39ec12cf-395a-43f1-b3ca-edad66783fb9" /> | 

| Without Chat | Without Both |
| --- | --- |
| <img width="1080" height="2400" alt="Screenshot_20260525_075353" src="https://github.com/user-attachments/assets/21b8b53d-2601-45a8-8bc4-9e4a5d27285b" /> | <img width="1080" height="2400" alt="Screenshot_20260525_075436" src="https://github.com/user-attachments/assets/cc2d4bf0-f04d-40a8-8d6a-f08de1fe236c" /> | 

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
