### PR TITLE
[TV] Add sign up screen

### DIFF
--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2834,4 +2834,7 @@
     <string name="tv_onboarding_syncing">Syncing your podcasts\u2026</string>
     <string name="tv_onboarding_welcome_back">Welcome back!</string>
     <string name="tv_onboarding_syncing_subtitle">Your podcasts are syncing, we\'ll sign you in soon!</string>
+    <string name="tv_create_account_title">Create your free account</string>
+    <string name="tv_create_account_subtitle">Scan this code to get started on your phone, it only takes a minute.</string>
+    <string name="tv_create_account_come_back">Once you\'ve created your account, come back and sign in</string>
 </resources>

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingNavHost.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingNavHost.kt
@@ -8,6 +8,7 @@ import androidx.navigation.compose.rememberNavController
 import androidx.tv.material3.MaterialTheme
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.home.TvScaffold
+import au.com.shiftyjelly.pocketcasts.onboarding.createaccount.TvCreateAccountScreen
 import au.com.shiftyjelly.pocketcasts.onboarding.signin.TvSignInScreen
 import au.com.shiftyjelly.pocketcasts.onboarding.signin.TvSyncingScreen
 import au.com.shiftyjelly.pocketcasts.onboarding.welcome.TvWelcomeScreen
@@ -27,13 +28,18 @@ fun TvOnboardingNavHost(
                 composable(TvOnboardingRoutes.LANDING) {
                     TvWelcomeScreen(
                         onSignIn = { navController.navigate(TvOnboardingRoutes.SIGN_IN) },
-                        onCreateAccount = { navController.navigate(TvOnboardingRoutes.SIGN_IN) },
+                        onCreateAccount = { navController.navigate(TvOnboardingRoutes.CREATE_ACCOUNT) },
                         onContinueWithoutAccount = {
                             viewModel.completeOnboarding()
                             navController.navigate(TvOnboardingRoutes.HOME) {
                                 popUpTo(TvOnboardingRoutes.LANDING) { inclusive = true }
                             }
                         },
+                    )
+                }
+                composable(TvOnboardingRoutes.CREATE_ACCOUNT) {
+                    TvCreateAccountScreen(
+                        onSignIn = { navController.navigate(TvOnboardingRoutes.SIGN_IN) },
                     )
                 }
                 composable(TvOnboardingRoutes.SIGN_IN) {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingRoutes.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingRoutes.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.onboarding
 
 object TvOnboardingRoutes {
     const val LANDING = "tv_landing"
+    const val CREATE_ACCOUNT = "tv_create_account"
     const val SIGN_IN = "tv_sign_in"
     const val SYNCING = "tv_syncing"
     const val HOME = "tv_home"

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/createaccount/TvCreateAccountScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/createaccount/TvCreateAccountScreen.kt
@@ -27,8 +27,8 @@ import androidx.tv.material3.Button
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.BuildConfig
-import au.com.shiftyjelly.pocketcasts.component.rememberQrPainter
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.qr.rememberQrPainter
 import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
 import au.com.shiftyjelly.pocketcasts.theme.TvColors
 import au.com.shiftyjelly.pocketcasts.theme.TvTextStyles

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/createaccount/TvCreateAccountScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/createaccount/TvCreateAccountScreen.kt
@@ -1,0 +1,116 @@
+package au.com.shiftyjelly.pocketcasts.onboarding.createaccount
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.tv.material3.Button
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.BuildConfig
+import au.com.shiftyjelly.pocketcasts.component.rememberQrPainter
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
+import au.com.shiftyjelly.pocketcasts.theme.TvColors
+import au.com.shiftyjelly.pocketcasts.theme.TvTextStyles
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+fun TvCreateAccountScreen(
+    onSignIn: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val focusRequester = remember { FocusRequester() }
+    val createAccountUrl = remember { "https://${BuildConfig.WEB_BASE_HOST}/create" }
+    val qrPainter = rememberQrPainter(content = createAccountUrl, size = 160.dp)
+
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = modifier
+            .fillMaxSize()
+            .background(TvColors.Dark),
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Image(
+                painter = painterResource(IR.drawable.ic_pocket_casts_logo),
+                contentDescription = null,
+                modifier = Modifier.size(36.dp),
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = stringResource(LR.string.tv_create_account_title),
+                color = Color.White,
+                style = TvTextStyles.WelcomeTitle,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = stringResource(LR.string.tv_create_account_subtitle),
+                color = TvColors.TextSecondary,
+                style = TvTextStyles.SignInSubtitle,
+            )
+            Spacer(modifier = Modifier.height(24.dp))
+            Box(
+                modifier = Modifier
+                    .background(Color.White, RoundedCornerShape(4.dp))
+                    .padding(4.dp),
+            ) {
+                Image(
+                    painter = qrPainter,
+                    contentDescription = stringResource(LR.string.tv_create_account_subtitle),
+                    modifier = Modifier.size(160.dp),
+                )
+            }
+            Spacer(modifier = Modifier.height(24.dp))
+            Text(
+                text = stringResource(LR.string.tv_create_account_come_back),
+                color = TvColors.TextSecondary,
+                style = TvTextStyles.SignInSubtitle,
+            )
+            Spacer(modifier = Modifier.height(24.dp))
+            Button(
+                onClick = onSignIn,
+                colors = TvButtonDefaults.prominentButtonColors(),
+                modifier = Modifier.focusRequester(focusRequester),
+            ) {
+                Text(text = stringResource(LR.string.sign_in))
+            }
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+}
+
+@Preview(device = Devices.TV_1080p)
+@Composable
+private fun TvCreateAccountScreenPreview() {
+    AppTheme(themeType = Theme.ThemeType.EXTRA_DARK) {
+        MaterialTheme {
+            TvCreateAccountScreen(onSignIn = {})
+        }
+    }
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/createaccount/TvCreateAccountScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/createaccount/TvCreateAccountScreen.kt
@@ -43,7 +43,7 @@ fun TvCreateAccountScreen(
 ) {
     val focusRequester = remember { FocusRequester() }
     val createAccountUrl = remember { "https://${BuildConfig.WEB_BASE_HOST}/create" }
-    val qrPainter = rememberQrPainter(content = createAccountUrl, size = 160.dp)
+    val qrPainter = rememberQrPainter(content = createAccountUrl, size = 118.dp)
 
     Box(
         contentAlignment = Alignment.Center,
@@ -80,7 +80,7 @@ fun TvCreateAccountScreen(
                 Image(
                     painter = qrPainter,
                     contentDescription = stringResource(LR.string.tv_create_account_subtitle),
-                    modifier = Modifier.size(160.dp),
+                    modifier = Modifier.size(118.dp),
                 )
             }
             Spacer(modifier = Modifier.height(24.dp))


### PR DESCRIPTION
## Description
This PR adds the sign up screen. The screen shows a QR code to `<website>/create` which is a non-existent url both on stage and prod... we'll have to check with iOS team about that. The appleTV app shows the same one, so I thought it's best to follow their implementation.

figma: CatsKh221Javk7wNG7jzEt-fi-586_3634

Fixes PCDROID-599 https://linear.app/a8c/issue/PCDROID-599/create-sign-up-screen

## Testing Instructions
1. Reinstall tv app
2. On welcome, select "Create free account"
3. Observe

## Screenshots or Screencast 
<img width="1920" height="1080" alt="Screenshot_20260609_190149" src="https://github.com/user-attachments/assets/b14bbb4d-185d-490b-b5fb-229a0d195c5f" />


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack