### PR TITLE
[Buildkite] Test Android Staging on `ami-08ace45d52a5caade`

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@
 ---
 
 agents:
-  queue: "android"
+  queue: "android-staging"
 
 steps:
   - label: Gradle Wrapper Validation

--- a/dependencies.gradle.kts
+++ b/dependencies.gradle.kts
@@ -74,7 +74,7 @@ project.apply {
         set("targetSdkVersionWear", 36)
         set("targetSdkVersionAutomotive", 35)
         set("targetSdkVersionTv", 36)
-        set("compileSdkVersion", 37)
+        set("compileSdkVersion", 36)
         set("testInstrumentationRunner", "androidx.test.runner.AndroidJUnitRunner")
 
         // App Signing

--- a/dependencies.gradle.kts
+++ b/dependencies.gradle.kts
@@ -74,7 +74,7 @@ project.apply {
         set("targetSdkVersionWear", 36)
         set("targetSdkVersionAutomotive", 35)
         set("targetSdkVersionTv", 36)
-        set("compileSdkVersion", 36)
+        set("compileSdkVersion", 37)
         set("testInstrumentationRunner", "androidx.test.runner.AndroidJUnitRunner")
 
         // App Signing

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingLoginPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingLoginPage.kt
@@ -127,7 +127,6 @@ internal fun OnboardingLoginPage(
                 onUpdatePassword = viewModel::updatePassword,
                 isCreatingAccount = false,
                 modifier = Modifier.padding(vertical = 16.dp),
-                focusEnabled = false,
             )
 
             state.errorMessage?.let { errorMessage ->

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/extensions/EditText.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/extensions/EditText.kt
@@ -1,10 +1,13 @@
 package au.com.shiftyjelly.pocketcasts.views.extensions
 
+import android.app.Activity
 import android.content.Context
 import android.text.Editable
 import android.text.TextWatcher
 import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
 
 fun EditText.addAfterTextChanged(onChange: (text: String) -> Unit) {
     addTextChangedListener(object : TextWatcher {
@@ -32,6 +35,11 @@ fun EditText.addOnTextChanged(onChange: (text: String) -> Unit) {
 
 fun EditText.showKeyboard() {
     requestFocus()
-    val inputMethodManager = context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-    inputMethodManager.showSoftInput(this, InputMethodManager.SHOW_IMPLICIT)
+    val activity = context as? Activity
+    if (activity != null) {
+        WindowCompat.getInsetsController(activity.window, this).show(WindowInsetsCompat.Type.ime())
+    } else {
+        val inputMethodManager = context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+        inputMethodManager.showSoftInput(this, 0)
+    }
 }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/extensions/EditText.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/extensions/EditText.kt
@@ -33,11 +33,20 @@ fun EditText.addOnTextChanged(onChange: (text: String) -> Unit) {
 }
 
 fun EditText.showKeyboard() {
-    requestFocus()
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-        windowInsetsController?.show(WindowInsets.Type.ime())
-    } else {
-        val inputMethodManager = context.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager
-        inputMethodManager?.showSoftInput(this, 0)
+    post {
+        requestFocus()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            val controller = windowInsetsController
+            if (controller != null) {
+                controller.show(WindowInsets.Type.ime())
+            } else {
+                // The view isn't attached to a window yet (e.g. called from onViewCreated),
+                // so windowInsetsController is null. Retry once the view is attached.
+                post { windowInsetsController?.show(WindowInsets.Type.ime()) }
+            }
+        } else {
+            val inputMethodManager = context.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager
+            inputMethodManager?.showSoftInput(this, 0)
+        }
     }
 }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/extensions/EditText.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/extensions/EditText.kt
@@ -1,13 +1,12 @@
 package au.com.shiftyjelly.pocketcasts.views.extensions
 
-import android.app.Activity
 import android.content.Context
+import android.os.Build
 import android.text.Editable
 import android.text.TextWatcher
+import android.view.WindowInsets
 import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
-import androidx.core.view.WindowCompat
-import androidx.core.view.WindowInsetsCompat
 
 fun EditText.addAfterTextChanged(onChange: (text: String) -> Unit) {
     addTextChangedListener(object : TextWatcher {
@@ -35,11 +34,10 @@ fun EditText.addOnTextChanged(onChange: (text: String) -> Unit) {
 
 fun EditText.showKeyboard() {
     requestFocus()
-    val activity = context as? Activity
-    if (activity != null) {
-        WindowCompat.getInsetsController(activity.window, this).show(WindowInsetsCompat.Type.ime())
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        windowInsetsController?.show(WindowInsets.Type.ime())
     } else {
-        val inputMethodManager = context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-        inputMethodManager.showSoftInput(this, 0)
+        val inputMethodManager = context.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager
+        inputMethodManager?.showSoftInput(this, 0)
     }
 }


### PR DESCRIPTION
Related: [buildkite-ci#872](https://github.com/Automattic/buildkite-ci/pull/872)

AMI Name: `android-build-image-6.53.0v1.15.0`

---

## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

This PR changes the Buildkite agent from `android` to `android-staging`. This change is not meant to be merged, but rather used to verify that the new AMI `ami-08ace45d52a5caade` works as expected.

---

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

Check CI and verify everything is working as expected with the `android-staging` agent.

---

## Screenshots or Screencast `N/A`

## Checklist `N/A`

#### I have tested any UI changes... `N/A`