### PR TITLE
[HLS] Add feature flag and make model changes

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabaseTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabaseTest.kt
@@ -199,6 +199,7 @@ class AppDatabaseTest {
                 AppDatabase.MIGRATION_127_128,
                 AppDatabase.MIGRATION_129_130,
                 AppDatabase.MIGRATION_130_131,
+                AppDatabase.MIGRATION_131_132,
             )
             .build()
         // close the database and release any stream resources when the test finishes

--- a/modules/services/model/schemas/au.com.shiftyjelly.pocketcasts.models.db.AppDatabase/132.json
+++ b/modules/services/model/schemas/au.com.shiftyjelly.pocketcasts.models.db.AppDatabase/132.json
@@ -1,0 +1,2255 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 132,
+    "identityHash": "ee662eee688f375cbacbfdc7ad8f0d85",
+    "entities": [
+      {
+        "tableName": "bump_stats",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `event_time` INTEGER NOT NULL, `custom_event_props` TEXT NOT NULL, PRIMARY KEY(`name`, `event_time`, `custom_event_props`))",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventTime",
+            "columnName": "event_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customEventProps",
+            "columnName": "custom_event_props",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "name",
+            "event_time",
+            "custom_event_props"
+          ]
+        }
+      },
+      {
+        "tableName": "bookmarks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `podcast_uuid` TEXT NOT NULL, `episode_uuid` TEXT NOT NULL, `time` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, `title` TEXT NOT NULL, `title_modified` INTEGER, `deleted` INTEGER NOT NULL, `deleted_modified` INTEGER, `ai_title` TEXT, `ai_summary` TEXT, `ai_title_modified` INTEGER, `ai_summary_modified` INTEGER, `sync_status` INTEGER NOT NULL, `clean_title` TEXT NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcast_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeUuid",
+            "columnName": "episode_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timeSecs",
+            "columnName": "time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "titleModified",
+            "columnName": "title_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedModified",
+            "columnName": "deleted_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "aiTitle",
+            "columnName": "ai_title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "aiSummary",
+            "columnName": "ai_summary",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "aiTitleModified",
+            "columnName": "ai_title_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "aiSummaryModified",
+            "columnName": "ai_summary_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "sync_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cleanTitle",
+            "columnName": "clean_title",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "bookmarks_podcast_uuid",
+            "unique": false,
+            "columnNames": [
+              "podcast_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `bookmarks_podcast_uuid` ON `${TABLE_NAME}` (`podcast_uuid`)"
+          }
+        ]
+      },
+      {
+        "tableName": "podcast_episodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `episode_description` TEXT NOT NULL, `published_date` INTEGER NOT NULL, `title` TEXT NOT NULL, `size_in_bytes` INTEGER NOT NULL, `episode_status` INTEGER NOT NULL, `file_type` TEXT, `duration` REAL NOT NULL, `download_url` TEXT, `hls_url` TEXT, `downloaded_file_path` TEXT, `downloaded_error_details` TEXT, `play_error_details` TEXT, `played_up_to` REAL NOT NULL, `playing_status` INTEGER NOT NULL, `podcast_id` TEXT NOT NULL, `added_date` INTEGER NOT NULL, `auto_download_status` INTEGER NOT NULL, `starred` INTEGER NOT NULL, `thumbnail_status` INTEGER NOT NULL, `last_download_attempt_date` INTEGER, `playing_status_modified` INTEGER, `played_up_to_modified` INTEGER, `duration_modified` INTEGER, `starred_modified` INTEGER, `last_starred_date` INTEGER, `archived` INTEGER NOT NULL, `archived_modified` INTEGER, `season` INTEGER, `number` INTEGER, `type` TEXT, `last_playback_interaction_date` INTEGER, `last_playback_interaction_sync_status` INTEGER NOT NULL, `exclude_from_episode_limit` INTEGER NOT NULL, `download_task_id` TEXT, `last_archive_interaction_date` INTEGER, `image_url` TEXT, `deselected_chapters` TEXT NOT NULL, `deselected_chapters_modified` INTEGER, `slug` TEXT NOT NULL, `has_generated_transcript` INTEGER NOT NULL, `cleanTitle` TEXT, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeDescription",
+            "columnName": "episode_description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publishedDate",
+            "columnName": "published_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeInBytes",
+            "columnName": "size_in_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadStatus",
+            "columnName": "episode_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileType",
+            "columnName": "file_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadUrl",
+            "columnName": "download_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "hlsUrl",
+            "columnName": "hls_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadedFilePath",
+            "columnName": "downloaded_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadErrorDetails",
+            "columnName": "downloaded_error_details",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playErrorDetails",
+            "columnName": "play_error_details",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playedUpTo",
+            "columnName": "played_up_to",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playingStatus",
+            "columnName": "playing_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcast_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedDate",
+            "columnName": "added_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoDownloadStatus",
+            "columnName": "auto_download_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isStarred",
+            "columnName": "starred",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailStatus",
+            "columnName": "thumbnail_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDownloadAttemptDate",
+            "columnName": "last_download_attempt_date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "playingStatusModified",
+            "columnName": "playing_status_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "playedUpToModified",
+            "columnName": "played_up_to_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "durationModified",
+            "columnName": "duration_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "starredModified",
+            "columnName": "starred_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastStarredDate",
+            "columnName": "last_starred_date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isArchived",
+            "columnName": "archived",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "archivedModified",
+            "columnName": "archived_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "season",
+            "columnName": "season",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "number",
+            "columnName": "number",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastPlaybackInteraction",
+            "columnName": "last_playback_interaction_date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastPlaybackInteractionSyncStatus",
+            "columnName": "last_playback_interaction_sync_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "excludeFromEpisodeLimit",
+            "columnName": "exclude_from_episode_limit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadTaskId",
+            "columnName": "download_task_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastArchiveInteraction",
+            "columnName": "last_archive_interaction_date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "image_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "deselectedChapters",
+            "columnName": "deselected_chapters",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deselectedChaptersModified",
+            "columnName": "deselected_chapters_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "slug",
+            "columnName": "slug",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasGeneratedTranscript",
+            "columnName": "has_generated_transcript",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cleanTitle",
+            "columnName": "cleanTitle",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "episode_last_download_attempt_date",
+            "unique": false,
+            "columnNames": [
+              "last_download_attempt_date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `episode_last_download_attempt_date` ON `${TABLE_NAME}` (`last_download_attempt_date`)"
+          },
+          {
+            "name": "episode_podcast_id",
+            "unique": false,
+            "columnNames": [
+              "podcast_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `episode_podcast_id` ON `${TABLE_NAME}` (`podcast_id`)"
+          },
+          {
+            "name": "episode_published_date",
+            "unique": false,
+            "columnNames": [
+              "published_date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `episode_published_date` ON `${TABLE_NAME}` (`published_date`)"
+          }
+        ]
+      },
+      {
+        "tableName": "folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `name` TEXT NOT NULL, `color` INTEGER NOT NULL, `added_date` INTEGER NOT NULL, `sort_position` INTEGER NOT NULL, `podcasts_sort_type` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, `sync_modified` INTEGER NOT NULL, `clean_name` TEXT NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedDate",
+            "columnName": "added_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortPosition",
+            "columnName": "sort_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastsSortType",
+            "columnName": "podcasts_sort_type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncModified",
+            "columnName": "sync_modified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cleanName",
+            "columnName": "clean_name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        }
+      },
+      {
+        "tableName": "suggested_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`folder_name` TEXT NOT NULL, `podcast_uuid` TEXT NOT NULL, PRIMARY KEY(`folder_name`, `podcast_uuid`))",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "folder_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcast_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "folder_name",
+            "podcast_uuid"
+          ]
+        }
+      },
+      {
+        "tableName": "playlists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `title` TEXT NOT NULL, `iconId` INTEGER NOT NULL, `sortPosition` INTEGER, `sortId` INTEGER NOT NULL, `manual` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, `syncStatus` INTEGER NOT NULL, `autoDownload` INTEGER NOT NULL, `autoDownloadLimit` INTEGER NOT NULL, `unplayed` INTEGER NOT NULL, `partiallyPlayed` INTEGER NOT NULL, `finished` INTEGER NOT NULL, `downloaded` INTEGER NOT NULL, `notDownloaded` INTEGER NOT NULL, `audioVideo` INTEGER NOT NULL, `filterHours` INTEGER NOT NULL, `starred` INTEGER NOT NULL, `allPodcasts` INTEGER NOT NULL, `podcastUuids` TEXT, `filterDuration` INTEGER NOT NULL, `longerThan` INTEGER NOT NULL, `shorterThan` INTEGER NOT NULL, `showArchivedEpisodes` INTEGER NOT NULL, `clean_title` TEXT NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iconId",
+            "columnName": "iconId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortPosition",
+            "columnName": "sortPosition",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "sortType",
+            "columnName": "sortId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "manual",
+            "columnName": "manual",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "syncStatus",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoDownload",
+            "columnName": "autoDownload",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autodownloadLimit",
+            "columnName": "autoDownloadLimit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unplayed",
+            "columnName": "unplayed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "partiallyPlayed",
+            "columnName": "partiallyPlayed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "finished",
+            "columnName": "finished",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloaded",
+            "columnName": "downloaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notDownloaded",
+            "columnName": "notDownloaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioVideo",
+            "columnName": "audioVideo",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filterHours",
+            "columnName": "filterHours",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "starred",
+            "columnName": "starred",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "allPodcasts",
+            "columnName": "allPodcasts",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastUuids",
+            "columnName": "podcastUuids",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "filterDuration",
+            "columnName": "filterDuration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longerThan",
+            "columnName": "longerThan",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shorterThan",
+            "columnName": "shorterThan",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showArchivedEpisodes",
+            "columnName": "showArchivedEpisodes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cleanTitle",
+            "columnName": "clean_title",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        }
+      },
+      {
+        "tableName": "podcasts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `added_date` INTEGER, `thumbnail_url` TEXT, `title` TEXT NOT NULL, `podcast_url` TEXT, `podcast_description` TEXT NOT NULL, `podcast_html_description` TEXT NOT NULL, `podcast_category` TEXT NOT NULL, `podcast_language` TEXT NOT NULL, `media_type` TEXT, `latest_episode_uuid` TEXT, `author` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, `episodes_sort_order` INTEGER NOT NULL, `episodes_sort_order_modified` INTEGER, `latest_episode_date` INTEGER, `episodes_to_keep` INTEGER NOT NULL, `override_global_settings` INTEGER NOT NULL, `override_global_effects` INTEGER NOT NULL, `override_global_effects_modified` INTEGER, `start_from` INTEGER NOT NULL, `start_from_modified` INTEGER, `playback_speed` REAL NOT NULL, `playback_speed_modified` INTEGER, `volume_boosted` INTEGER NOT NULL, `volume_boosted_modified` INTEGER, `is_folder` INTEGER NOT NULL, `subscribed` INTEGER NOT NULL, `show_notifications` INTEGER NOT NULL, `show_notifications_modified` INTEGER, `auto_download_status` INTEGER NOT NULL, `auto_add_to_up_next` INTEGER NOT NULL, `auto_add_to_up_next_modified` INTEGER, `most_popular_color` INTEGER NOT NULL, `primary_color` INTEGER NOT NULL, `secondary_color` INTEGER NOT NULL, `light_overlay_color` INTEGER NOT NULL, `fab_for_light_bg` INTEGER NOT NULL, `link_for_dark_bg` INTEGER NOT NULL, `link_for_light_bg` INTEGER NOT NULL, `color_version` INTEGER NOT NULL, `color_last_downloaded` INTEGER NOT NULL, `sync_status` INTEGER NOT NULL, `exclude_from_auto_archive` INTEGER NOT NULL, `override_global_archive` INTEGER NOT NULL, `override_global_archive_modified` INTEGER, `auto_archive_played_after` INTEGER NOT NULL, `auto_archive_played_after_modified` INTEGER, `auto_archive_inactive_after` INTEGER NOT NULL, `auto_archive_inactive_after_modified` INTEGER, `auto_archive_episode_limit` INTEGER NOT NULL, `auto_archive_episode_limit_modified` INTEGER, `estimated_next_episode` INTEGER, `episode_frequency` TEXT, `grouping` INTEGER NOT NULL, `grouping_modified` INTEGER, `skip_last` INTEGER NOT NULL, `skip_last_modified` INTEGER, `show_archived` INTEGER NOT NULL, `show_archived_modified` INTEGER, `trim_silence_level` INTEGER NOT NULL, `trim_silence_level_modified` INTEGER, `refresh_available` INTEGER NOT NULL, `folder_uuid` TEXT, `licensing` INTEGER NOT NULL, `isPaid` INTEGER NOT NULL, `is_private` INTEGER NOT NULL, `is_header_expanded` INTEGER NOT NULL DEFAULT 1, `funding_url` TEXT, `slug` TEXT NOT NULL, `explicit` INTEGER, `web_feed` INTEGER NOT NULL DEFAULT 0, `clean_title` TEXT NOT NULL, `bundleuuid` TEXT, `bundlebundleUrl` TEXT, `bundlepaymentUrl` TEXT, `bundledescription` TEXT, `bundlepodcastUuid` TEXT, `bundlepaidType` TEXT, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedDate",
+            "columnName": "added_date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnail_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastUrl",
+            "columnName": "podcast_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "podcastDescription",
+            "columnName": "podcast_description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastHtmlDescription",
+            "columnName": "podcast_html_description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastCategory",
+            "columnName": "podcast_category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastLanguage",
+            "columnName": "podcast_language",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "media_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latestEpisodeUuid",
+            "columnName": "latest_episode_uuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortPosition",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodesSortType",
+            "columnName": "episodes_sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodesSortTypeModified",
+            "columnName": "episodes_sort_order_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "latestEpisodeDate",
+            "columnName": "latest_episode_date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "episodesToKeep",
+            "columnName": "episodes_to_keep",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "overrideGlobalSettings",
+            "columnName": "override_global_settings",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "overrideGlobalEffects",
+            "columnName": "override_global_effects",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "overrideGlobalEffectsModified",
+            "columnName": "override_global_effects_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "startFromSecs",
+            "columnName": "start_from",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startFromModified",
+            "columnName": "start_from_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "playbackSpeed",
+            "columnName": "playback_speed",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playbackSpeedModified",
+            "columnName": "playback_speed_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isVolumeBoosted",
+            "columnName": "volume_boosted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "volumeBoostedModified",
+            "columnName": "volume_boosted_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isFolder",
+            "columnName": "is_folder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSubscribed",
+            "columnName": "subscribed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isShowNotifications",
+            "columnName": "show_notifications",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showNotificationsModified",
+            "columnName": "show_notifications_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "autoDownloadStatus",
+            "columnName": "auto_download_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoAddToUpNext",
+            "columnName": "auto_add_to_up_next",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoAddToUpNextModified",
+            "columnName": "auto_add_to_up_next_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "backgroundColor",
+            "columnName": "most_popular_color",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tintColorForLightBg",
+            "columnName": "primary_color",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tintColorForDarkBg",
+            "columnName": "secondary_color",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fabColorForDarkBg",
+            "columnName": "light_overlay_color",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fabColorForLightBg",
+            "columnName": "fab_for_light_bg",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "linkColorForLightBg",
+            "columnName": "link_for_dark_bg",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "linkColorForDarkBg",
+            "columnName": "link_for_light_bg",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "colorVersion",
+            "columnName": "color_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "colorLastDownloaded",
+            "columnName": "color_last_downloaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "sync_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "excludeFromAutoArchive",
+            "columnName": "exclude_from_auto_archive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "overrideGlobalArchive",
+            "columnName": "override_global_archive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "overrideGlobalArchiveModified",
+            "columnName": "override_global_archive_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "rawAutoArchiveAfterPlaying",
+            "columnName": "auto_archive_played_after",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoArchiveAfterPlayingModified",
+            "columnName": "auto_archive_played_after_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "rawAutoArchiveInactive",
+            "columnName": "auto_archive_inactive_after",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoArchiveInactiveModified",
+            "columnName": "auto_archive_inactive_after_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "rawAutoArchiveEpisodeLimit",
+            "columnName": "auto_archive_episode_limit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoArchiveEpisodeLimitModified",
+            "columnName": "auto_archive_episode_limit_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "estimatedNextEpisode",
+            "columnName": "estimated_next_episode",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "episodeFrequency",
+            "columnName": "episode_frequency",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "grouping",
+            "columnName": "grouping",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "groupingModified",
+            "columnName": "grouping_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "skipLastSecs",
+            "columnName": "skip_last",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skipLastModified",
+            "columnName": "skip_last_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showArchived",
+            "columnName": "show_archived",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showArchivedModified",
+            "columnName": "show_archived_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "trimMode",
+            "columnName": "trim_silence_level",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trimModeModified",
+            "columnName": "trim_silence_level_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "refreshAvailable",
+            "columnName": "refresh_available",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rawFolderUuid",
+            "columnName": "folder_uuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "licensing",
+            "columnName": "licensing",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPaid",
+            "columnName": "isPaid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPrivate",
+            "columnName": "is_private",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isHeaderExpanded",
+            "columnName": "is_header_expanded",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "fundingUrl",
+            "columnName": "funding_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "slug",
+            "columnName": "slug",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "explicit",
+            "columnName": "explicit",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "webFeed",
+            "columnName": "web_feed",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "cleanTitle",
+            "columnName": "clean_title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "singleBundle.uuid",
+            "columnName": "bundleuuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "singleBundle.bundleUrl",
+            "columnName": "bundlebundleUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "singleBundle.paymentUrl",
+            "columnName": "bundlepaymentUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "singleBundle.description",
+            "columnName": "bundledescription",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "singleBundle.podcastUuid",
+            "columnName": "bundlepodcastUuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "singleBundle.paidType",
+            "columnName": "bundlepaidType",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        }
+      },
+      {
+        "tableName": "search_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT, `modified` INTEGER NOT NULL, `term` TEXT, `podcast_uuid` TEXT, `podcast_title` TEXT, `podcast_author` TEXT, `folder_uuid` TEXT, `folder_title` TEXT, `folder_color` INTEGER, `folder_podcastIds` TEXT, `episode_uuid` TEXT, `episode_title` TEXT, `episode_duration` REAL, `episode_podcastUuid` TEXT, `episode_podcastTitle` TEXT, `episode_artworkUrl` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "modified",
+            "columnName": "modified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "term",
+            "columnName": "term",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "podcast.uuid",
+            "columnName": "podcast_uuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "podcast.title",
+            "columnName": "podcast_title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "podcast.author",
+            "columnName": "podcast_author",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "folder.uuid",
+            "columnName": "folder_uuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "folder.title",
+            "columnName": "folder_title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "folder.color",
+            "columnName": "folder_color",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "folder.podcastIds",
+            "columnName": "folder_podcastIds",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "episode.uuid",
+            "columnName": "episode_uuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "episode.title",
+            "columnName": "episode_title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "episode.duration",
+            "columnName": "episode_duration",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "episode.podcastUuid",
+            "columnName": "episode_podcastUuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "episode.podcastTitle",
+            "columnName": "episode_podcastTitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "episode.artworkUrl",
+            "columnName": "episode_artworkUrl",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_search_history_term",
+            "unique": true,
+            "columnNames": [
+              "term"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_search_history_term` ON `${TABLE_NAME}` (`term`)"
+          },
+          {
+            "name": "index_search_history_podcast_uuid",
+            "unique": true,
+            "columnNames": [
+              "podcast_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_search_history_podcast_uuid` ON `${TABLE_NAME}` (`podcast_uuid`)"
+          },
+          {
+            "name": "index_search_history_folder_uuid",
+            "unique": true,
+            "columnNames": [
+              "folder_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_search_history_folder_uuid` ON `${TABLE_NAME}` (`folder_uuid`)"
+          },
+          {
+            "name": "index_search_history_episode_uuid",
+            "unique": true,
+            "columnNames": [
+              "episode_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_search_history_episode_uuid` ON `${TABLE_NAME}` (`episode_uuid`)"
+          }
+        ]
+      },
+      {
+        "tableName": "up_next_changes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT, `type` INTEGER NOT NULL, `uuid` TEXT, `uuids` TEXT, `modified` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "uuids",
+            "columnName": "uuids",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "modified",
+            "columnName": "modified",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        }
+      },
+      {
+        "tableName": "up_next_episodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT, `episodeUuid` TEXT NOT NULL, `position` INTEGER NOT NULL, `playlistId` INTEGER, `title` TEXT NOT NULL, `publishedDate` INTEGER, `downloadUrl` TEXT, `podcastUuid` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "episodeUuid",
+            "columnName": "episodeUuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publishedDate",
+            "columnName": "publishedDate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "downloadUrl",
+            "columnName": "downloadUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcastUuid",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "up_next_episode_episodeUuid",
+            "unique": false,
+            "columnNames": [
+              "episodeUuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `up_next_episode_episodeUuid` ON `${TABLE_NAME}` (`episodeUuid`)"
+          }
+        ]
+      },
+      {
+        "tableName": "user_episodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `published_date` INTEGER NOT NULL, `episode_description` TEXT NOT NULL, `title` TEXT NOT NULL, `size_in_bytes` INTEGER NOT NULL, `episode_status` INTEGER NOT NULL, `file_type` TEXT, `duration` REAL NOT NULL, `download_url` TEXT, `played_up_to` REAL NOT NULL, `playing_status` INTEGER NOT NULL, `added_date` INTEGER NOT NULL, `auto_download_status` INTEGER NOT NULL, `last_download_attempt_date` INTEGER, `archived` INTEGER NOT NULL, `download_task_id` TEXT, `downloaded_file_path` TEXT, `playing_status_modified` INTEGER, `played_up_to_modified` INTEGER, `artwork_url` TEXT, `play_error_details` TEXT, `server_status` INTEGER NOT NULL, `upload_error_details` TEXT, `downloaded_error_details` TEXT, `tint_color_index` INTEGER NOT NULL, `has_custom_image` INTEGER NOT NULL, `upload_task_id` TEXT, `deselected_chapters` TEXT NOT NULL, `deselected_chapters_modified` INTEGER, `clean_title` TEXT NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publishedDate",
+            "columnName": "published_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeDescription",
+            "columnName": "episode_description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeInBytes",
+            "columnName": "size_in_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadStatus",
+            "columnName": "episode_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileType",
+            "columnName": "file_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadUrl",
+            "columnName": "download_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playedUpTo",
+            "columnName": "played_up_to",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playingStatus",
+            "columnName": "playing_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedDate",
+            "columnName": "added_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoDownloadStatus",
+            "columnName": "auto_download_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDownloadAttemptDate",
+            "columnName": "last_download_attempt_date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isArchived",
+            "columnName": "archived",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadTaskId",
+            "columnName": "download_task_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadedFilePath",
+            "columnName": "downloaded_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playingStatusModified",
+            "columnName": "playing_status_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "playedUpToModified",
+            "columnName": "played_up_to_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "artworkUrl",
+            "columnName": "artwork_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playErrorDetails",
+            "columnName": "play_error_details",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "serverStatus",
+            "columnName": "server_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uploadErrorDetails",
+            "columnName": "upload_error_details",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadErrorDetails",
+            "columnName": "downloaded_error_details",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tintColorIndex",
+            "columnName": "tint_color_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasCustomImage",
+            "columnName": "has_custom_image",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uploadTaskId",
+            "columnName": "upload_task_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "deselectedChapters",
+            "columnName": "deselected_chapters",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deselectedChaptersModified",
+            "columnName": "deselected_chapters_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "cleanTitle",
+            "columnName": "clean_title",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "user_episode_last_download_attempt_date",
+            "unique": false,
+            "columnNames": [
+              "last_download_attempt_date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `user_episode_last_download_attempt_date` ON `${TABLE_NAME}` (`last_download_attempt_date`)"
+          },
+          {
+            "name": "user_episode_published_date",
+            "unique": false,
+            "columnNames": [
+              "published_date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `user_episode_published_date` ON `${TABLE_NAME}` (`published_date`)"
+          }
+        ]
+      },
+      {
+        "tableName": "podcast_ratings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`podcast_uuid` TEXT NOT NULL, `average` REAL, `total` INTEGER, PRIMARY KEY(`podcast_uuid`))",
+        "fields": [
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcast_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "average",
+            "columnName": "average",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "total",
+            "columnName": "total",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "podcast_uuid"
+          ]
+        }
+      },
+      {
+        "tableName": "episode_chapters",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`chapter_index` INTEGER NOT NULL, `episode_uuid` TEXT NOT NULL, `start_time` INTEGER NOT NULL, `end_time` INTEGER, `title` TEXT, `image_url` TEXT, `url` TEXT, `is_embedded` INTEGER NOT NULL, `is_generated` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`episode_uuid`, `chapter_index`))",
+        "fields": [
+          {
+            "fieldPath": "index",
+            "columnName": "chapter_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeUuid",
+            "columnName": "episode_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTimeMs",
+            "columnName": "start_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endTimeMs",
+            "columnName": "end_time",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "image_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isEmbedded",
+            "columnName": "is_embedded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isGenerated",
+            "columnName": "is_generated",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "episode_uuid",
+            "chapter_index"
+          ]
+        },
+        "indices": [
+          {
+            "name": "chapter_episode_uuid_index",
+            "unique": false,
+            "columnNames": [
+              "episode_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `chapter_episode_uuid_index` ON `${TABLE_NAME}` (`episode_uuid`)"
+          }
+        ]
+      },
+      {
+        "tableName": "curated_podcasts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`list_id` TEXT NOT NULL, `list_title` TEXT NOT NULL, `podcast_id` TEXT NOT NULL, `podcast_title` TEXT NOT NULL, `podcast_description` TEXT, PRIMARY KEY(`list_id`, `podcast_id`))",
+        "fields": [
+          {
+            "fieldPath": "listId",
+            "columnName": "list_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listTitle",
+            "columnName": "list_title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastId",
+            "columnName": "podcast_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastTitle",
+            "columnName": "podcast_title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastDescription",
+            "columnName": "podcast_description",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "list_id",
+            "podcast_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "curated_podcasts_list_id_index",
+            "unique": false,
+            "columnNames": [
+              "list_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `curated_podcasts_list_id_index` ON `${TABLE_NAME}` (`list_id`)"
+          },
+          {
+            "name": "curated_podcasts_podcast_id_index",
+            "unique": false,
+            "columnNames": [
+              "podcast_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `curated_podcasts_podcast_id_index` ON `${TABLE_NAME}` (`podcast_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "episode_transcript",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`episode_uuid` TEXT NOT NULL, `url` TEXT NOT NULL, `type` TEXT NOT NULL, `is_generated` INTEGER NOT NULL, `language` TEXT, PRIMARY KEY(`episode_uuid`, `url`))",
+        "fields": [
+          {
+            "fieldPath": "episodeUuid",
+            "columnName": "episode_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isGenerated",
+            "columnName": "is_generated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "episode_uuid",
+            "url"
+          ]
+        }
+      },
+      {
+        "tableName": "user_podcast_ratings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`podcast_uuid` TEXT NOT NULL, `rating` INTEGER NOT NULL, `modified_at` INTEGER NOT NULL, PRIMARY KEY(`podcast_uuid`))",
+        "fields": [
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcast_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "podcast_uuid"
+          ]
+        }
+      },
+      {
+        "tableName": "up_next_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`episodeUuid` TEXT NOT NULL, `position` INTEGER NOT NULL, `playlistId` INTEGER, `title` TEXT NOT NULL, `publishedDate` INTEGER, `downloadUrl` TEXT, `podcastUuid` TEXT, `addedDate` INTEGER NOT NULL, PRIMARY KEY(`episodeUuid`, `addedDate`))",
+        "fields": [
+          {
+            "fieldPath": "episodeUuid",
+            "columnName": "episodeUuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publishedDate",
+            "columnName": "publishedDate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "downloadUrl",
+            "columnName": "downloadUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcastUuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addedDate",
+            "columnName": "addedDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "episodeUuid",
+            "addedDate"
+          ]
+        }
+      },
+      {
+        "tableName": "user_notifications",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`notification_id` INTEGER NOT NULL, `sent_this_week` INTEGER NOT NULL, `last_sent_at` INTEGER NOT NULL, `interacted_at` INTEGER, PRIMARY KEY(`notification_id`))",
+        "fields": [
+          {
+            "fieldPath": "notificationId",
+            "columnName": "notification_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sentThisWeek",
+            "columnName": "sent_this_week",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSentAt",
+            "columnName": "last_sent_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "interactedAt",
+            "columnName": "interacted_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "notification_id"
+          ]
+        }
+      },
+      {
+        "tableName": "user_category_visits",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`category_id` INTEGER NOT NULL, `total_visits` INTEGER NOT NULL, PRIMARY KEY(`category_id`))",
+        "fields": [
+          {
+            "fieldPath": "categoryId",
+            "columnName": "category_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalVisits",
+            "columnName": "total_visits",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "category_id"
+          ]
+        }
+      },
+      {
+        "tableName": "manual_playlist_episodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_uuid` TEXT NOT NULL, `episode_uuid` TEXT NOT NULL, `podcast_uuid` TEXT NOT NULL, `title` TEXT NOT NULL, `added_at` INTEGER NOT NULL, `published_at` INTEGER NOT NULL, `download_url` TEXT, `episode_slug` TEXT NOT NULL, `podcast_slug` TEXT NOT NULL, `sort_position` INTEGER NOT NULL, `is_synced` INTEGER NOT NULL, `clean_title` TEXT NOT NULL, PRIMARY KEY(`playlist_uuid`, `episode_uuid`))",
+        "fields": [
+          {
+            "fieldPath": "playlistUuid",
+            "columnName": "playlist_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeUuid",
+            "columnName": "episode_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcast_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publishedAt",
+            "columnName": "published_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadUrl",
+            "columnName": "download_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "episodeSlug",
+            "columnName": "episode_slug",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastSlug",
+            "columnName": "podcast_slug",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortPosition",
+            "columnName": "sort_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSynced",
+            "columnName": "is_synced",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cleanTitle",
+            "columnName": "clean_title",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_uuid",
+            "episode_uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "manual_playlist_episodes_playlist_uuid_index",
+            "unique": false,
+            "columnNames": [
+              "playlist_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `manual_playlist_episodes_playlist_uuid_index` ON `${TABLE_NAME}` (`playlist_uuid`)"
+          },
+          {
+            "name": "manual_playlist_episodes_episode_uuid_index",
+            "unique": false,
+            "columnNames": [
+              "episode_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `manual_playlist_episodes_episode_uuid_index` ON `${TABLE_NAME}` (`episode_uuid`)"
+          },
+          {
+            "name": "manual_playlist_episodes_podcast_uuid_index",
+            "unique": false,
+            "columnNames": [
+              "podcast_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `manual_playlist_episodes_podcast_uuid_index` ON `${TABLE_NAME}` (`podcast_uuid`)"
+          },
+          {
+            "name": "manual_playlist_episodes_playlist_uuid_is_synced_index",
+            "unique": false,
+            "columnNames": [
+              "playlist_uuid",
+              "is_synced"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `manual_playlist_episodes_playlist_uuid_is_synced_index` ON `${TABLE_NAME}` (`playlist_uuid`, `is_synced`)"
+          }
+        ]
+      },
+      {
+        "tableName": "blaze_ads",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `text` TEXT NOT NULL, `image_url` TEXT NOT NULL, `url_title` TEXT NOT NULL, `url` TEXT NOT NULL, `location` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "image_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "urlTitle",
+            "columnName": "url_title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "location",
+            "columnName": "location",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "playback_stats_events",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `episode_uuid` TEXT NOT NULL, `podcast_uuid` TEXT NOT NULL, `started_at_ms` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeUuid",
+            "columnName": "episode_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcast_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAtMs",
+            "columnName": "started_at_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "playback_stats_events_started_at_ms",
+            "unique": false,
+            "columnNames": [
+              "started_at_ms"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `playback_stats_events_started_at_ms` ON `${TABLE_NAME}` (`started_at_ms`)"
+          }
+        ]
+      },
+      {
+        "tableName": "episode_chats",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`episode_uuid` TEXT NOT NULL, `podcast_uuid` TEXT, `created_at` INTEGER NOT NULL, PRIMARY KEY(`episode_uuid`), FOREIGN KEY(`episode_uuid`) REFERENCES `podcast_episodes`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "episodeUuid",
+            "columnName": "episode_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcast_uuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "episode_uuid"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "podcast_episodes",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "episode_uuid"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "episode_chat_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `episode_uuid` TEXT NOT NULL, `text` TEXT NOT NULL, `role` TEXT NOT NULL, `created_at` INTEGER NOT NULL, `metadata` TEXT, PRIMARY KEY(`uuid`), FOREIGN KEY(`episode_uuid`) REFERENCES `episode_chats`(`episode_uuid`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeUuid",
+            "columnName": "episode_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadata",
+            "columnName": "metadata",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "episode_chat_messages_episode_uuid",
+            "unique": false,
+            "columnNames": [
+              "episode_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `episode_chat_messages_episode_uuid` ON `${TABLE_NAME}` (`episode_uuid`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "episode_chats",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "episode_uuid"
+            ],
+            "referencedColumns": [
+              "episode_uuid"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'ee662eee688f375cbacbfdc7ad8f0d85')"
+    ]
+  }
+}

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabase.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabase.kt
@@ -115,7 +115,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
         EpisodeChat::class,
         EpisodeChatMessage::class,
     ],
-    version = 131,
+    version = 132,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 81, to = 82, spec = AppDatabase.Companion.DeleteSilenceRemovedMigration::class),
@@ -1458,6 +1458,10 @@ abstract class AppDatabase : RoomDatabase() {
             database.execSQL("ALTER TABLE bookmarks ADD COLUMN ai_summary_modified INTEGER")
         }
 
+        val MIGRATION_131_132 = addMigration(131, 132) { database ->
+            database.execSQL("ALTER TABLE podcast_episodes ADD COLUMN hls_url TEXT")
+        }
+
         fun addMigrations(databaseBuilder: Builder<AppDatabase>, context: Context) {
             databaseBuilder.addMigrations(
                 addMigration(1, 2) { },
@@ -1878,6 +1882,7 @@ abstract class AppDatabase : RoomDatabase() {
                 MIGRATION_127_128,
                 MIGRATION_129_130,
                 MIGRATION_130_131,
+                MIGRATION_131_132,
             )
         }
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/BaseEpisode.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/BaseEpisode.kt
@@ -2,6 +2,8 @@ package au.com.shiftyjelly.pocketcasts.models.entity
 
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeDownloadStatus
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import java.util.Date
 import java.util.UUID
 
@@ -9,6 +11,17 @@ sealed interface BaseEpisode {
     companion object {
         const val AUTO_DOWNLOAD_STATUS_ALLOW = 0
         const val AUTO_DOWNLOAD_STATUS_IGNORE = 1
+
+        fun isHlsUrl(url: String?): Boolean {
+            url ?: return false
+            val path = url.substringBefore('?').substringBefore('#')
+            return path.endsWith(".m3u8", ignoreCase = true)
+        }
+
+        private fun isHlsMimeType(type: String?): Boolean {
+            return type.equals("application/x-mpegURL", ignoreCase = true) ||
+                type.equals("application/vnd.apple.mpegurl", ignoreCase = true)
+        }
 
         /**
          * Used to reduce the changes sent out by the media session.
@@ -34,6 +47,9 @@ sealed interface BaseEpisode {
     var fileType: String?
     var duration: Double
     var downloadUrl: String?
+
+    val hlsUrl: String?
+        get() = null
     var playedUpTo: Double
     var playingStatus: EpisodePlayingStatus
     var addedDate: Date
@@ -105,13 +121,28 @@ sealed interface BaseEpisode {
         get() = autoDownloadStatus == AUTO_DOWNLOAD_STATUS_IGNORE
 
     val canQueueForAutoDownload
-        get() = !isFinished && !isArchived && !isAutoDownloadDisabled
+        get() = !isFinished && !isArchived && !isAutoDownloadDisabled && !isHlsOnly
 
     val isInProgress: Boolean
         get() = EpisodePlayingStatus.IN_PROGRESS == playingStatus
 
     val isVideo: Boolean
         get() = fileType?.startsWith("video/") ?: false
+
+    /** The enclosure itself is HLS or missing, so there is no progressive file to download. */
+    val isHlsOnly: Boolean
+        get() = isHlsUrl(downloadUrl) || isHlsMimeType(fileType) || (downloadUrl == null && hlsUrl != null)
+
+    /** The URL to use when streaming. Downloaded playback uses [downloadedFilePath] instead. */
+    val streamUrl: String?
+        get() = if (FeatureFlag.isEnabled(Feature.HLS_STREAMING)) hlsUrl ?: downloadUrl else downloadUrl
+
+    /** Whether the URL that streaming will actually use is HLS. */
+    val isStreamUrlHls: Boolean
+        get() {
+            val url = streamUrl ?: return false
+            return (hlsUrl != null && url == hlsUrl) || isHlsUrl(url) || (url == downloadUrl && isHlsMimeType(fileType))
+        }
 
     val isHLS: Boolean
         get() = downloadUrl?.endsWith("m3u8") ?: false
@@ -158,6 +189,8 @@ sealed interface BaseEpisode {
             fileType.equals("audio/x-m4p", ignoreCase = true) -> return ".m4p"
             fileType.equals("audio/ogg", ignoreCase = true) -> return ".ogg"
             fileType.equals("audio/x-ms-wma", ignoreCase = true) -> return ".wma"
+            fileType.equals("application/x-mpegURL", ignoreCase = true) -> return ".m3u8"
+            fileType.equals("application/vnd.apple.mpegurl", ignoreCase = true) -> return ".m3u8"
             else -> return if (fileType.startsWith("video/")) ".mp4" else ".mp3"
         }
     }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/PodcastEpisode.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/PodcastEpisode.kt
@@ -34,6 +34,7 @@ data class PodcastEpisode(
     @ColumnInfo(name = "file_type") override var fileType: String? = null,
     @ColumnInfo(name = "duration") override var duration: Double = 0.0,
     @ColumnInfo(name = "download_url") override var downloadUrl: String? = null,
+    @ColumnInfo(name = "hls_url") override var hlsUrl: String? = null,
     @ColumnInfo(name = "downloaded_file_path") override var downloadedFilePath: String? = null,
     @ColumnInfo(name = "downloaded_error_details") override var downloadErrorDetails: String? = null,
     @ColumnInfo(name = "play_error_details") override var playErrorDetails: String? = null,

--- a/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/entity/BaseEpisodeHlsDetectionTest.kt
+++ b/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/entity/BaseEpisodeHlsDetectionTest.kt
@@ -1,0 +1,174 @@
+package au.com.shiftyjelly.pocketcasts.models.entity
+
+import au.com.shiftyjelly.pocketcasts.models.type.EpisodeDownloadStatus
+import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
+import au.com.shiftyjelly.pocketcasts.sharedtest.InMemoryFeatureFlagRule
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
+import java.util.Date
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+class BaseEpisodeHlsDetectionTest {
+
+    @get:Rule
+    val featureFlagRule = InMemoryFeatureFlagRule()
+
+    @Test
+    fun `m3u8 extension is HLS only`() {
+        val episode = createEpisode(downloadUrl = "https://example.com/episode.m3u8")
+        assertTrue(episode.isHlsOnly)
+    }
+
+    @Test
+    fun `m3u8 with query params is HLS only`() {
+        val episode = createEpisode(downloadUrl = "https://example.com/episode.m3u8?token=abc&sig=123")
+        assertTrue(episode.isHlsOnly)
+    }
+
+    @Test
+    fun `m3u8 with fragment is HLS only`() {
+        val episode = createEpisode(downloadUrl = "https://example.com/episode.m3u8#fragment")
+        assertTrue(episode.isHlsOnly)
+    }
+
+    @Test
+    fun `m3u8 with query params and fragment is HLS only`() {
+        val episode = createEpisode(downloadUrl = "https://example.com/episode.m3u8?token=abc#frag")
+        assertTrue(episode.isHlsOnly)
+    }
+
+    @Test
+    fun `uppercase M3U8 extension is HLS only`() {
+        val episode = createEpisode(downloadUrl = "https://example.com/episode.M3U8")
+        assertTrue(episode.isHlsOnly)
+    }
+
+    @Test
+    fun `application x-mpegURL fileType is HLS only`() {
+        val episode = createEpisode(downloadUrl = "https://example.com/stream", fileType = "application/x-mpegURL")
+        assertTrue(episode.isHlsOnly)
+    }
+
+    @Test
+    fun `application vnd apple mpegurl fileType is HLS only`() {
+        val episode = createEpisode(downloadUrl = "https://example.com/stream", fileType = "application/vnd.apple.mpegurl")
+        assertTrue(episode.isHlsOnly)
+    }
+
+    @Test
+    fun `hls url without enclosure is HLS only`() {
+        val episode = createEpisode(downloadUrl = null, hlsUrl = "https://example.com/episode.m3u8")
+        assertTrue(episode.isHlsOnly)
+    }
+
+    @Test
+    fun `mp3 URL is not HLS only`() {
+        val episode = createEpisode(downloadUrl = "https://example.com/episode.mp3")
+        assertFalse(episode.isHlsOnly)
+    }
+
+    @Test
+    fun `dual URL episode is not HLS only`() {
+        val episode = createEpisode(downloadUrl = "https://example.com/episode.mp3", hlsUrl = "https://example.com/episode.m3u8")
+        assertFalse(episode.isHlsOnly)
+    }
+
+    @Test
+    fun `null download URL and null fileType is not HLS only`() {
+        val episode = createEpisode(downloadUrl = null, fileType = null)
+        assertFalse(episode.isHlsOnly)
+    }
+
+    @Test
+    fun `mp3 URL with audio mpeg fileType is not HLS only`() {
+        val episode = createEpisode(downloadUrl = "https://example.com/episode.mp3", fileType = "audio/mpeg")
+        assertFalse(episode.isHlsOnly)
+    }
+
+    @Test
+    fun `m3u8 file extension is returned for HLS MIME type`() {
+        val episode = createEpisode(fileType = "application/x-mpegURL")
+        assert(episode.getFileExtension() == ".m3u8")
+    }
+
+    @Test
+    fun `m3u8 file extension is returned for Apple HLS MIME type`() {
+        val episode = createEpisode(fileType = "application/vnd.apple.mpegurl")
+        assert(episode.getFileExtension() == ".m3u8")
+    }
+
+    @Test
+    fun `HLS only episode cannot be queued for auto download`() {
+        val episode = createEpisode(downloadUrl = "https://example.com/episode.m3u8")
+        assertFalse(episode.canQueueForAutoDownload)
+    }
+
+    @Test
+    fun `non-HLS episode can be queued for auto download`() {
+        val episode = createEpisode(downloadUrl = "https://example.com/episode.mp3")
+        assertTrue(episode.canQueueForAutoDownload)
+    }
+
+    @Test
+    fun `dual URL episode can be queued for auto download`() {
+        val episode = createEpisode(downloadUrl = "https://example.com/episode.mp3", hlsUrl = "https://example.com/episode.m3u8")
+        assertTrue(episode.canQueueForAutoDownload)
+    }
+
+    @Test
+    fun `stream url prefers hls url when flag is enabled`() {
+        FeatureFlag.setEnabled(Feature.HLS_STREAMING, true)
+        val episode = createEpisode(downloadUrl = "https://example.com/episode.mp3", hlsUrl = "https://example.com/episode.m3u8")
+        assertEquals("https://example.com/episode.m3u8", episode.streamUrl)
+        assertTrue(episode.isStreamUrlHls)
+    }
+
+    @Test
+    fun `stream url uses download url when flag is disabled`() {
+        FeatureFlag.setEnabled(Feature.HLS_STREAMING, false)
+        val episode = createEpisode(downloadUrl = "https://example.com/episode.mp3", hlsUrl = "https://example.com/episode.m3u8")
+        assertEquals("https://example.com/episode.mp3", episode.streamUrl)
+        assertFalse(episode.isStreamUrlHls)
+    }
+
+    @Test
+    fun `stream url falls back to download url when hls url is null`() {
+        FeatureFlag.setEnabled(Feature.HLS_STREAMING, true)
+        val episode = createEpisode(downloadUrl = "https://example.com/episode.mp3")
+        assertEquals("https://example.com/episode.mp3", episode.streamUrl)
+        assertFalse(episode.isStreamUrlHls)
+    }
+
+    @Test
+    fun `stream url is hls for m3u8 enclosure even when flag is disabled`() {
+        FeatureFlag.setEnabled(Feature.HLS_STREAMING, false)
+        val episode = createEpisode(downloadUrl = "https://example.com/episode.m3u8")
+        assertEquals("https://example.com/episode.m3u8", episode.streamUrl)
+        assertTrue(episode.isStreamUrlHls)
+    }
+
+    @Test
+    fun `stream url is hls for HLS MIME type enclosure`() {
+        FeatureFlag.setEnabled(Feature.HLS_STREAMING, false)
+        val episode = createEpisode(downloadUrl = "https://example.com/stream", fileType = "application/x-mpegURL")
+        assertTrue(episode.isStreamUrlHls)
+    }
+
+    private fun createEpisode(
+        downloadUrl: String? = null,
+        hlsUrl: String? = null,
+        fileType: String? = null,
+    ): PodcastEpisode = PodcastEpisode(
+        uuid = "test-uuid",
+        publishedDate = Date(),
+        downloadUrl = downloadUrl,
+        hlsUrl = hlsUrl,
+        fileType = fileType,
+        downloadStatus = EpisodeDownloadStatus.DownloadNotRequested,
+        playingStatus = EpisodePlayingStatus.NOT_PLAYED,
+    )
+}

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -360,6 +360,15 @@ enum class Feature(
         hasDevToggle = true,
         addedOn = LocalDate.parse("2026-06-11"),
     ),
+    HLS_STREAMING(
+        key = "hls_streaming",
+        title = "Prefer HLS stream when available",
+        defaultValue = isDebugOrPrototypeBuild,
+        tier = FeatureTier.Free,
+        hasFirebaseRemoteFlag = true,
+        hasDevToggle = true,
+        addedOn = LocalDate.parse("2026-06-11"),
+    ),
 }
 
 sealed class FeatureTier {


### PR DESCRIPTION
## Description
This is the first step of HLS support, adding `hls_streaming` flag, extending `BaseEpisode` model with a new `hlsUrl` field, and the database model with `hls_url` column. 
DB migration and unit tests shouls cover loose ends.

Fixes PCDROID-606 https://linear.app/a8c/issue/PCDROID-606/add-feature-flag
Fixes PCDROID-607 https://linear.app/a8c/issue/PCDROID-607/extend-database-and-domain-episode-models

## Testing Instructions
Just review the code please.


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
