### PR TITLE
[TV] Add focusable rows and tiles

### DIFF
--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvRow.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvRow.kt
@@ -1,0 +1,118 @@
+package au.com.shiftyjelly.pocketcasts
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.focusGroup
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.focusRestorer
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.PlatformTextStyle
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+
+private const val TITLE_UNFOCUSED_SIZE = 17f
+private const val TITLE_FOCUSED_SIZE = 21f
+
+@Composable
+fun <T> TvRow(
+    title: String,
+    items: List<T>,
+    modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(horizontal = 32.dp),
+    itemSpacing: Dp = 16.dp,
+    key: ((T) -> Any)? = null,
+    content: @Composable (T) -> Unit,
+) {
+    var hasFocus by remember { mutableStateOf(false) }
+    val titleSize by animateFloatAsState(
+        targetValue = if (hasFocus) TITLE_FOCUSED_SIZE else TITLE_UNFOCUSED_SIZE,
+        label = "TvRowTitleSize",
+    )
+
+    Column(
+        modifier = modifier.onFocusChanged { focusState ->
+            hasFocus = focusState.hasFocus
+        },
+    ) {
+        Text(
+            text = title,
+            color = Color.White,
+            style = TextStyle(
+                fontSize = titleSize.sp,
+                fontWeight = FontWeight(510),
+                platformStyle = PlatformTextStyle(includeFontPadding = false),
+            ),
+            modifier = Modifier
+                .padding(contentPadding)
+                .padding(bottom = 17.dp),
+        )
+
+        LazyRow(
+            contentPadding = contentPadding,
+            horizontalArrangement = Arrangement.spacedBy(itemSpacing),
+            modifier = Modifier
+                .focusGroup()
+                .focusRestorer(),
+        ) {
+            items(
+                items = items,
+                key = key,
+            ) { item ->
+                content(item)
+            }
+        }
+    }
+}
+
+@Preview(device = Devices.TV_1080p, showBackground = true)
+@Composable
+private fun TvRowPreview() {
+    AppTheme(themeType = Theme.ThemeType.EXTRA_DARK) {
+        MaterialTheme {
+            Box(modifier = Modifier.background(TvColors.Dark)) {
+                TvRow(
+                    title = "Recently Played",
+                    items = (1..8).toList(),
+                ) { index ->
+                    TvTile(onClick = {}) {
+                        Box(
+                            modifier = Modifier
+                                .size(160.dp, 100.dp)
+                                .padding(12.dp),
+                            contentAlignment = Alignment.BottomStart,
+                        ) {
+                            Text(
+                                text = "Tile $index",
+                                color = Color.White,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvRow.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvRow.kt
@@ -10,7 +10,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -18,6 +18,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
@@ -71,18 +73,24 @@ fun <T> TvRow(
                 .padding(bottom = 17.dp),
         )
 
+        val firstItemFocusRequester = remember { FocusRequester() }
+
         LazyRow(
             contentPadding = contentPadding,
             horizontalArrangement = Arrangement.spacedBy(itemSpacing),
             modifier = Modifier
                 .focusGroup()
-                .focusRestorer(),
+                .focusRestorer(firstItemFocusRequester),
         ) {
-            items(
+            itemsIndexed(
                 items = items,
-                key = key,
-            ) { item ->
-                content(item)
+                key = key?.let { k -> { _, item: T -> k(item) } },
+            ) { index, item ->
+                Box(
+                    modifier = if (index == 0) Modifier.focusRequester(firstItemFocusRequester) else Modifier,
+                ) {
+                    content(item)
+                }
             }
         }
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvTabBar.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvTabBar.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -59,6 +60,7 @@ fun TvTabBar(
     ) {
         TabRow(
             selectedTabIndex = selectedTabIndex,
+            modifier = Modifier.focusRestorer(),
             containerColor = Color.Transparent,
             indicator = @Composable { tabPositions, doesTabRowHaveFocus ->
                 tabPositions.getOrNull(selectedTabIndex)?.let { currentTabPosition ->
@@ -66,7 +68,7 @@ fun TvTabBar(
                         currentTabPosition = currentTabPosition,
                         doesTabRowHaveFocus = doesTabRowHaveFocus,
                         activeColor = Color.White,
-                        inactiveColor = Color.White.copy(alpha = 0.12f),
+                        inactiveColor = Color.White,
                     )
                 }
             },
@@ -84,7 +86,7 @@ fun TvTabBar(
                         selectedContentColor = TvColors.Dark,
                         focusedContentColor = Color.White,
                         focusedSelectedContentColor = TvColors.Dark,
-                        inactiveContentColor = Color.White.copy(alpha = 0.6f),
+                        inactiveContentColor = Color.White,
                     ),
                 ) {
                     Box(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvTabBar.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvTabBar.kt
@@ -24,14 +24,9 @@ import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.PlatformTextStyle
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.tv.material3.Icon
 import androidx.tv.material3.LocalContentColor
 import androidx.tv.material3.MaterialTheme
@@ -98,14 +93,7 @@ fun TvTabBar(
                                 Text(
                                     text = stringResource(tab.labelRes),
                                     color = LocalContentColor.current,
-                                    style = TextStyle(
-                                        fontSize = 17.sp,
-                                        fontWeight = FontWeight(510),
-                                        lineHeight = 21.sp,
-                                        letterSpacing = 0.sp,
-                                        textAlign = TextAlign.Center,
-                                        platformStyle = PlatformTextStyle(includeFontPadding = false),
-                                    ),
+                                    style = TvTextStyles.TabLabel,
                                 )
                             }
 
@@ -128,14 +116,7 @@ fun TvTabBar(
                                     Text(
                                         text = stringResource(tab.labelRes),
                                         color = LocalContentColor.current,
-                                        style = TextStyle(
-                                            fontSize = 17.sp,
-                                            fontWeight = FontWeight(510),
-                                            lineHeight = 21.sp,
-                                            letterSpacing = 0.sp,
-                                            textAlign = TextAlign.Center,
-                                            platformStyle = PlatformTextStyle(includeFontPadding = false),
-                                        ),
+                                        style = TvTextStyles.TabLabel,
                                     )
                                 }
                             }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvTabPlaceholder.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvTabPlaceholder.kt
@@ -1,32 +1,72 @@
 package au.com.shiftyjelly.pocketcasts
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
-import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+
+private data class SampleRow(
+    val title: String,
+    val itemCount: Int,
+)
 
 @Composable
 fun TvTabPlaceholder(
     tab: TvTab,
     modifier: Modifier = Modifier,
 ) {
-    Box(
-        modifier = modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center,
-    ) {
-        TextH10(
-            text = stringResource(tab.contentDescriptionRes),
-            color = Color.White,
+    val rows = remember {
+        listOf(
+            SampleRow("Made for TV", (4..10).random()),
+            SampleRow("Recommendations", (4..10).random()),
+            SampleRow("Because you liked Podcast", (4..10).random()),
         )
+    }
+
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(24.dp),
+    ) {
+        item { Spacer(modifier = Modifier.height(8.dp)) }
+        items(rows) { row ->
+            TvRow(
+                title = row.title,
+                items = (1..row.itemCount).toList(),
+            ) { index ->
+                TvTile(onClick = {}) {
+                    Box(
+                        modifier = Modifier
+                            .size(180.dp, 120.dp)
+                            .padding(12.dp),
+                        contentAlignment = Alignment.BottomStart,
+                    ) {
+                        Text(
+                            text = "Item $index",
+                            color = Color.White,
+                        )
+                    }
+                }
+            }
+        }
+        item { Spacer(modifier = Modifier.height(8.dp)) }
     }
 }
 
@@ -35,7 +75,9 @@ fun TvTabPlaceholder(
 private fun TvTabPlaceholderPreview() {
     AppTheme(themeType = Theme.ThemeType.EXTRA_DARK) {
         MaterialTheme {
-            TvTabPlaceholder(tab = TvTab.Home)
+            Box(modifier = Modifier.background(TvColors.Dark)) {
+                TvTabPlaceholder(tab = TvTab.Home)
+            }
         }
     }
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvTextStyles.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvTextStyles.kt
@@ -1,0 +1,18 @@
+package au.com.shiftyjelly.pocketcasts
+
+import androidx.compose.ui.text.PlatformTextStyle
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.sp
+
+object TvTextStyles {
+    val TabLabel = TextStyle(
+        fontSize = 17.sp,
+        fontWeight = FontWeight(510),
+        lineHeight = 21.sp,
+        letterSpacing = 0.sp,
+        textAlign = TextAlign.Center,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvTile.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvTile.kt
@@ -1,0 +1,79 @@
+package au.com.shiftyjelly.pocketcasts
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.tv.material3.Card
+import androidx.tv.material3.CardBorder
+import androidx.tv.material3.CardColors
+import androidx.tv.material3.CardDefaults
+import androidx.tv.material3.CardGlow
+import androidx.tv.material3.CardScale
+import androidx.tv.material3.CardShape
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+
+@Composable
+fun TvTile(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    onLongClick: (() -> Unit)? = null,
+    scale: CardScale = CardDefaults.scale(focusedScale = 1.1f),
+    shape: CardShape = CardDefaults.shape(),
+    colors: CardColors = CardDefaults.colors(
+        containerColor = TvColors.DarkGray,
+        focusedContainerColor = TvColors.Gray,
+    ),
+    border: CardBorder = CardDefaults.border(),
+    glow: CardGlow = CardDefaults.glow(),
+    interactionSource: MutableInteractionSource? = null,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    Card(
+        onClick = onClick,
+        onLongClick = onLongClick,
+        modifier = modifier,
+        scale = scale,
+        shape = shape,
+        colors = colors,
+        border = border,
+        glow = glow,
+        interactionSource = interactionSource,
+        content = content,
+    )
+}
+
+@Preview(device = Devices.TV_1080p, showBackground = true)
+@Composable
+private fun TvTilePreview() {
+    AppTheme(themeType = Theme.ThemeType.EXTRA_DARK) {
+        MaterialTheme {
+            TvTile(onClick = {}) {
+                Box(
+                    modifier = Modifier
+                        .size(160.dp, 100.dp)
+                        .background(TvColors.DarkGray)
+                        .padding(12.dp),
+                    contentAlignment = Alignment.BottomStart,
+                ) {
+                    Text(
+                        text = "Sample Tile",
+                        color = Color.White,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvTile.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvTile.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.tv.material3.Border
 import androidx.tv.material3.Card
 import androidx.tv.material3.CardBorder
 import androidx.tv.material3.CardColors
@@ -36,7 +37,11 @@ fun TvTile(
         containerColor = TvColors.DarkGray,
         focusedContainerColor = TvColors.Gray,
     ),
-    border: CardBorder = CardDefaults.border(),
+    border: CardBorder = CardDefaults.border(
+        border = Border.None,
+        focusedBorder = Border.None,
+        pressedBorder = Border.None,
+    ),
     glow: CardGlow = CardDefaults.glow(),
     interactionSource: MutableInteractionSource? = null,
     content: @Composable ColumnScope.() -> Unit,


### PR DESCRIPTION
## Description
This is the next step of the TV work, introducing focusable rows and tiles.
Each `TvRow` has a title that grows in size upon taking focus and an arbitrary number of items that are wrapped to `TvTile` composables. The latter one is responsible for the grow animation when the tile comes into focus.
All tabs showing 3 rows with mock tiles for now.
I also fixed some small issues I noticed with the tab bar.

Fixes PCDROID-575 https://linear.app/a8c/issue/PCDROID-589/create-focusable-rows-and-tiles

## Testing Instructions
1. Build and install tv app 
2. Run the app on tv emulator and observe

## Screenshots or Screencast 

https://github.com/user-attachments/assets/0ee292b4-abdc-46f1-a5e4-5e4e554ffc02



## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
