### PR TITLE
Attempt to fix ExoPlayer crash

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -136,12 +136,11 @@ class SimplePlayer(
             Toast.makeText(context, "Unable to seek. File headers appear to be invalid.", Toast.LENGTH_SHORT).show()
         } else {
             val currentPlayer = player ?: return
-            val state = currentPlayer.playbackState
-            // attempting to fix this crash: https://linear.app/a8c/issue/PCDROID-591/attempt-to-fix-classcastexception-crash-of-exoplayer
-            if (state == Player.STATE_READY || state == Player.STATE_BUFFERING) {
+            // https://linear.app/a8c/issue/PCDROID-591/attempt-to-fix-classcastexception-crash-of-exoplayer
+            if (currentPlayer.isReadyForSeek()) {
                 seekPlayer(currentPlayer, positionMs)
             } else {
-                currentPlayer.addListener(object : Player.Listener {
+                val listener = object : Player.Listener {
                     override fun onPlaybackStateChanged(playbackState: Int) {
                         if (playbackState == Player.STATE_READY || playbackState == Player.STATE_BUFFERING) {
                             currentPlayer.removeListener(this)
@@ -150,18 +149,29 @@ class SimplePlayer(
                             currentPlayer.removeListener(this)
                         }
                     }
-                })
+                }
+                currentPlayer.addListener(listener)
+                if (currentPlayer.isReadyForSeek()) {
+                    currentPlayer.removeListener(listener)
+                    seekPlayer(currentPlayer, positionMs)
+                }
             }
         }
+    }
+
+    private fun ExoPlayer.isReadyForSeek(): Boolean {
+        val state = playbackState
+        return state == Player.STATE_READY || state == Player.STATE_BUFFERING
     }
 
     private fun seekPlayer(player: ExoPlayer, positionMs: Int) {
         try {
             player.seekTo(positionMs.toLong())
+            super.onSeekComplete(positionMs)
         } catch (e: ClassCastException) {
             LogBuffer.e(LogBuffer.TAG_PLAYBACK, e, "Seek to %.3f failed due to Media3 timeline race", positionMs / 1000f)
+            super.onSeekComplete(player.currentPosition.toInt())
         }
-        super.onSeekComplete(positionMs)
     }
 
     override fun handleIsBuffering(): Boolean {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -139,20 +139,25 @@ class SimplePlayer(
             // https://linear.app/a8c/issue/PCDROID-591/attempt-to-fix-classcastexception-crash-of-exoplayer
             if (currentPlayer.isReadyForSeek()) {
                 seekPlayer(currentPlayer, positionMs)
-            } else {
-                val listener = object : Player.Listener {
-                    override fun onPlaybackStateChanged(playbackState: Int) {
-                        if (playbackState == Player.STATE_READY || playbackState == Player.STATE_BUFFERING) {
-                            currentPlayer.removeListener(this)
-                            seekPlayer(currentPlayer, positionMs)
-                        } else if (playbackState == Player.STATE_IDLE || playbackState == Player.STATE_ENDED) {
-                            currentPlayer.removeListener(this)
+            } else when (currentPlayer.playbackState) {
+                Player.STATE_IDLE -> {
+                    val listener = object : Player.Listener {
+                        override fun onPlaybackStateChanged(playbackState: Int) {
+                            if (playbackState == Player.STATE_READY || playbackState == Player.STATE_BUFFERING) {
+                                currentPlayer.removeListener(this)
+                                seekPlayer(currentPlayer, positionMs)
+                            } else if (playbackState == Player.STATE_IDLE || playbackState == Player.STATE_ENDED) {
+                                currentPlayer.removeListener(this)
+                            }
                         }
                     }
+                    currentPlayer.addListener(listener)
+                    if (currentPlayer.isReadyForSeek()) {
+                        currentPlayer.removeListener(listener)
+                        seekPlayer(currentPlayer, positionMs)
+                    }
                 }
-                currentPlayer.addListener(listener)
-                if (currentPlayer.isReadyForSeek()) {
-                    currentPlayer.removeListener(listener)
+                else -> {
                     seekPlayer(currentPlayer, positionMs)
                 }
             }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -135,9 +135,33 @@ class SimplePlayer(
         if (player?.isCurrentMediaItemSeekable == false && player?.isPlaying == true) {
             Toast.makeText(context, "Unable to seek. File headers appear to be invalid.", Toast.LENGTH_SHORT).show()
         } else {
-            player?.seekTo(positionMs.toLong())
-            super.onSeekComplete(positionMs)
+            val currentPlayer = player ?: return
+            val state = currentPlayer.playbackState
+            // attempting to fix this crash: https://linear.app/a8c/issue/PCDROID-591/attempt-to-fix-classcastexception-crash-of-exoplayer
+            if (state == Player.STATE_READY || state == Player.STATE_BUFFERING) {
+                seekPlayer(currentPlayer, positionMs)
+            } else {
+                currentPlayer.addListener(object : Player.Listener {
+                    override fun onPlaybackStateChanged(playbackState: Int) {
+                        if (playbackState == Player.STATE_READY || playbackState == Player.STATE_BUFFERING) {
+                            currentPlayer.removeListener(this)
+                            seekPlayer(currentPlayer, positionMs)
+                        } else if (playbackState == Player.STATE_IDLE || playbackState == Player.STATE_ENDED) {
+                            currentPlayer.removeListener(this)
+                        }
+                    }
+                })
+            }
         }
+    }
+
+    private fun seekPlayer(player: ExoPlayer, positionMs: Int) {
+        try {
+            player.seekTo(positionMs.toLong())
+        } catch (e: ClassCastException) {
+            LogBuffer.e(LogBuffer.TAG_PLAYBACK, e, "Seek to %.3f failed due to Media3 timeline race", positionMs / 1000f)
+        }
+        super.onSeekComplete(positionMs)
     }
 
     override fun handleIsBuffering(): Boolean {


### PR DESCRIPTION
## Description
Noticed this crash in 8.13-rc-1, see ticket for details.

Claude's investigation:
`ExoPlayer.seekTo()` internally accesses playbackInfo.periodId.periodUid and passes it to `PlaylistTimeline.getPeriodByUid()`, which casts it to `Pair`. If the UID is a plain `Object` (not yet wrapped in a Pair by the PlaylistTimeline), it throws `ClassCastException`.                                           
Why it happens: SimplePlayer.prepare() calls player.setMediaSource(source) then player.prepare(). The prepare() call is asynchronous — it kicks off work on ExoPlayer's internal playback thread. But our code immediately sets prepared = true and proceeds to playIfAllowed(), which calls player.seekTo(). At this point, ExoPlayer's internal playbackInfo may not yet have consistent period UIDs — the internal thread hasn't finished processing, and the masking state between the application thread and the playback thread can be momentarily inconsistent. We're seeking before the player's timeline is actually ready for timeline-dependent operations.

How the fix works:
  1. Deferred seek: Before seeking, we check player.playbackState. If it's STATE_READY or STATE_BUFFERING, the timeline is initialized and seeking is safe. If it's still STATE_IDLE (the state right after prepare() is called but before the internal thread has processed it), we register a one-shot listener and seek
   when the player transitions to BUFFERING/READY. This respects Media3's async prepare contract.
  2. Try-catch safety net: Even with the deferred seek, there may be other code paths where a seek reaches the ExoPlayer at a bad time (e.g., a Bluetooth controller sending a seek command through the MediaSession during player initialization). The ClassCastException catch prevents those from crashing.


**UPDATE**
after a discussion with @geekygecko we have decided not to include this fix in 8.13 as it only affected 2 users in the beta cycle. i will change target to `main` and milestone to 8.14

Fixes PCDROID-591 https://linear.app/a8c/issue/PCDROID-591/attempt-to-fix-classcastexception-crash-of-exoplayer

## Testing Instructions
I was not able to reproduce it :(
Just smoke test playback, seeking, resuming from previous position on cold app start.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
