### PR TITLE
Fix typos in comments and test names

### DIFF
--- a/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/clip/ClipPlayer.kt
+++ b/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/clip/ClipPlayer.kt
@@ -201,7 +201,7 @@ private class ExoPlayerClipPlayer(
     }
 
     private fun ExoPlayerDataSourceFactory.createMediaSource(clip: Clip): MediaSource? {
-        // Divide and multiple by 100 to drop insignificant for clip creation milliseconds resolution
+        // Divide and multiply by 100 to drop insignificant for clip creation milliseconds resolution
         val clipStart = (clip.range.start.inWholeMilliseconds / 100) * 100
         val clipEnd = (clip.range.end.inWholeMilliseconds / 100) * 100
         return createMediaSource(clip.episodeLocation, clipStart..clipEnd)

--- a/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/clip/ClipPlayer.kt
+++ b/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/clip/ClipPlayer.kt
@@ -90,7 +90,7 @@ private class ExoPlayerClipPlayer(
         }
     }.stateIn(coroutineScope, SharingStarted.Lazily, Duration.ZERO)
 
-    // Progress UI indicator syncs with playback progress emited from the player.
+    // Progress UI indicator syncs with playback progress emitted from the player.
     // Disable the dispatch to make dragging animation smoother.
     private var isPlaybackProgressDispatchEnabled = true
     private var playbackPollingFrequency = 100.milliseconds
@@ -201,7 +201,7 @@ private class ExoPlayerClipPlayer(
     }
 
     private fun ExoPlayerDataSourceFactory.createMediaSource(clip: Clip): MediaSource? {
-        // Divide and multiple by 100 to drop insignificant for clip creation millseconds resolution
+        // Divide and multiple by 100 to drop insignificant for clip creation milliseconds resolution
         val clipStart = (clip.range.start.inWholeMilliseconds / 100) * 100
         val clipEnd = (clip.range.end.inWholeMilliseconds / 100) * 100
         return createMediaSource(clip.episodeLocation, clipStart..clipEnd)

--- a/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/stats/StatsViewModelTest.kt
+++ b/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/stats/StatsViewModelTest.kt
@@ -73,7 +73,7 @@ class StatsViewModelTest {
     }
 
     @Test
-    fun `given last 7 days played up to sum less than 2_5 hrs, when stats are loaded, then app review dialog  is not shown`() = runTest {
+    fun `given last 7 days played up to sum less than 2_5 hrs, when stats are loaded, then app review dialog is not shown`() = runTest {
         initViewModel(playedUpToSumInHours = 2.0)
 
         viewModel.loadStats()

--- a/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/stats/StatsViewModelTest.kt
+++ b/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/stats/StatsViewModelTest.kt
@@ -64,7 +64,7 @@ class StatsViewModelTest {
     }
 
     @Test
-    fun `given last 7 days played upto sum more than 2_5 hrs, when stats are loaded, then app review dialog is shown`() = runTest {
+    fun `given last 7 days played up to sum more than 2_5 hrs, when stats are loaded, then app review dialog is shown`() = runTest {
         initViewModel(playedUpToSumInHours = 3.0)
 
         viewModel.loadStats()
@@ -73,7 +73,7 @@ class StatsViewModelTest {
     }
 
     @Test
-    fun `given last 7 days played upto sum less than 2_5 hrs, when stats are loaded, then app review dialog  is not shown`() = runTest {
+    fun `given last 7 days played up to sum less than 2_5 hrs, when stats are loaded, then app review dialog  is not shown`() = runTest {
         initViewModel(playedUpToSumInHours = 2.0)
 
         viewModel.loadStats()

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/reorderable/ReorderableDataSource.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/reorderable/ReorderableDataSource.kt
@@ -97,7 +97,7 @@ fun <T : Any, K : Any, I : Any, S : ReorderableLazyCollectionState<I>> rememberR
     // because after commit on drag stop, we don't want to emit the original items
     // before the commit had a chance to recompose us with the updated items. We do this
     // in order to avoid flicker caused by transient resetting to the original unordered items
-    // before the commited changes come through.
+    // before the committed changes come through.
     //
     // Note that in case the commit did not update the items, we will stay in PendingRefresh
     // state until down the line either items changes, or another drag is started

--- a/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentClientTest.kt
+++ b/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentClientTest.kt
@@ -331,7 +331,7 @@ class PaymentClientTest {
     }
 
     @Test
-    fun `dispatch loading acknowledged subscription purchases succesfully`() = runTest {
+    fun `dispatch loading acknowledged subscription purchases successfully`() = runTest {
         client.loadAcknowledgedSubscriptions()
 
         listener.assertEvents(

--- a/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/billing/BillingPaymentMapperFlowParamsTest.kt
+++ b/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/billing/BillingPaymentMapperFlowParamsTest.kt
@@ -231,7 +231,7 @@ class BillingPaymentMapperFlowParamsTest {
         }
 
         @Test
-        fun `do not log anything when mapped succesfully`() {
+        fun `do not log anything when mapped successfully`() {
             val planKey = SubscriptionPlan.Key(SubscriptionTier.Plus, BillingCycle.Monthly, offer = null)
             val product = createGoogleProductDetails(
                 productId = requireNotNull(planKey.productId),

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/auto/PackageValidator.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/auto/PackageValidator.kt
@@ -131,7 +131,7 @@ class PackageValidator(context: Context, @XmlRes xmlResId: Int) {
 
             // [MEDIA_CONTENT_CONTROL] permission is only available to system applications, and
             // while it isn't required to allow these apps to connect to a
-            // [MediaBrowserServiceCompat], allowing this ensures optimal compatability with apps
+            // [MediaBrowserServiceCompat], allowing this ensures optimal compatibility with apps
             // such as Android TV and the Google Assistant.
             callerPackageInfo.permissions.contains(MEDIA_CONTENT_CONTROL) -> true
 


### PR DESCRIPTION
Mechanical typo fixes in code comments and backticked test names.
No behavior changes.

Each commit fixes typos in a single file.

## To test

- Skim the diff; verify each replacement is the obvious correction.
- CI should be green.

---

*Posted by Claude (Opus 4.7) on behalf of @mokagio with approval.*