### PR TITLE
chore: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -7,4 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      # SHA-pinned for supply-chain safety (the trailing "# v6.1.0" is the readable version).
+      # Dependabot (github-actions ecosystem) auto-bumps the SHA + comment on new releases —
+      # no manual step. To pin a tag by hand: gh api repos/gradle/actions/commits/v6.1.0 --jq .sha
       - uses: gradle/actions/wrapper-validation@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -7,4 +7,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: gradle/actions/wrapper-validation@v6
+      - uses: gradle/actions/wrapper-validation@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0

--- a/.github/workflows/high-prio-issue-notify-slack.yml
+++ b/.github/workflows/high-prio-issue-notify-slack.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Send Slack Notification
         if: env.SEND_SLACK == 'true'
-        uses: slackapi/slack-github-action@v3.0.3
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           webhook: ${{ secrets.SLACK_NOTIFIER_WEBHOOK_URL }}
           webhook-type: webhook-trigger

--- a/.github/workflows/submit-gradle-dependencies.yml
+++ b/.github/workflows/submit-gradle-dependencies.yml
@@ -16,4 +16,4 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: Setup Gradle to generate and submit dependency graphs
-        uses: gradle/actions/dependency-submission@v6
+        uses: gradle/actions/dependency-submission@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0


### PR DESCRIPTION
Pins third-party GitHub Actions in this repo to immutable commit SHAs.

This is a draft PR for review before merging. It was prepared with agent assistance and manually verified.

Tracking: DEVPROD-1072

Repo-level summary:
- Pinned distinct third-party action refs in this PR: 3
- Repo-level unpinned usage count from the trunk recheck: 3
- Dependabot GitHub Actions coverage: already_present (.github/dependabot.yml)


Verification commands:

```bash
# gradle/actions/dependency-submission # v6.1.0 -> 50e97c2cd7a37755bbfafc9c5b7cafaece252f6e
gh api repos/gradle/actions/commits/v6.1.0 --jq '.sha'
# expected: 50e97c2cd7a37755bbfafc9c5b7cafaece252f6e

# gradle/actions/wrapper-validation # v6.1.0 -> 50e97c2cd7a37755bbfafc9c5b7cafaece252f6e
gh api repos/gradle/actions/commits/v6.1.0 --jq '.sha'
# expected: 50e97c2cd7a37755bbfafc9c5b7cafaece252f6e

# slackapi/slack-github-action # v3.0.3 -> 45a88b9581bfab2566dc881e2cd66d334e621e2c
gh api repos/slackapi/slack-github-action/commits/v3.0.3 --jq '.sha'
# expected: 45a88b9581bfab2566dc881e2cd66d334e621e2c
```
