### PR TITLE
[RSM] Move bookmark enrichment from sync-api to podcast-api

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerTest.kt
@@ -13,6 +13,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.SyncStatus
 import au.com.shiftyjelly.pocketcasts.preferences.model.BookmarksSortTypeDefault
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.repositories.transcript.TranscriptWindowExtractor
+import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServiceManager
 import au.com.shiftyjelly.pocketcasts.servers.podcast.TranscriptService
 import com.automattic.eventhorizon.BookmarkSourceType
 import com.automattic.eventhorizon.EventHorizon
@@ -46,6 +47,7 @@ class BookmarkManagerTest {
             appDatabase = appDatabase,
             eventHorizon = EventHorizon(TestEventSink()),
             syncManager = mock<SyncManager>(),
+            podcastCacheServiceManager = mock<PodcastCacheServiceManager>(),
             transcriptWindowExtractor = TranscriptWindowExtractor(
                 transcriptDao = mock<TranscriptDao>(),
                 transcriptService = mock<TranscriptService>(),

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/BookmarkDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/BookmarkDao.kt
@@ -238,7 +238,7 @@ abstract class BookmarkDao {
 
     @Transaction
     open suspend fun getAll(uuids: Collection<String>): List<Bookmark> {
-        return uuids.chunked(999).flatMap { chunk ->
+        return uuids.chunked(AppDatabase.SQLITE_BIND_ARG_LIMIT).flatMap { chunk ->
             getAllUnsafe(chunk)
         }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerImpl.kt
@@ -13,6 +13,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.transcript.TranscriptWindowEx
 import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServiceManager
 import au.com.shiftyjelly.pocketcasts.servers.sync.TokenHandler
 import au.com.shiftyjelly.pocketcasts.servers.sync.bookmark.BookmarkEnrichRequest
+import au.com.shiftyjelly.pocketcasts.servers.sync.bookmark.BookmarkEnrichResponse
 import com.automattic.eventhorizon.BookmarkCreatedEvent
 import com.automattic.eventhorizon.BookmarkSourceType
 import com.automattic.eventhorizon.BookmarkUpdateTitleEvent
@@ -30,6 +31,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
+import retrofit2.HttpException
 import timber.log.Timber
 
 class BookmarkManagerImpl @Inject constructor(
@@ -245,15 +247,7 @@ class BookmarkManagerImpl @Inject constructor(
                     timeSecs = bookmark.timeSecs,
                 ) ?: return@launch
 
-                val token = tokenHandler.getAccessToken()
-                if (token == null) {
-                    Timber.w("Smart bookmark enrichment skipped: no access token")
-                    return@launch
-                }
-                val response = podcastCacheServiceManager.enrichBookmark(
-                    authorization = "Bearer ${token.value}",
-                    request = BookmarkEnrichRequest(transcriptSnippet = snippet),
-                )
+                val response = callEnrichApi(bookmark, snippet)
                 if (response.error != null) {
                     Timber.w("Smart bookmark enrichment returned error for ${bookmark.uuid}: ${response.error}")
                 }
@@ -274,6 +268,29 @@ class BookmarkManagerImpl @Inject constructor(
                 throw e
             } catch (e: Exception) {
                 Timber.e(e, "Smart bookmark enrichment failed for ${bookmark.uuid}")
+            }
+        }
+    }
+
+    private suspend fun callEnrichApi(bookmark: Bookmark, snippet: String): BookmarkEnrichResponse {
+        val token = tokenHandler.getAccessToken()
+            ?: error("Smart bookmark enrichment skipped for ${bookmark.uuid}: no access token")
+        return try {
+            podcastCacheServiceManager.enrichBookmark(
+                authorization = "Bearer ${token.value}",
+                request = BookmarkEnrichRequest(transcriptSnippet = snippet),
+            )
+        } catch (e: HttpException) {
+            if (e.code() == 401) {
+                tokenHandler.invalidateAccessToken()
+                val refreshedToken = tokenHandler.getAccessToken()
+                    ?: error("Smart bookmark enrichment skipped for ${bookmark.uuid}: no access token after refresh")
+                podcastCacheServiceManager.enrichBookmark(
+                    authorization = "Bearer ${refreshedToken.value}",
+                    request = BookmarkEnrichRequest(transcriptSnippet = snippet),
+                )
+            } else {
+                throw e
             }
         }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerImpl.kt
@@ -9,9 +9,9 @@ import au.com.shiftyjelly.pocketcasts.models.type.SyncStatus
 import au.com.shiftyjelly.pocketcasts.preferences.model.BookmarksSortTypeDefault
 import au.com.shiftyjelly.pocketcasts.preferences.model.BookmarksSortTypeForPodcast
 import au.com.shiftyjelly.pocketcasts.preferences.model.BookmarksSortTypeForProfile
+import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.repositories.transcript.TranscriptWindowExtractor
 import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServiceManager
-import au.com.shiftyjelly.pocketcasts.servers.sync.TokenHandler
 import au.com.shiftyjelly.pocketcasts.servers.sync.bookmark.BookmarkEnrichRequest
 import au.com.shiftyjelly.pocketcasts.servers.sync.bookmark.BookmarkEnrichResponse
 import com.automattic.eventhorizon.BookmarkCreatedEvent
@@ -31,13 +31,12 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
-import retrofit2.HttpException
 import timber.log.Timber
 
 class BookmarkManagerImpl @Inject constructor(
     appDatabase: AppDatabase,
     private val eventHorizon: EventHorizon,
-    private val tokenHandler: TokenHandler,
+    private val syncManager: SyncManager,
     private val podcastCacheServiceManager: PodcastCacheServiceManager,
     private val transcriptWindowExtractor: TranscriptWindowExtractor,
 ) : BookmarkManager,
@@ -247,7 +246,7 @@ class BookmarkManagerImpl @Inject constructor(
                     timeSecs = bookmark.timeSecs,
                 ) ?: return@launch
 
-                val response = callEnrichApi(bookmark, snippet)
+                val response = callEnrichApi(snippet)
                 if (response.error != null) {
                     Timber.w("Smart bookmark enrichment returned error for ${bookmark.uuid}: ${response.error}")
                 }
@@ -272,26 +271,12 @@ class BookmarkManagerImpl @Inject constructor(
         }
     }
 
-    private suspend fun callEnrichApi(bookmark: Bookmark, snippet: String): BookmarkEnrichResponse {
-        val token = tokenHandler.getAccessToken()
-            ?: error("Smart bookmark enrichment skipped for ${bookmark.uuid}: no access token")
-        return try {
+    private suspend fun callEnrichApi(snippet: String): BookmarkEnrichResponse {
+        return syncManager.getCacheTokenOrLogin { token ->
             podcastCacheServiceManager.enrichBookmark(
                 authorization = "Bearer ${token.value}",
                 request = BookmarkEnrichRequest(transcriptSnippet = snippet),
             )
-        } catch (e: HttpException) {
-            if (e.code() == 401) {
-                tokenHandler.invalidateAccessToken()
-                val refreshedToken = tokenHandler.getAccessToken()
-                    ?: error("Smart bookmark enrichment skipped for ${bookmark.uuid}: no access token after refresh")
-                podcastCacheServiceManager.enrichBookmark(
-                    authorization = "Bearer ${refreshedToken.value}",
-                    request = BookmarkEnrichRequest(transcriptSnippet = snippet),
-                )
-            } else {
-                throw e
-            }
         }
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerImpl.kt
@@ -9,8 +9,10 @@ import au.com.shiftyjelly.pocketcasts.models.type.SyncStatus
 import au.com.shiftyjelly.pocketcasts.preferences.model.BookmarksSortTypeDefault
 import au.com.shiftyjelly.pocketcasts.preferences.model.BookmarksSortTypeForPodcast
 import au.com.shiftyjelly.pocketcasts.preferences.model.BookmarksSortTypeForProfile
-import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.repositories.transcript.TranscriptWindowExtractor
+import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServiceManager
+import au.com.shiftyjelly.pocketcasts.servers.sync.TokenHandler
+import au.com.shiftyjelly.pocketcasts.servers.sync.bookmark.BookmarkEnrichRequest
 import com.automattic.eventhorizon.BookmarkCreatedEvent
 import com.automattic.eventhorizon.BookmarkSourceType
 import com.automattic.eventhorizon.BookmarkUpdateTitleEvent
@@ -33,7 +35,8 @@ import timber.log.Timber
 class BookmarkManagerImpl @Inject constructor(
     appDatabase: AppDatabase,
     private val eventHorizon: EventHorizon,
-    private val syncManager: SyncManager,
+    private val tokenHandler: TokenHandler,
+    private val podcastCacheServiceManager: PodcastCacheServiceManager,
     private val transcriptWindowExtractor: TranscriptWindowExtractor,
 ) : BookmarkManager,
     CoroutineScope {
@@ -242,7 +245,15 @@ class BookmarkManagerImpl @Inject constructor(
                     timeSecs = bookmark.timeSecs,
                 ) ?: return@launch
 
-                val response = syncManager.enrichBookmark(transcriptSnippet = snippet)
+                val token = tokenHandler.getAccessToken()
+                if (token == null) {
+                    Timber.w("Smart bookmark enrichment skipped: no access token")
+                    return@launch
+                }
+                val response = podcastCacheServiceManager.enrichBookmark(
+                    authorization = "Bearer ${token.value}",
+                    request = BookmarkEnrichRequest(transcriptSnippet = snippet),
+                )
                 if (response.error != null) {
                     Timber.w("Smart bookmark enrichment returned error for ${bookmark.uuid}: ${response.error}")
                 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManager.kt
@@ -23,7 +23,6 @@ import au.com.shiftyjelly.pocketcasts.servers.sync.SubscriptionStatusResponse
 import au.com.shiftyjelly.pocketcasts.servers.sync.UpNextSyncRequest
 import au.com.shiftyjelly.pocketcasts.servers.sync.UpNextSyncResponse
 import au.com.shiftyjelly.pocketcasts.servers.sync.UserChangeResponse
-import au.com.shiftyjelly.pocketcasts.servers.sync.bookmark.BookmarkEnrichResponse
 import au.com.shiftyjelly.pocketcasts.servers.sync.history.HistoryYearResponse
 import au.com.shiftyjelly.pocketcasts.servers.sync.login.ExchangeSonosResponse
 import au.com.shiftyjelly.pocketcasts.utils.Optional
@@ -125,7 +124,6 @@ interface SyncManager : NamedSettingsCaller {
     suspend fun upNextSync(request: UpNextSyncRequest): UpNextSyncResponse
     suspend fun upNextSyncProtobuf(request: UpNextSyncRequestProtobuf): UpNextResponse
     suspend fun getBookmarks(): List<Bookmark>
-    suspend fun enrichBookmark(transcriptSnippet: String): BookmarkEnrichResponse
     suspend fun sendAnonymousFeedback(subject: String, inbox: String, message: String): Response<Void>
     suspend fun sendFeedback(subject: String, inbox: String, message: String): Response<Void>
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
@@ -36,8 +36,6 @@ import au.com.shiftyjelly.pocketcasts.servers.sync.SyncServiceManager
 import au.com.shiftyjelly.pocketcasts.servers.sync.UpNextSyncRequest
 import au.com.shiftyjelly.pocketcasts.servers.sync.UpNextSyncResponse
 import au.com.shiftyjelly.pocketcasts.servers.sync.UserChangeResponse
-import au.com.shiftyjelly.pocketcasts.servers.sync.bookmark.BookmarkEnrichRequest
-import au.com.shiftyjelly.pocketcasts.servers.sync.bookmark.BookmarkEnrichResponse
 import au.com.shiftyjelly.pocketcasts.servers.sync.bookmark.toBookmark
 import au.com.shiftyjelly.pocketcasts.servers.sync.exception.RefreshTokenExpiredException
 import au.com.shiftyjelly.pocketcasts.servers.sync.history.HistoryYearResponse
@@ -447,15 +445,6 @@ class SyncManagerImpl @Inject constructor(
         return getCacheTokenOrLogin { token ->
             syncServiceManager.getBookmarks(token).bookmarksList.map { it.toBookmark() }
         }
-    }
-
-    override suspend fun enrichBookmark(
-        transcriptSnippet: String,
-    ): BookmarkEnrichResponse = getCacheTokenOrLogin { token ->
-        syncServiceManager.enrichBookmark(
-            request = BookmarkEnrichRequest(transcriptSnippet = transcriptSnippet),
-            token = token,
-        )
     }
 
     override suspend fun sendAnonymousFeedback(subject: String, inbox: String, message: String): Response<Void> {

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheService.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheService.kt
@@ -136,7 +136,7 @@ interface PodcastCacheService {
         @Body request: EpisodeChatRequest,
     ): EpisodeChatResponse
 
-    @POST("mobile/bookmark/enrich")
+    @POST("/mobile/bookmark/enrich")
     suspend fun enrichBookmark(
         @Header("Authorization") authorization: String,
         @Body request: BookmarkEnrichRequest,

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheService.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheService.kt
@@ -4,6 +4,8 @@ import au.com.shiftyjelly.pocketcasts.models.entity.PodcastRatings
 import au.com.shiftyjelly.pocketcasts.models.to.EpisodeItem
 import au.com.shiftyjelly.pocketcasts.servers.search.CombinedSearchRequest
 import au.com.shiftyjelly.pocketcasts.servers.search.CombinedSearchResponse
+import au.com.shiftyjelly.pocketcasts.servers.sync.bookmark.BookmarkEnrichRequest
+import au.com.shiftyjelly.pocketcasts.servers.sync.bookmark.BookmarkEnrichResponse
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import io.reactivex.Single
@@ -133,4 +135,10 @@ interface PodcastCacheService {
         @Header("Authorization") authorization: String,
         @Body request: EpisodeChatRequest,
     ): EpisodeChatResponse
+
+    @POST("mobile/bookmark/enrich")
+    suspend fun enrichBookmark(
+        @Header("Authorization") authorization: String,
+        @Body request: BookmarkEnrichRequest,
+    ): BookmarkEnrichResponse
 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServiceManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServiceManager.kt
@@ -5,6 +5,8 @@ import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastRatings
 import au.com.shiftyjelly.pocketcasts.models.entity.SuggestedFolder
 import au.com.shiftyjelly.pocketcasts.servers.discover.EpisodeSearch
+import au.com.shiftyjelly.pocketcasts.servers.sync.bookmark.BookmarkEnrichRequest
+import au.com.shiftyjelly.pocketcasts.servers.sync.bookmark.BookmarkEnrichResponse
 import io.reactivex.Single
 import retrofit2.Response
 
@@ -21,4 +23,5 @@ interface PodcastCacheServiceManager {
     suspend fun getEpisodeUrl(episode: PodcastEpisode): String?
     suspend fun suggestedFolders(request: SuggestedFoldersRequest): List<SuggestedFolder>
     suspend fun episodeChat(authorization: String, request: EpisodeChatRequest): EpisodeChatResponse
+    suspend fun enrichBookmark(authorization: String, request: BookmarkEnrichRequest): BookmarkEnrichResponse
 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServiceManagerImpl.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServiceManagerImpl.kt
@@ -5,6 +5,8 @@ import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastRatings
 import au.com.shiftyjelly.pocketcasts.models.entity.SuggestedFolder
 import au.com.shiftyjelly.pocketcasts.servers.discover.EpisodeSearch
+import au.com.shiftyjelly.pocketcasts.servers.sync.bookmark.BookmarkEnrichRequest
+import au.com.shiftyjelly.pocketcasts.servers.sync.bookmark.BookmarkEnrichResponse
 import io.reactivex.Single
 import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
@@ -93,6 +95,10 @@ class PodcastCacheServiceManagerImpl @Inject constructor(
             authorization = authorization,
             request = request,
         )
+    }
+
+    override suspend fun enrichBookmark(authorization: String, request: BookmarkEnrichRequest): BookmarkEnrichResponse {
+        return service.enrichBookmark(authorization, request)
     }
 
     private fun Map<String, List<String>>.toSuggestedFolders(): List<SuggestedFolder> {

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncService.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncService.kt
@@ -2,8 +2,6 @@ package au.com.shiftyjelly.pocketcasts.servers.sync
 
 import au.com.shiftyjelly.pocketcasts.models.to.HistorySyncRequest
 import au.com.shiftyjelly.pocketcasts.models.to.HistorySyncResponse
-import au.com.shiftyjelly.pocketcasts.servers.sync.bookmark.BookmarkEnrichRequest
-import au.com.shiftyjelly.pocketcasts.servers.sync.bookmark.BookmarkEnrichResponse
 import au.com.shiftyjelly.pocketcasts.servers.sync.forgotpassword.ForgotPasswordRequest
 import au.com.shiftyjelly.pocketcasts.servers.sync.forgotpassword.ForgotPasswordResponse
 import au.com.shiftyjelly.pocketcasts.servers.sync.history.HistoryYearResponse
@@ -181,9 +179,6 @@ interface SyncService {
     @Headers("Content-Type: application/octet-stream")
     @POST("/user/bookmark/list")
     suspend fun getBookmarkList(@Header("Authorization") authorization: String, @Body request: BookmarkRequest): BookmarksResponse
-
-    @POST("/user/bookmark/enrich")
-    suspend fun enrichBookmark(@Header("Authorization") authorization: String, @Body request: BookmarkEnrichRequest): BookmarkEnrichResponse
 
     @Headers("Content-Type: application/octet-stream")
     @POST("/user/podcast_rating/add")

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServiceManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServiceManager.kt
@@ -10,8 +10,6 @@ import au.com.shiftyjelly.pocketcasts.preferences.AccessToken
 import au.com.shiftyjelly.pocketcasts.preferences.RefreshToken
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.servers.di.Cached
-import au.com.shiftyjelly.pocketcasts.servers.sync.bookmark.BookmarkEnrichRequest
-import au.com.shiftyjelly.pocketcasts.servers.sync.bookmark.BookmarkEnrichResponse
 import au.com.shiftyjelly.pocketcasts.servers.sync.forgotpassword.ForgotPasswordRequest
 import au.com.shiftyjelly.pocketcasts.servers.sync.forgotpassword.ForgotPasswordResponse
 import au.com.shiftyjelly.pocketcasts.servers.sync.history.HistoryYearResponse
@@ -178,10 +176,6 @@ open class SyncServiceManager @Inject constructor(
 
     suspend fun getBookmarks(token: AccessToken): BookmarksResponse {
         return service.getBookmarkList(addBearer(token), bookmarkRequest {})
-    }
-
-    suspend fun enrichBookmark(request: BookmarkEnrichRequest, token: AccessToken): BookmarkEnrichResponse {
-        return service.enrichBookmark(addBearer(token), request)
     }
 
     suspend fun getEpisodes(request: PodcastsEpisodesRequest, token: AccessToken): EpisodesResponse {


### PR DESCRIPTION
## Description
This moves the smart bookmark enrichment call from sync-api (which proxied to node-server) to podcast-api directly. The change was prompted by review feedback on [Automattic/pocket-casts-node-server#1247](https://github.com/Automattic/pocket-casts-node-server/pull/1247) from @srjakes and @psrpinto — node-server is a single instance not designed for user-facing traffic, while podcast-api is horizontally scaled and already has JWT auth re-enabled.

`BookmarkManagerImpl` now uses `TokenHandler` to get the access token and calls `PodcastCacheServiceManager.enrichBookmark()` instead of `SyncManager.enrichBookmark()`. The Retrofit endpoint on `PodcastCacheService` passes the Bearer token explicitly via `@Header("Authorization")` since the podcast-api `@Cached` OkHttpClient doesn't include the token interceptor.

The `enrichBookmark` method has been removed from `SyncService`, `SyncServiceManager`, `SyncManager`, and `SyncManagerImpl`. The `BookmarkEnrichModels` stay in their current package as a shared import.

Server-side companion PR: [Automattic/pocket-casts-podcast-api#346](https://github.com/Automattic/pocket-casts-podcast-api/pull/346)

## Testing Instructions
Since the server changes are not deployed yet, this is a code-review-only PR for now. Once the podcast-api endpoint is live:
1. Enable the Smart Bookmarks feature flag
2. Open an episode that has a transcript
3. Create a bookmark → enrichment should fire in the background
4. Verify the AI-generated title and summary appear on the bookmark
5. Sign out and create a bookmark → enrichment should be skipped gracefully (no crash)

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.