### PR TITLE
Fix Up Next header count and time-left using inconsistent scopes

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
@@ -237,12 +237,11 @@ class UpNextAdapter(
                 }
 
                 val time = TimeHelper.getTimeDurationShortString(timeMs = (header.totalTimeSecs * 1000).toLong(), context = root.context)
-                lblUpNextTime.isVisible = hasEpisodeInProgress()
-                lblUpNextTime.text = if (header.episodeCount == 0) {
-                    root.resources.getString(LR.string.player_up_next_time_left, time)
-                } else {
-                    root.resources.getQuantityString(LR.plurals.player_up_next_header_title, header.episodeCount, header.episodeCount, time)
-                }
+                // Only show the Up Next time summary when there are queued episodes. When the
+                // queue is empty the no-content banner below already communicates the empty
+                // state, so don't show a "0s left" line above it.
+                lblUpNextTime.isVisible = hasEpisodeInProgress() && header.episodeCount > 0
+                lblUpNextTime.text = root.resources.getQuantityString(LR.plurals.player_up_next_header_title, header.episodeCount, header.episodeCount, time)
 
                 sort.isVisible = isUpNextNotEmpty
                 shuffle.isVisible = isUpNextNotEmpty

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -226,11 +226,12 @@ class PlayerViewModel @Inject constructor(
             upNextEpisodes = upNextState.queue
             episodeCount = upNextState.queue.size
 
-            val countEpisodes = listOf(nowPlaying) + upNextEpisodes
-            for (countEpisode in countEpisodes) {
-                totalTime += countEpisode.duration
-                if (countEpisode.isInProgress) {
-                    totalTime -= countEpisode.playedUpTo
+            // Keep the time total scoped to the same episodes as the count: the Up Next
+            // queue only, excluding the currently-playing episode (which has its own row).
+            for (upNextEpisode in upNextEpisodes) {
+                totalTime += upNextEpisode.duration
+                if (upNextEpisode.isInProgress) {
+                    totalTime -= upNextEpisode.playedUpTo
                 }
             }
         }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -456,7 +456,6 @@
     <string name="player_up_next_move_to_top">Move to top</string>
     <string name="player_up_next_select">Select</string>
     <string name="player_up_next_time_remaining">Total time remaining %s</string>
-    <string name="player_up_next_time_left" translatable="false">@string/time_left</string>
     <plurals name="player_up_next_header_title">
         <item formatted="true" quantity="one">%1$d episode - %2$s left</item>
         <item formatted="true" quantity="other">%1$d episodes - %2$s left</item>


### PR DESCRIPTION
## References
Relates to [PCDROID-586](https://linear.app/a8c/issue/PCDROID-586) (Linear; no linked GitHub issue)

## What it does
Fixes the Up Next screen header showing an episode count and a "time left" total that described different sets of episodes. The count excluded the currently-playing episode while the time total included it — so a header like "5 episodes - 3h 58m left" mixed scopes. Both values now describe the same episodes: the queued (Up Next) episodes only.

## Changes
- In `PlayerViewModel.upNextPlusData`, scope the `totalTime` calculation to the Up Next queue only (`upNextEpisodes`), dropping the currently-playing episode (`nowPlaying`) from the time total so it matches `episodeCount` (which was already `upNextState.queue.size`). This also matches `mergeListData` (the player-screen Up Next footer), which already excluded the playing episode.
- In `UpNextAdapter`, hide the footer time label when the queue is empty (`episodeCount == 0`). Without this, the "playing but empty Up Next" state would show "0s left" above the no-content banner; now the banner stands alone. The currently-playing episode's remaining time is still shown on its own now-playing row, so no information is lost.
- Removed the now-unused `player_up_next_time_left` string (the `player_up_next_header_title` plural covers the only remaining case). The shared `time_left` string is retained — it's still used by `TimeHelper`.

## Checklist
- [ ] I have reviewed my own changes
- [ ] This PR adds fewer than 500 lines of code

## Testing
### How to test
**Normal case (queued episodes + playing):**
- Start playing an episode, then add several episodes to Up Next.
- Open the Up Next screen and read the header summary (e.g. "X episodes - Yh Zm left").
- [ ] Verify the episode count reflects only the queued (Up Next) episodes, excluding the currently-playing one.
- [ ] Verify the "time left" total now equals the sum of remaining time for those **same** queued episodes, and no longer includes the currently-playing episode's remaining time.
- [ ] Confirm an in-progress queued episode contributes only its *remaining* time (duration minus played-up-to), not its full duration.
- [ ] Check the player-screen Up Next footer still matches the Up Next screen header (both consistent).

**Empty-queue case (playing, but nothing in Up Next):**
- Play an episode with an empty Up Next queue.
- [ ] Verify the Up Next screen shows the now-playing row + the "nothing in Up Next" banner, with **no** "0s left" line.
- [ ] Confirm the now-playing row still shows the current episode and its own remaining time.
