### PR TITLE
[AI Summary] Put feature behind paygate

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingFlowRoutes.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingFlowRoutes.kt
@@ -349,6 +349,7 @@ object OnboardingFlowRoutes {
                 OnboardingUpgradeSource.UP_NEXT_SHUFFLE,
                 OnboardingUpgradeSource.GENERATED_TRANSCRIPTS,
                 OnboardingUpgradeSource.EPISODE_CHAT,
+                OnboardingUpgradeSource.AI_SUMMARIES,
                 OnboardingUpgradeSource.DEEP_LINK,
                 OnboardingUpgradeSource.FINISHED_ONBOARDING,
                 OnboardingUpgradeSource.SYNCED_TRANSCRIPTS,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
@@ -293,7 +293,10 @@ class PlayerContainerFragment :
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 summaryViewModel.state.collect { state ->
-                    adapter.updateSummary(addSummary = state is SummaryViewModel.SummaryState.Loaded)
+                    adapter.updateSummary(
+                        addSummary = state is SummaryViewModel.SummaryState.Loaded ||
+                            state is SummaryViewModel.SummaryState.Upsell,
+                    )
                 }
             }
         }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/SummaryFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/SummaryFragment.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.MaterialTheme
@@ -14,16 +15,22 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
+import androidx.compose.ui.unit.dp
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.extensions.contentWithoutConsumedInsets
 import au.com.shiftyjelly.pocketcasts.compose.summary.SummaryContent
+import au.com.shiftyjelly.pocketcasts.compose.summary.SummaryPaywall
+import au.com.shiftyjelly.pocketcasts.compose.summary.SummaryPaywallColors
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.PlayerViewModel
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.SummaryViewModel
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.SummaryViewModel.SummaryState
+import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
+import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
+import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
@@ -67,9 +74,31 @@ class SummaryFragment : BaseFragment() {
                         )
                     }
 
+                    is SummaryState.Upsell -> {
+                        SummaryPaywall(
+                            summaryText = s.text,
+                            isFreeTrialAvailable = s.isFreeTrialAvailable,
+                            onClickSubscribe = ::openUpgradeFlow,
+                            colors = SummaryPaywallColors.player(
+                                background = backgroundColor,
+                                contrast01 = MaterialTheme.theme.colors.playerContrast01,
+                                contrast02 = MaterialTheme.theme.colors.playerContrast02,
+                            ),
+                            contentPadding = PaddingValues(horizontal = 24.dp, vertical = 24.dp),
+                            modifier = Modifier.fillMaxSize(),
+                        )
+                    }
+
                     is SummaryState.NotAvailable -> Unit
                 }
             }
         }
+    }
+
+    private fun openUpgradeFlow() {
+        OnboardingLauncher.openOnboardingFlow(
+            requireActivity(),
+            OnboardingFlow.Upsell(OnboardingUpgradeSource.AI_SUMMARIES),
+        )
     }
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/SummaryViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/SummaryViewModel.kt
@@ -2,6 +2,12 @@ package au.com.shiftyjelly.pocketcasts.player.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.payment.BillingCycle
+import au.com.shiftyjelly.pocketcasts.payment.PaymentClient
+import au.com.shiftyjelly.pocketcasts.payment.SubscriptionOffer
+import au.com.shiftyjelly.pocketcasts.payment.SubscriptionTier
+import au.com.shiftyjelly.pocketcasts.payment.getOrNull
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.di.IoDispatcher
 import au.com.shiftyjelly.pocketcasts.repositories.transcript.TranscriptManager
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -16,12 +22,15 @@ import kotlinx.coroutines.launch
 @HiltViewModel
 class SummaryViewModel @Inject constructor(
     private val transcriptManager: TranscriptManager,
+    private val settings: Settings,
+    private val paymentClient: PaymentClient,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
 
     sealed interface SummaryState {
         data object Loading : SummaryState
         data class Loaded(val text: String) : SummaryState
+        data class Upsell(val text: String, val isFreeTrialAvailable: Boolean) : SummaryState
         data object NotAvailable : SummaryState
     }
 
@@ -29,26 +38,56 @@ class SummaryViewModel @Inject constructor(
     val state: StateFlow<SummaryState> = _state.asStateFlow()
 
     private var currentEpisodeUuid: String? = null
+    private var loadedText: String? = null
     private var loadJob: Job? = null
+    private var isFreeTrialAvailable = false
+
+    init {
+        viewModelScope.launch {
+            val plans = paymentClient.loadSubscriptionPlans().getOrNull()
+            isFreeTrialAvailable = plans?.findOfferPlan(
+                SubscriptionTier.Plus,
+                BillingCycle.Monthly,
+                SubscriptionOffer.Trial,
+            ) != null
+        }
+        viewModelScope.launch {
+            settings.cachedSubscription.flow.collect {
+                val text = loadedText
+                if (text != null) {
+                    _state.value = resolveState(text)
+                }
+            }
+        }
+    }
 
     fun clearSummary() {
         currentEpisodeUuid = null
+        loadedText = null
         loadJob?.cancel()
         _state.value = SummaryState.NotAvailable
     }
 
     fun loadSummary(episodeUuid: String) {
         if (currentEpisodeUuid == episodeUuid && _state.value is SummaryState.Loaded) return
+        if (currentEpisodeUuid == episodeUuid && _state.value is SummaryState.Upsell) return
         currentEpisodeUuid = episodeUuid
+        loadedText = null
         loadJob?.cancel()
         _state.value = SummaryState.Loading
         loadJob = viewModelScope.launch(ioDispatcher) {
             val text = transcriptManager.loadSummaryText(episodeUuid)
+            loadedText = text
             _state.value = if (text != null) {
-                SummaryState.Loaded(text)
+                resolveState(text)
             } else {
                 SummaryState.NotAvailable
             }
         }
+    }
+
+    private fun resolveState(text: String): SummaryState {
+        val isPaidUser = settings.cachedSubscription.value != null
+        return if (isPaidUser) SummaryState.Loaded(text) else SummaryState.Upsell(text, isFreeTrialAvailable)
     }
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/SummaryViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/SummaryViewModel.kt
@@ -50,6 +50,10 @@ class SummaryViewModel @Inject constructor(
                 BillingCycle.Monthly,
                 SubscriptionOffer.Trial,
             ) != null
+            val text = loadedText
+            if (text != null) {
+                _state.value = resolveState(text)
+            }
         }
         viewModelScope.launch {
             settings.cachedSubscription.flow.collect {

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/SummaryViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/SummaryViewModelTest.kt
@@ -1,16 +1,28 @@
 package au.com.shiftyjelly.pocketcasts.player.viewmodel
 
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPlatform
+import au.com.shiftyjelly.pocketcasts.payment.BillingCycle
+import au.com.shiftyjelly.pocketcasts.payment.PaymentClient
+import au.com.shiftyjelly.pocketcasts.payment.PaymentResult
+import au.com.shiftyjelly.pocketcasts.payment.PaymentResultCode
+import au.com.shiftyjelly.pocketcasts.payment.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.SummaryViewModel.SummaryState
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.transcript.TranscriptManager
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import java.time.Instant
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
@@ -25,7 +37,38 @@ class SummaryViewModelTest {
     @Mock
     private lateinit var transcriptManager: TranscriptManager
 
-    private fun createViewModel() = SummaryViewModel(transcriptManager, coroutineRule.testDispatcher)
+    @Mock
+    private lateinit var settings: Settings
+
+    @Mock
+    private lateinit var paymentClient: PaymentClient
+
+    private val cachedSubscription = MutableStateFlow<Subscription?>(
+        Subscription(
+            tier = SubscriptionTier.Plus,
+            billingCycle = BillingCycle.Monthly,
+            platform = SubscriptionPlatform.Android,
+            expiryDate = Instant.now(),
+            isAutoRenewing = true,
+            giftDays = 0,
+        ),
+    )
+
+    @Before
+    fun setUp() = runTest {
+        val readSetting = mock<au.com.shiftyjelly.pocketcasts.preferences.ReadSetting<Subscription?>>()
+        whenever(readSetting.flow).thenReturn(cachedSubscription)
+        whenever(readSetting.value).thenAnswer { cachedSubscription.value }
+        whenever(settings.cachedSubscription).thenReturn(readSetting)
+        whenever(paymentClient.loadSubscriptionPlans()).thenReturn(PaymentResult.Failure(PaymentResultCode.Error, "test"))
+    }
+
+    private fun createViewModel() = SummaryViewModel(
+        transcriptManager,
+        settings,
+        paymentClient,
+        coroutineRule.testDispatcher,
+    )
 
     @Test
     fun `initial state is Loading`() {
@@ -35,13 +78,24 @@ class SummaryViewModelTest {
     }
 
     @Test
-    fun `state is Loaded when summary text is available`() = runTest {
+    fun `state is Loaded when summary text is available and user is subscribed`() = runTest {
         whenever(transcriptManager.loadSummaryText("episode-1")).thenReturn("Summary text")
         val viewModel = createViewModel()
 
         viewModel.loadSummary("episode-1")
 
         assertEquals(SummaryState.Loaded("Summary text"), viewModel.state.value)
+    }
+
+    @Test
+    fun `state is Upsell when summary text is available but user is not subscribed`() = runTest {
+        cachedSubscription.value = null
+        whenever(transcriptManager.loadSummaryText("episode-1")).thenReturn("Summary text")
+        val viewModel = createViewModel()
+
+        viewModel.loadSummary("episode-1")
+
+        assertEquals(SummaryState.Upsell(text = "Summary text", isFreeTrialAvailable = false), viewModel.state.value)
     }
 
     @Test
@@ -55,7 +109,40 @@ class SummaryViewModelTest {
     }
 
     @Test
+    fun `state changes from Upsell to Loaded when user subscribes`() = runTest {
+        cachedSubscription.value = null
+        whenever(transcriptManager.loadSummaryText("episode-1")).thenReturn("Summary text")
+        val viewModel = createViewModel()
+
+        viewModel.loadSummary("episode-1")
+        assertEquals(SummaryState.Upsell(text = "Summary text", isFreeTrialAvailable = false), viewModel.state.value)
+
+        cachedSubscription.value = Subscription(
+            tier = SubscriptionTier.Plus,
+            billingCycle = BillingCycle.Monthly,
+            platform = SubscriptionPlatform.Android,
+            expiryDate = Instant.now(),
+            isAutoRenewing = true,
+            giftDays = 0,
+        )
+
+        assertEquals(SummaryState.Loaded("Summary text"), viewModel.state.value)
+    }
+
+    @Test
     fun `loading same episode twice does not re-fetch when already loaded`() = runTest {
+        whenever(transcriptManager.loadSummaryText("episode-1")).thenReturn("Summary text")
+        val viewModel = createViewModel()
+
+        viewModel.loadSummary("episode-1")
+        viewModel.loadSummary("episode-1")
+
+        verify(transcriptManager).loadSummaryText("episode-1")
+    }
+
+    @Test
+    fun `loading same episode twice does not re-fetch when in upsell state`() = runTest {
+        cachedSubscription.value = null
         whenever(transcriptManager.loadSummaryText("episode-1")).thenReturn("Summary text")
         val viewModel = createViewModel()
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -93,6 +93,7 @@ import au.com.shiftyjelly.pocketcasts.compose.buttons.ButtonTab
 import au.com.shiftyjelly.pocketcasts.compose.buttons.ButtonTabs
 import au.com.shiftyjelly.pocketcasts.compose.components.AnimatedPlayPauseButton
 import au.com.shiftyjelly.pocketcasts.compose.extensions.setContentWithViewCompositionStrategy
+import au.com.shiftyjelly.pocketcasts.compose.summary.SummaryPaywall
 import au.com.shiftyjelly.pocketcasts.compose.text.HtmlText
 import au.com.shiftyjelly.pocketcasts.compose.text.markdownToHtml
 import au.com.shiftyjelly.pocketcasts.compose.theme
@@ -730,6 +731,7 @@ class EpisodeFragment : BaseFragment() {
             val transcript = pageState.transcript as? Transcript.Text
             val isSummaryEnabled = FeatureFlag.isEnabledFlow(Feature.AI_SUMMARIES).collectAsState().value
             val isPlusUser = pageState.isPlusUser
+            val isFreeTrialAvailable = pageState.isFreeTrialAvailable
             val selectedTab = pageState.selectedContentTab
 
             val showDescription = !isSummaryEnabled ||
@@ -821,22 +823,33 @@ class EpisodeFragment : BaseFragment() {
                         }
 
                         if (selectedTab == EpisodeContentTab.SUMMARY && summaryText != null) {
-                            Column(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(horizontal = 16.dp, vertical = 16.dp),
-                            ) {
-                                Text(
-                                    text = stringResource(LR.string.episode_summary),
-                                    color = MaterialTheme.theme.colors.primaryText01,
-                                    fontSize = 20.sp,
-                                    fontWeight = FontWeight.Bold,
-                                    modifier = Modifier.padding(bottom = 16.dp),
-                                )
-                                HtmlText(
-                                    html = markdownToHtml(summaryText.orEmpty()),
-                                    color = MaterialTheme.theme.colors.primaryText01,
-                                    textStyleResId = UR.style.P40,
+                            if (isPlusUser) {
+                                Column(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(horizontal = 16.dp, vertical = 16.dp),
+                                ) {
+                                    Text(
+                                        text = stringResource(LR.string.episode_summary),
+                                        color = MaterialTheme.theme.colors.primaryText01,
+                                        fontSize = 20.sp,
+                                        fontWeight = FontWeight.Bold,
+                                        modifier = Modifier.padding(bottom = 16.dp),
+                                    )
+                                    HtmlText(
+                                        html = markdownToHtml(summaryText.orEmpty()),
+                                        color = MaterialTheme.theme.colors.primaryText01,
+                                        textStyleResId = UR.style.P40,
+                                    )
+                                }
+                            } else {
+                                val screenHeight = with(LocalDensity.current) { LocalWindowInfo.current.containerSize.height.toDp() }
+                                SummaryPaywall(
+                                    summaryText = summaryText.orEmpty(),
+                                    isFreeTrialAvailable = isFreeTrialAvailable,
+                                    onClickSubscribe = ::onSummaryUpgradeClick,
+                                    contentPadding = PaddingValues(16.dp),
+                                    modifier = Modifier.height(screenHeight),
                                 )
                             }
                         }
@@ -1202,6 +1215,13 @@ class EpisodeFragment : BaseFragment() {
             source = OnboardingUpgradeSource.BOOKMARKS,
         )
         OnboardingLauncher.openOnboardingFlow(requireActivity(), onboardingFlow)
+    }
+
+    private fun onSummaryUpgradeClick() {
+        OnboardingLauncher.openOnboardingFlow(
+            requireActivity(),
+            OnboardingFlow.Upsell(OnboardingUpgradeSource.AI_SUMMARIES),
+        )
     }
 
     private fun showBookmarksOptionsDialog(selectedValue: Int) {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
@@ -13,6 +13,11 @@ import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.Transcript
+import au.com.shiftyjelly.pocketcasts.payment.BillingCycle
+import au.com.shiftyjelly.pocketcasts.payment.PaymentClient
+import au.com.shiftyjelly.pocketcasts.payment.SubscriptionOffer
+import au.com.shiftyjelly.pocketcasts.payment.SubscriptionTier
+import au.com.shiftyjelly.pocketcasts.payment.getOrNull
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadProgressCache
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadQueue
@@ -76,6 +81,7 @@ class EpisodeFragmentViewModel @Inject constructor(
     private val eventHorizon: EventHorizon,
     private val transcriptManager: TranscriptManager,
     private val userManager: UserManager,
+    private val paymentClient: PaymentClient,
 ) : ViewModel(),
     CoroutineScope {
     override val coroutineContext: CoroutineContext
@@ -106,6 +112,7 @@ class EpisodeFragmentViewModel @Inject constructor(
     data class EpisodePageState(
         val transcript: Transcript? = null,
         val isPlusUser: Boolean = false,
+        val isFreeTrialAvailable: Boolean = false,
         val summary: String? = null,
         val selectedContentTab: EpisodeContentTab = EpisodeContentTab.DESCRIPTION,
         val episodePublishedDate: Date? = null,
@@ -164,6 +171,17 @@ class EpisodeFragmentViewModel @Inject constructor(
                 _pageState.update { state ->
                     state.copy(isPlusUser = signInState.isSignedInAsPlusOrPatron)
                 }
+            }
+        }
+        viewModelScope.launch {
+            val plans = paymentClient.loadSubscriptionPlans().getOrNull()
+            val hasTrial = plans?.findOfferPlan(
+                SubscriptionTier.Plus,
+                BillingCycle.Monthly,
+                SubscriptionOffer.Trial,
+            ) != null
+            _pageState.update { state ->
+                state.copy(isFreeTrialAvailable = hasTrial)
             }
         }
     }

--- a/modules/features/podcasts/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModelTest.kt
+++ b/modules/features/podcasts/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModelTest.kt
@@ -4,6 +4,9 @@ import au.com.shiftyjelly.pocketcasts.analytics.testing.TestEventSink
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.SignInState
+import au.com.shiftyjelly.pocketcasts.payment.PaymentClient
+import au.com.shiftyjelly.pocketcasts.payment.PaymentResult
+import au.com.shiftyjelly.pocketcasts.payment.PaymentResultCode
 import au.com.shiftyjelly.pocketcasts.podcasts.view.episode.EpisodeFragmentViewModel.EpisodeContentTab.DESCRIPTION
 import au.com.shiftyjelly.pocketcasts.podcasts.view.episode.EpisodeFragmentViewModel.EpisodeContentTab.SUMMARY
 import au.com.shiftyjelly.pocketcasts.podcasts.view.episode.EpisodeFragmentViewModel.EpisodePageState
@@ -69,18 +72,22 @@ class EpisodeFragmentViewModelTest {
     @Mock
     lateinit var userManager: UserManager
 
+    @Mock
+    lateinit var paymentClient: PaymentClient
+
     private val eventSink = TestEventSink()
 
     private lateinit var viewModel: EpisodeFragmentViewModel
 
     @Before
-    fun setUp() {
+    fun setUp() = kotlinx.coroutines.test.runTest {
         whenever(playbackManager.playbackStateLive).thenReturn(
             androidx.lifecycle.MutableLiveData(PlaybackState()),
         )
         whenever(userManager.getSignInState()).thenReturn(
             Flowable.just(SignInState.SignedOut),
         )
+        whenever(paymentClient.loadSubscriptionPlans()).thenReturn(PaymentResult.Failure(PaymentResultCode.Error, "test"))
         viewModel = EpisodeFragmentViewModel(
             episodeManager = episodeManager,
             podcastManager = podcastManager,
@@ -93,6 +100,7 @@ class EpisodeFragmentViewModelTest {
             eventHorizon = EventHorizon(eventSink),
             transcriptManager = transcriptManager,
             userManager = userManager,
+            paymentClient = paymentClient,
         )
     }
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingUpgradeSource.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingUpgradeSource.kt
@@ -89,6 +89,9 @@ enum class OnboardingUpgradeSource(
     EPISODE_CHAT(
         analyticsValue = OnboardingSourceType.EpisodeChat,
     ),
+    AI_SUMMARIES(
+        analyticsValue = OnboardingSourceType.Unknown,
+    ),
     FINISHED_ONBOARDING(
         analyticsValue = OnboardingSourceType.AccountCreated,
     ),

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/summary/SummaryPaywall.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/summary/SummaryPaywall.kt
@@ -1,0 +1,220 @@
+package au.com.shiftyjelly.pocketcasts.compose.summary
+
+import android.os.Build
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.LocalRippleConfiguration
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.RippleConfiguration
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.blur
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH20
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH50
+import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadge
+import au.com.shiftyjelly.pocketcasts.compose.plusGoldDark
+import au.com.shiftyjelly.pocketcasts.compose.plusGoldLight
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.compose.text.HtmlText
+import au.com.shiftyjelly.pocketcasts.compose.text.markdownToHtml
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+import au.com.shiftyjelly.pocketcasts.ui.R as UR
+
+data class SummaryPaywallColors(
+    val background: Color,
+    val primaryText: Color,
+    val secondaryText: Color,
+) {
+    companion object {
+        @Composable
+        fun default() = SummaryPaywallColors(
+            background = MaterialTheme.theme.colors.primaryUi01,
+            primaryText = MaterialTheme.theme.colors.primaryText01,
+            secondaryText = MaterialTheme.theme.colors.primaryText02,
+        )
+
+        fun player(
+            background: Color,
+            contrast01: Color,
+            contrast02: Color,
+        ) = SummaryPaywallColors(
+            background = background,
+            primaryText = contrast01,
+            secondaryText = contrast02,
+        )
+    }
+}
+
+@Composable
+fun SummaryPaywall(
+    summaryText: String,
+    isFreeTrialAvailable: Boolean,
+    onClickSubscribe: () -> Unit,
+    modifier: Modifier = Modifier,
+    colors: SummaryPaywallColors = SummaryPaywallColors.default(),
+    contentPadding: PaddingValues = PaddingValues(16.dp),
+) {
+    val startPadding = contentPadding.calculateStartPadding(LocalLayoutDirection.current)
+    val endPadding = contentPadding.calculateEndPadding(LocalLayoutDirection.current)
+    val topPadding = contentPadding.calculateTopPadding()
+    val bottomPadding = contentPadding.calculateBottomPadding()
+
+    val obscureModifier = if (Build.VERSION.SDK_INT >= 31) {
+        Modifier.blur(6.dp)
+    } else {
+        Modifier.alpha(0.1f)
+    }
+
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier
+            .background(colors.background)
+            .padding(start = startPadding, end = endPadding),
+    ) {
+        Spacer(modifier = Modifier.height(topPadding))
+        SubscriptionBadge(
+            iconRes = IR.drawable.ic_plus,
+            shortNameRes = LR.string.pocket_casts_plus_short,
+            contentDescriptionRes = LR.string.pocket_casts_plus_badge,
+            fontSize = 16.sp,
+            padding = 6.dp,
+            textColor = Color.Black,
+            iconColor = Color.Black,
+            backgroundBrush = Brush.horizontalGradient(
+                0f to Color.plusGoldLight,
+                1f to Color.plusGoldDark,
+            ),
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+        TextH20(
+            text = stringResource(LR.string.summary_upsell_title),
+            color = colors.primaryText,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        TextH50(
+            text = stringResource(LR.string.transcript_generated_paywall_description),
+            color = colors.secondaryText,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+
+        BlurredSummaryPreview(
+            summaryText = summaryText,
+            textColor = colors.primaryText,
+            backgroundColor = colors.background,
+            modifier = obscureModifier.weight(1f),
+        )
+
+        CompositionLocalProvider(
+            LocalRippleConfiguration provides RippleConfiguration(color = Color.Black),
+        ) {
+            RowButton(
+                text = if (isFreeTrialAvailable) {
+                    stringResource(LR.string.profile_start_free_trial)
+                } else {
+                    stringResource(LR.string.onboarding_subscribe_to_plus)
+                },
+                textColor = Color.Black,
+                fontSize = 18.sp,
+                fontWeight = FontWeight.SemiBold,
+                colors = ButtonDefaults.buttonColors(
+                    backgroundColor = Color.plusGoldLight,
+                ),
+                includePadding = false,
+                onClick = onClickSubscribe,
+                modifier = Modifier.padding(bottom = bottomPadding),
+            )
+        }
+    }
+}
+
+@Composable
+private fun ColumnScope.BlurredSummaryPreview(
+    summaryText: String,
+    textColor: Color,
+    backgroundColor: Color,
+    modifier: Modifier = Modifier,
+) {
+    val gradientBrush = Brush.verticalGradient(
+        0.0f to Color.Transparent,
+        0.7f to Color.Transparent,
+        1.0f to backgroundColor,
+    )
+
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .clipToBounds(),
+    ) {
+        HtmlText(
+            html = markdownToHtml(summaryText),
+            color = textColor,
+            textStyleResId = UR.style.P40,
+            modifier = Modifier.padding(horizontal = 8.dp),
+        )
+        Box(
+            modifier = Modifier
+                .matchParentSize()
+                .background(gradientBrush),
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun SummaryPaywallPreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: Theme.ThemeType,
+) {
+    AppThemeWithBackground(theme) {
+        SummaryPaywall(
+            summaryText = "## Episode Highlights\n\n- First key point discussed in the episode\n- Second important topic covered by the hosts\n- **Notable quote** from the guest speaker\n\nThe hosts wrap up with their final thoughts on the matter.",
+            isFreeTrialAvailable = false,
+            onClickSubscribe = {},
+            modifier = Modifier.fillMaxSize(),
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun SummaryPaywallFreeTrialPreview() {
+    AppThemeWithBackground(Theme.ThemeType.DARK) {
+        SummaryPaywall(
+            summaryText = "## Episode Highlights\n\n- First key point discussed\n- Second important topic\n- **Notable quote** from the guest",
+            isFreeTrialAvailable = true,
+            onClickSubscribe = {},
+            modifier = Modifier.fillMaxSize(),
+        )
+    }
+}

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/summary/SummaryPaywall.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/summary/SummaryPaywall.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.RippleConfiguration
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -123,7 +124,7 @@ fun SummaryPaywall(
         )
         Spacer(modifier = Modifier.height(16.dp))
         TextH50(
-            text = stringResource(LR.string.transcript_generated_paywall_description),
+            text = stringResource(LR.string.summary_upsell_description),
             color = colors.secondaryText,
             textAlign = TextAlign.Center,
         )
@@ -172,13 +173,15 @@ private fun ColumnScope.BlurredSummaryPreview(
         1.0f to backgroundColor,
     )
 
+    val html = remember(summaryText) { markdownToHtml(summaryText) }
+
     Box(
         modifier = modifier
             .fillMaxWidth()
             .clipToBounds(),
     ) {
         HtmlText(
-            html = markdownToHtml(summaryText),
+            html = html,
             color = textColor,
             textStyleResId = UR.style.P40,
             modifier = Modifier.padding(horizontal = 8.dp),

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -128,6 +128,7 @@
     <string name="view_transcript">View transcript</string>
     <string name="episode_chat">Chat with Episode</string>
     <string name="episode_summary">Episode Summary</string>
+    <string name="summary_upsell_title">AI-Powered Summaries</string>
     <string name="description">Description</string>
     <string name="summary">Summary</string>
     <string name="transcript">Transcript</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -129,6 +129,7 @@
     <string name="episode_chat">Chat with Episode</string>
     <string name="episode_summary">Episode Summary</string>
     <string name="summary_upsell_title">AI-Powered Summaries</string>
+    <string name="summary_upsell_description">Subscribe to Plus to get access to it and other Premium&#160;features like bookmarks and folders.</string>
     <string name="description">Description</string>
     <string name="summary">Summary</string>
     <string name="transcript">Transcript</string>

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -328,7 +328,7 @@ enum class Feature(
         key = "ai_summaries",
         title = "AI Summaries",
         defaultValue = isDebugOrPrototypeBuild,
-        tier = FeatureTier.Free,
+        tier = FeatureTier.Plus(),
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
         addedOn = LocalDate.parse("2026-05-12"),


### PR DESCRIPTION
## Description
As of our recent decision, summaries should be only accessible for Plus users.
This PR makes sure to show a paywall similar to Transcripts when a normal user is trying to see summaries of an episode.
The paywall is added to the episode details and to the fullscreen player as well.

see: p1780966883902809/1780621552.408879-slack-C075WBQ9WKH

## Testing Instructions
1. Sign in with a regular account
2. Open a podcast, tap on a random episode to see details
3. Tap the "Summary" tab
4. Verify paywall 
5. Tap the CTA on paywall
6. Verify it takes you to the upgrade screen
7. Now start playing that episode and open up fullscreen player
8. Select the Summary tab
9. Verify same things

## Screenshots or Screencast 

https://github.com/user-attachments/assets/7042a956-87c9-49d9-9bf4-822db4fc8c7a



## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack