### PR TITLE
[RSM] Add ChatScreen Compose preview

### DIFF
--- a/modules/features/chat/src/main/kotlin/au/com/shiftyjelly/pocketcasts/chat/ui/ChatScreen.kt
+++ b/modules/features/chat/src/main/kotlin/au/com/shiftyjelly/pocketcasts/chat/ui/ChatScreen.kt
@@ -17,11 +17,16 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.chat.ChatError
 import au.com.shiftyjelly.pocketcasts.chat.ChatUiState
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.repositories.chat.ChatMessage
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
@@ -139,4 +144,46 @@ private fun ChatErrorMessage(
             .fillMaxWidth()
             .padding(horizontal = 32.dp),
     )
+}
+
+@Preview
+@Composable
+private fun ChatScreenPreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: ThemeType,
+) {
+    AppThemeWithBackground(themeType) {
+        ChatScreen(
+            uiState = ChatUiState(
+                inputText = "Ask a follow-up",
+                episodeTitle = "The future of podcast discovery",
+                episodeSubtitle = "May 25",
+                podcastUuid = "preview-podcast-uuid",
+                podcastTitle = "Pocket Casts Weekly",
+                episodeDurationMs = 3_600_000,
+                messages = listOf(
+                    ChatMessage.Assistant(
+                        text = "Ask me anything about this episode. I can summarize topics or find key moments.",
+                    ),
+                    ChatMessage.User(
+                        text = "What was the main point?",
+                    ),
+                    ChatMessage.Assistant(
+                        text = "The hosts focused on making discovery feel personal without adding friction.",
+                    ),
+                    ChatMessage.Quote(
+                        text = "The important idea is to keep the interface simple while still surfacing useful context.",
+                        start = "12:04",
+                        end = "12:18",
+                        canPlay = true,
+                    ),
+                ),
+            ),
+            onClickClose = {},
+            onClickMore = {},
+            onInputTextChange = {},
+            onSend = {},
+            onRetry = {},
+            onPlayQuote = {},
+        )
+    }
 }


### PR DESCRIPTION
## Description
Adds a Compose preview for `ChatScreen` so the chat UI can be inspected across app themes without launching the full chat flow. The preview uses representative assistant, user, and playable quote messages to cover the main conversation layout.

Fixes: None

## Testing Instructions
1. Open `ChatScreenPreview` in Android Studio's Compose Preview.
2. Verify the chat toolbar, context bubble, messages, quote card, and input bar render with the supplied preview state.
3. Run `./gradlew :modules:features:chat:compileDebugKotlin`.

## Screenshots or Screencast 
![ChatScreenPreview themes](https://github.com/user-attachments/assets/d371d8a2-1fd2-42d8-8d38-9c4d60bd3d4a)

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack

