### PR TITLE
[Synced Transcripts] Stop highlighting when detecting long period of mismatch of fingerprints

### DIFF
--- a/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptPage.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptPage.kt
@@ -275,8 +275,11 @@ private fun HighlightEffect(
         playbackManager.playbackStateFlow
     }.collectAsState(initial = null)
     val isPlaying = playbackState?.isPlaying == true
+    val isAdInProgress by remember(fingerprintTimingManager) {
+        fingerprintTimingManager.isAdInProgress
+    }.collectAsState()
 
-    if (isPlaying && isSyncedActive) {
+    if (isPlaying && isSyncedActive && !isAdInProgress) {
         LaunchedEffect(transcript.entries) {
             var cachedIndex = 0
             while (true) {
@@ -298,8 +301,8 @@ private fun HighlightEffect(
                 }
             }
         }
-    } else if (!isSyncedActive) {
-        LaunchedEffect(Unit) { latestOnHighlightChanged(HighlightState()) }
+    } else if (!isSyncedActive || isAdInProgress) {
+        LaunchedEffect(isAdInProgress) { latestOnHighlightChanged(HighlightState()) }
     }
 }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintConstants.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintConstants.kt
@@ -14,7 +14,7 @@ object FingerprintConstants {
     const val WINDOW_DURATION_MS = 8000
 
     /** Interval between windowed fingerprints during live matching, in milliseconds. */
-    const val WINDOW_INTERVAL_MS = 2000
+    const val WINDOW_INTERVAL_MS = 1000
 
     /** Seconds of decoded PCM read per chunk during fingerprint generation. */
     const val STREAM_CHUNK_SECONDS = 5.0

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintConstants.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintConstants.kt
@@ -52,6 +52,9 @@ object FingerprintConstants {
     /** Minimum fraction of reference timeline a cached mapping must cover. */
     const val FULL_COVERAGE_THRESHOLD = 0.95
 
+    /** Minimum unmatched gap in the processed range (seconds) to consider as an ad. */
+    const val AD_COVERAGE_GAP_SECONDS = 12.0
+
     /** Persistent cache schema version. Bump when on-disk shape changes. */
     const val MAPPING_CACHE_SCHEMA_VERSION = 3
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
@@ -66,6 +66,9 @@ class FingerprintTimingManager @Inject constructor(
     val state: State get() = _stateFlow.value
     val mappingSnapshot: List<TimeMappingEntry> get() = snapshotPlaybackToReference
 
+    private val _isAdInProgress = MutableStateFlow(false)
+    val isAdInProgress: StateFlow<Boolean> = _isAdInProgress.asStateFlow()
+
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     private val mutex = Mutex()
 
@@ -93,6 +96,9 @@ class FingerprintTimingManager @Inject constructor(
 
     @Volatile
     private var generation = 0L
+
+    private var processedStart: Double = Double.MAX_VALUE
+    private var processedFrontier: Double = 0.0
 
     // Drift filter state
     private var filterLastTrusted: TimeMappingEntry? = null
@@ -217,6 +223,9 @@ class FingerprintTimingManager @Inject constructor(
         currentMatcher?.close()
         currentMatcher = null
         hasReachedActive = false
+        processedStart = Double.MAX_VALUE
+        processedFrontier = 0.0
+        _isAdInProgress.value = false
     }
 
     private suspend fun prepareForEpisode(
@@ -331,6 +340,8 @@ class FingerprintTimingManager @Inject constructor(
                 mappingReferenceToPlayback = cached.entries.sortedBy { it.referenceTime }.toMutableList()
                 publishSnapshot()
                 filterLastTrusted = cached.entries.lastOrNull()
+                processedStart = 0.0
+                processedFrontier = currentReferenceDuration
             }
             val coverage = cached.entries.size
             _stateFlow.value = State.Active(coverage)
@@ -383,6 +394,8 @@ class FingerprintTimingManager @Inject constructor(
                 startStream(audioPath, matcher, uuid, startPosition = positionMs / 1000.0)
             }
         }
+
+        evaluateAdState(positionMs / 1000.0)
     }
 
     private fun isWithinMappedRange(playbackTimeSec: Double): Boolean {
@@ -394,10 +407,51 @@ class FingerprintTimingManager @Inject constructor(
             playbackTimeSec <= last.playbackTime + margin
     }
 
+    @VisibleForTesting
+    internal fun evaluateAdState(playbackTimeSeconds: Double) {
+        if (!hasReachedActive || processedStart == Double.MAX_VALUE) {
+            _isAdInProgress.value = false
+            return
+        }
+        if (playbackTimeSeconds < processedStart || playbackTimeSeconds > processedFrontier) {
+            _isAdInProgress.value = false
+            return
+        }
+
+        val entries = mappingPlaybackToReference
+        if (entries.isEmpty()) {
+            _isAdInProgress.value = (processedFrontier - processedStart) > FingerprintConstants.AD_COVERAGE_GAP_SECONDS
+            return
+        }
+
+        var lo = 0
+        var hi = entries.size
+        while (lo < hi) {
+            val mid = (lo + hi) / 2
+            if (entries[mid].playbackTime <= playbackTimeSeconds) {
+                lo = mid + 1
+            } else {
+                hi = mid
+            }
+        }
+        val insertionPoint = lo
+
+        val lowerBound = if (insertionPoint > 0) entries[insertionPoint - 1].playbackTime else processedStart
+        val upperBound = if (insertionPoint < entries.size) entries[insertionPoint].playbackTime else processedFrontier
+
+        _isAdInProgress.value = (upperBound - lowerBound) > FingerprintConstants.AD_COVERAGE_GAP_SECONDS
+    }
+
     private fun startStream(audioFilePath: String, matcher: CheckpointMatcher, episodeUuid: String, startPosition: Double) {
         generationJob?.cancel()
         generationJob = scope.launch {
             val aligned = alignToWindowGrid(startPosition)
+            if (aligned < processedStart) {
+                processedStart = aligned
+            }
+            if (aligned > processedFrontier) {
+                processedFrontier = aligned
+            }
             try {
                 streamFingerprint(audioFilePath, matcher, episodeUuid, startingAt = aligned)
                 persistMappingCacheIfFull()
@@ -610,6 +664,14 @@ class FingerprintTimingManager @Inject constructor(
         matcher: CheckpointMatcher,
         startOffset: Double,
     ) {
+        if (windows.isNotEmpty()) {
+            val lastWindow = windows.last()
+            val batchEnd = startOffset + lastWindow.timestampMs.toDouble() / 1000.0 + lastWindow.durationMs.toDouble() / 1000.0
+            if (batchEnd > processedFrontier) {
+                processedFrontier = batchEnd
+            }
+        }
+
         val isDebug = debugTrackingEnabled || FeatureFlag.isEnabled(Feature.SYNCED_TRANSCRIPT_DEBUG)
 
         for (window in windows) {
@@ -649,6 +711,10 @@ class FingerprintTimingManager @Inject constructor(
                 hasReachedActive = true
                 Timber.d("FingerprintTimingManager: reached active state with $coverage mappings")
             }
+        }
+        val currentPositionMs = lastProgressPositionMs
+        if (currentPositionMs >= 0) {
+            evaluateAdState(currentPositionMs / 1000.0)
         }
         if (isDebug) {
             debugRejectionsSnapshot = debugRejections.toList()
@@ -756,6 +822,19 @@ class FingerprintTimingManager @Inject constructor(
     fun insert(mapping: TimeMappingEntry) {
         insertMapping(mapping)
         publishSnapshot()
+    }
+
+    /** Test seam: set the processed range directly. Must only be called from single-threaded tests. */
+    @VisibleForTesting
+    fun setProcessedRange(start: Double, frontier: Double) {
+        processedStart = start
+        processedFrontier = frontier
+    }
+
+    /** Test seam: mark as having reached active state. Must only be called from single-threaded tests. */
+    @VisibleForTesting
+    fun setHasReachedActive(value: Boolean) {
+        hasReachedActive = value
     }
 
     /** Test seam: route candidates through the drift filter. Must only be called from single-threaded tests. */

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
@@ -444,14 +444,10 @@ class FingerprintTimingManager @Inject constructor(
 
     private fun startStream(audioFilePath: String, matcher: CheckpointMatcher, episodeUuid: String, startPosition: Double) {
         generationJob?.cancel()
+        val aligned = alignToWindowGrid(startPosition)
+        processedStart = aligned
+        processedFrontier = aligned
         generationJob = scope.launch {
-            val aligned = alignToWindowGrid(startPosition)
-            if (aligned < processedStart) {
-                processedStart = aligned
-            }
-            if (aligned > processedFrontier) {
-                processedFrontier = aligned
-            }
             try {
                 streamFingerprint(audioFilePath, matcher, episodeUuid, startingAt = aligned)
                 persistMappingCacheIfFull()

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/AdDetectionTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/AdDetectionTest.kt
@@ -1,0 +1,173 @@
+package au.com.shiftyjelly.pocketcasts.repositories.fingerprint
+
+import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.FingerprintTimingManager.TimeMappingEntry
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.whenever
+
+class AdDetectionTest {
+
+    private lateinit var manager: FingerprintTimingManager
+
+    @Before
+    fun setUp() {
+        val playbackManager = mock(PlaybackManager::class.java)
+        whenever(playbackManager.playbackStateFlow).thenReturn(MutableStateFlow(PlaybackState()))
+        manager = FingerprintTimingManager(
+            playbackManager = playbackManager,
+            referenceRetriever = mock(FingerprintReferenceRetriever::class.java),
+        )
+    }
+
+    @Test
+    fun `ad not flagged when not yet active`() {
+        manager.setProcessedRange(0.0, 200.0)
+        // hasReachedActive is false by default
+        manager.evaluateAdState(100.0)
+        assertFalse(manager.isAdInProgress.value)
+    }
+
+    @Test
+    fun `ad not flagged when position is before processed range`() {
+        manager.setHasReachedActive(true)
+        manager.setProcessedRange(10.0, 200.0)
+        manager.insert(TimeMappingEntry(playbackTime = 30.0, referenceTime = 30.0))
+
+        manager.evaluateAdState(5.0)
+        assertFalse(manager.isAdInProgress.value)
+    }
+
+    @Test
+    fun `ad not flagged when position is after processed range`() {
+        manager.setHasReachedActive(true)
+        manager.setProcessedRange(0.0, 100.0)
+        manager.insert(TimeMappingEntry(playbackTime = 30.0, referenceTime = 30.0))
+
+        manager.evaluateAdState(110.0)
+        assertFalse(manager.isAdInProgress.value)
+    }
+
+    @Test
+    fun `pre-roll ad detected`() {
+        manager.setHasReachedActive(true)
+        manager.setProcessedRange(0.0, 200.0)
+        manager.insert(TimeMappingEntry(playbackTime = 30.0, referenceTime = 30.0))
+        manager.insert(TimeMappingEntry(playbackTime = 32.0, referenceTime = 32.0))
+
+        manager.evaluateAdState(10.0)
+        assertTrue(manager.isAdInProgress.value)
+    }
+
+    @Test
+    fun `pre-roll position past first anchor is not ad`() {
+        manager.setHasReachedActive(true)
+        manager.setProcessedRange(0.0, 200.0)
+        manager.insert(TimeMappingEntry(playbackTime = 30.0, referenceTime = 30.0))
+        manager.insert(TimeMappingEntry(playbackTime = 32.0, referenceTime = 32.0))
+
+        manager.evaluateAdState(31.0)
+        assertFalse(manager.isAdInProgress.value)
+    }
+
+    @Test
+    fun `mid-roll ad detected`() {
+        manager.setHasReachedActive(true)
+        manager.setProcessedRange(0.0, 200.0)
+        manager.insert(TimeMappingEntry(playbackTime = 40.0, referenceTime = 40.0))
+        manager.insert(TimeMappingEntry(playbackTime = 70.0, referenceTime = 55.0))
+
+        manager.evaluateAdState(55.0)
+        assertTrue(manager.isAdInProgress.value)
+    }
+
+    @Test
+    fun `mid-roll position in matched cluster is not ad`() {
+        manager.setHasReachedActive(true)
+        manager.setProcessedRange(0.0, 200.0)
+        manager.insert(TimeMappingEntry(playbackTime = 10.0, referenceTime = 10.0))
+        manager.insert(TimeMappingEntry(playbackTime = 12.0, referenceTime = 12.0))
+        // 16s gap
+        manager.insert(TimeMappingEntry(playbackTime = 28.0, referenceTime = 28.0))
+        manager.insert(TimeMappingEntry(playbackTime = 30.0, referenceTime = 30.0))
+
+        manager.evaluateAdState(11.0)
+        assertFalse(manager.isAdInProgress.value)
+
+        manager.evaluateAdState(29.0)
+        assertFalse(manager.isAdInProgress.value)
+    }
+
+    @Test
+    fun `post-roll ad detected`() {
+        manager.setHasReachedActive(true)
+        manager.setProcessedRange(0.0, 200.0)
+        manager.insert(TimeMappingEntry(playbackTime = 168.0, referenceTime = 168.0))
+        manager.insert(TimeMappingEntry(playbackTime = 170.0, referenceTime = 170.0))
+
+        manager.evaluateAdState(185.0)
+        assertTrue(manager.isAdInProgress.value)
+    }
+
+    @Test
+    fun `gap exactly at threshold is not ad`() {
+        manager.setHasReachedActive(true)
+        manager.setProcessedRange(0.0, 100.0)
+        manager.insert(TimeMappingEntry(playbackTime = 10.0, referenceTime = 10.0))
+        manager.insert(TimeMappingEntry(playbackTime = 22.0, referenceTime = 22.0))
+
+        manager.evaluateAdState(15.0)
+        assertFalse(manager.isAdInProgress.value)
+    }
+
+    @Test
+    fun `gap below threshold is not ad`() {
+        manager.setHasReachedActive(true)
+        manager.setProcessedRange(0.0, 100.0)
+        manager.insert(TimeMappingEntry(playbackTime = 10.0, referenceTime = 10.0))
+        manager.insert(TimeMappingEntry(playbackTime = 20.0, referenceTime = 20.0))
+
+        manager.evaluateAdState(15.0)
+        assertFalse(manager.isAdInProgress.value)
+    }
+
+    @Test
+    fun `ad clears when anchors fill the gap`() {
+        manager.setHasReachedActive(true)
+        manager.setProcessedRange(0.0, 200.0)
+        manager.insert(TimeMappingEntry(playbackTime = 40.0, referenceTime = 40.0))
+        manager.insert(TimeMappingEntry(playbackTime = 70.0, referenceTime = 55.0))
+
+        manager.evaluateAdState(55.0)
+        assertTrue(manager.isAdInProgress.value)
+
+        manager.insert(TimeMappingEntry(playbackTime = 50.0, referenceTime = 45.0))
+        manager.insert(TimeMappingEntry(playbackTime = 60.0, referenceTime = 50.0))
+
+        manager.evaluateAdState(55.0)
+        assertFalse(manager.isAdInProgress.value)
+    }
+
+    @Test
+    fun `no anchors with small processed range is not ad`() {
+        manager.setHasReachedActive(true)
+        manager.setProcessedRange(0.0, 10.0)
+
+        manager.evaluateAdState(5.0)
+        assertFalse(manager.isAdInProgress.value)
+    }
+
+    @Test
+    fun `no anchors with large processed range is ad`() {
+        manager.setHasReachedActive(true)
+        manager.setProcessedRange(0.0, 20.0)
+
+        manager.evaluateAdState(10.0)
+        assertTrue(manager.isAdInProgress.value)
+    }
+}

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManagerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManagerTest.kt
@@ -107,7 +107,7 @@ class FingerprintTimingManagerTest {
     @Test
     fun `alignToWindowGrid aligns to stride boundary`() {
         val aligned = FingerprintTimingManager.alignToWindowGrid(5.7)
-        assertEquals(4.0, aligned, 0.001)
+        assertEquals(5.0, aligned, 0.001)
     }
 
     @Test


### PR DESCRIPTION
## Description
This PR is the android equivalent of the [iOS-side change](https://github.com/Automattic/pocket-casts-ios/pull/4460)

## Testing Instructions
1. Build and install prodDebug
2. Log in with a Plus account
3. Find a podcast episode with mid-episode ads
4. Play the episode on web and try memorise the ad position
5. Seek around that position on the mobile app
6. Notice transcript highlighting ceases when reaching the ad section

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
