### PR TITLE
Add Git workflow guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,20 @@ Core Services (model, servers)
 
 ## Development Guidelines
 
+### Git Workflow
+
+**Develop feature work on a branch off `main`. The only reason to branch off a release branch is to cherry-pick an already-merged commit into that release.**
+
+Branching feature *development* off a release branch causes confusion later: when
+the release branch is merged back into `main`, it is unclear which commits belong
+to the release and which belong to the unrelated feature work. To avoid this:
+
+- **Create every feature branch from `main`** (`git checkout main && git pull && git checkout -b my-feature`), even if the change is also needed in an in-flight release. Never develop a feature on a branch based on `release/*`.
+- If a change must also land in a release branch (e.g. a fix needed for an upcoming release):
+  1. Develop and merge it on a branch off `main` first.
+  2. Create a **new branch off the release branch** and **cherry-pick** the relevant commit(s) onto it, then open a PR into the release branch (`git checkout release/x.y && git pull && git checkout -b cherry-pick/my-fix && git cherry-pick <sha>`).
+- Keep cherry-picks limited to the specific commits the release needs, so the release branch never accumulates feature work that does not belong in it.
+
 ### Technology Preferences
 
 **Use Jetpack Compose for new UI**:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,10 +136,21 @@ Branching feature *development* off a release branch causes confusion later: whe
 the release branch is merged back into `main`, it is unclear which commits belong
 to the release and which belong to the unrelated feature work. To avoid this:
 
-- **Create every feature branch from `main`** (`git checkout main && git pull && git checkout -b my-feature`), even if the change is also needed in an in-flight release. Never develop a feature on a branch based on `release/*`.
-- If a change must also land in a release branch (e.g. a fix needed for an upcoming release):
+- **Create every feature branch from `main`** (`git checkout main && git pull && git checkout -b my-feature`), even if the
+  change is also needed in an in-flight release. Never develop a feature on a
+  branch based on `release/*`.
+- If a change must also land in a release branch (e.g. a fix needed for an
+  upcoming release):
   1. Develop and merge it on a branch off `main` first.
-  2. Create a **new branch off the release branch** and **cherry-pick** the relevant commit(s) onto it, then open a PR into the release branch (`git checkout release/x.y && git pull && git checkout -b cherry-pick/my-fix && git cherry-pick <sha>`).
+  2. Create a **new branch off the release branch** and **cherry-pick** the relevant commit(s) onto it,
+     then open a PR into the release branch:
+
+     ```
+     git checkout release/x.y
+     git pull
+     git checkout -b cherry-pick/my-fix
+     git cherry-pick <sha>
+     ```
 - Keep cherry-picks limited to the specific commits the release needs, so the release branch never accumulates feature work that does not belong in it.
 
 ### Technology Preferences

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,13 +145,14 @@ to the release and which belong to the unrelated feature work. To avoid this:
   2. Create a **new branch off the release branch** and **cherry-pick** the relevant commit(s) onto it,
      then open a PR into the release branch:
 
-     ```
+     ```bash
      git checkout release/x.y
      git pull
      git checkout -b cherry-pick/my-fix
      git cherry-pick <sha>
      ```
-- Keep cherry-picks limited to the specific commits the release needs, so the release branch never accumulates feature work that does not belong in it.
+- Keep cherry-picks limited to the specific commits the release needs, so the release branch never accumulates
+  feature work that does not belong in it.
 
 ### Technology Preferences
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,23 +136,20 @@ Branching feature *development* off a release branch causes confusion later: whe
 the release branch is merged back into `main`, it is unclear which commits belong
 to the release and which belong to the unrelated feature work. To avoid this:
 
-- **Create every feature branch from `main`** (`git checkout main && git pull && git checkout -b my-feature`), even if the
+- **Create every feature branch from `main`**, even if the
   change is also needed in an in-flight release. Never develop a feature on a
   branch based on `release/*`.
 - If a change must also land in a release branch (e.g. a fix needed for an
   upcoming release):
   1. Develop and merge it on a branch off `main` first.
-  2. Create a **new branch off the release branch** and **cherry-pick** the relevant commit(s) onto it,
-     then open a PR into the release branch:
-
-     ```bash
-     git checkout release/x.y
-     git pull
-     git checkout -b cherry-pick/my-fix
-     git cherry-pick <sha>
-     ```
+  2. Create a new branch off the release branch, cherry-pick the relevant commit(s)
+     from the origin branch onto it, then open a PR into the release branch.
 - Keep cherry-picks limited to the specific commits the release needs, so the release branch never accumulates
   feature work that does not belong in it.
+- Cherry-picking may surface merge conflicts. Resolve them carefully, then verify the result before opening the PR:
+  - The apps build on all platforms (`app`, `automotive`, `wear`).
+  - All quality gates pass (`./gradlew spotlessCheck`, lint).
+  - Unit and integration tests succeed.
 
 ### Technology Preferences
 


### PR DESCRIPTION
## Description

Adds a **Git Workflow** section to `AGENTS.md` to resolve recurring confusion when merging release branches back into `main`.

Previously, feature branches were sometimes created off a `release/*` branch. When that release branch was later merged back into `main`, it was unclear which commits belonged to the release and which were unrelated feature work. This documents the expected flow:

- Develop all feature work on a branch off `main` — never develop a feature off `release/*`.
- The only legitimate reason to branch off a release branch is to **cherry-pick an already-merged commit** into that release: create a new branch off the release branch, cherry-pick the specific commit(s), and open a PR into the release branch.
- Keep cherry-picks limited to exactly what the release needs, so release branches never accumulate unrelated feature work.

This is documentation-only; no code or behavior changes.

## Testing Instructions

1. Open `AGENTS.md`.
2. Confirm the new **Git Workflow** section appears under **Development Guidelines** (before **Technology Preferences**).
3. Verify the guidance is internally consistent: feature work branches off `main`, and the only release-branch branching is for cherry-picking already-merged commits.

## Screenshots or Screencast

N/A — documentation-only change.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

#### I have tested any UI changes...
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
