### PR TITLE
Request reviews from apps-infra-tooling on Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,8 +22,6 @@ updates:
     labels:
       - "[Type] Tech Debt"
       - "[Area] Dependencies"
-    reviewers:
-      - "Automattic/apps-infra-tooling"
     groups:
       kotlin-ksp:
         applies-to: version-updates

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
     labels:
       - "[Type] Tech Debt"
       - "[Area] Dependencies"
+    reviewers:
+      - "Automattic/apps-infra-tooling"
     ignore:
       # These dependencies cannot be updated beyond v2 for non-Enterpise clients
       - dependency-name: "gradle-build-action"
@@ -20,6 +22,8 @@ updates:
     labels:
       - "[Type] Tech Debt"
       - "[Area] Dependencies"
+    reviewers:
+      - "Automattic/apps-infra-tooling"
     groups:
       kotlin-ksp:
         applies-to: version-updates
@@ -62,6 +66,8 @@ updates:
     labels:
       - "[Type] Tech Debt"
       - "[Area] Dependencies"
+    reviewers:
+      - "Automattic/apps-infra-tooling"
     groups:
       ruby-minor-and-patch:
         update-types: [minor, patch]


### PR DESCRIPTION
The intent of this config change is to get folks in the new @Automattic/apps-infra-tooling team notified when PRs such as #5357 happen so that we can act on them without distracting the product devs.