### PR TITLE
Add dependabot bundler block for Ruby deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,3 +54,14 @@ updates:
       - dependency-name: "androidx.wear.compose:compose-foundation"
       - dependency-name: "androidx.wear.compose:compose-material"
       - dependency-name: "androidx.wear.compose:compose-navigation"
+  - package-ecosystem: "bundler"
+    open-pull-requests-limit: 5
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "[Type] Tech Debt"
+      - "[Area] Dependencies"
+    groups:
+      ruby-minor-and-patch:
+        update-types: [minor, patch]


### PR DESCRIPTION
## Description

Sets up Dependabot to check Ruby dependencies daily so we can more easily address security updates. See [AINFRA-2437](https://linear.app/a8c/issue/AINFRA-2437).

Existing `gradle` and `github-actions` ecosystem entries are left untouched.

## Testing Instructions

Dependabot config is consumed by GitHub, not the repo's CI. YAML validation passes (`yq . .github/dependabot.yml`); existing `gradle` and `github-actions` entries are untouched.

## Checklist

- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md — _N/A, infra-only change_
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting) — _N/A, YAML-only change_
- [x] I have considered whether it makes sense to add tests for my changes — _N/A_
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml` — _N/A_
- [x] Any jetpack compose components I added or changed are covered by compose previews — _N/A_
- [x] I have updated (or requested that someone edit) the spreadsheet to reflect any new or changed analytics — _N/A_

---

Posted by Claude (Opus 4.7, 1M context) on behalf of @mokagio with approval.