### PR TITLE
[TV] Add tv module with placeholder screen

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -98,6 +98,13 @@ dependencyAnalysis {
                 exclude("org.jetbrains.kotlin:kotlin-stdlib")
             }
         }
+
+        project(":tv") {
+            onIncorrectConfiguration {
+                severity("warn")
+                exclude("org.jetbrains.kotlin:kotlin-stdlib")
+            }
+        }
     }
 }
 
@@ -118,6 +125,7 @@ val spotlessPreCommitKotlinFiles = spotlessPreCommitFiles?.filter { file ->
         (
             path.startsWith("app/src/") ||
                 path.startsWith("automotive/src/") ||
+                path.startsWith("tv/src/") ||
                 path.startsWith("wear/src/") ||
                 (path.startsWith("modules/") && "/src/" in path)
             )
@@ -146,6 +154,7 @@ spotless {
                 "app/src/**/*.kt",
                 "automotive/src/**/*.kt",
                 "modules/**/src/**/*.kt",
+                "tv/src/**/*.kt",
                 "wear/src/**/*.kt",
             )
         }
@@ -475,5 +484,5 @@ tasks.register("aggregatedLintRelease") {
     group = "verification"
     description = "Run Lint tasks for application modules"
 
-    dependsOn(":app:lintRelease", ":automotive:lintRelease", ":wear:lintRelease")
+    dependsOn(":app:lintRelease", ":automotive:lintRelease", ":tv:lintRelease", ":wear:lintRelease")
 }

--- a/dependencies.gradle.kts
+++ b/dependencies.gradle.kts
@@ -73,7 +73,7 @@ project.apply {
         set("targetSdkVersion", 36)
         set("targetSdkVersionWear", 36)
         set("targetSdkVersionAutomotive", 35)
-        set("targetSdkVersionTv", 35)
+        set("targetSdkVersionTv", 36)
         set("compileSdkVersion", 36)
         set("testInstrumentationRunner", "androidx.test.runner.AndroidJUnitRunner")
 

--- a/dependencies.gradle.kts
+++ b/dependencies.gradle.kts
@@ -2,6 +2,7 @@ import java.util.Properties
 
 val versionCodeDifferenceBetweenAppAndAutomotive = 50000
 val versionCodeDifferenceBetweenAppAndWear = 50000 + versionCodeDifferenceBetweenAppAndAutomotive
+val versionCodeDifferenceBetweenAppAndTv = 150000
 
 val secretProperties = loadPropertiesFromFile(file("secret.properties"))
 val versionProperties = loadPropertiesFromFile(file("version.properties"))
@@ -27,11 +28,13 @@ fun loadPropertiesFromFile(file: File): Properties {
 // app & automotive modules and pass this information to the modules that require it.
 val isAutomotiveBuild = (project.findProperty("IS_AUTOMOTIVE_BUILD") as? String)?.toBoolean() ?: false
 val isWearBuild = (project.findProperty("IS_WEAR_BUILD") as? String)?.toBoolean() ?: false
+val isTvBuild = (project.findProperty("IS_TV_BUILD") as? String)?.toBoolean() ?: false
 val getVersionCode = {
     val appVersionCode = versionProperties.getProperty("versionCode", null).toInt()
     when {
         isAutomotiveBuild -> appVersionCode + versionCodeDifferenceBetweenAppAndAutomotive
         isWearBuild -> appVersionCode + versionCodeDifferenceBetweenAppAndWear
+        isTvBuild -> appVersionCode + versionCodeDifferenceBetweenAppAndTv
         else -> appVersionCode
     }
 }
@@ -40,6 +43,7 @@ val getVersionName = {
     when {
         isAutomotiveBuild -> "${versionName}a"
         isWearBuild -> "${versionName}w"
+        isTvBuild -> "${versionName}t"
         else -> versionName
     }
 }
@@ -47,6 +51,7 @@ val getBuildPlatform = {
     when {
         isAutomotiveBuild -> "automotive"
         isWearBuild -> "wear"
+        isTvBuild -> "tv"
         else -> "mobile"
     }
 }
@@ -64,9 +69,11 @@ project.apply {
         set("minSdkVersion", 24)
         set("minSdkVersionWear", 26)
         set("minSdkVersionAutomotive", 28)
+        set("minSdkVersionTv", 28)
         set("targetSdkVersion", 36)
         set("targetSdkVersionWear", 36)
         set("targetSdkVersionAutomotive", 35)
+        set("targetSdkVersionTv", 35)
         set("compileSdkVersion", 36)
         set("testInstrumentationRunner", "androidx.test.runner.AndroidJUnitRunner")
 
@@ -103,6 +110,7 @@ project.apply {
         val sentryDsn = when {
             isAutomotiveBuild -> secretProperties.getProperty("sentryAutomotiveDsn", "").ifBlank { sentryAndroidDsn }
             isWearBuild -> secretProperties.getProperty("sentryWearDsn", "").ifBlank { sentryAndroidDsn }
+            isTvBuild -> secretProperties.getProperty("sentryTvDsn", "").ifBlank { sentryAndroidDsn }
             else -> sentryAndroidDsn
         }
         set("pocketcastsSentryDsn", sentryDsn)
@@ -117,5 +125,6 @@ project.apply {
         set("sentryAndroidProject", secretProperties.getProperty("sentryAndroidProject", ""))
         set("sentryAutomotiveProject", secretProperties.getProperty("sentryAutomotiveProject", ""))
         set("sentryWearProject", secretProperties.getProperty("sentryWearProject", ""))
+        set("sentryTvProject", secretProperties.getProperty("sentryTvProject", ""))
     }
 }

--- a/dependencies.gradle.kts
+++ b/dependencies.gradle.kts
@@ -2,7 +2,7 @@ import java.util.Properties
 
 val versionCodeDifferenceBetweenAppAndAutomotive = 50000
 val versionCodeDifferenceBetweenAppAndWear = 50000 + versionCodeDifferenceBetweenAppAndAutomotive
-val versionCodeDifferenceBetweenAppAndTv = 150000
+val versionCodeDifferenceBetweenAppAndTv = 50000 + versionCodeDifferenceBetweenAppAndWear
 
 val secretProperties = loadPropertiesFromFile(file("secret.properties"))
 val versionProperties = loadPropertiesFromFile(file("version.properties"))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -53,6 +53,7 @@ security-lint = "1.0.4"
 sentry-plugin = "6.9.0"
 tasker-plugin = "0.4.10"
 test = "1.7.0"
+tv-material = "1.1.0"
 espresso = "3.7.0"
 tracks = "6.0.8"
 wear-compose = "1.6.0-alpha05"
@@ -248,6 +249,9 @@ automattic-explat = { module = "com.automattic.tracks:experimentation", version.
 wear-input = "androidx.wear:wear-input:1.2.0"
 wear-remote-interactions = "androidx.wear:wear-remote-interactions:1.2.0"
 wear-tooling-preview = "androidx.wear:wear-tooling-preview:1.0.0"
+
+# TV
+tv-material = { module = "androidx.tv:tv-material", version.ref = "tv-material" }
 
 # Wear Compose
 wear-compose-foundation = { module = "androidx.wear.compose:compose-foundation", version.ref = "wear-compose" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -43,6 +43,7 @@ rootProject.name = "pocket-casts-android"
 
 include(":app")
 include(":automotive")
+include(":tv")
 include(":wear")
 
 // features

--- a/tv/build.gradle.kts
+++ b/tv/build.gradle.kts
@@ -62,6 +62,7 @@ dependencies {
 
     implementation(projects.modules.services.images)
     implementation(projects.modules.services.localization)
+    implementation(projects.modules.services.utils)
 
     debugImplementation(libs.compose.ui.tooling)
 

--- a/tv/build.gradle.kts
+++ b/tv/build.gradle.kts
@@ -1,0 +1,69 @@
+plugins {
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.hilt)
+    alias(libs.plugins.compose.compiler)
+}
+
+android {
+    namespace = "au.com.shiftyjelly.pocketcasts"
+
+    defaultConfig {
+        minSdk = project.property("minSdkVersionTv") as Int
+        targetSdk = project.property("targetSdkVersionTv") as Int
+        applicationId = project.property("applicationId").toString()
+    }
+
+    buildFeatures {
+        buildConfig = true
+        compose = true
+    }
+
+    buildTypes {
+        named("debug") {
+            manifestPlaceholders["appIcon"] = "@mipmap/ic_launcher_radioactive"
+        }
+
+        named("debugProd") {
+            manifestPlaceholders["appIcon"] = "@mipmap/ic_launcher_radioactive"
+        }
+
+        named("release") {
+            manifestPlaceholders["appIcon"] = "@mipmap/ic_launcher"
+        }
+    }
+
+    lint {
+        checkDependencies = false
+    }
+}
+
+androidComponents {
+    beforeVariants { builder ->
+        builder.enable = builder.buildType != "prototype"
+    }
+}
+
+dependencies {
+    ksp(libs.dagger.hilt.compiler)
+    ksp(libs.hilt.compiler)
+
+    implementation(platform(libs.compose.bom))
+
+    implementation(libs.androidx.appcompat)
+    implementation(libs.compose.activity)
+    implementation(libs.compose.foundation)
+    implementation(libs.compose.ui)
+    implementation(libs.compose.ui.tooling.preview)
+    implementation(libs.dagger.hilt.android)
+    implementation(libs.dagger.hilt.core)
+    implementation(libs.timber)
+    implementation(libs.tv.material)
+
+    implementation(projects.modules.services.images)
+    implementation(projects.modules.services.localization)
+
+    debugImplementation(libs.compose.ui.tooling)
+
+    debugProdImplementation(libs.compose.ui.tooling)
+}

--- a/tv/lint-baseline.xml
+++ b/tv/lint-baseline.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 8.13.2" type="baseline" client="gradle" dependencies="false" name="AGP (8.13.2)" variant="all" version="8.13.2">
+
+</issues>

--- a/tv/src/main/AndroidManifest.xml
+++ b/tv/src/main/AndroidManifest.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-feature
+        android:name="android.software.leanback"
+        android:required="true" />
+    <uses-feature
+        android:name="android.hardware.touchscreen"
+        android:required="false" />
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="false" />
+    <uses-feature
+        android:name="android.hardware.telephony"
+        android:required="false" />
+    <uses-feature
+        android:name="android.hardware.nfc"
+        android:required="false" />
+    <uses-feature
+        android:name="android.hardware.microphone"
+        android:required="false" />
+
+    <application
+        android:name=".TvApplication"
+        android:allowBackup="true"
+        android:icon="${appIcon}"
+        android:label="@string/app_name"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.AppCompat.NoActionBar"
+        android:appCategory="audio">
+
+        <activity
+            android:name=".TvActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+    </application>
+
+</manifest>

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvActivity.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvActivity.kt
@@ -1,0 +1,16 @@
+package au.com.shiftyjelly.pocketcasts
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class TvActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            TvPlaceholderScreen()
+        }
+    }
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvApplication.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvApplication.kt
@@ -10,7 +10,7 @@ class TvApplication : Application() {
     override fun onCreate() {
         super.onCreate()
         if (BuildConfig.DEBUG) {
-            Timber.plant(Timber.DebugTree())
+            Timber.plant(au.com.shiftyjelly.pocketcasts.utils.TimberDebugTree())
         }
     }
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvApplication.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvApplication.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts
 
 import android.app.Application
+import au.com.shiftyjelly.pocketcasts.utils.TimberDebugTree
 import dagger.hilt.android.HiltAndroidApp
 import timber.log.Timber
 
@@ -10,7 +11,7 @@ class TvApplication : Application() {
     override fun onCreate() {
         super.onCreate()
         if (BuildConfig.DEBUG) {
-            Timber.plant(au.com.shiftyjelly.pocketcasts.utils.TimberDebugTree())
+            Timber.plant(TimberDebugTree())
         }
     }
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvApplication.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvApplication.kt
@@ -1,0 +1,16 @@
+package au.com.shiftyjelly.pocketcasts
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+import timber.log.Timber
+
+@HiltAndroidApp
+class TvApplication : Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+        if (BuildConfig.DEBUG) {
+            Timber.plant(Timber.DebugTree())
+        }
+    }
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvPlaceholderScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvPlaceholderScreen.kt
@@ -1,0 +1,51 @@
+package au.com.shiftyjelly.pocketcasts
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+fun TvPlaceholderScreen(modifier: Modifier = Modifier) {
+    MaterialTheme {
+        Column(
+            modifier = modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.surface),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Image(
+                painter = painterResource(IR.drawable.ic_launcher_foreground),
+                contentDescription = stringResource(LR.string.app_name),
+                modifier = Modifier.size(120.dp),
+            )
+            Spacer(modifier = Modifier.height(24.dp))
+            Text(
+                text = stringResource(LR.string.app_name),
+                style = MaterialTheme.typography.headlineLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "Coming soon",
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Description
This is the first step in the TV app development.
Created a new module `tv` that builds for the tv platform that has similar build configurations to wear and automotive: `debug, debugProd and release`.
Added basic dependencies to build upon them later.
Placeholder screen shows when the app launches.

Fixes PCDROID-572 https://linear.app/a8c/issue/PCDROID-572/create-new-tv-module

## Testing Instructions
1. Create an AVD for TV
2. Select tv build target
3. Build and install the tv app

## Screenshots or Screencast 
<img width="3840" height="2160" alt="Screenshot_20260602_173805" src="https://github.com/user-attachments/assets/59633c32-f9aa-4633-aafe-750a7be57c99" />
<img width="3840" height="2160" alt="Screenshot_20260602_173800" src="https://github.com/user-attachments/assets/767ab4f3-bbea-4c90-b7a5-ed4ee4e4f70f" />


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
