### PR TITLE
[RSM] Fix episode chat failed message persistence

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/UpgradeFeatureItem.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/UpgradeFeatureItem.kt
@@ -42,7 +42,7 @@ fun UpgradeFeatureItem(
             .semantics(mergeDescendants = true) {}
             .fillMaxWidth()
             .padding(vertical = 8.dp),
-        verticalAlignment = Alignment.Top,
+        verticalAlignment = Alignment.CenterVertically,
     ) {
         Icon(
             painter = painterResource(item.image),

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeFeatureItem.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeFeatureItem.kt
@@ -34,6 +34,13 @@ enum class PlusUpgradeFeatureItem(
     ) {
         override fun title() = LR.string.onboarding_upgrade_features_transcripts
     },
+    EpisodeChat(
+        image = IR.drawable.ic_ai,
+    ) {
+        override val isYearlyFeature get() = FeatureFlag.isEnabled(Feature.EPISODE_CHAT)
+        override val isMonthlyFeature get() = FeatureFlag.isEnabled(Feature.EPISODE_CHAT)
+        override fun title() = LR.string.episode_chat
+    },
     Folders(
         image = IR.drawable.ic_plus_feature_folder,
     ) {

--- a/modules/features/account/src/test/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/PlusUpgradeFeatureItemTest.kt
+++ b/modules/features/account/src/test/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/PlusUpgradeFeatureItemTest.kt
@@ -1,0 +1,30 @@
+package au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade
+
+import au.com.shiftyjelly.pocketcasts.sharedtest.InMemoryFeatureFlagRule
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+class PlusUpgradeFeatureItemTest {
+    @get:Rule
+    val featureFlagRule = InMemoryFeatureFlagRule()
+
+    @Test
+    fun `given episode chat flag disabled, when checking feature visibility, then episode chat is hidden`() {
+        FeatureFlag.setEnabled(Feature.EPISODE_CHAT, false)
+
+        assertFalse(PlusUpgradeFeatureItem.EpisodeChat.isMonthlyFeature)
+        assertFalse(PlusUpgradeFeatureItem.EpisodeChat.isYearlyFeature)
+    }
+
+    @Test
+    fun `given episode chat flag enabled, when checking feature visibility, then episode chat is shown`() {
+        FeatureFlag.setEnabled(Feature.EPISODE_CHAT, true)
+
+        assertTrue(PlusUpgradeFeatureItem.EpisodeChat.isMonthlyFeature)
+        assertTrue(PlusUpgradeFeatureItem.EpisodeChat.isYearlyFeature)
+    }
+}

--- a/modules/features/chat/src/main/kotlin/au/com/shiftyjelly/pocketcasts/chat/ChatPaywallFragment.kt
+++ b/modules/features/chat/src/main/kotlin/au/com/shiftyjelly/pocketcasts/chat/ChatPaywallFragment.kt
@@ -1,7 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.chat
 
 import android.os.Bundle
-import android.os.Parcelable
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.compose.foundation.layout.PaddingValues
@@ -16,28 +15,11 @@ import au.com.shiftyjelly.pocketcasts.compose.extensions.contentWithoutConsumedI
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
-import au.com.shiftyjelly.pocketcasts.utils.extensions.requireParcelable
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.parcelize.Parcelize
 
 @AndroidEntryPoint
 class ChatPaywallFragment : BaseDialogFragment() {
-    companion object {
-        private const val ARGS_KEY = "chat_paywall_args"
-
-        fun newInstance(
-            episodeUuid: String,
-            podcastUuid: String?,
-        ) = ChatPaywallFragment().apply {
-            arguments = Bundle().apply {
-                putParcelable(ARGS_KEY, Args(episodeUuid, podcastUuid))
-            }
-        }
-    }
-
-    private val args get() = requireArguments().requireParcelable<Args>(ARGS_KEY)
-
     private val viewModel by viewModels<ChatPaywallViewModel>()
 
     override fun onCreateView(
@@ -62,10 +44,4 @@ class ChatPaywallFragment : BaseDialogFragment() {
             )
         }
     }
-
-    @Parcelize
-    private class Args(
-        val episodeUuid: String,
-        val podcastUuid: String?,
-    ) : Parcelable
 }

--- a/modules/features/chat/src/main/kotlin/au/com/shiftyjelly/pocketcasts/chat/ChatViewModel.kt
+++ b/modules/features/chat/src/main/kotlin/au/com/shiftyjelly/pocketcasts/chat/ChatViewModel.kt
@@ -43,6 +43,7 @@ class ChatViewModel @Inject constructor(
 
     private var sendJob: Job? = null
     private var quotePlaybackSession: QuotePlaybackSession? = null
+    private var transientUserMessage: ChatMessage.User? = null
     private lateinit var episodeUuid: String
     private lateinit var welcomeMessageText: String
 
@@ -84,7 +85,7 @@ class ChatViewModel @Inject constructor(
         viewModelScope.launch {
             chatManager.observeMessages(episodeUuid).collect { messages ->
                 _uiState.update { state ->
-                    state.copy(messages = messages.withQuotePlaybackState(state.messages.playingQuoteUuid()))
+                    state.copy(messages = messages.withTransientUserMessage().withQuotePlaybackState(state.messages.playingQuoteUuid()))
                 }
             }
         }
@@ -106,9 +107,16 @@ class ChatViewModel @Inject constructor(
 
     fun clearChat() {
         sendJob?.cancel()
-        _uiState.update { it.copy(isAwaitingReply = false, error = null) }
+        transientUserMessage = null
+        val welcomeMsg = ChatMessage.Assistant(text = welcomeMessageText)
+        _uiState.update {
+            it.copy(
+                messages = listOf(welcomeMsg),
+                isAwaitingReply = false,
+                error = null,
+            )
+        }
         viewModelScope.launch {
-            val welcomeMsg = ChatMessage.Assistant(text = welcomeMessageText)
             chatManager.clearMessages(episodeUuid, welcomeMsg)
         }
     }
@@ -118,12 +126,12 @@ class ChatViewModel @Inject constructor(
         if (text.isEmpty()) return
 
         _uiState.update { it.copy(inputText = "") }
-        performSend(message = text, isRetry = false)
+        performSend(message = ChatMessage.User(text = text))
     }
 
     fun retry() {
-        val lastUserMessage = _uiState.value.messages.lastOrNull { it is ChatMessage.User } as? ChatMessage.User ?: return
-        performSend(message = lastUserMessage.text, isRetry = true)
+        val failedUserMessage = transientUserMessage ?: return
+        performSend(message = failedUserMessage)
     }
 
     fun playQuote(quoteUuid: String) {
@@ -339,14 +347,22 @@ class ChatViewModel @Inject constructor(
         }
     }
 
-    private fun performSend(message: String, isRetry: Boolean) {
-        val currentMessages = _uiState.value.messages
+    private fun performSend(message: ChatMessage.User) {
+        transientUserMessage = message
+        val currentMessages = _uiState.value.messages.filterNot { it.uuid == message.uuid }
 
-        _uiState.update { it.copy(isAwaitingReply = true, error = null) }
+        _uiState.update {
+            it.copy(
+                isAwaitingReply = true,
+                error = null,
+                messages = it.messages.withTransientUserMessage(),
+            )
+        }
 
         sendJob = viewModelScope.launch {
             try {
-                chatManager.sendMessage(episodeUuid, message, currentMessages, isRetry)
+                chatManager.sendMessage(episodeUuid, message, currentMessages)
+                transientUserMessage = null
             } catch (e: IOException) {
                 _uiState.update { it.copy(error = ChatError.NetworkError) }
             } catch (e: CancellationException) {
@@ -357,6 +373,11 @@ class ChatViewModel @Inject constructor(
                 _uiState.update { it.copy(isAwaitingReply = false) }
             }
         }
+    }
+
+    private fun List<ChatMessage>.withTransientUserMessage(): List<ChatMessage> {
+        val message = transientUserMessage ?: return this
+        return if (any { it.uuid == message.uuid }) this else this + message
     }
 
     private fun List<ChatMessage>.playingQuoteUuid(): String? {

--- a/modules/features/chat/src/test/kotlin/au/com/shiftyjelly/pocketcasts/chat/ChatViewModelTest.kt
+++ b/modules/features/chat/src/test/kotlin/au/com/shiftyjelly/pocketcasts/chat/ChatViewModelTest.kt
@@ -36,16 +36,18 @@ class ChatViewModelTest {
 
     @Before
     fun setUp() {
-        viewModel = ChatViewModel(
-            networkConnectionWatcher = networkConnectionWatcher,
-            chatManager = chatManager,
-            playbackManager = mock<PlaybackManager> {
-                on { playbackStateFlow } doReturn MutableStateFlow(PlaybackState())
-            },
-            episodeManager = mock<EpisodeManager>(),
-            applicationScope = kotlinx.coroutines.CoroutineScope(coroutineRule.testDispatcher),
-        )
+        viewModel = createViewModel()
     }
+
+    private fun createViewModel() = ChatViewModel(
+        networkConnectionWatcher = networkConnectionWatcher,
+        chatManager = chatManager,
+        playbackManager = mock<PlaybackManager> {
+            on { playbackStateFlow } doReturn MutableStateFlow(PlaybackState())
+        },
+        episodeManager = mock<EpisodeManager>(),
+        applicationScope = kotlinx.coroutines.CoroutineScope(coroutineRule.testDispatcher),
+    )
 
     @Test
     fun `set episode info creates chat with welcome message when empty`() = runTest {
@@ -119,7 +121,6 @@ class ChatViewModelTest {
             SendMessage(
                 episodeUuid = EPISODE_UUID,
                 message = "What happened?",
-                isRetry = false,
             ),
             chatManager.sentMessages.single(),
         )
@@ -137,17 +138,20 @@ class ChatViewModelTest {
         advanceUntilIdle()
 
         assertEquals(ChatError.NetworkError, viewModel.uiState.value.error)
+        val failedMessage = viewModel.uiState.value.messages.last()
+        assertTrue(failedMessage is ChatMessage.User)
+        assertEquals("Question", (failedMessage as ChatMessage.User).text)
         assertFalse(viewModel.uiState.value.isAwaitingReply)
     }
 
     @Test
-    fun `retry resends last user message`() = runTest {
-        chatManager.messages.value = listOf(
-            ChatMessage.User(text = "First question", uuid = "first-user-uuid"),
-            ChatMessage.Assistant(text = "Failure", uuid = "assistant-uuid"),
-            ChatMessage.User(text = "Last question", uuid = "last-user-uuid"),
-        )
+    fun `retry resends failed transient user message`() = runTest {
         setEpisodeInfo()
+        chatManager.sendMessageException = IOException()
+        viewModel.onInputTextChange("Last question")
+        viewModel.onSend()
+        advanceUntilIdle()
+        chatManager.sendMessageException = null
 
         viewModel.retry()
         advanceUntilIdle()
@@ -156,10 +160,27 @@ class ChatViewModelTest {
             SendMessage(
                 episodeUuid = EPISODE_UUID,
                 message = "Last question",
-                isRetry = true,
             ),
             chatManager.sentMessages.single(),
         )
+    }
+
+    @Test
+    fun `failed user message is not restored in a new chat session`() = runTest {
+        setEpisodeInfo()
+        chatManager.sendMessageException = IOException()
+        viewModel.onInputTextChange("Failed question")
+        viewModel.onSend()
+        advanceUntilIdle()
+        val failedMessage = viewModel.uiState.value.messages.last()
+        assertTrue(failedMessage is ChatMessage.User)
+        assertEquals("Failed question", (failedMessage as ChatMessage.User).text)
+
+        viewModel = createViewModel()
+        setEpisodeInfo()
+        advanceUntilIdle()
+
+        assertEquals(listOf(ChatMessage.Assistant(text = "Welcome", uuid = "welcome-uuid")), viewModel.uiState.value.messages)
     }
 
     @Test
@@ -175,7 +196,9 @@ class ChatViewModelTest {
         advanceUntilIdle()
 
         assertEquals(ClearMessages(EPISODE_UUID, "Welcome"), chatManager.clearedMessages.single())
-        assertEquals(listOf(ChatMessage.Assistant(text = "Welcome", uuid = "welcome-uuid")), viewModel.uiState.value.messages)
+        val message = viewModel.uiState.value.messages.single()
+        assertTrue(message is ChatMessage.Assistant)
+        assertEquals("Welcome", (message as ChatMessage.Assistant).text)
         assertEquals(null, viewModel.uiState.value.error)
         assertFalse(viewModel.uiState.value.isAwaitingReply)
     }
@@ -214,12 +237,12 @@ class ChatViewModelTest {
 
         override suspend fun sendMessage(
             episodeUuid: String,
-            message: String,
+            message: ChatMessage.User,
             allMessages: List<ChatMessage>,
-            isRetry: Boolean,
         ) {
             sendMessageException?.let { throw it }
-            sentMessages += SendMessage(episodeUuid, message, isRetry)
+            sentMessages += SendMessage(episodeUuid, message.text)
+            messages.value += listOf(message, ChatMessage.Assistant(text = "Response", uuid = "response-uuid"))
         }
 
         override suspend fun clearMessages(episodeUuid: String, welcomeMessage: ChatMessage) {
@@ -229,7 +252,7 @@ class ChatViewModelTest {
     }
 
     private data class CreateChat(val episodeUuid: String, val podcastUuid: String, val welcomeMessage: String)
-    private data class SendMessage(val episodeUuid: String, val message: String, val isRetry: Boolean)
+    private data class SendMessage(val episodeUuid: String, val message: String)
     private data class ClearMessages(val episodeUuid: String, val welcomeMessage: String)
 
     private companion object {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -860,7 +860,7 @@ class EpisodeFragment : BaseFragment() {
             }
         } else {
             if (parentFragmentManager.findFragmentByTag("episode_chat_paywall") == null) {
-                val fragment = ChatPaywallFragment.newInstance(episodeUuid, podcastUuid)
+                val fragment = ChatPaywallFragment()
                 fragment.show(parentFragmentManager, "episode_chat_paywall")
             }
         }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -644,9 +644,9 @@ class EpisodeFragment : BaseFragment() {
 
             AppTheme(activeTheme) {
                 if (isSummaryEnabled) {
-                    // AI-enhanced layout: "Ask this episode" + simple tabs + inline summary
+                    // AI-enhanced layout: "Chat with episode" + simple tabs + inline summary
                     Column(modifier = Modifier.fillMaxWidth()) {
-                        // "Ask this episode" input-style banner
+                        // "Chat with episode" input-style banner
                         val askTheEpisodeVisible = FeatureFlag.isEnabled(Feature.EPISODE_CHAT) && transcript != null
                         AnimatedVisibility(
                             visible = askTheEpisodeVisible,
@@ -669,7 +669,7 @@ class EpisodeFragment : BaseFragment() {
                                     )
                                     .clickable(
                                         role = Role.Button,
-                                        onClickLabel = stringResource(LR.string.ask_this_episode),
+                                        onClickLabel = stringResource(LR.string.episode_chat),
                                     ) {
                                         val t = transcript ?: return@clickable
                                         openChat(t.episodeUuid, t.podcastUuid, isPlusUser)
@@ -684,7 +684,7 @@ class EpisodeFragment : BaseFragment() {
                                     modifier = Modifier.size(18.dp),
                                 )
                                 Text(
-                                    text = stringResource(LR.string.ask_this_episode),
+                                    text = stringResource(LR.string.episode_chat),
                                     color = MaterialTheme.theme.colors.primaryText02,
                                     fontSize = 15.sp,
                                     fontWeight = FontWeight(500),
@@ -813,7 +813,7 @@ class EpisodeFragment : BaseFragment() {
                                     .fillMaxWidth()
                                     .clickable(
                                         role = Role.Button,
-                                        onClickLabel = stringResource(LR.string.ask_this_episode),
+                                        onClickLabel = stringResource(LR.string.episode_chat),
                                     ) {
                                         openChat(transcript.episodeUuid, transcript.podcastUuid, isPlusUser)
                                     },

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -125,7 +125,6 @@
     <string name="token_refresh_sign_in_error_description">There was a problem and you\'ve been signed out. Tap here to sign back in.</string>
     <string name="view_transcript">View transcript</string>
     <string name="episode_chat">Chat with Episode</string>
-    <string name="ask_this_episode">Ask this episode</string>
     <string name="episode_summary">Episode Summary</string>
     <string name="description">Description</string>
     <string name="summary">Summary</string>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/chat/ChatManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/chat/ChatManager.kt
@@ -15,9 +15,8 @@ interface ChatManager {
 
     suspend fun sendMessage(
         episodeUuid: String,
-        message: String,
+        message: ChatMessage.User,
         allMessages: List<ChatMessage>,
-        isRetry: Boolean = false,
     )
 
     suspend fun clearMessages(

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/chat/ChatManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/chat/ChatManagerImpl.kt
@@ -41,15 +41,9 @@ class ChatManagerImpl @Inject constructor(
 
     override suspend fun sendMessage(
         episodeUuid: String,
-        message: String,
+        message: ChatMessage.User,
         allMessages: List<ChatMessage>,
-        isRetry: Boolean,
     ) {
-        if (!isRetry) {
-            val userMessage = ChatMessage.User(text = message)
-            episodeChatDao.insertMessage(userMessage.toEntity(episodeUuid, quoteMetadataAdapter))
-        }
-
         val history = allMessages.mapNotNull { msg ->
             val content = msg.textOrNull() ?: return@mapNotNull null
             ConversationMessage(role = msg.role.apiRole, content = content)
@@ -60,7 +54,7 @@ class ChatManagerImpl @Inject constructor(
         }
         val request = EpisodeChatRequest(
             transcriptUrl = transcript.url,
-            message = message,
+            message = message.text,
             conversationHistory = history,
         )
 
@@ -71,6 +65,8 @@ class ChatManagerImpl @Inject constructor(
             authorization = "Bearer ${accessToken.value}",
             request = request,
         )
+
+        episodeChatDao.insertMessage(message.toEntity(episodeUuid, quoteMetadataAdapter))
 
         val aiReply = ChatMessage.Assistant(text = response.reply)
         episodeChatDao.insertMessage(aiReply.toEntity(episodeUuid, quoteMetadataAdapter))

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/chat/ChatManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/chat/ChatManagerImplTest.kt
@@ -13,6 +13,7 @@ import au.com.shiftyjelly.pocketcasts.servers.podcast.EpisodeChatResponse
 import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServiceManager
 import au.com.shiftyjelly.pocketcasts.servers.sync.TokenHandler
 import com.squareup.moshi.Moshi
+import java.io.IOException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
@@ -83,13 +84,12 @@ class ChatManagerImplTest {
 
         manager.sendMessage(
             episodeUuid = EPISODE_UUID,
-            message = "What happened?",
+            message = ChatMessage.User(text = "What happened?", uuid = "user-uuid"),
             allMessages = listOf(
                 ChatMessage.Assistant(text = "Welcome", uuid = "welcome-uuid"),
                 ChatMessage.User(text = "Earlier question", uuid = "earlier-user-uuid"),
                 ChatMessage.Quote(text = "Earlier quote", start = "00:00", end = "00:01", uuid = "quote-uuid"),
             ),
-            isRetry = false,
         )
 
         val requestCaptor = argumentCaptor<EpisodeChatRequest>()
@@ -109,6 +109,7 @@ class ChatManagerImplTest {
             requestCaptor.firstValue,
         )
         assertEquals(listOf(ChatRole.User.value, ChatRole.Assistant.value, ChatRole.Quote.value), episodeChatDao.messages.map { it.role })
+        assertEquals("user-uuid", episodeChatDao.messages[0].uuid)
         assertEquals("What happened?", episodeChatDao.messages[0].text)
         assertEquals("Assistant reply", episodeChatDao.messages[1].text)
 
@@ -124,7 +125,7 @@ class ChatManagerImplTest {
     }
 
     @Test
-    fun `send retry skips storing user message`() = runTest {
+    fun `send message stores user message after successful response`() = runTest {
         transcripts.value = listOf(createTranscript())
         whenever(podcastCacheServiceManager.episodeChat(any(), any())).thenReturn(
             EpisodeChatResponse(reply = "Assistant reply", quote = null),
@@ -132,13 +133,14 @@ class ChatManagerImplTest {
 
         manager.sendMessage(
             episodeUuid = EPISODE_UUID,
-            message = "Retry message",
+            message = ChatMessage.User(text = "Retry message", uuid = "retry-user-uuid"),
             allMessages = emptyList(),
-            isRetry = true,
         )
 
-        assertEquals(listOf(ChatRole.Assistant.value), episodeChatDao.messages.map { it.role })
-        assertEquals("Assistant reply", episodeChatDao.messages.single().text)
+        assertEquals(listOf(ChatRole.User.value, ChatRole.Assistant.value), episodeChatDao.messages.map { it.role })
+        assertEquals("retry-user-uuid", episodeChatDao.messages[0].uuid)
+        assertEquals("Retry message", episodeChatDao.messages[0].text)
+        assertEquals("Assistant reply", episodeChatDao.messages[1].text)
     }
 
     @Test
@@ -146,14 +148,30 @@ class ChatManagerImplTest {
         val exception = runCatching {
             manager.sendMessage(
                 episodeUuid = EPISODE_UUID,
-                message = "Question",
+                message = ChatMessage.User(text = "Question", uuid = "user-uuid"),
                 allMessages = emptyList(),
-                isRetry = false,
             )
         }.exceptionOrNull() as IllegalStateException
 
         assertEquals("Transcript URL is required to send episode chat messages", exception.message)
-        assertEquals(listOf(ChatRole.User.value), episodeChatDao.messages.map { it.role })
+        assertEquals(emptyList<String>(), episodeChatDao.messages.map { it.role })
+    }
+
+    @Test
+    fun `send message does not store user message when request fails`() = runTest {
+        transcripts.value = listOf(createTranscript())
+        whenever(podcastCacheServiceManager.episodeChat(any(), any())).thenAnswer { throw IOException() }
+
+        val exception = runCatching {
+            manager.sendMessage(
+                episodeUuid = EPISODE_UUID,
+                message = ChatMessage.User(text = "Question", uuid = "user-uuid"),
+                allMessages = emptyList(),
+            )
+        }.exceptionOrNull()
+
+        assertEquals(IOException::class, exception!!::class)
+        assertEquals(emptyList<String>(), episodeChatDao.messages.map { it.role })
     }
 
     @Test
@@ -185,9 +203,8 @@ class ChatManagerImplTest {
 
         manager.sendMessage(
             episodeUuid = EPISODE_UUID,
-            message = "Question",
+            message = ChatMessage.User(text = "Question", uuid = "user-uuid"),
             allMessages = emptyList(),
-            isRetry = false,
         )
 
         assertEquals(listOf(ChatRole.User.value, ChatRole.Assistant.value), episodeChatDao.messages.map { it.role })


### PR DESCRIPTION
## Description
- Keeps failed episode chat user messages in ViewModel memory instead of persisting them to Room, so they disappear after leaving or restarting the chat session.
- Persists the user message only after the episode chat API request succeeds, while still allowing retry during the current chat session.
- Adds Chat with episode to the Plus paywall feature list when the episode chat feature flag is enabled.
- Reuses the existing episode_chat string for episode chat entry points and removes the duplicate ask_this_episode string.

Fixes # N/A

## Testing Instructions
1. Open an episode with chat available.
2. Turn off network connectivity and send a chat message.
3. Confirm the message shows an error/retry state while staying on the chat screen.
4. Leave the chat screen or restart the app, then reopen chat for the same episode.
5. Confirm the failed user message is gone and is not shown as a sent message.
6. Enable the Episode Chat feature flag and open a Plus upgrade/paywall feature list.
7. Confirm Chat with episode appears in the feature list; disable the flag and confirm it is hidden.
8. Run `./gradlew :modules:features:chat:testDebugUnitTest --tests au.com.shiftyjelly.pocketcasts.chat.ChatViewModelTest :modules:services:repositories:testDebugUnitTest --tests au.com.shiftyjelly.pocketcasts.repositories.chat.ChatManagerImplTest`.
9. Run `./gradlew spotlessKotlinCheck`.

## Screenshots or Screencast 
UI text and paywall feature list changed. Screenshots are not included; please add before review if needed.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack