### PR TITLE
Add sorting to beta features

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/BetaFeaturesFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/BetaFeaturesFragment.kt
@@ -8,6 +8,10 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.selection.toggleable
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Sort
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -31,9 +35,11 @@ import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvi
 import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.settings.viewmodel.BetaFeaturesViewModel
+import au.com.shiftyjelly.pocketcasts.settings.viewmodel.BetaFeaturesViewModel.SortOrder
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.extensions.pxToDp
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.views.dialog.OptionsDialog
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -57,6 +63,7 @@ class BetaFeaturesFragment : BaseFragment() {
             BetaFeaturesPage(
                 state = state,
                 onFeatureChange = viewModel::setFeatureEnabled,
+                onSortClick = ::openSortOptions,
                 onBackPress = {
                     activity?.onBackPressedDispatcher?.onBackPressed()
                 },
@@ -64,12 +71,26 @@ class BetaFeaturesFragment : BaseFragment() {
             )
         }
     }
+
+    private fun openSortOptions() {
+        val selectedSortOrder = viewModel.state.value.sortOrder
+        val dialog = OptionsDialog().setTitle(getString(R.string.sort_by))
+        for (sortOrder in SortOrder.entries) {
+            dialog.addCheckedOption(
+                titleId = sortOrder.labelId,
+                checked = sortOrder == selectedSortOrder,
+                click = { viewModel.setSortOrder(sortOrder) },
+            )
+        }
+        dialog.show(parentFragmentManager, "beta_features_sort_dialog")
+    }
 }
 
 @Composable
 private fun BetaFeaturesPage(
     state: BetaFeaturesViewModel.State,
     onFeatureChange: (Feature, Boolean) -> Unit,
+    onSortClick: () -> Unit,
     onBackPress: () -> Unit,
     bottomInset: Dp,
 ) {
@@ -79,6 +100,15 @@ private fun BetaFeaturesPage(
         ThemedTopAppBar(
             title = stringResource(R.string.settings_beta_features),
             onNavigationClick = { onBackPress() },
+            actions = { iconColor ->
+                IconButton(onClick = onSortClick) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.Sort,
+                        contentDescription = stringResource(R.string.settings_beta_features_sort),
+                        tint = iconColor,
+                    )
+                }
+            },
         )
         LazyColumn(
             contentPadding = PaddingValues(vertical = 16.dp),
@@ -111,6 +141,7 @@ private fun BetaFeaturesPagePreview(
         BetaFeaturesPage(
             state = BetaFeaturesViewModel.State(featureFlags = Feature.entries.map { BetaFeaturesViewModel.FeatureFlagWrapper(featureFlag = it, isEnabled = true) }),
             onFeatureChange = { _, _ -> },
+            onSortClick = {},
             onBackPress = {},
             bottomInset = 0.dp,
         )

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/BetaFeaturesViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/BetaFeaturesViewModel.kt
@@ -1,6 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.settings.viewmodel
 
+import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModel
+import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -11,30 +13,48 @@ import kotlinx.coroutines.flow.StateFlow
 @HiltViewModel
 class BetaFeaturesViewModel @Inject constructor() : ViewModel() {
 
+    enum class SortOrder(@StringRes val labelId: Int) {
+        Name(R.string.settings_beta_features_sort_name),
+        ReleaseDate(R.string.settings_beta_features_sort_release_date),
+    }
+
     data class State(
         val featureFlags: List<FeatureFlagWrapper>,
+        val sortOrder: SortOrder = SortOrder.Name,
     )
 
     private val _state = MutableStateFlow(
-        State(featureFlags = featureFlags),
+        State(featureFlags = featureFlags(SortOrder.Name)),
     )
     val state: StateFlow<State> = _state
 
-    private val featureFlags: List<FeatureFlagWrapper>
-        get() = Feature.entries
+    private fun featureFlags(sortOrder: SortOrder): List<FeatureFlagWrapper> {
+        val comparator = when (sortOrder) {
+            SortOrder.Name -> compareBy { it.title }
+            SortOrder.ReleaseDate -> compareByDescending<Feature> { it.addedOn }.thenBy { it.title }
+        }
+        return Feature.entries
             .filter { it.hasDevToggle }
-            .sortedBy { it.title }
+            .sortedWith(comparator)
             .map {
                 FeatureFlagWrapper(
                     featureFlag = it,
                     isEnabled = FeatureFlag.isEnabled(it),
                 )
             }
+    }
 
     fun setFeatureEnabled(feature: Feature, enabled: Boolean) {
         FeatureFlag.setEnabled(feature, enabled)
         _state.value = _state.value.copy(
-            featureFlags = featureFlags,
+            featureFlags = featureFlags(_state.value.sortOrder),
+        )
+    }
+
+    fun setSortOrder(sortOrder: SortOrder) {
+        _state.value = _state.value.copy(
+            sortOrder = sortOrder,
+            featureFlags = featureFlags(sortOrder),
         )
     }
 

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1469,6 +1469,9 @@
     <string name="settings_auto_play">Auto play</string>
     <string name="settings_auto_play_summary">When there\'s nothing left to play, automatically pick an episode for me</string>
     <string name="settings_beta_features">Beta features</string>
+    <string name="settings_beta_features_sort">Sort beta features</string>
+    <string name="settings_beta_features_sort_name">Name (A–Z)</string>
+    <string name="settings_beta_features_sort_release_date">Release date (newest first)</string>
     <string name="settings_battery">Battery</string>
     <string name="settings_battery_settings">Battery settings</string>
     <string name="settings_battery_learn_more">Learn more</string>

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.utils.featureflag
 
 import au.com.shiftyjelly.pocketcasts.helper.BuildConfig
+import java.time.LocalDate
 
 private val isDebugOrPrototypeBuild = BuildConfig.DEBUG || BuildConfig.IS_PROTOTYPE
 
@@ -11,6 +12,7 @@ enum class Feature(
     val tier: FeatureTier,
     val hasFirebaseRemoteFlag: Boolean,
     val hasDevToggle: Boolean,
+    val addedOn: LocalDate,
 ) {
     // This is a set of features used only for testing purposes.
     TEST_FREE_FEATURE(
@@ -20,6 +22,7 @@ enum class Feature(
         tier = FeatureTier.Free,
         hasFirebaseRemoteFlag = false,
         hasDevToggle = false,
+        addedOn = LocalDate.parse("2025-06-05"),
     ),
     TEST_PLUS_FEATURE(
         key = "test_plus_feature",
@@ -28,6 +31,7 @@ enum class Feature(
         tier = FeatureTier.Plus(),
         hasFirebaseRemoteFlag = false,
         hasDevToggle = false,
+        addedOn = LocalDate.parse("2025-06-05"),
     ),
     TEST_PLUS_RESTRICTED_FEATURE(
         key = "test_plus_restricted_feature",
@@ -36,6 +40,7 @@ enum class Feature(
         tier = FeatureTier.Plus(ReleaseVersion(1, 0)),
         hasFirebaseRemoteFlag = false,
         hasDevToggle = false,
+        addedOn = LocalDate.parse("2025-06-05"),
     ),
     TEST_PATRON_FEATURE(
         key = "test_patron_feature",
@@ -44,6 +49,7 @@ enum class Feature(
         tier = FeatureTier.Patron,
         hasFirebaseRemoteFlag = false,
         hasDevToggle = false,
+        addedOn = LocalDate.parse("2025-06-05"),
     ),
 
     // Here are the feature flags used by the app
@@ -54,6 +60,7 @@ enum class Feature(
         tier = FeatureTier.Free,
         hasFirebaseRemoteFlag = true,
         hasDevToggle = false,
+        addedOn = LocalDate.parse("2024-10-23"),
     ),
     END_OF_YEAR_2025(
         key = "end_of_year_2025",
@@ -62,6 +69,7 @@ enum class Feature(
         tier = FeatureTier.Free,
         hasFirebaseRemoteFlag = true,
         hasDevToggle = false,
+        addedOn = LocalDate.parse("2025-10-27"),
     ),
     INTERCEPTOR_REFRESH_TOKEN_FALLBACK(
         key = "interceptor_refresh_token_fallback",
@@ -70,6 +78,7 @@ enum class Feature(
         tier = FeatureTier.Free,
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
+        addedOn = LocalDate.parse("2026-06-01"),
     ),
     INTRO_PLUS_OFFER_ENABLED(
         key = "intro_plus_offer_enabled",
@@ -78,6 +87,7 @@ enum class Feature(
         tier = FeatureTier.Free,
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
+        addedOn = LocalDate.parse("2024-02-06"),
     ),
     SLUMBER_STUDIOS_YEARLY_PROMO(
         key = "slumber_studios_yearly_promo_code",
@@ -86,6 +96,7 @@ enum class Feature(
         tier = FeatureTier.Plus(null),
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
+        addedOn = LocalDate.parse("2024-02-28"),
     ),
     EXPLAT_EXPERIMENT(
         key = "explat_experiment",
@@ -94,6 +105,7 @@ enum class Feature(
         tier = FeatureTier.Free,
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
+        addedOn = LocalDate.parse("2024-09-26"),
     ),
     ENGAGE_SDK(
         key = "engage_sdk",
@@ -102,6 +114,7 @@ enum class Feature(
         tier = FeatureTier.Free,
         hasFirebaseRemoteFlag = true,
         hasDevToggle = false,
+        addedOn = LocalDate.parse("2024-08-20"),
     ),
     PODCASTS_SORT_CHANGES(
         key = "podcasts_sort_changes",
@@ -110,6 +123,7 @@ enum class Feature(
         tier = FeatureTier.Free,
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
+        addedOn = LocalDate.parse("2025-03-07"),
     ),
     GUEST_LISTS_NETWORK_HIGHLIGHTS_REDESIGN(
         key = "guest_lists_network_highlights_redesign",
@@ -118,6 +132,7 @@ enum class Feature(
         tier = FeatureTier.Free,
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
+        addedOn = LocalDate.parse("2025-03-07"),
     ),
     LIBRO_FM(
         key = "libro_fm",
@@ -126,6 +141,7 @@ enum class Feature(
         tier = FeatureTier.Plus(),
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
+        addedOn = LocalDate.parse("2025-04-11"),
     ),
     RECOMMENDATIONS(
         key = "recommendations",
@@ -134,6 +150,7 @@ enum class Feature(
         tier = FeatureTier.Free,
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
+        addedOn = LocalDate.parse("2025-04-04"),
     ),
     NOTIFICATIONS_REVAMP(
         key = "notifications_revamp",
@@ -142,6 +159,7 @@ enum class Feature(
         tier = FeatureTier.Free,
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
+        addedOn = LocalDate.parse("2025-04-03"),
     ),
     BANNER_ADS_PLAYER(
         key = "banner_ad_player",
@@ -150,6 +168,7 @@ enum class Feature(
         tier = FeatureTier.Free,
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
+        addedOn = LocalDate.parse("2025-08-29"),
     ),
     BANNER_ADS_PODCASTS(
         key = "banner_ad_podcasts",
@@ -158,6 +177,7 @@ enum class Feature(
         tier = FeatureTier.Free,
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
+        addedOn = LocalDate.parse("2025-08-29"),
     ),
     SHARE_TRANSCRIPTS(
         key = "share_transcripts",
@@ -166,6 +186,7 @@ enum class Feature(
         tier = FeatureTier.Free,
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
+        addedOn = LocalDate.parse("2025-08-18"),
     ),
     IMPROVED_SEARCH_SUGGESTIONS(
         key = "search_predictive",
@@ -174,6 +195,7 @@ enum class Feature(
         tier = FeatureTier.Free,
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
+        addedOn = LocalDate.parse("2025-10-07"),
     ),
     IMPROVED_SEARCH_RESULTS(
         key = "search_improvements",
@@ -182,6 +204,7 @@ enum class Feature(
         tier = FeatureTier.Free,
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
+        addedOn = LocalDate.parse("2025-10-10"),
     ),
     IMPROVE_APP_RATINGS(
         key = "improve_app_ratings",
@@ -190,6 +213,7 @@ enum class Feature(
         tier = FeatureTier.Free,
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
+        addedOn = LocalDate.parse("2025-11-05"),
     ),
     NEW_INSTALLMENT_PLAN(
         key = "new_installment_plan",
@@ -198,6 +222,7 @@ enum class Feature(
         tier = FeatureTier.Free,
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
+        addedOn = LocalDate.parse("2026-01-08"),
     ),
 
     MEDIA3_SESSION(
@@ -207,6 +232,7 @@ enum class Feature(
         tier = FeatureTier.Free,
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
+        addedOn = LocalDate.parse("2026-03-04"),
     ),
     NEXT_EPISODE_PREFETCH(
         key = "next_episode_prefetch",
@@ -215,6 +241,7 @@ enum class Feature(
         tier = FeatureTier.Free,
         hasFirebaseRemoteFlag = false,
         hasDevToggle = true,
+        addedOn = LocalDate.parse("2026-03-04"),
     ),
     LOAD_ERROR_HANDLING_POLICY(
         key = "load_error_handling_policy",
@@ -223,6 +250,7 @@ enum class Feature(
         tier = FeatureTier.Free,
         hasFirebaseRemoteFlag = false,
         hasDevToggle = true,
+        addedOn = LocalDate.parse("2026-03-13"),
     ),
     UP_NEXT_SYNC_PROTOBUF(
         key = "up_next_sync_protobuf",
@@ -231,6 +259,7 @@ enum class Feature(
         tier = FeatureTier.Free,
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
+        addedOn = LocalDate.parse("2025-12-18"),
     ),
     LIVE_ANALYTICS(
         key = "live_analytics",
@@ -239,6 +268,7 @@ enum class Feature(
         tier = FeatureTier.Free,
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
+        addedOn = LocalDate.parse("2026-03-17"),
     ),
     PLAYBACK_ERROR_INFO_BAR(
         key = "display_errors_on_player",
@@ -247,6 +277,7 @@ enum class Feature(
         tier = FeatureTier.Free,
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
+        addedOn = LocalDate.parse("2026-03-31"),
     ),
     EXPLICIT_PODCAST_INDICATOR(
         key = "explicit_podcast_indicator",
@@ -255,6 +286,7 @@ enum class Feature(
         tier = FeatureTier.Free,
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
+        addedOn = LocalDate.parse("2026-04-23"),
     ),
     IMPROVED_LISTENING_STATS(
         key = "improved_listening_stats",
@@ -263,6 +295,7 @@ enum class Feature(
         tier = FeatureTier.Free,
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
+        addedOn = LocalDate.parse("2026-04-28"),
     ),
     BLOGS(
         key = "blogs",
@@ -271,6 +304,7 @@ enum class Feature(
         tier = FeatureTier.Free,
         hasFirebaseRemoteFlag = false,
         hasDevToggle = true,
+        addedOn = LocalDate.parse("2026-05-04"),
     ),
     PROFILE_SHARING(
         key = "profile_sharing",
@@ -279,6 +313,7 @@ enum class Feature(
         tier = FeatureTier.Free,
         hasFirebaseRemoteFlag = false,
         hasDevToggle = true,
+        addedOn = LocalDate.parse("2026-05-12"),
     ),
     EPISODE_CHAT(
         key = "episode_chat",
@@ -287,6 +322,7 @@ enum class Feature(
         tier = FeatureTier.Plus(),
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
+        addedOn = LocalDate.parse("2026-04-22"),
     ),
     EPISODE_CHAT_PLAYABLE_QUOTES(
         key = "episode_chat_playable_quotes",
@@ -295,6 +331,7 @@ enum class Feature(
         tier = FeatureTier.Plus(),
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
+        addedOn = LocalDate.parse("2026-04-27"),
     ),
     AI_SUMMARIES(
         key = "ai_summaries",
@@ -303,6 +340,7 @@ enum class Feature(
         tier = FeatureTier.Free,
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
+        addedOn = LocalDate.parse("2026-05-12"),
     ),
     GENERATED_CHAPTERS(
         key = "generated_chapters",
@@ -311,6 +349,7 @@ enum class Feature(
         tier = FeatureTier.Free,
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
+        addedOn = LocalDate.parse("2026-05-12"),
     ),
     SYNCED_TRANSCRIPTS(
         key = "synced_transcripts",
@@ -319,6 +358,7 @@ enum class Feature(
         tier = FeatureTier.Free,
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
+        addedOn = LocalDate.parse("2026-05-08"),
     ),
     SYNCED_TRANSCRIPT_DEBUG(
         key = "synced_transcript_debug",
@@ -327,6 +367,7 @@ enum class Feature(
         tier = FeatureTier.Free,
         hasFirebaseRemoteFlag = false,
         hasDevToggle = true,
+        addedOn = LocalDate.parse("2026-05-29"),
     ),
 }
 


### PR DESCRIPTION
It often takes me awhile to find the new beta features as I'm not to sure on the name. This change helps by adding a sort by release date. It will also help us find old feature flags we should remove.

<img width="300" src="https://github.com/user-attachments/assets/2f3801d9-ef38-4852-a958-6ea460499261" />

## Testing Instructions

1. Open the app and go to **Settings → Beta features**
2. Confirm the list is sorted alphabetically by name (A–Z) by default.
3. Tap the **sort** icon in the top app bar.
4. In the bottom sheet, confirm **Name (A–Z)** is checked and **Release date (newest first)** is available.
5. Select **Release date (newest first)** and confirm the list reorders to show the most recently added flags first.
6. Re-open the sort dialog and confirm **Release date (newest first)** is now the checked option.
7. Toggle a feature on/off and confirm the current sort order is preserved.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

#### I have tested any UI changes...
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack