### PR TITLE
[TV] Implement Welcome screen

### DIFF
--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2826,7 +2826,6 @@
     <string name="tv_onboarding_subtitle">Your podcasts, on the big screen</string>
     <string name="tv_onboarding_create_free_account">Create free account</string>
     <string name="tv_onboarding_browse_without_account">Browse without an account</string>
-    <string name="tv_onboarding_continue_without_account">Continue without account</string>
     <string name="tv_onboarding_sign_in_title">Sign in to Pocket Casts</string>
     <string name="tv_onboarding_sign_in_instructions">Scan the QR code or visit the URL below and enter the code</string>
     <string name="tv_onboarding_signed_in">I\'ve signed in</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2822,6 +2822,10 @@
 
     <!-- TV Onboarding -->
     <string name="tv_onboarding_welcome">Welcome to Pocket Casts</string>
+    <string name="tv_onboarding_welcome_tv">Welcome to Pocket Casts TV</string>
+    <string name="tv_onboarding_subtitle">Your podcasts, on the big screen</string>
+    <string name="tv_onboarding_create_free_account">Create free account</string>
+    <string name="tv_onboarding_browse_without_account">Browse without an account</string>
     <string name="tv_onboarding_continue_without_account">Continue without account</string>
     <string name="tv_onboarding_sign_in_title">Sign in to Pocket Casts</string>
     <string name="tv_onboarding_sign_in_instructions">Scan the QR code or visit the URL below and enter the code</string>

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvAnimatedPodcastGrid.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvAnimatedPodcastGrid.kt
@@ -8,17 +8,15 @@ import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
@@ -61,7 +59,7 @@ private val ArtworkResIds = listOf(
 fun TvAnimatedPodcastGrid(modifier: Modifier = Modifier) {
     val infiniteTransition = rememberInfiniteTransition(label = "podcast_grid")
     val animationProgress by infiniteTransition.animateFloat(
-        initialValue = 0f,
+        initialValue = -1f,
         targetValue = 1f,
         animationSpec = infiniteRepeatable(
             animation = tween(durationMillis = ANIMATION_DURATION_MS, easing = LinearEasing),
@@ -90,24 +88,21 @@ fun TvAnimatedPodcastGrid(modifier: Modifier = Modifier) {
             val direction = if (rowIndex % 2 == 0) 1f else -1f
             val translationX = animationProgress * offsetPx * direction
 
-            Box(
-                modifier = Modifier.fillMaxWidth(),
-                contentAlignment = Alignment.Center,
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(TILE_SPACING_DP.dp),
+                modifier = Modifier
+                    .wrapContentWidth(unbounded = true)
+                    .graphicsLayer { this.translationX = translationX },
             ) {
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(TILE_SPACING_DP.dp),
-                    modifier = Modifier.graphicsLayer { this.translationX = translationX },
-                ) {
-                    artworks.forEach { resId ->
-                        Image(
-                            painter = painterResource(resId),
-                            contentDescription = null,
-                            contentScale = ContentScale.Crop,
-                            modifier = Modifier
-                                .size(TILE_SIZE_DP.dp)
-                                .clip(RoundedCornerShape(TILE_CORNER_RADIUS_DP.dp)),
-                        )
-                    }
+                artworks.forEach { resId ->
+                    Image(
+                        painter = painterResource(resId),
+                        contentDescription = null,
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier
+                            .size(TILE_SIZE_DP.dp)
+                            .clip(RoundedCornerShape(TILE_CORNER_RADIUS_DP.dp)),
+                    )
                 }
             }
         }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvAnimatedPodcastGrid.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvAnimatedPodcastGrid.kt
@@ -1,0 +1,105 @@
+package au.com.shiftyjelly.pocketcasts.onboarding
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+
+private const val TILE_SIZE_DP = 181
+private const val TILE_SPACING_DP = 11
+private const val TILE_CORNER_RADIUS_DP = 8
+private const val ANIMATION_OFFSET_DP = 133
+private const val ANIMATION_DURATION_MS = 20_000
+private const val ROW_COUNT = 3
+private const val TILES_PER_ROW = 8
+
+private val ArtworkResIds = listOf(
+    IR.drawable.artwork_0,
+    IR.drawable.artwork_1,
+    IR.drawable.artwork_2,
+    IR.drawable.artwork_3,
+    IR.drawable.artwork_4,
+    IR.drawable.artwork_5,
+    IR.drawable.artwork_6,
+    IR.drawable.artwork_7,
+    IR.drawable.artwork_8,
+    IR.drawable.artwork_9,
+    IR.drawable.artwork_10,
+    IR.drawable.artwork_11,
+    IR.drawable.artwork_12,
+    IR.drawable.artwork_13,
+    IR.drawable.artwork_14,
+    IR.drawable.artwork_15,
+    IR.drawable.artwork_16,
+    IR.drawable.artwork_17,
+)
+
+@Composable
+fun TvAnimatedPodcastGrid(modifier: Modifier = Modifier) {
+    val infiniteTransition = rememberInfiniteTransition(label = "podcast_grid")
+    val animationProgress by infiniteTransition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = ANIMATION_DURATION_MS, easing = LinearEasing),
+            repeatMode = RepeatMode.Reverse,
+        ),
+        label = "grid_offset",
+    )
+
+    val offsetPx = with(LocalDensity.current) { ANIMATION_OFFSET_DP.dp.toPx() }
+
+    val rows = remember {
+        (0 until ROW_COUNT).map { rowIndex ->
+            (0 until TILES_PER_ROW).map { tileIndex ->
+                ArtworkResIds[(rowIndex * TILES_PER_ROW + tileIndex) % ArtworkResIds.size]
+            }
+        }
+    }
+
+    Column(
+        modifier = modifier.clipToBounds(),
+        verticalArrangement = Arrangement.spacedBy(TILE_SPACING_DP.dp),
+    ) {
+        rows.forEachIndexed { rowIndex, artworks ->
+            val direction = if (rowIndex % 2 == 0) 1f else -1f
+            val translationX = animationProgress * offsetPx * direction
+
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(TILE_SPACING_DP.dp),
+                modifier = Modifier.graphicsLayer { this.translationX = translationX },
+            ) {
+                artworks.forEach { resId ->
+                    Image(
+                        painter = painterResource(resId),
+                        contentDescription = null,
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier
+                            .size(TILE_SIZE_DP.dp)
+                            .clip(RoundedCornerShape(TILE_CORNER_RADIUS_DP.dp)),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvAnimatedPodcastGrid.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvAnimatedPodcastGrid.kt
@@ -8,14 +8,17 @@ import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
@@ -33,7 +36,7 @@ private const val ANIMATION_OFFSET_DP = 107
 private const val GRID_VERTICAL_OFFSET_DP = -73
 private const val ANIMATION_DURATION_MS = 20_000
 private const val ROW_COUNT = 3
-private const val TILES_PER_ROW = 8
+private const val TILES_PER_ROW = 10
 
 private val ArtworkResIds = listOf(
     IR.drawable.artwork_0,
@@ -45,7 +48,6 @@ private val ArtworkResIds = listOf(
     IR.drawable.artwork_6,
     IR.drawable.artwork_7,
     IR.drawable.artwork_8,
-    IR.drawable.artwork_9,
     IR.drawable.artwork_10,
     IR.drawable.artwork_11,
     IR.drawable.artwork_12,
@@ -53,7 +55,6 @@ private val ArtworkResIds = listOf(
     IR.drawable.artwork_14,
     IR.drawable.artwork_15,
     IR.drawable.artwork_16,
-    IR.drawable.artwork_17,
 )
 
 @Composable
@@ -89,19 +90,24 @@ fun TvAnimatedPodcastGrid(modifier: Modifier = Modifier) {
             val direction = if (rowIndex % 2 == 0) 1f else -1f
             val translationX = animationProgress * offsetPx * direction
 
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(TILE_SPACING_DP.dp),
-                modifier = Modifier.graphicsLayer { this.translationX = translationX },
+            Box(
+                modifier = Modifier.fillMaxWidth(),
+                contentAlignment = Alignment.Center,
             ) {
-                artworks.forEach { resId ->
-                    Image(
-                        painter = painterResource(resId),
-                        contentDescription = null,
-                        contentScale = ContentScale.Crop,
-                        modifier = Modifier
-                            .size(TILE_SIZE_DP.dp)
-                            .clip(RoundedCornerShape(TILE_CORNER_RADIUS_DP.dp)),
-                    )
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(TILE_SPACING_DP.dp),
+                    modifier = Modifier.graphicsLayer { this.translationX = translationX },
+                ) {
+                    artworks.forEach { resId ->
+                        Image(
+                            painter = painterResource(resId),
+                            contentDescription = null,
+                            contentScale = ContentScale.Crop,
+                            modifier = Modifier
+                                .size(TILE_SIZE_DP.dp)
+                                .clip(RoundedCornerShape(TILE_CORNER_RADIUS_DP.dp)),
+                        )
+                    }
                 }
             }
         }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvAnimatedPodcastGrid.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvAnimatedPodcastGrid.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
@@ -25,10 +26,11 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 
-private const val TILE_SIZE_DP = 181
-private const val TILE_SPACING_DP = 11
-private const val TILE_CORNER_RADIUS_DP = 8
-private const val ANIMATION_OFFSET_DP = 133
+private const val TILE_SIZE_DP = 145
+private const val TILE_SPACING_DP = 9
+private const val TILE_CORNER_RADIUS_DP = 6
+private const val ANIMATION_OFFSET_DP = 107
+private const val GRID_VERTICAL_OFFSET_DP = -73
 private const val ANIMATION_DURATION_MS = 20_000
 private const val ROW_COUNT = 3
 private const val TILES_PER_ROW = 8
@@ -78,7 +80,9 @@ fun TvAnimatedPodcastGrid(modifier: Modifier = Modifier) {
     }
 
     Column(
-        modifier = modifier.clipToBounds(),
+        modifier = modifier
+            .clipToBounds()
+            .offset(y = GRID_VERTICAL_OFFSET_DP.dp),
         verticalArrangement = Arrangement.spacedBy(TILE_SPACING_DP.dp),
     ) {
         rows.forEachIndexed { rowIndex, artworks ->

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvLandingScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvLandingScreen.kt
@@ -104,8 +104,8 @@ fun TvLandingScreen(
                 Button(
                     onClick = onSignIn,
                     colors = ButtonDefaults.colors(
-                        containerColor = Color.White,
-                        contentColor = TvColors.Dark,
+                        containerColor = TvColors.DarkGray,
+                        contentColor = Color.White,
                         focusedContainerColor = Color.White,
                         focusedContentColor = TvColors.Dark,
                     ),

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvLandingScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvLandingScreen.kt
@@ -5,12 +5,13 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.widthIn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
@@ -18,6 +19,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -25,11 +27,10 @@ import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.tv.material3.Border
 import androidx.tv.material3.Button
 import androidx.tv.material3.ButtonDefaults
 import androidx.tv.material3.MaterialTheme
-import androidx.tv.material3.OutlinedButton
-import androidx.tv.material3.OutlinedButtonDefaults
 import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.theme.TvColors
@@ -47,67 +48,100 @@ fun TvLandingScreen(
     val focusRequester = remember { FocusRequester() }
 
     Box(
-        contentAlignment = Alignment.Center,
         modifier = modifier
             .fillMaxSize()
-            .background(TvColors.Dark)
-            .padding(horizontal = 48.dp, vertical = 27.dp),
+            .background(TvColors.Dark),
     ) {
+        TvAnimatedPodcastGrid(
+            modifier = Modifier
+                .fillMaxWidth()
+                .align(Alignment.TopCenter),
+        )
+
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(
+                    Brush.verticalGradient(
+                        colorStops = arrayOf(
+                            0f to TvColors.Dark.copy(alpha = 0.5f),
+                            0.17f to TvColors.Dark.copy(alpha = 0.5f),
+                            0.45f to TvColors.Dark,
+                            1f to TvColors.Dark,
+                        ),
+                    ),
+                ),
+        )
+
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center,
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 48.dp, vertical = 27.dp),
         ) {
+            Spacer(modifier = Modifier.weight(0.45f))
+
             Image(
                 painter = painterResource(IR.drawable.ic_pocket_casts_logo),
                 contentDescription = null,
-                modifier = Modifier.size(80.dp),
+                modifier = Modifier.size(72.dp),
             )
-            Spacer(modifier = Modifier.height(24.dp))
+            Spacer(modifier = Modifier.height(16.dp))
             Text(
-                text = stringResource(LR.string.tv_onboarding_welcome),
+                text = stringResource(LR.string.tv_onboarding_welcome_tv),
                 color = Color.White,
                 fontSize = 32.sp,
             )
-            Spacer(modifier = Modifier.height(48.dp))
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = stringResource(LR.string.tv_onboarding_subtitle),
+                color = TvColors.TextSecondary,
+                fontSize = 18.sp,
+            )
+            Spacer(modifier = Modifier.height(32.dp))
+
+            Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                Button(
+                    onClick = onSignIn,
+                    colors = ButtonDefaults.colors(
+                        containerColor = Color.White,
+                        contentColor = TvColors.Dark,
+                        focusedContainerColor = Color.White,
+                        focusedContentColor = TvColors.Dark,
+                    ),
+                    modifier = Modifier.focusRequester(focusRequester),
+                ) {
+                    Text(text = stringResource(LR.string.sign_in))
+                }
+                Button(
+                    onClick = onCreateAccount,
+                    colors = ButtonDefaults.colors(
+                        containerColor = TvColors.DarkGray,
+                        contentColor = Color.White,
+                        focusedContainerColor = Color.White,
+                        focusedContentColor = TvColors.Dark,
+                    ),
+                ) {
+                    Text(text = stringResource(LR.string.tv_onboarding_create_free_account))
+                }
+            }
+
+            Spacer(modifier = Modifier.weight(0.55f))
+
             Button(
-                onClick = onSignIn,
-                colors = ButtonDefaults.colors(
-                    containerColor = Color.White,
-                    contentColor = TvColors.Dark,
-                    focusedContainerColor = Color.White,
-                    focusedContentColor = TvColors.Dark,
-                ),
-                modifier = Modifier
-                    .widthIn(min = 280.dp)
-                    .focusRequester(focusRequester),
-            ) {
-                Text(text = stringResource(LR.string.sign_in))
-            }
-            Spacer(modifier = Modifier.height(12.dp))
-            OutlinedButton(
-                onClick = onCreateAccount,
-                colors = OutlinedButtonDefaults.colors(
-                    containerColor = Color.Transparent,
-                    contentColor = Color.White,
-                    focusedContainerColor = Color.White,
-                    focusedContentColor = TvColors.Dark,
-                ),
-                modifier = Modifier.widthIn(min = 280.dp),
-            ) {
-                Text(text = stringResource(LR.string.create_account))
-            }
-            Spacer(modifier = Modifier.height(12.dp))
-            OutlinedButton(
                 onClick = onContinueWithoutAccount,
-                colors = OutlinedButtonDefaults.colors(
+                colors = ButtonDefaults.colors(
                     containerColor = Color.Transparent,
                     contentColor = TvColors.TextSecondary,
-                    focusedContainerColor = Color.White,
-                    focusedContentColor = TvColors.Dark,
+                    focusedContainerColor = Color.White.copy(alpha = 0.1f),
+                    focusedContentColor = Color.White,
                 ),
-                modifier = Modifier.widthIn(min = 280.dp),
+                border = ButtonDefaults.border(
+                    border = Border.None,
+                    focusedBorder = Border.None,
+                ),
             ) {
-                Text(text = stringResource(LR.string.tv_onboarding_continue_without_account))
+                Text(text = stringResource(LR.string.tv_onboarding_browse_without_account))
             }
         }
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingNavHost.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingNavHost.kt
@@ -8,6 +8,9 @@ import androidx.navigation.compose.rememberNavController
 import androidx.tv.material3.MaterialTheme
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.home.TvScaffold
+import au.com.shiftyjelly.pocketcasts.onboarding.signin.TvSignInScreen
+import au.com.shiftyjelly.pocketcasts.onboarding.signin.TvSyncingScreen
+import au.com.shiftyjelly.pocketcasts.onboarding.welcome.TvWelcomeScreen
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 
 @Composable
@@ -22,7 +25,7 @@ fun TvOnboardingNavHost(
                 startDestination = viewModel.startDestination,
             ) {
                 composable(TvOnboardingRoutes.LANDING) {
-                    TvLandingScreen(
+                    TvWelcomeScreen(
                         onSignIn = { navController.navigate(TvOnboardingRoutes.SIGN_IN) },
                         onCreateAccount = { navController.navigate(TvOnboardingRoutes.SIGN_IN) },
                         onContinueWithoutAccount = {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInScreen.kt
@@ -1,4 +1,4 @@
-package au.com.shiftyjelly.pocketcasts.onboarding
+package au.com.shiftyjelly.pocketcasts.onboarding.signin
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSyncingScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSyncingScreen.kt
@@ -1,4 +1,4 @@
-package au.com.shiftyjelly.pocketcasts.onboarding
+package au.com.shiftyjelly.pocketcasts.onboarding.signin
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.core.LinearEasing

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/welcome/TvAnimatedPodcastGrid.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/welcome/TvAnimatedPodcastGrid.kt
@@ -1,4 +1,4 @@
-package au.com.shiftyjelly.pocketcasts.onboarding
+package au.com.shiftyjelly.pocketcasts.onboarding.welcome
 
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.RepeatMode

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/welcome/TvAnimatedPodcastGrid.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/welcome/TvAnimatedPodcastGrid.kt
@@ -56,7 +56,7 @@ private val ArtworkResIds = listOf(
 )
 
 @Composable
-fun TvAnimatedPodcastGrid(modifier: Modifier = Modifier) {
+internal fun TvAnimatedPodcastGrid(modifier: Modifier = Modifier) {
     val infiniteTransition = rememberInfiniteTransition(label = "podcast_grid")
     val animationProgress by infiniteTransition.animateFloat(
         initialValue = -1f,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/welcome/TvWelcomeScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/welcome/TvWelcomeScreen.kt
@@ -1,4 +1,4 @@
-package au.com.shiftyjelly.pocketcasts.onboarding
+package au.com.shiftyjelly.pocketcasts.onboarding.welcome
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -39,7 +39,7 @@ import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
-fun TvLandingScreen(
+fun TvWelcomeScreen(
     onSignIn: () -> Unit,
     onCreateAccount: () -> Unit,
     onContinueWithoutAccount: () -> Unit,
@@ -153,10 +153,10 @@ fun TvLandingScreen(
 
 @Preview(device = Devices.TV_1080p)
 @Composable
-private fun TvLandingScreenPreview() {
+private fun TvWelcomeScreenPreview() {
     AppTheme(themeType = Theme.ThemeType.EXTRA_DARK) {
         MaterialTheme {
-            TvLandingScreen(
+            TvWelcomeScreen(
                 onSignIn = {},
                 onCreateAccount = {},
                 onContinueWithoutAccount = {},

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/welcome/TvWelcomeScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/welcome/TvWelcomeScreen.kt
@@ -26,14 +26,13 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import androidx.tv.material3.Border
 import androidx.tv.material3.Button
-import androidx.tv.material3.ButtonDefaults
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
 import au.com.shiftyjelly.pocketcasts.theme.TvColors
+import au.com.shiftyjelly.pocketcasts.theme.TvTextStyles
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -84,43 +83,33 @@ fun TvWelcomeScreen(
             Image(
                 painter = painterResource(IR.drawable.ic_pocket_casts_logo),
                 contentDescription = null,
-                modifier = Modifier.size(72.dp),
+                modifier = Modifier.size(36.dp),
             )
             Spacer(modifier = Modifier.height(16.dp))
             Text(
                 text = stringResource(LR.string.tv_onboarding_welcome_tv),
                 color = Color.White,
-                fontSize = 32.sp,
+                style = TvTextStyles.WelcomeTitle,
             )
             Spacer(modifier = Modifier.height(8.dp))
             Text(
                 text = stringResource(LR.string.tv_onboarding_subtitle),
                 color = TvColors.TextSecondary,
-                fontSize = 18.sp,
+                style = TvTextStyles.WelcomeSubtitle,
             )
             Spacer(modifier = Modifier.height(32.dp))
 
             Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
                 Button(
                     onClick = onSignIn,
-                    colors = ButtonDefaults.colors(
-                        containerColor = TvColors.DarkGray,
-                        contentColor = Color.White,
-                        focusedContainerColor = Color.White,
-                        focusedContentColor = TvColors.Dark,
-                    ),
+                    colors = TvButtonDefaults.filledButtonColors(),
                     modifier = Modifier.focusRequester(focusRequester),
                 ) {
                     Text(text = stringResource(LR.string.sign_in))
                 }
                 Button(
                     onClick = onCreateAccount,
-                    colors = ButtonDefaults.colors(
-                        containerColor = TvColors.DarkGray,
-                        contentColor = Color.White,
-                        focusedContainerColor = Color.White,
-                        focusedContentColor = TvColors.Dark,
-                    ),
+                    colors = TvButtonDefaults.filledButtonColors(),
                 ) {
                     Text(text = stringResource(LR.string.tv_onboarding_create_free_account))
                 }
@@ -130,16 +119,8 @@ fun TvWelcomeScreen(
 
             Button(
                 onClick = onContinueWithoutAccount,
-                colors = ButtonDefaults.colors(
-                    containerColor = Color.Transparent,
-                    contentColor = TvColors.TextSecondary,
-                    focusedContainerColor = Color.White.copy(alpha = 0.1f),
-                    focusedContentColor = Color.White,
-                ),
-                border = ButtonDefaults.border(
-                    border = Border.None,
-                    focusedBorder = Border.None,
-                ),
+                colors = TvButtonDefaults.borderlessButtonColors(),
+                border = TvButtonDefaults.borderlessButtonBorder(),
             ) {
                 Text(text = stringResource(LR.string.tv_onboarding_browse_without_account))
             }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/welcome/TvWelcomeScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/welcome/TvWelcomeScreen.kt
@@ -74,12 +74,11 @@ fun TvWelcomeScreen(
 
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
             modifier = Modifier
                 .fillMaxSize()
                 .padding(horizontal = 48.dp, vertical = 27.dp),
         ) {
-            Spacer(modifier = Modifier.weight(0.45f))
-
             Image(
                 painter = painterResource(IR.drawable.ic_pocket_casts_logo),
                 contentDescription = null,
@@ -114,16 +113,17 @@ fun TvWelcomeScreen(
                     Text(text = stringResource(LR.string.tv_onboarding_create_free_account))
                 }
             }
+        }
 
-            Spacer(modifier = Modifier.weight(0.55f))
-
-            Button(
-                onClick = onContinueWithoutAccount,
-                colors = TvButtonDefaults.borderlessButtonColors(),
-                border = TvButtonDefaults.borderlessButtonBorder(),
-            ) {
-                Text(text = stringResource(LR.string.tv_onboarding_browse_without_account))
-            }
+        Button(
+            onClick = onContinueWithoutAccount,
+            colors = TvButtonDefaults.borderlessButtonColors(),
+            border = TvButtonDefaults.borderlessButtonBorder(),
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(bottom = 27.dp),
+        ) {
+            Text(text = stringResource(LR.string.tv_onboarding_browse_without_account))
         }
     }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/welcome/TvWelcomeScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/welcome/TvWelcomeScreen.kt
@@ -64,8 +64,8 @@ fun TvWelcomeScreen(
                     Brush.verticalGradient(
                         colorStops = arrayOf(
                             0f to TvColors.Dark.copy(alpha = 0.5f),
-                            0.17f to TvColors.Dark.copy(alpha = 0.5f),
-                            0.45f to TvColors.Dark,
+                            0.12f to TvColors.Dark.copy(alpha = 0.5f),
+                            0.35f to TvColors.Dark,
                             1f to TvColors.Dark,
                         ),
                     ),

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/welcome/TvWelcomeScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/welcome/TvWelcomeScreen.kt
@@ -64,8 +64,8 @@ fun TvWelcomeScreen(
                     Brush.verticalGradient(
                         colorStops = arrayOf(
                             0f to TvColors.Dark.copy(alpha = 0.5f),
-                            0.12f to TvColors.Dark.copy(alpha = 0.5f),
-                            0.35f to TvColors.Dark,
+                            0.15f to TvColors.Dark.copy(alpha = 0.5f),
+                            0.40f to TvColors.Dark,
                             1f to TvColors.Dark,
                         ),
                     ),

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvButtonDefaults.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvButtonDefaults.kt
@@ -1,0 +1,33 @@
+package au.com.shiftyjelly.pocketcasts.theme
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.tv.material3.Border
+import androidx.tv.material3.ButtonBorder
+import androidx.tv.material3.ButtonColors
+import androidx.tv.material3.ButtonDefaults
+
+object TvButtonDefaults {
+
+    @Composable
+    fun filledButtonColors(): ButtonColors = ButtonDefaults.colors(
+        containerColor = TvColors.BgActive20,
+        contentColor = TvColors.TextSecondary,
+        focusedContainerColor = Color.White,
+        focusedContentColor = TvColors.Dark,
+    )
+
+    @Composable
+    fun borderlessButtonColors(): ButtonColors = ButtonDefaults.colors(
+        containerColor = Color.Transparent,
+        contentColor = TvColors.TextSecondary,
+        focusedContainerColor = Color.White.copy(alpha = 0.1f),
+        focusedContentColor = Color.White,
+    )
+
+    @Composable
+    fun borderlessButtonBorder(): ButtonBorder = ButtonDefaults.border(
+        border = Border.None,
+        focusedBorder = Border.None,
+    )
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvTextStyles.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvTextStyles.kt
@@ -43,4 +43,22 @@ object TvTextStyles {
         lineHeight = 20.sp,
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
+
+    val WelcomeTitle = TextStyle(
+        fontSize = 27.sp,
+        fontWeight = FontWeight.Medium,
+        lineHeight = 27.sp,
+        letterSpacing = (-0.25).sp,
+        textAlign = TextAlign.Center,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    val WelcomeSubtitle = TextStyle(
+        fontSize = 16.sp,
+        fontWeight = FontWeight.Medium,
+        lineHeight = 16.sp,
+        letterSpacing = (-0.04).sp,
+        textAlign = TextAlign.Center,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
 }


### PR DESCRIPTION
## Description
This PR adds the implementation of the welcome screen.
Tiles are being animated to move on top, similarly what apple TV does.

figma: CatsKh221Javk7wNG7jzEt-fi-586_733

Fixes PCDROID-595 https://linear.app/a8c/issue/PCDROID-595/create-landing-screen-with-animation

## Testing Instructions
1. Clean install the TV app and observe welcome screen

## Screenshots or Screencast 

https://github.com/user-attachments/assets/7848e6e7-0a68-4233-adc2-2e8e60eaa746



## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack