### PR TITLE
Remove podcast sort changes feature flag

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsOptionsDialog.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsOptionsDialog.kt
@@ -10,8 +10,6 @@ import au.com.shiftyjelly.pocketcasts.podcasts.view.share.ShareListCreateActivit
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.model.BadgeType
 import au.com.shiftyjelly.pocketcasts.preferences.model.PodcastGridLayoutType
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.dialog.OptionsDialog
 import com.automattic.eventhorizon.EventHorizon
 import com.automattic.eventhorizon.PodcastListModalOptionType
@@ -110,12 +108,7 @@ class PodcastsOptionsDialog(
         val sortOrder = settings.podcastsSortType.value
         val title = fragment.getString(LR.string.sort_by)
         val dialog = OptionsDialog().setTitle(title)
-        val sortOptions = if (FeatureFlag.isEnabled(Feature.PODCASTS_SORT_CHANGES)) {
-            PodcastsSortType.entries
-        } else {
-            PodcastsSortType.entries.filterNot { it == PodcastsSortType.RECENTLY_PLAYED }
-        }
-        for (order in sortOptions) {
+        for (order in PodcastsSortType.entries) {
             dialog.addCheckedOption(
                 titleId = order.labelId,
                 checked = order.clientId == sortOrder.clientId,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
@@ -17,8 +17,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.FolderManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.SuggestedFoldersManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import com.automattic.eventhorizon.EpisodeRecentlyPlayedSortOptionTooltipDismissedEvent
 import com.automattic.eventhorizon.EpisodeRecentlyPlayedSortOptionTooltipShownEvent
 import com.automattic.eventhorizon.EventHorizon
@@ -308,7 +306,7 @@ class PodcastsViewModel @AssistedInject constructor(
         return suggestedFoldersPopupPolicy.isEligibleForPopup()
     }
 
-    fun shouldShowTooltip() = FeatureFlag.isEnabled(Feature.PODCASTS_SORT_CHANGES) && settings.showPodcastsRecentlyPlayedSortOrderTooltip.value
+    fun shouldShowTooltip() = settings.showPodcastsRecentlyPlayedSortOrderTooltip.value
 
     fun onTooltipShown() {
         eventHorizon.track(EpisodeRecentlyPlayedSortOptionTooltipShownEvent)

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/PodcastsSortType.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/PodcastsSortType.kt
@@ -4,8 +4,6 @@ import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
 import au.com.shiftyjelly.pocketcasts.utils.extensions.removeAccents
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import com.automattic.eventhorizon.PodcastListSortType
 import com.squareup.moshi.JsonAdapter
@@ -78,9 +76,7 @@ enum class PodcastsSortType(
             if (serverId == null) {
                 return default
             }
-            val sortType = entries
-                .filter { FeatureFlag.isEnabled(Feature.PODCASTS_SORT_CHANGES) || it.serverId != RECENTLY_PLAYED.serverId }
-                .firstOrNull { it.serverId == serverId }
+            val sortType = entries.firstOrNull { it.serverId == serverId }
             if (sortType == null) {
                 LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Invalid server ID for PodcastsSortType: $serverId")
                 return default
@@ -90,9 +86,7 @@ enum class PodcastsSortType(
 
         fun fromClientIdString(clientIdString: String): PodcastsSortType {
             val clientId = clientIdString.toIntOrNull()
-            val sortType = entries
-                .filter { FeatureFlag.isEnabled(Feature.PODCASTS_SORT_CHANGES) || it.clientId != RECENTLY_PLAYED.clientId }
-                .firstOrNull { it.clientId == clientId }
+            val sortType = entries.firstOrNull { it.clientId == clientId }
             if (sortType == null) {
                 LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Invalid client ID for PodcastsSortType: $clientIdString")
                 return default

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -103,14 +103,6 @@ enum class Feature(
         hasFirebaseRemoteFlag = true,
         hasDevToggle = false,
     ),
-    PODCASTS_SORT_CHANGES(
-        key = "podcasts_sort_changes",
-        title = "Podcasts Sort Changes",
-        defaultValue = true,
-        tier = FeatureTier.Free,
-        hasFirebaseRemoteFlag = true,
-        hasDevToggle = true,
-    ),
     GUEST_LISTS_NETWORK_HIGHLIGHTS_REDESIGN(
         key = "guest_lists_network_highlights_redesign",
         title = "Guest Lists and Network Highlights Redesign",


### PR DESCRIPTION
## Description

Removes the `PODCASTS_SORT_CHANGES` feature flag now that the podcasts sort changes have fully shipped. The flag defaulted to `true`, so this enables the behaviour permanently and deletes the now-dead branches:

- The **Recently Played** sort option is now always shown in the podcasts sort options dialog (previously filtered out when the flag was off).
- `PodcastsSortType.fromServerId` / `fromClientIdString` no longer filter out `RECENTLY_PLAYED` based on the flag.
- The recently-played sort tooltip is now gated only on the user setting, not the flag.
- The `PODCASTS_SORT_CHANGES` entry is removed from `Feature.kt`.

This is a tech-debt cleanup with no intended change in user-facing behaviour, since the flag already defaulted to enabled.

## Testing Instructions

1. Open the **Podcasts** tab.
2. Tap the options/overflow menu and choose **Sort by**.
3. Confirm the **Recently Played** option is present in the list of sort orders.
4. Select **Recently Played** and confirm podcasts re-sort accordingly.
5. Confirm the recently-played sort tooltip still appears/dismisses according to the existing user setting.

## Screenshots 

<img width="300" src="https://github.com/user-attachments/assets/9aeee928-363b-4f4e-a6ee-a595e6a48a40" />

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

#### I have tested any UI changes...
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack