### PR TITLE
[TV] Remove duplicated dependency

### DIFF
--- a/tv/build.gradle.kts
+++ b/tv/build.gradle.kts
@@ -70,10 +70,6 @@ dependencies {
 
     implementation(platform(libs.firebase.bom))
 
-    implementation(platform(libs.firebase.bom))
-
-    implementation(platform(libs.firebase.bom))
-
     implementation(projects.modules.features.shared)
     implementation(projects.modules.services.compose)
     implementation(projects.modules.services.images)


### PR DESCRIPTION
## Description
It's been flagged that tv module defines some dependencies multiple times. This PR gets rid of those redefinitions.

conversation: p1781595215918419-slack-C028JAG44VD

## Testing Instructions
just see if pipeline is still green


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 