### PR TITLE
[HLS] Stream HLS rendition when available via ExoPlayer and Chromecast

### DIFF
--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/BaseEpisode.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/BaseEpisode.kt
@@ -144,9 +144,6 @@ sealed interface BaseEpisode {
             return (hlsUrl != null && url == hlsUrl) || isHlsUrl(url) || (url == downloadUrl && isHlsMimeType(fileType))
         }
 
-    val isHLS: Boolean
-        get() = downloadUrl?.endsWith("m3u8") ?: false
-
     val isAudio: Boolean
         get() = !isVideo
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
@@ -150,6 +150,7 @@ class FingerprintTimingManager @Inject constructor(
 
         val episodeUuid = episode.uuid
         val podcastUuid = episode.podcastOrSubstituteUuid
+        // Fingerprint the progressive enclosure, not the HLS rendition; timings may drift if the renditions differ.
         val audioSource = episode.downloadedFilePath ?: episode.downloadUrl
 
         scope.launch {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CastPlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CastPlayer.kt
@@ -237,7 +237,7 @@ class CastPlayer(
     }
 
     override fun setEpisode(episode: BaseEpisode) {
-        this.episodeLocation = EpisodeLocation.Stream(episode, episode.downloadUrl)
+        this.episodeLocation = EpisodeLocation.Stream(episode, episode.streamUrl, episode.isStreamUrlHls)
         localEpisodeUuid = episode.uuid
         buildCustomData()
     }
@@ -262,7 +262,7 @@ class CastPlayer(
         if (episode == null || podcast == null || episodeUuid != episode.uuid) {
             return
         }
-        val url = episode.downloadUrl ?: return
+        val url = episodeLocation?.uri ?: return
         if (episode is UserEpisode && (episode.serverStatus != UserEpisodeServerStatus.UPLOADED || episode.downloadUrl == null)) {
             onPlayerEvent(this, PlayerEvent.PlayerError("Unable to cast local file"))
             return
@@ -286,8 +286,15 @@ class CastPlayer(
             putString(MediaMetadata.KEY_ALBUM_TITLE, podcast.title)
             addImage(WebImage(Uri.parse(podcast.getArtworkUrl(960))))
         }
+        // STREAM_TYPE_BUFFERED is correct for VOD podcasts (including VOD HLS). Live HLS would
+        // need STREAM_TYPE_LIVE, but we don't currently serve live streams.
         var mediaInfo = MediaInfo.Builder(url).setStreamType(MediaInfo.STREAM_TYPE_BUFFERED).setMetadata(mediaMetadata)
-        episode.fileType?.let {
+        val contentType = if (episodeLocation.isHlsStream) {
+            "application/x-mpegURL"
+        } else {
+            episode.fileType
+        }
+        contentType?.let {
             mediaInfo = mediaInfo.setContentType(it)
         }
         customData?.let {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CastPlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CastPlayer.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.repositories.playback
 import android.net.Uri
 import android.text.TextUtils
 import androidx.annotation.OptIn
+import androidx.media3.common.MimeTypes
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.util.UnstableApi
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
@@ -290,7 +291,7 @@ class CastPlayer(
         // need STREAM_TYPE_LIVE, but we don't currently serve live streams.
         var mediaInfo = MediaInfo.Builder(url).setStreamType(MediaInfo.STREAM_TYPE_BUFFERED).setMetadata(mediaMetadata)
         val contentType = if (episodeLocation.isHlsStream) {
-            "application/x-mpegURL"
+            MimeTypes.APPLICATION_M3U8
         } else {
             episode.fileType
         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ExoPlayerDataSourceFactory.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ExoPlayerDataSourceFactory.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.annotation.OptIn
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaItem.ClippingConfiguration
+import androidx.media3.common.MimeTypes
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.database.StandaloneDatabaseProvider
 import androidx.media3.datasource.DefaultDataSource
@@ -17,7 +18,6 @@ import androidx.media3.exoplayer.source.MediaSource
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
 import androidx.media3.extractor.DefaultExtractorsFactory
 import androidx.media3.extractor.mp3.Mp3Extractor
-import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.servers.di.Player
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
@@ -69,11 +69,12 @@ class ExoPlayerDataSourceFactory @Inject constructor(
         val episodeUri = episodeLocation.uri ?: return null
         val mediaItem = MediaItem.Builder()
             .setUri(episodeUri)
-            .let { builder ->
+            .apply {
+                if (episodeLocation.isHlsStream) {
+                    setMimeType(MimeTypes.APPLICATION_M3U8)
+                }
                 if (clipRange != null) {
-                    builder.setClippingConfiguration(clipRange.toClippingConfiguration())
-                } else {
-                    builder
+                    setClippingConfiguration(clipRange.toClippingConfiguration())
                 }
             }
             .setCustomCacheKey(episodeLocation.episode.uuid)
@@ -86,7 +87,7 @@ class ExoPlayerDataSourceFactory @Inject constructor(
 
         val cacheFactory = cacheFactory
             .setCacheWriteDataSinkFactory(null)
-            .takeIf { episodeLocation.episode.shouldUseCache() }
+            .takeIf { episodeLocation.shouldUseCache() }
 
         startCachingEntireEpisodeIfNeeded(
             cacheDataSourceFactory = cacheFactory,
@@ -95,9 +96,10 @@ class ExoPlayerDataSourceFactory @Inject constructor(
         )
 
         val dataFactory = cacheFactory ?: defaultFactory
+        // Only DefaultMediaSourceFactory applies the ClippingConfiguration, so clipping must win over HLS.
         val factory = when {
-            episodeLocation.episode.isHLS -> HlsMediaSource.Factory(dataFactory)
             (clipRange != null) -> DefaultMediaSourceFactory(dataFactory, extractorsFactory)
+            episodeLocation.isHlsStream -> HlsMediaSource.Factory(dataFactory)
             else -> ProgressiveMediaSource.Factory(dataFactory, extractorsFactory)
         }
         if (FeatureFlag.isEnabled(Feature.LOAD_ERROR_HANDLING_POLICY)) {
@@ -111,10 +113,11 @@ class ExoPlayerDataSourceFactory @Inject constructor(
         episodeLocation: EpisodeLocation,
         onCachingComplete: (String) -> Unit,
     ) {
+        if (episodeLocation.isHlsStream) return
         val episodeUri = episodeLocation.uri ?: return
         val cacheFactory = cacheDataSourceFactory ?: cacheFactory
             .setCacheWriteDataSinkFactory(null)
-            .takeIf { episodeLocation.episode.shouldUseCache() }
+            .takeIf { episodeLocation.shouldUseCache() }
 
         if (cacheFactory != null) {
             CacheWorker.startCachingEntireEpisode(
@@ -133,7 +136,7 @@ class ExoPlayerDataSourceFactory @Inject constructor(
     ) {
         val episodeUuid = episodeLocation.episode.uuid
         try {
-            if (episodeLocation.episode.shouldUseCache().not()) return
+            if (episodeLocation.shouldUseCache().not()) return
 
             cache?.removeResource(episodeUuid)
             onCachingReset(episodeUuid)
@@ -152,7 +155,7 @@ class ExoPlayerDataSourceFactory @Inject constructor(
         }
     }
 
-    private fun BaseEpisode.shouldUseCache() = !isDownloaded && !isDownloading && settings.cacheEntirePlayingEpisode.value
+    private fun EpisodeLocation.shouldUseCache() = !episode.isDownloaded && !episode.isDownloading && !isHlsStream && settings.cacheEntirePlayingEpisode.value
 
     private fun ClosedRange<Long>.toClippingConfiguration() = ClippingConfiguration.Builder()
         .setStartPositionMs(start)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1647,6 +1647,9 @@ open class PlaybackManager @Inject constructor(
         val durationDiffSeconds = (durationMs - episode.durationMs) / 1000
         if (abs(durationDiffSeconds) > 0) {
             LogBuffer.i(LogBuffer.TAG_PLAYBACK, "The total episode duration has changed by $durationDiffSeconds seconds")
+            if (episode.hlsUrl != null && episode.isStreamUrlHls && player?.isStreaming == true) {
+                LogBuffer.i(LogBuffer.TAG_PLAYBACK, "HLS rendition duration differs from enclosure by $durationDiffSeconds seconds for episode ${episode.uuid}")
+            }
             eventHorizon.track(
                 PlaybackEpisodeDurationChangedEvent(
                     durationChange = durationDiffSeconds.toLong(),
@@ -2723,7 +2726,7 @@ internal fun buildPrefetchRequest(
     val episode = nextEpisode ?: return null
     if (episode.isDownloaded) return null
     if (episode.isDownloading) return null
-    if (episode.isHLS) return null
+    if (episode.isStreamUrlHls) return null
     val url = episode.downloadUrl ?: return null
 
     val networkConstraint = if (warnOnMeteredNetwork) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Player.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Player.kt
@@ -11,6 +11,7 @@ sealed interface EpisodeLocation {
     data class Stream(
         override val episode: BaseEpisode,
         override val uri: String?,
+        val isHls: Boolean,
     ) : EpisodeLocation
 
     data class Downloaded(
@@ -22,10 +23,13 @@ sealed interface EpisodeLocation {
         fun create(episode: BaseEpisode) = if (episode.isDownloaded) {
             EpisodeLocation.Downloaded(episode, episode.downloadedFilePath)
         } else {
-            EpisodeLocation.Stream(episode, episode.downloadUrl)
+            EpisodeLocation.Stream(episode, episode.streamUrl, episode.isStreamUrlHls)
         }
     }
 }
+
+val EpisodeLocation?.isHlsStream: Boolean
+    get() = (this as? EpisodeLocation.Stream)?.isHls == true
 
 interface Player {
     var isPip: Boolean

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/EpisodeLocationTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/EpisodeLocationTest.kt
@@ -1,0 +1,80 @@
+package au.com.shiftyjelly.pocketcasts.repositories.playback
+
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.type.EpisodeDownloadStatus
+import au.com.shiftyjelly.pocketcasts.sharedtest.InMemoryFeatureFlagRule
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
+import java.util.Date
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+class EpisodeLocationTest {
+
+    @get:Rule
+    val featureFlagRule = InMemoryFeatureFlagRule()
+
+    @Test
+    fun `downloaded episode uses downloaded file path`() {
+        val episode = createEpisode(
+            downloadStatus = EpisodeDownloadStatus.Downloaded,
+            downloadedFilePath = "/path/episode.mp3",
+            hlsUrl = "https://example.com/episode.m3u8",
+        )
+
+        val location = EpisodeLocation.create(episode)
+
+        assertTrue(location is EpisodeLocation.Downloaded)
+        assertEquals("/path/episode.mp3", location.uri)
+        assertFalse(location.isHlsStream)
+    }
+
+    @Test
+    fun `stream prefers hls url when flag is enabled`() {
+        FeatureFlag.setEnabled(Feature.HLS_STREAMING, true)
+        val episode = createEpisode(hlsUrl = "https://example.com/episode.m3u8")
+
+        val location = EpisodeLocation.create(episode)
+
+        assertEquals("https://example.com/episode.m3u8", location.uri)
+        assertTrue(location.isHlsStream)
+    }
+
+    @Test
+    fun `stream uses download url when flag is disabled`() {
+        FeatureFlag.setEnabled(Feature.HLS_STREAMING, false)
+        val episode = createEpisode(hlsUrl = "https://example.com/episode.m3u8")
+
+        val location = EpisodeLocation.create(episode)
+
+        assertEquals("https://example.com/episode.mp3", location.uri)
+        assertFalse(location.isHlsStream)
+    }
+
+    @Test
+    fun `stream falls back to download url when hls url is null`() {
+        FeatureFlag.setEnabled(Feature.HLS_STREAMING, true)
+        val episode = createEpisode(hlsUrl = null)
+
+        val location = EpisodeLocation.create(episode)
+
+        assertEquals("https://example.com/episode.mp3", location.uri)
+        assertFalse(location.isHlsStream)
+    }
+
+    private fun createEpisode(
+        downloadStatus: EpisodeDownloadStatus = EpisodeDownloadStatus.DownloadNotRequested,
+        downloadedFilePath: String? = null,
+        hlsUrl: String? = null,
+    ) = PodcastEpisode(
+        uuid = "episode-uuid",
+        publishedDate = Date(),
+        downloadUrl = "https://example.com/episode.mp3",
+        hlsUrl = hlsUrl,
+        downloadedFilePath = downloadedFilePath,
+        downloadStatus = downloadStatus,
+    )
+}

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PrefetchNextEpisodeTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PrefetchNextEpisodeTest.kt
@@ -3,22 +3,31 @@ package au.com.shiftyjelly.pocketcasts.repositories.playback
 import androidx.work.NetworkType
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeDownloadStatus
+import au.com.shiftyjelly.pocketcasts.sharedtest.InMemoryFeatureFlagRule
 import au.com.shiftyjelly.pocketcasts.utils.AppPlatform
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import java.util.Date
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Rule
 import org.junit.Test
 
 class PrefetchNextEpisodeTest {
 
+    @get:Rule
+    val featureFlagRule = InMemoryFeatureFlagRule()
+
     private fun createEpisode(
         uuid: String = "episode-uuid",
         downloadUrl: String? = "https://example.com/episode.mp3",
+        hlsUrl: String? = null,
         downloadStatus: EpisodeDownloadStatus = EpisodeDownloadStatus.DownloadNotRequested,
     ) = PodcastEpisode(
         uuid = uuid,
         publishedDate = Date(),
         downloadUrl = downloadUrl,
+        hlsUrl = hlsUrl,
         downloadStatus = downloadStatus,
     )
 
@@ -107,6 +116,32 @@ class PrefetchNextEpisodeTest {
         )
 
         assertNull(result)
+    }
+
+    @Test
+    fun `should not prefetch dual URL episode when HLS streaming is enabled`() {
+        FeatureFlag.setEnabled(Feature.HLS_STREAMING, true)
+        val result = buildPrefetchRequest(
+            isFeatureEnabled = true,
+            isPlayerRemote = false,
+            nextEpisode = createEpisode(hlsUrl = "https://example.com/episode.m3u8"),
+            warnOnMeteredNetwork = false,
+        )
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `should prefetch dual URL episode when HLS streaming is disabled`() {
+        FeatureFlag.setEnabled(Feature.HLS_STREAMING, false)
+        val result = buildPrefetchRequest(
+            isFeatureEnabled = true,
+            isPlayerRemote = false,
+            nextEpisode = createEpisode(hlsUrl = "https://example.com/episode.m3u8"),
+            warnOnMeteredNetwork = false,
+        )
+
+        assertEquals("https://example.com/episode.mp3", result?.downloadUrl)
     }
 
     @Test


### PR DESCRIPTION
## Description
Next step of the HLS implementation, the player now favors the HLS url when the feature flag is enabled and the hls stream is available.

Fixes PCDROID-609 https://linear.app/a8c/issue/PCDROID-609/make-sure-player-favors-hls-url-when-ff-is-on

## Testing Instructions
Since the backend doesn't send the new field as of writing this PR, we can only test things manually, if you apply this patch: [hls-test.patch](https://github.com/user-attachments/files/28957896/hls-test.patch)
1. Build the app and clean install it
2. Make sure FF is ON
3. Start playing an episode
4. Notice that the test hls stream is playing
5. You can also check logs to confirm, filter to HlsTesting tag
6. Download an episode
7. Go offline
8. Play downloaded episode
9. Make sure the original mp3/mp4 file gets played
10. Go back online
11. Disable feature flag
12. Start playing another episode
13. Notice that the original mp3/mp4 gets played
14. Confirm this on logcat

## Screenshots or Screencast 

<img width="2239" height="224" alt="SCR-20260615-nmqz" src="https://github.com/user-attachments/assets/0bef7e15-710f-4293-99f4-4db2251b7163" />

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 