### PR TITLE
Add an explicit podcast badge to search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
         ([#5278](https://github.com/Automattic/pocket-casts-android/pull/5278))
     *   Use generated chapters when author didn't provide them
         ([#5277](https://github.com/Automattic/pocket-casts-android/pull/5277))
+    *   Add an explicit podcast badge to search results
+        ([#5351](https://github.com/Automattic/pocket-casts-android/pull/5351)) 
 
 8.12
 -----

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastHeader.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastHeader.kt
@@ -366,7 +366,7 @@ private fun PodcastCategoriesLabel(
         textAlign = TextAlign.Center,
         inlineContent = if (showExplicitIndicator && explicit) {
             mapOf(
-                "explicit" to InlineTextContent(Placeholder(13.sp, 13.sp, PlaceholderVerticalAlign.TextCenter)) {
+                "explicit" to InlineTextContent(Placeholder(16.sp, 16.sp, PlaceholderVerticalAlign.TextCenter)) {
                     val explicitDescription = stringResource(LR.string.explicit)
                     Icon(
                         painter = painterResource(IR.drawable.explicit),

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchHandler.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchHandler.kt
@@ -215,13 +215,20 @@ class SearchHandler @Inject constructor(
                 author = folderItem.podcast.author,
                 title = folderItem.title,
                 isSubscribed = true,
+                isExplicit = folderItem.podcast.explicit == true,
             )
 
             is FolderItem.Folder -> SearchAutoCompleteItem.Folder(
                 uuid = folderItem.uuid,
                 title = folderItem.title,
                 podcasts = folderItem.podcasts.map {
-                    SearchAutoCompleteItem.Podcast(uuid = it.uuid, title = it.title, author = it.author, isSubscribed = true)
+                    SearchAutoCompleteItem.Podcast(
+                        uuid = it.uuid,
+                        title = it.title,
+                        author = it.author,
+                        isSubscribed = true,
+                        isExplicit = it.explicit == true,
+                    )
                 },
                 color = folderItem.folder.color,
             )
@@ -374,7 +381,14 @@ class SearchHandler @Inject constructor(
                         val localResults = localPodcasts.map {
                             when (it) {
                                 is FolderItem.Folder -> ImprovedSearchResultItem.FolderItem(folder = it.folder, podcasts = it.podcasts)
-                                is FolderItem.Podcast -> ImprovedSearchResultItem.PodcastItem(uuid = it.uuid, isFollowed = true, title = it.podcast.title, author = it.podcast.author)
+
+                                is FolderItem.Podcast -> ImprovedSearchResultItem.PodcastItem(
+                                    uuid = it.uuid,
+                                    isFollowed = true,
+                                    title = it.podcast.title,
+                                    author = it.podcast.author,
+                                    isExplicit = it.podcast.explicit == true,
+                                )
                             }
                         }
                         if (localResults.isNotEmpty()) {

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/component/ImprovedSearchPodcastResultRow.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/component/ImprovedSearchPodcastResultRow.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
@@ -21,6 +22,7 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
@@ -151,12 +153,14 @@ private fun PodcastResultTitle(
         )
         if (isExplicit) {
             val explicitDescription = stringResource(LR.string.explicit)
+            // scale the icon to match the text size
+            val explicitIconSize = with(LocalDensity.current) { 16.sp.toDp() }
             Icon(
                 painter = painterResource(IR.drawable.explicit),
                 contentDescription = null,
                 tint = MaterialTheme.theme.colors.primaryText02,
                 modifier = Modifier
-                    .size(16.dp)
+                    .size(explicitIconSize)
                     .clearAndSetSemantics { contentDescription = explicitDescription },
             )
         }

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/component/ImprovedSearchPodcastResultRow.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/component/ImprovedSearchPodcastResultRow.kt
@@ -5,17 +5,23 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
@@ -25,7 +31,10 @@ import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.models.to.ImprovedSearchResultItem
 import au.com.shiftyjelly.pocketcasts.models.to.SearchAutoCompleteItem
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.images.R as IR
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 fun ImprovedSearchPodcastResultRow(
@@ -39,6 +48,7 @@ fun ImprovedSearchPodcastResultRow(
         title = item.title,
         author = item.author,
         isSubscribed = item.isSubscribed,
+        isExplicit = item.isExplicit,
         onClick = onClick,
         onFollow = onFollow,
         modifier = modifier,
@@ -57,6 +67,7 @@ fun ImprovedSearchPodcastResultRow(
         title = podcastItem.title,
         author = podcastItem.author,
         isSubscribed = podcastItem.isFollowed,
+        isExplicit = podcastItem.isExplicit,
         onClick = onClick,
         onFollow = onFollow,
         modifier = modifier,
@@ -69,10 +80,15 @@ private fun ImprovedSearchPodcastResultRow(
     title: String,
     author: String,
     isSubscribed: Boolean,
+    isExplicit: Boolean,
     onClick: () -> Unit,
     onFollow: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val showExplicitIndicator by FeatureFlag
+        .isEnabledFlow(Feature.EXPLICIT_PODCAST_INDICATOR)
+        .collectAsStateWithLifecycle()
+
     Row(
         modifier = modifier
             .clickable(onClick = onClick)
@@ -86,10 +102,9 @@ private fun ImprovedSearchPodcastResultRow(
             cornerSize = 4.dp,
         )
         Column(modifier = Modifier.weight(1f)) {
-            TextH40(
-                text = title,
-                color = MaterialTheme.theme.colors.primaryText01,
-                maxLines = 1,
+            PodcastResultTitle(
+                title = title,
+                isExplicit = isExplicit && showExplicitIndicator,
             )
             TextP50(
                 text = author,
@@ -117,6 +132,37 @@ private fun ImprovedSearchPodcastResultRow(
     }
 }
 
+@Composable
+private fun PodcastResultTitle(
+    title: String,
+    isExplicit: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        TextH40(
+            text = title,
+            color = MaterialTheme.theme.colors.primaryText01,
+            maxLines = 1,
+            modifier = Modifier.weight(1f, fill = false),
+        )
+        if (isExplicit) {
+            val explicitDescription = stringResource(LR.string.explicit)
+            Icon(
+                painter = painterResource(IR.drawable.explicit),
+                contentDescription = null,
+                tint = MaterialTheme.theme.colors.primaryText02,
+                modifier = Modifier
+                    .size(16.dp)
+                    .clearAndSetSemantics { contentDescription = explicitDescription },
+            )
+        }
+    }
+}
+
 @Preview
 @Composable
 private fun PreviewPodcastRow(
@@ -128,6 +174,7 @@ private fun PreviewPodcastRow(
             title = "Podcast title",
             author = "Author name",
             isSubscribed = false,
+            isExplicit = true,
             onClick = {},
             onFollow = {},
         )

--- a/modules/services/images/src/main/res/drawable/explicit.xml
+++ b/modules/services/images/src/main/res/drawable/explicit.xml
@@ -1,18 +1,24 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="13dp"
-    android:height="13dp"
-    android:viewportWidth="13"
-    android:viewportHeight="13">
-  <group>
-    <clip-path
-        android:pathData="M0,0h13v13h-13z"/>
-    <path
-        android:pathData="M8.75,0.75H4.25C2.317,0.75 0.75,2.317 0.75,4.25V8.75C0.75,10.683 2.317,12.25 4.25,12.25H8.75C10.683,12.25 12.25,10.683 12.25,8.75V4.25C12.25,2.317 10.683,0.75 8.75,0.75Z"
-        android:strokeWidth="1.5"
-        android:fillColor="#00000000"
-        android:strokeColor="#F43F5E"/>
-    <path
-        android:pathData="M4.226,10V3.193H8.813V4.379H5.665V6.001H8.577V7.188H5.665V8.813H8.826V10H4.226Z"
-        android:fillColor="#F43F5E"/>
-  </group>
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M19,3L5,3c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2L21,5c0,-1.1 -0.9,-2 -2,-2zM14,9h-3v2h3c0.55,0 1,0.45 1,1s-0.45,1 -1,1h-3v2h3c0.55,0 1,0.45 1,1s-0.45,1 -1,1h-4c-0.55,0 -1,-0.45 -1,-1L9,8c0,-0.55 0.45,-1 1,-1h4c0.55,0 1,0.45 1,1s-0.45,1 -1,1z"/>
 </vector>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/ImprovedSearchResultItem.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/ImprovedSearchResultItem.kt
@@ -22,6 +22,7 @@ sealed interface ImprovedSearchResultItem {
         override val title: String,
         val author: String,
         val isFollowed: Boolean,
+        val isExplicit: Boolean = false,
     ) : ImprovedSearchResultItem
 
     data class EpisodeItem(

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/SearchAutoCompleteItem.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/SearchAutoCompleteItem.kt
@@ -9,6 +9,7 @@ sealed class SearchAutoCompleteItem {
         val title: String,
         val author: String,
         val isSubscribed: Boolean = false,
+        val isExplicit: Boolean = false,
     ) : SearchAutoCompleteItem()
     data class Folder(
         val uuid: String,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/search/ImprovedSearchManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/search/ImprovedSearchManagerImpl.kt
@@ -19,7 +19,13 @@ class ImprovedSearchManagerImpl @Inject constructor(
         return response.results.map {
             when (it) {
                 is AutoCompleteResult.TermResult -> SearchAutoCompleteItem.Term(term = it.value)
-                is AutoCompleteResult.PodcastResult -> SearchAutoCompleteItem.Podcast(uuid = it.value.uuid, title = it.value.title, author = it.value.author.orEmpty())
+
+                is AutoCompleteResult.PodcastResult -> SearchAutoCompleteItem.Podcast(
+                    uuid = it.value.uuid,
+                    title = it.value.title,
+                    author = it.value.author.orEmpty(),
+                    isExplicit = it.value.explicit == true,
+                )
             }
         }
     }
@@ -33,6 +39,7 @@ class ImprovedSearchManagerImpl @Inject constructor(
                     title = it.title,
                     author = it.author.orEmpty(),
                     isFollowed = false,
+                    isExplicit = it.explicit == true,
                 )
 
                 is CombinedResult.EpisodeResult -> ImprovedSearchResultItem.EpisodeItem(

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/search/AutoCompleteResponse.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/search/AutoCompleteResponse.kt
@@ -31,4 +31,5 @@ data class PodcastResultValue(
     val uuid: String,
     val title: String,
     val author: String? = null,
+    val explicit: Boolean? = null,
 )

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/search/CombinedSearchResponse.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/search/CombinedSearchResponse.kt
@@ -17,6 +17,7 @@ sealed interface CombinedResult {
         val title: String,
         val author: String? = "",
         val slug: String,
+        val explicit: Boolean? = null,
     ) : CombinedResult
 
     @JsonClass(generateAdapter = true)


### PR DESCRIPTION
## Description

This change switch to the explicit icon that design prefer, it also adds the explicit icon to the quick and full search podcast rows.

## Testing Instructions

1. Use either the `debug` or `debugProd` variant
2. Go to the Discover tab
3. Search for an explicit podcast such as Joe Rogan
4. ✅ Verify the explicit badge appears to the right of the podcast title
5. Search for a non-explicit podcast
6. ✅ Confirm no badge is shown
7. Turn off the "Explicit podcast indicator" feature flag
8. ✅ Confirm no badge is shown for an explicit podcast

## Screenshots 

| Light | Dark |
| --- | --- |
| <img width="1080" height="2400" alt="Screenshot_20260527_155040" src="https://github.com/user-attachments/assets/5174b266-fc25-4517-bd0f-185119063a41" /> | <img width="1080" height="2400" alt="Screenshot_20260527_155205" src="https://github.com/user-attachments/assets/23ec3459-8434-4bbc-af1e-0ac135f5ee58" /> | 
| <img width="1080" height="2400" alt="Screenshot_20260527_155051" src="https://github.com/user-attachments/assets/7988bfd8-b9a2-43c0-b7d6-833ee6cb4a43" /> | <img width="1080" height="2400" alt="Screenshot_20260527_155104" src="https://github.com/user-attachments/assets/d3507ab8-40f9-4039-8ec2-1e5a7d736b89" /> | 

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

#### I have tested any UI changes...
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack