### PR TITLE
Speed up the git pre-commit hook

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -103,6 +103,29 @@ dependencyAnalysis {
 
 val ktlintVersion = libs.versions.ktlint.asProvider().get()
 val ktlintComposeRules = libs.ktlint.compose.rules.get().toString()
+val spotlessPreCommitFiles = providers.gradleProperty("spotlessPreCommitFiles").orNull
+    ?.let { fileList ->
+        file(fileList)
+            .readLines()
+            .map(String::trim)
+            .filter(String::isNotEmpty)
+            .map { rootProject.file(it) }
+            .filter { it.isFile }
+    }
+val spotlessPreCommitKotlinFiles = spotlessPreCommitFiles?.filter { file ->
+    val path = file.relativeTo(rootDir).invariantSeparatorsPath
+    path.endsWith(".kt") &&
+        (
+            path.startsWith("app/src/") ||
+                path.startsWith("automotive/src/") ||
+                path.startsWith("wear/src/") ||
+                (path.startsWith("modules/") && "/src/" in path)
+            )
+}
+val spotlessPreCommitKotlinGradleFiles = spotlessPreCommitFiles?.filter { file ->
+    val path = file.relativeTo(rootDir).invariantSeparatorsPath
+    path.endsWith(".kts") && "/" !in path
+}
 
 spotless {
     val ktLintConfigOverride = mapOf(
@@ -116,12 +139,16 @@ spotless {
     )
 
     kotlin {
-        target(
-            "app/src/**/*.kt",
-            "automotive/src/**/*.kt",
-            "modules/**/src/**/*.kt",
-            "wear/src/**/*.kt",
-        )
+        if (spotlessPreCommitKotlinFiles != null) {
+            target(spotlessPreCommitKotlinFiles)
+        } else {
+            target(
+                "app/src/**/*.kt",
+                "automotive/src/**/*.kt",
+                "modules/**/src/**/*.kt",
+                "wear/src/**/*.kt",
+            )
+        }
         targetExclude("**/uniffi/**/*.kt")
         ktlint(ktlintVersion)
             .editorConfigOverride(ktLintConfigOverride + ktLintConfigComposeOverride)
@@ -129,7 +156,11 @@ spotless {
     }
 
     kotlinGradle {
-        target("*.kts")
+        if (spotlessPreCommitKotlinGradleFiles != null) {
+            target(spotlessPreCommitKotlinGradleFiles)
+        } else {
+            target("*.kts")
+        }
         ktlint(ktlintVersion).editorConfigOverride(ktLintConfigOverride)
     }
 }

--- a/scripts/git-hooks/pre-commit.sh
+++ b/scripts/git-hooks/pre-commit.sh
@@ -5,15 +5,26 @@
 # Spotless
 ##################
 
-echo "Running Spotless..."
-./gradlew spotlessCheck
-RESULT=$?
+STAGED_SPOTLESS_FILES="$(git diff --cached --name-only --diff-filter=ACMR -- '*.kt' '*.kts')"
+
+if [ -n "$STAGED_SPOTLESS_FILES" ]; then
+  SPOTLESS_FILE_LIST="$(mktemp "${TMPDIR:-/tmp}/pocketcasts-spotless.XXXXXX")"
+  trap 'rm -f "$SPOTLESS_FILE_LIST"' EXIT HUP INT TERM
+  printf '%s\n' "$STAGED_SPOTLESS_FILES" > "$SPOTLESS_FILE_LIST"
+
+  echo "Running Spotless on staged Kotlin files..."
+  ./gradlew spotlessCheck "-PspotlessPreCommitFiles=$SPOTLESS_FILE_LIST"
+  RESULT=$?
+else
+  echo "No staged Kotlin files. Skipping Spotless..."
+  RESULT=0
+fi
 
 if [ $RESULT -ne 0 ]; then
   echo ""
   echo "Spotless found format violations, so aborting the commit and applying formatting changes..."
   # using "> /dev/null/" because --quiet doesn't suppress ALL non-error output
-  ./gradlew spotlessApply > /dev/null
+  ./gradlew spotlessApply "-PspotlessPreCommitFiles=$SPOTLESS_FILE_LIST" > /dev/null
 
   echo "Recommended changes from spotless have been applied."
   exit $RESULT


### PR DESCRIPTION
## Description

The git pre-commit hook previously ran `./gradlew spotlessCheck` over the **entire** repository on every commit, which is slow regardless of how small the change is. This PR scopes Spotless to only the files that are actually staged for the commit. It takes the commit from a few minutes to seconds! 

## Testing Instructions

1. Run `./gradlew installGitHooks` to ensure the hook is installed.
2. Stage a single Kotlin file with a deliberate formatting issue (e.g. add extra blank lines) and run `git commit`. Confirm the hook prints "Running Spotless on staged Kotlin files...", reports the violation, auto-applies the fix, and aborts the commit.
3. Re-stage the now-formatted file and commit again. Confirm it passes quickly.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

#### I have tested any UI changes...
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack