### PR TITLE
Attempt to fix RefreshTokenExpiredException crash

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncAccountManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncAccountManagerImpl.kt
@@ -120,6 +120,9 @@ open class SyncAccountManagerImpl @Inject constructor(
                 } else {
                     AccessToken(token)
                 }
+            } catch (e: RefreshTokenExpiredException) {
+                LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Could not get token because the refresh token has expired")
+                throw e
             } catch (e: Exception) {
                 LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, e, "Could not get token")
                 throw e // Rethrow the exception so it carries on

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/di/InterceptorModule.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/di/InterceptorModule.kt
@@ -9,8 +9,11 @@ import au.com.shiftyjelly.pocketcasts.servers.OkHttpInterceptor
 import au.com.shiftyjelly.pocketcasts.servers.interceptors.BasicAuthInterceptor
 import au.com.shiftyjelly.pocketcasts.servers.interceptors.InternationalizationInterceptor
 import au.com.shiftyjelly.pocketcasts.servers.sync.TokenHandler
+import au.com.shiftyjelly.pocketcasts.servers.sync.exception.RefreshTokenExpiredException
 import au.com.shiftyjelly.pocketcasts.servers.toClientInterceptor
 import au.com.shiftyjelly.pocketcasts.servers.toNetworkInterceptor
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import com.automattic.android.tracks.crashlogging.CrashLoggingOkHttpInterceptorProvider
 import com.automattic.android.tracks.crashlogging.FormattedUrl
 import com.automattic.android.tracks.crashlogging.RequestFormatter
@@ -109,17 +112,30 @@ object InterceptorModule {
             return builder.build()
         }
 
+        fun getAccessToken(): AccessToken? {
+            return if (FeatureFlag.isEnabled(Feature.INTERCEPTOR_REFRESH_TOKEN_FALLBACK)) {
+                try {
+                    runBlocking { tokenHandler.getAccessToken() }
+                } catch (_: RefreshTokenExpiredException) {
+                    null
+                }
+            } else {
+                runBlocking { tokenHandler.getAccessToken() }
+            }
+        }
+
         return Interceptor { chain ->
             val original = chain.request()
             if (unauthenticatedEndpoints.contains(original.url.encodedPathSegments.firstOrNull())) {
                 chain.proceed(original)
             } else {
-                val token = runBlocking { tokenHandler.getAccessToken() }
+                val token = getAccessToken()
                 return@Interceptor if (token != null) {
                     val response = chain.proceed(buildRequestWithToken(original, token))
                     if (response.code == HttpURLConnection.HTTP_UNAUTHORIZED) {
                         tokenHandler.invalidateAccessToken()
-                        val newToken = runBlocking { tokenHandler.getAccessToken() }
+                        response.close()
+                        val newToken = getAccessToken()
                         chain.proceed(buildRequestWithToken(original, newToken))
                     } else {
                         response

--- a/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/di/TokenInterceptorTest.kt
+++ b/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/di/TokenInterceptorTest.kt
@@ -54,6 +54,7 @@ class TokenInterceptorTest {
         val request = requireNotNull(server.takeRequest(5, TimeUnit.SECONDS))
         assertNull(request.getHeader("Authorization"))
         assertEquals(0, tokenHandler.getAccessTokenCalls)
+    }
 
     @Test
     fun `throws when refresh token has expired and fallback is disabled`() {
@@ -82,6 +83,7 @@ class TokenInterceptorTest {
         val request = requireNotNull(server.takeRequest(5, TimeUnit.SECONDS))
         assertNull(request.getHeader("Authorization"))
         assertEquals(1, tokenHandler.getAccessTokenCalls)
+    }
 
     @Test
     fun `throws when refreshed token has expired and fallback is disabled`() {

--- a/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/di/TokenInterceptorTest.kt
+++ b/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/di/TokenInterceptorTest.kt
@@ -51,10 +51,9 @@ class TokenInterceptorTest {
             assertEquals(HttpURLConnection.HTTP_OK, response.code)
         }
 
-        val request = server.takeRequest(5, TimeUnit.SECONDS)
-        assertNull(request?.getHeader("Authorization"))
+        val request = requireNotNull(server.takeRequest(5, TimeUnit.SECONDS))
+        assertNull(request.getHeader("Authorization"))
         assertEquals(0, tokenHandler.getAccessTokenCalls)
-    }
 
     @Test
     fun `throws when refresh token has expired and fallback is disabled`() {
@@ -80,10 +79,9 @@ class TokenInterceptorTest {
             assertEquals(HttpURLConnection.HTTP_OK, response.code)
         }
 
-        val request = server.takeRequest(5, TimeUnit.SECONDS)
-        assertNull(request?.getHeader("Authorization"))
+        val request = requireNotNull(server.takeRequest(5, TimeUnit.SECONDS))
+        assertNull(request.getHeader("Authorization"))
         assertEquals(1, tokenHandler.getAccessTokenCalls)
-    }
 
     @Test
     fun `throws when refreshed token has expired and fallback is disabled`() {
@@ -120,10 +118,10 @@ class TokenInterceptorTest {
             assertEquals(HttpURLConnection.HTTP_OK, response.code)
         }
 
-        val firstRequest = server.takeRequest(5, TimeUnit.SECONDS)
-        val secondRequest = server.takeRequest(5, TimeUnit.SECONDS)
-        assertEquals("Bearer expired-access-token", firstRequest?.getHeader("Authorization"))
-        assertNull(secondRequest?.getHeader("Authorization"))
+        val firstRequest = requireNotNull(server.takeRequest(5, TimeUnit.SECONDS))
+        val secondRequest = requireNotNull(server.takeRequest(5, TimeUnit.SECONDS))
+        assertEquals("Bearer expired-access-token", firstRequest.getHeader("Authorization"))
+        assertNull(secondRequest.getHeader("Authorization"))
         assertEquals(2, tokenHandler.getAccessTokenCalls)
         assertTrue(tokenHandler.invalidatedAccessToken)
     }

--- a/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/di/TokenInterceptorTest.kt
+++ b/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/di/TokenInterceptorTest.kt
@@ -1,0 +1,166 @@
+package au.com.shiftyjelly.pocketcasts.servers.di
+
+import au.com.shiftyjelly.pocketcasts.preferences.AccessToken
+import au.com.shiftyjelly.pocketcasts.servers.sync.TokenHandler
+import au.com.shiftyjelly.pocketcasts.servers.sync.exception.RefreshTokenExpiredException
+import au.com.shiftyjelly.pocketcasts.sharedtest.InMemoryFeatureFlagRule
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
+import java.net.HttpURLConnection
+import java.util.ArrayDeque
+import java.util.concurrent.TimeUnit
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+class TokenInterceptorTest {
+    @get:Rule
+    val server = MockWebServer()
+
+    @get:Rule
+    val featureFlagRule = InMemoryFeatureFlagRule()
+
+    @Test
+    fun `adds authorization header when token is available`() {
+        val tokenHandler = FakeTokenHandler(TokenResult.Token(AccessToken("access-token")))
+        val client = newClient(tokenHandler)
+        server.enqueue(MockResponse())
+
+        client.newCall(Request.Builder().url(server.url("/podcasts/search")).build()).execute().use { response ->
+            assertEquals(HttpURLConnection.HTTP_OK, response.code)
+        }
+
+        val request = server.takeRequest(5, TimeUnit.SECONDS)
+        assertEquals("Bearer access-token", request?.getHeader("Authorization"))
+    }
+
+    @Test
+    fun `does not ask for token on unauthenticated endpoints`() {
+        val tokenHandler = FakeTokenHandler(TokenResult.Token(AccessToken("access-token")))
+        val client = newClient(tokenHandler)
+        server.enqueue(MockResponse())
+
+        client.newCall(Request.Builder().url(server.url("/security/token")).build()).execute().use { response ->
+            assertEquals(HttpURLConnection.HTTP_OK, response.code)
+        }
+
+        val request = server.takeRequest(5, TimeUnit.SECONDS)
+        assertNull(request?.getHeader("Authorization"))
+        assertEquals(0, tokenHandler.getAccessTokenCalls)
+    }
+
+    @Test
+    fun `throws when refresh token has expired and fallback is disabled`() {
+        FeatureFlag.setEnabled(Feature.INTERCEPTOR_REFRESH_TOKEN_FALLBACK, false)
+        val tokenHandler = FakeTokenHandler(TokenResult.Expired)
+        val client = newClient(tokenHandler)
+        server.enqueue(MockResponse())
+
+        assertThrows(RefreshTokenExpiredException::class.java) {
+            client.newCall(Request.Builder().url(server.url("/podcasts/search")).build()).execute()
+        }
+        assertEquals(1, tokenHandler.getAccessTokenCalls)
+    }
+
+    @Test
+    fun `continues without authorization when refresh token has expired and fallback is enabled`() {
+        FeatureFlag.setEnabled(Feature.INTERCEPTOR_REFRESH_TOKEN_FALLBACK, true)
+        val tokenHandler = FakeTokenHandler(TokenResult.Expired)
+        val client = newClient(tokenHandler)
+        server.enqueue(MockResponse())
+
+        client.newCall(Request.Builder().url(server.url("/podcasts/search")).build()).execute().use { response ->
+            assertEquals(HttpURLConnection.HTTP_OK, response.code)
+        }
+
+        val request = server.takeRequest(5, TimeUnit.SECONDS)
+        assertNull(request?.getHeader("Authorization"))
+        assertEquals(1, tokenHandler.getAccessTokenCalls)
+    }
+
+    @Test
+    fun `throws when refreshed token has expired and fallback is disabled`() {
+        FeatureFlag.setEnabled(Feature.INTERCEPTOR_REFRESH_TOKEN_FALLBACK, false)
+        val tokenHandler = FakeTokenHandler(
+            TokenResult.Token(AccessToken("expired-access-token")),
+            TokenResult.Expired,
+        )
+        val client = newClient(tokenHandler)
+        server.enqueue(MockResponse().setResponseCode(HttpURLConnection.HTTP_UNAUTHORIZED))
+
+        assertThrows(RefreshTokenExpiredException::class.java) {
+            client.newCall(Request.Builder().url(server.url("/podcasts/search")).build()).execute()
+        }
+
+        val firstRequest = server.takeRequest(5, TimeUnit.SECONDS)
+        assertEquals("Bearer expired-access-token", firstRequest?.getHeader("Authorization"))
+        assertEquals(2, tokenHandler.getAccessTokenCalls)
+        assertTrue(tokenHandler.invalidatedAccessToken)
+    }
+
+    @Test
+    fun `continues without authorization when refreshed token has expired and fallback is enabled`() {
+        FeatureFlag.setEnabled(Feature.INTERCEPTOR_REFRESH_TOKEN_FALLBACK, true)
+        val tokenHandler = FakeTokenHandler(
+            TokenResult.Token(AccessToken("expired-access-token")),
+            TokenResult.Expired,
+        )
+        val client = newClient(tokenHandler)
+        server.enqueue(MockResponse().setResponseCode(HttpURLConnection.HTTP_UNAUTHORIZED))
+        server.enqueue(MockResponse())
+
+        client.newCall(Request.Builder().url(server.url("/podcasts/search")).build()).execute().use { response ->
+            assertEquals(HttpURLConnection.HTTP_OK, response.code)
+        }
+
+        val firstRequest = server.takeRequest(5, TimeUnit.SECONDS)
+        val secondRequest = server.takeRequest(5, TimeUnit.SECONDS)
+        assertEquals("Bearer expired-access-token", firstRequest?.getHeader("Authorization"))
+        assertNull(secondRequest?.getHeader("Authorization"))
+        assertEquals(2, tokenHandler.getAccessTokenCalls)
+        assertTrue(tokenHandler.invalidatedAccessToken)
+    }
+
+    private fun newClient(tokenHandler: TokenHandler): OkHttpClient {
+        return OkHttpClient.Builder()
+            .addInterceptor(InterceptorModule.provideTokenInterceptor(tokenHandler))
+            .build()
+    }
+
+    private class FakeTokenHandler(
+        vararg results: TokenResult,
+    ) : TokenHandler {
+        private val results = ArrayDeque<TokenResult>().apply { addAll(results.toList()) }
+
+        var getAccessTokenCalls = 0
+            private set
+
+        var invalidatedAccessToken = false
+            private set
+
+        override suspend fun getAccessToken(): AccessToken? {
+            getAccessTokenCalls++
+            check(results.isNotEmpty()) { "No token result configured" }
+            return when (val result = results.removeFirst()) {
+                TokenResult.Expired -> throw RefreshTokenExpiredException()
+                is TokenResult.Token -> result.accessToken
+            }
+        }
+
+        override fun invalidateAccessToken() {
+            invalidatedAccessToken = true
+        }
+    }
+
+    private sealed class TokenResult {
+        data class Token(val accessToken: AccessToken?) : TokenResult()
+        object Expired : TokenResult()
+    }
+}

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -63,6 +63,14 @@ enum class Feature(
         hasFirebaseRemoteFlag = true,
         hasDevToggle = false,
     ),
+    INTERCEPTOR_REFRESH_TOKEN_FALLBACK(
+        key = "interceptor_refresh_token_fallback",
+        title = "Interceptor refresh token fallback",
+        defaultValue = true,
+        tier = FeatureTier.Free,
+        hasFirebaseRemoteFlag = true,
+        hasDevToggle = true,
+    ),
     INTRO_PLUS_OFFER_ENABLED(
         key = "intro_plus_offer_enabled",
         title = "Intro Offer Plus",


### PR DESCRIPTION
## Description

When the OkHttp token interceptor requested an access token and the refresh token had expired, `TokenHandler.getAccessToken()` threw a `RefreshTokenExpiredException`. That exception propagated out of the interceptor and looked like it was causing app crashes in Sentry. 

This change is behind a remote feature flag so we can disable it quickly if needed.

## Testing Instructions

This is tricky one to test so it's covered by the new `TokenInterceptorTest` unit test.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

#### I have tested any UI changes...
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack