### PR TITLE
Extend Apps Infra CODEOWNERS routing to CI and toolchain

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,3 +14,6 @@ Dangerfile* @Automattic/apps-infra-tooling
 
 # Toolchain and environment pins
 .java-version @Automattic/apps-infra-tooling
+
+# Secrets
+.configure-files/     @Automattic/apps-infra-tooling

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,13 @@
 /.ruby-version @Automattic/apps-infra-tooling
 /.bundle/ @Automattic/apps-infra-tooling
 /.rubocop*.yml @Automattic/apps-infra-tooling
+fastlane/ @Automattic/apps-infra-tooling
+
+# CI and automation
+.buildkite/ @Automattic/apps-infra-tooling
+.github/workflows/ @Automattic/apps-infra-tooling
+.github/dependabot.yml @Automattic/apps-infra-tooling
+Dangerfile* @Automattic/apps-infra-tooling
+
+# Toolchain and environment pins
+.java-version @Automattic/apps-infra-tooling


### PR DESCRIPTION
Extends the CODEOWNERS routing from #5372 beyond the Ruby dependency surface to the broader Apps Infra surface — CI config, automation, and toolchain pins — still routed to @Automattic/apps-infra-tooling. Only paths that exist in this repo are included. See [AINFRA-2437](https://linear.app/a8c/issue/AINFRA-2437).

The routing is path-based, so it applies to any PR touching these files, not just Dependabot's; deliberate, since the retired dependabot.yml `reviewers` key has no source-scoped replacement.

---

Posted by Claude Code (Fable 5) on behalf of @mokagio.
