### PR TITLE
Fix missing episode date and duration in the Android Auto / Wear OS browse list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 *   Bug Fixes
     *   Fix Profile settings gear being unreachable in landscape
         ([#5371](https://github.com/Automattic/pocket-casts-android/pull/5371))
+    *   Fix missing episode dates and durations in Android Auto
+        ([#5388](https://github.com/Automattic/pocket-casts-android/pull/5388))
 
 8.13
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 *   Bug Fixes
     *   Fix Profile settings gear being unreachable in landscape
         ([#5371](https://github.com/Automattic/pocket-casts-android/pull/5371))
-    *   Fix missing episode dates and durations in Android Auto
+    *   Fix missing episode dates and durations in Android Auto and Wear OS
         ([#5388](https://github.com/Automattic/pocket-casts-android/pull/5388))
 
 8.13

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/auto/MediaItemCompatConverter.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/auto/MediaItemCompatConverter.kt
@@ -13,7 +13,8 @@ object MediaItemCompatConverter {
             .setTitle(metadata.title)
             // The browse-row subtitle (episode date + duration) is carried in MediaMetadata.subtitle,
             // not artist, which is never set on browse items. Reading artist here left the subtitle
-            // blank for every MediaBrowser client on the legacy path (Android Auto, Automotive, Wear OS).
+            // blank for the legacy MediaBrowser clients (Android Auto and Wear OS). Android Automotive
+            // OS uses the media3 MediaLibraryService path instead, so it is unaffected by this converter.
             .setSubtitle(metadata.subtitle)
             .setDescription(metadata.description)
             .setIconUri(metadata.artworkUri)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/auto/MediaItemCompatConverter.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/auto/MediaItemCompatConverter.kt
@@ -11,10 +11,6 @@ object MediaItemCompatConverter {
         val descBuilder = MediaDescriptionCompat.Builder()
             .setMediaId(item.mediaId)
             .setTitle(metadata.title)
-            // The browse-row subtitle (episode date + duration) is carried in MediaMetadata.subtitle,
-            // not artist, which is never set on browse items. Reading artist here left the subtitle
-            // blank for the legacy MediaBrowser clients (Android Auto and Wear OS). Android Automotive
-            // OS uses the media3 MediaLibraryService path instead, so it is unaffected by this converter.
             .setSubtitle(metadata.subtitle)
             .setDescription(metadata.description)
             .setIconUri(metadata.artworkUri)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/auto/MediaItemCompatConverter.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/auto/MediaItemCompatConverter.kt
@@ -11,7 +11,10 @@ object MediaItemCompatConverter {
         val descBuilder = MediaDescriptionCompat.Builder()
             .setMediaId(item.mediaId)
             .setTitle(metadata.title)
-            .setSubtitle(metadata.artist)
+            // The browse-row subtitle (episode date + duration) is carried in MediaMetadata.subtitle,
+            // not artist, which is never set on browse items. Reading artist here left the subtitle
+            // blank for every MediaBrowser client on the legacy path (Android Auto, Automotive, Wear OS).
+            .setSubtitle(metadata.subtitle)
             .setDescription(metadata.description)
             .setIconUri(metadata.artworkUri)
         metadata.extras?.let { descBuilder.setExtras(it) }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/auto/MediaItemCompatConverterTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/auto/MediaItemCompatConverterTest.kt
@@ -20,7 +20,7 @@ class MediaItemCompatConverterTest {
             .setMediaMetadata(
                 MediaMetadata.Builder()
                     .setTitle("Test Podcast")
-                    .setArtist("Test Author")
+                    .setSubtitle("Test Subtitle")
                     .setDescription("A description")
                     .setArtworkUri("https://example.com/art.jpg".toUri())
                     .setIsBrowsable(true)
@@ -33,7 +33,7 @@ class MediaItemCompatConverterTest {
 
         assertEquals("podcast-123", compat.mediaId)
         assertEquals("Test Podcast", compat.description.title)
-        assertEquals("Test Author", compat.description.subtitle)
+        assertEquals("Test Subtitle", compat.description.subtitle)
         assertEquals("A description", compat.description.description)
         assertEquals("https://example.com/art.jpg".toUri(), compat.description.iconUri)
         assertTrue(compat.isBrowsable)
@@ -47,7 +47,9 @@ class MediaItemCompatConverterTest {
             .setMediaMetadata(
                 MediaMetadata.Builder()
                     .setTitle("Test Episode")
+                    // artist is set but unused; subtitle is the field that must win (PCDROID-563)
                     .setArtist("Test Podcast")
+                    .setSubtitle("5 days ago • 32 min")
                     .setIsBrowsable(false)
                     .setIsPlayable(true)
                     .build(),
@@ -58,6 +60,8 @@ class MediaItemCompatConverterTest {
 
         assertEquals("episode-456", compat.mediaId)
         assertEquals("Test Episode", compat.description.title)
+        // PCDROID-563: episode date + duration must come from MediaMetadata.subtitle, not artist
+        assertEquals("5 days ago • 32 min", compat.description.subtitle)
         assertTrue(compat.isPlayable)
         assertEquals(0, compat.flags and MediaBrowserCompat.MediaItem.FLAG_BROWSABLE)
     }


### PR DESCRIPTION
## Description

On the legacy `MediaBrowserServiceCompat` browse path, episode rows in the Android Auto (and Wear OS) episode list showed only the title — the air date and duration were missing, and the title grew larger to fill the empty subtitle line. 
** This issue affects Android Auto, when we project our phone app to the auto screen **

`MediaItemCompatConverter.toCompat` built each browse row's subtitle from `MediaMetadata.artist`, but `AutoConverter` never sets `artist` on browse items — it puts the episode date + duration into `MediaMetadata.subtitle` (via `getSummaryText(showDuration = true)`). So the subtitle was always blank on this path. This reads `MediaMetadata.subtitle` instead, matching what the media3 browse path (Android Automotive OS and newer Auto/Wear) already renders.

Non-episode rows (podcasts, folders, playlists) set no subtitle and are unaffected. Now-playing metadata is built by separate code and is untouched. Android Automotive OS is a separate app module that uses the media3 `MediaLibraryService` path, so it never touches this converter and was already correct.

Fixes PCDROID-563 — https://linear.app/a8c/issue/PCDROID-563

## Testing Instructions

These steps exercise the legacy `MediaBrowserService` path (`Feature.MEDIA3_SESSION` disabled — the current production default), which serves Android Auto and Wear OS.

1. Build & install a debug build with the media3 session feature flag **off**.
2. Connect to Android Auto (e.g. the Desktop Head Unit) or a Wear OS device/emulator.
3. Open Pocket Casts and browse to a podcast's episode list (also check Downloads, Up Next, and Listening History).
- [x] Verify each episode row shows the date and duration under the title (e.g. `5 days ago • 32 min`), not just the title.
- [x] Verify the episode title is no longer enlarged to fill the previously-empty subtitle line.
- [x] Confirm podcast / folder / playlist rows are unchanged (still no subtitle).
4. Run the unit tests:
   - `./gradlew :modules:services:repositories:testDebugUnitTest --tests "*MediaItemCompatConverterTest"`
- [x] Confirm `MediaItemCompatConverterTest` passes — it asserts the subtitle is taken from `MediaMetadata.subtitle`, ignoring `artist`.

## Screenshots or Screencast
| Before fix | After fix |
| --- | --- |
| <img width="797" height="508" alt="SCR-20260607-rnfb" src="https://github.com/user-attachments/assets/b9588e73-0746-499a-a5d3-b84918f3b6e9" /> | <img width="803" height="506" alt="SCR-20260607-rnlz" src="https://github.com/user-attachments/assets/547971e9-60c2-4da2-ac0e-787eceb560d2" /> |


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting) — verified with `./gradlew spotlessKotlinCheck`
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml` — n/a, no new strings
- [x] Any jetpack compose components I added or changed are covered by compose previews — n/a, no Compose changes
- [x] I have updated (or requested that someone edit) the spreadsheet to reflect any new or changed analytics. — n/a, no analytics changes

#### I have tested any UI changes...
<!-- This PR changes the car / Wear OS MediaBrowser browse list, not in-app Compose UI, so the in-app theme/orientation/font items below are not applicable. -->
