### PR TITLE
[Synced Transcripts] Change sampling window to 1sec

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintConstants.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintConstants.kt
@@ -14,7 +14,7 @@ object FingerprintConstants {
     const val WINDOW_DURATION_MS = 8000
 
     /** Interval between windowed fingerprints during live matching, in milliseconds. */
-    const val WINDOW_INTERVAL_MS = 2000
+    const val WINDOW_INTERVAL_MS = 1000
 
     /** Seconds of decoded PCM read per chunk during fingerprint generation. */
     const val STREAM_CHUNK_SECONDS = 5.0

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintConstants.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintConstants.kt
@@ -53,7 +53,7 @@ object FingerprintConstants {
     const val FULL_COVERAGE_THRESHOLD = 0.95
 
     /** Persistent cache schema version. Bump when on-disk shape changes. */
-    const val MAPPING_CACHE_SCHEMA_VERSION = 3
+    const val MAPPING_CACHE_SCHEMA_VERSION = 4
 
     /** Timeout for MediaCodec dequeue operations, in microseconds. */
     const val CODEC_TIMEOUT_US = 10_000L

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManagerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManagerTest.kt
@@ -107,7 +107,7 @@ class FingerprintTimingManagerTest {
     @Test
     fun `alignToWindowGrid aligns to stride boundary`() {
         val aligned = FingerprintTimingManager.alignToWindowGrid(5.7)
-        assertEquals(4.0, aligned, 0.001)
+        assertEquals(5.0, aligned, 0.001)
     }
 
     @Test


### PR DESCRIPTION
## Description
To better support and detect ads mid-episode, we have decided to oversample the audio stream and decreased the sampling window to 1 second.
For more context: p1780506275598209-slack-C0AU842PHTJ

## Testing Instructions
1. build `prodDebug`
2. log in with a  Plus account
3. start playing a podcast episode
4. verify that transcripts syncing still works
5. find an episode with a mid-episode ads like [this one](https://pocketcasts.com/podcast/the-daily/4eb5b260-c933-0134-10da-25324e2a541d/popcast-olivia-rodrigo-tried-writing-love-songs-then-life-got-messy/e856e8be-106c-4b7d-8261-b986c935a5b8) and start playing it with transcripts on
6. seek around the middle of the episode, listen to the ad then observe transcripts after ad

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
