### PR TITLE
Disable end of year feature in development

### DIFF
--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -58,7 +58,7 @@ enum class Feature(
     END_OF_YEAR_2025(
         key = "end_of_year_2025",
         title = "End of Year 2025",
-        defaultValue = isDebugOrPrototypeBuild,
+        defaultValue = false,
         tier = FeatureTier.Free,
         hasFirebaseRemoteFlag = true,
         hasDevToggle = false,


### PR DESCRIPTION
## Description

This change disables the feature flag for the end of the year playback feature. It gets in the way a little bit when developing and testing. So for now this turns it off. 

## Testing Instructions

Confirm the playback banner does not appear on the Profile tab. 

## Screenshots

| Before | After |
| --- | --- |
| <img width="1080" height="2400" alt="Screenshot_20260601_140543" src="https://github.com/user-attachments/assets/5255e8c2-372d-4303-86b6-ef1a78fa343f" /> | <img width="1080" height="2400" alt="Screenshot_20260601_140738" src="https://github.com/user-attachments/assets/2c807a1a-eee9-46d9-adb4-4c7035992c2f" /> | 

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

#### I have tested any UI changes...
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack