### PR TITLE
[AI Chapters] Use fingerprint syncing to get accurate chapter timestamps

### DIFF
--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/ChapterDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/ChapterDao.kt
@@ -54,6 +54,9 @@ abstract class ChapterDao {
     @Query("SELECT COUNT(*) FROM episode_chapters WHERE episode_uuid IS :episodeUuid")
     abstract suspend fun countForEpisode(episodeUuid: String): Int
 
+    @Query("SELECT COUNT(*) FROM episode_chapters WHERE episode_uuid IS :episodeUuid AND is_generated = 1")
+    abstract suspend fun countGeneratedForEpisode(episodeUuid: String): Int
+
     @Query("SELECT * FROM episode_chapters WHERE episode_uuid IS :episodeUuid ORDER BY start_time ASC")
     protected abstract fun observeRawChaptersForEpisode(episodeUuid: String): Flow<List<Chapter>>
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/RepositoryProviderModule.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/RepositoryProviderModule.kt
@@ -13,6 +13,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncAccountManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.servers.server.ListWebService
 import au.com.shiftyjelly.pocketcasts.servers.sync.TokenHandler
+import au.com.shiftyjelly.pocketcasts.utils.AppPlatform
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import com.automattic.eventhorizon.EventHorizon
 import dagger.Module
@@ -30,6 +31,10 @@ class RepositoryProviderModule {
     @Provides
     @Singleton
     fun provideTokenHandler(syncAccountManager: SyncAccountManager): TokenHandler = syncAccountManager
+
+    @Provides
+    @Singleton
+    fun provideAppPlatform(@ApplicationContext context: Context): AppPlatform = Util.getAppPlatform(context)
 
     @Provides
     @Singleton

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.repositories.fingerprint
 
+import android.content.Context
 import android.media.MediaCodec
 import android.media.MediaExtractor
 import android.media.MediaFormat
@@ -8,6 +9,10 @@ import androidx.annotation.VisibleForTesting
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.repositories.BuildConfig
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.ChapterManager
+import au.com.shiftyjelly.pocketcasts.utils.AppPlatform
+import au.com.shiftyjelly.pocketcasts.utils.Network
+import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import com.automattic.eventhorizon.EventHorizon
@@ -15,6 +20,8 @@ import com.automattic.eventhorizon.SyncedTranscriptsPreparationCompletedEvent
 import com.automattic.eventhorizon.SyncedTranscriptsPreparationFailedEvent
 import com.automattic.eventhorizon.SyncedTranscriptsPreparationStartedEvent
 import com.automattic.eventhorizon.SyncedTranscriptsUnavailableEvent
+import dagger.Lazy
+import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.File
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
@@ -48,6 +55,8 @@ class FingerprintTimingManager @Inject constructor(
     private val playbackManager: PlaybackManager,
     private val referenceRetriever: FingerprintReferenceRetriever,
     private val eventHorizon: EventHorizon,
+    @ApplicationContext private val context: Context,
+    private val chapterManager: Lazy<ChapterManager>,
 ) {
 
     sealed interface State {
@@ -131,6 +140,10 @@ class FingerprintTimingManager @Inject constructor(
     // Analytics context for the current preparation.
     private var preparationStartMs: Long = 0
     private var currentIsStreaming: Boolean = false
+
+    // When true, decode the whole stream from the start ignoring the playhead lookahead throttle,
+    // so the full reference<->playback map is available for chapter alignment.
+    private var currentEager: Boolean = false
 
     init {
         observePlaybackForProactivePreparation()
@@ -336,6 +349,20 @@ class FingerprintTimingManager @Inject constructor(
         hasReachedActive = false
         preparationStartMs = 0
         currentIsStreaming = false
+        currentEager = false
+    }
+
+    /**
+     * Eager full-stream mapping only makes sense on mobile, for episodes with generated chapters,
+     * and when pulling the whole audio is cheap: a local download, or streaming on an unmetered network.
+     */
+    private suspend fun shouldRunEagerPass(episodeUuid: String, isDownloaded: Boolean): Boolean {
+        if (Util.getAppPlatform(context) != AppPlatform.Phone) return false
+        return computeEager(
+            hasGeneratedChapters = chapterManager.get().hasGeneratedChapters(episodeUuid),
+            isDownloaded = isDownloaded,
+            isUnmetered = { Network.isUnmeteredConnection(context) },
+        )
     }
 
     private suspend fun prepareForEpisode(
@@ -368,6 +395,7 @@ class FingerprintTimingManager @Inject constructor(
         activeEpisodeUuid = episodeUuid
         currentAudioFilePath = audioSource
         currentIsStreaming = !isDownloaded
+        currentEager = shouldRunEagerPass(episodeUuid, isDownloaded)
         preparationStartMs = SystemClock.elapsedRealtime()
         eventHorizon.track(
             SyncedTranscriptsPreparationStartedEvent(
@@ -468,9 +496,10 @@ class FingerprintTimingManager @Inject constructor(
             return
         }
 
-        // Start streaming fingerprint generation
-        val currentTime = playbackManager.playbackStateFlow.first().positionMs / 1000.0
-        startStream(audioFilePath, matcher, episodeUuid, startPosition = currentTime)
+        // Start streaming fingerprint generation. An eager pass maps the whole timeline from the start;
+        // otherwise we follow the playhead.
+        val startPosition = if (currentEager) 0.0 else playbackManager.playbackStateFlow.first().positionMs / 1000.0
+        startStream(audioFilePath, matcher, episodeUuid, startPosition = startPosition)
     }
 
     private fun onPlaybackProgress(positionMs: Int, episodeUuid: String?) {
@@ -484,6 +513,11 @@ class FingerprintTimingManager @Inject constructor(
     }
 
     private fun processProgress(positionMs: Int) {
+        // The eager pass already decodes the whole stream, so playhead-driven restarts are unnecessary.
+        if (currentEager) {
+            lastProgressPositionMs = positionMs
+            return
+        }
         if (lastProgressPositionMs >= 0) {
             val deltaMs = abs(positionMs - lastProgressPositionMs)
             if (deltaMs > FingerprintConstants.RESTART_DELTA_SECONDS * 1000) {
@@ -691,10 +725,13 @@ class FingerprintTimingManager @Inject constructor(
                             }
                         }
 
-                        val decodedSeconds = startOffset + streamer.durationMs().toDouble() / 1000.0
-                        val lastKnownPositionMs = lastProgressPositionMs
-                        if (lastKnownPositionMs >= 0 && decodedSeconds - lastKnownPositionMs / 1000.0 > FingerprintConstants.LOOKAHEAD_SECONDS) {
-                            delay((FingerprintConstants.OUTSIDE_LOOKAHEAD_SLEEP_SECONDS * 1000).toLong())
+                        // Eager passes decode as fast as possible; throttled passes stay near the playhead.
+                        if (!currentEager) {
+                            val decodedSeconds = startOffset + streamer.durationMs().toDouble() / 1000.0
+                            val lastKnownPositionMs = lastProgressPositionMs
+                            if (lastKnownPositionMs >= 0 && decodedSeconds - lastKnownPositionMs / 1000.0 > FingerprintConstants.LOOKAHEAD_SECONDS) {
+                                delay((FingerprintConstants.OUTSIDE_LOOKAHEAD_SLEEP_SECONDS * 1000).toLong())
+                            }
                         }
                     }
                     codec.releaseOutputBuffer(outputIndex, false)
@@ -901,6 +938,16 @@ class FingerprintTimingManager @Inject constructor(
 
     companion object {
         private const val STREAM_BOOTSTRAP_COOLDOWN_MS = 5_000L
+
+        /**
+         * Core eager-pass gate (assumes the platform check already passed). [isUnmetered] is a supplier so the
+         * network lookup is skipped for downloaded episodes.
+         */
+        internal fun computeEager(
+            hasGeneratedChapters: Boolean,
+            isDownloaded: Boolean,
+            isUnmetered: () -> Boolean,
+        ): Boolean = hasGeneratedChapters && (isDownloaded || isUnmetered())
 
         fun interpolate(
             time: Double,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
@@ -74,6 +74,15 @@ class FingerprintTimingManager @Inject constructor(
     val state: State get() = _stateFlow.value
     val mappingSnapshot: List<TimeMappingEntry> get() = snapshotPlaybackToReference
 
+    // Monotonic counter bumped on every snapshot publish, so consumers can react to mapping growth.
+    private val _mappingVersion = MutableStateFlow(0L)
+    val mappingVersion: StateFlow<Long> = _mappingVersion.asStateFlow()
+
+    /** Episode the current mapping belongs to, or null when idle. Safe to read off the UI thread. */
+    @Volatile
+    var activeEpisodeUuid: String? = null
+        private set
+
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     private val mutex = Mutex()
 
@@ -323,6 +332,7 @@ class FingerprintTimingManager @Inject constructor(
         currentReferenceDuration = 0.0
         currentMatcher?.close()
         currentMatcher = null
+        activeEpisodeUuid = null
         hasReachedActive = false
         preparationStartMs = 0
         currentIsStreaming = false
@@ -355,6 +365,7 @@ class FingerprintTimingManager @Inject constructor(
         }
 
         currentEpisodeUuid = episodeUuid
+        activeEpisodeUuid = episodeUuid
         currentAudioFilePath = audioSource
         currentIsStreaming = !isDownloaded
         preparationStartMs = SystemClock.elapsedRealtime()
@@ -868,6 +879,7 @@ class FingerprintTimingManager @Inject constructor(
     private fun publishSnapshot() {
         snapshotPlaybackToReference = mappingPlaybackToReference.toList()
         snapshotReferenceToPlayback = mappingReferenceToPlayback.toList()
+        _mappingVersion.value++
     }
 
     /** Test seam: insert a mapping directly. Must only be called from single-threaded tests. */

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/ChapterManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/ChapterManager.kt
@@ -18,5 +18,7 @@ interface ChapterManager {
 
     suspend fun hasChapters(episodeUuid: String): Boolean
 
+    suspend fun hasGeneratedChapters(episodeUuid: String): Boolean
+
     fun observerChaptersForEpisode(episodeUuid: String): Flow<Chapters>
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/ChapterManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/ChapterManagerImpl.kt
@@ -5,16 +5,27 @@ import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.Chapter
 import au.com.shiftyjelly.pocketcasts.models.to.Chapters
 import au.com.shiftyjelly.pocketcasts.models.to.DbChapter
+import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.FingerprintTimingManager
+import au.com.shiftyjelly.pocketcasts.utils.AppPlatform
+import dagger.Lazy
 import javax.inject.Inject
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.DurationUnit
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.distinctUntilChangedBy
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.sample
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 
 class ChapterManagerImpl @Inject constructor(
     private val chapterDao: ChapterDao,
     private val episodeManager: EpisodeManager,
+    private val fingerprintTimingManager: Lazy<FingerprintTimingManager>,
+    private val appPlatform: AppPlatform,
 ) : ChapterManager {
     override suspend fun updateChapters(
         episodeUuid: String,
@@ -31,10 +42,39 @@ class ChapterManagerImpl @Inject constructor(
 
     override suspend fun hasGeneratedChapters(episodeUuid: String) = chapterDao.countGeneratedForEpisode(episodeUuid) > 0
 
-    override fun observerChaptersForEpisode(episodeUuid: String) = combine(
-        episodeManager.findEpisodeByUuidFlow(episodeUuid).distinctUntilChangedBy(BaseEpisode::deselectedChapters),
-        chapterDao.observeChaptersForEpisode(episodeUuid),
-    ) { episode, dbChapters -> Chapters(dbChapters.fixChapterTimestamps(episode)) }
+    @OptIn(FlowPreview::class)
+    override fun observerChaptersForEpisode(episodeUuid: String): Flow<Chapters> {
+        val rawChapters = combine(
+            episodeManager.findEpisodeByUuidFlow(episodeUuid).distinctUntilChangedBy(BaseEpisode::deselectedChapters),
+            chapterDao.observeChaptersForEpisode(episodeUuid),
+        ) { episode, dbChapters -> Chapters(dbChapters.fixChapterTimestamps(episode)) }
+
+        // Generated chapter timestamps are in the server reference timeline; align them to the real audio
+        // stream via the fingerprint map. Phone only, to spare resources on automotive/TV/wear.
+        if (appPlatform != AppPlatform.Phone) return rawChapters
+
+        // -1L primes combine so chapters emit immediately, before sample's first throttled tick.
+        val mappingTicks = fingerprintTimingManager.get().mappingVersion
+            .sample(MAPPING_SAMPLE_MS)
+            .onStart { emit(-1L) }
+        return combine(rawChapters, mappingTicks) { chapters, _ ->
+            alignGeneratedChapters(episodeUuid, chapters)
+        }.distinctUntilChanged()
+    }
+
+    /**
+     * Translate generated chapters from reference time to stream time using the fingerprint map.
+     * Embedded chapters already match the file, so they are left untouched.
+     */
+    private fun alignGeneratedChapters(episodeUuid: String, chapters: Chapters): Chapters {
+        val manager = fingerprintTimingManager.get()
+        if (manager.activeEpisodeUuid != episodeUuid || manager.mappingSnapshot.isEmpty()) {
+            return chapters
+        }
+        return alignGeneratedChapters(chapters) { reference ->
+            manager.playbackTimeMs(reference.toDouble(DurationUnit.SECONDS))?.milliseconds
+        }
+    }
 
     private fun List<DbChapter>.fixChapterTimestamps(episode: BaseEpisode) = asSequence()
         .withIndex()
@@ -62,4 +102,31 @@ class ChapterManagerImpl @Inject constructor(
         .filter { it.duration > Duration.ZERO }
         .mapIndexed { index, chapter -> chapter.copy(uiIndex = index + 1) }
         .toList()
+
+    companion object {
+        private const val MAPPING_SAMPLE_MS = 1000L
+
+        /**
+         * Translate generated chapters from reference time to stream time with [align]. Embedded chapters
+         * already match the file, so they are left untouched; zero-duration chapters are dropped and the
+         * UI index re-derived, mirroring [fixChapterTimestamps].
+         */
+        internal fun alignGeneratedChapters(chapters: Chapters, align: (Duration) -> Duration?): Chapters {
+            if (chapters.none { it.isGenerated }) return chapters
+            val aligned = chapters
+                .map { chapter ->
+                    if (!chapter.isGenerated) {
+                        chapter
+                    } else {
+                        chapter.copy(
+                            startTime = align(chapter.startTime) ?: chapter.startTime,
+                            endTime = align(chapter.endTime) ?: chapter.endTime,
+                        )
+                    }
+                }
+                .filter { it.duration > Duration.ZERO }
+                .mapIndexed { index, chapter -> chapter.copy(uiIndex = index + 1) }
+            return Chapters(aligned)
+        }
+    }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/ChapterManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/ChapterManagerImpl.kt
@@ -50,7 +50,7 @@ class ChapterManagerImpl @Inject constructor(
         ) { episode, dbChapters -> Chapters(dbChapters.fixChapterTimestamps(episode)) }
 
         // Generated chapter timestamps are in the server reference timeline; align them to the real audio
-        // stream via the fingerprint map. Phone only, to spare resources on automotive/TV/wear.
+        // stream via the fingerprint map. Phone only, to spare resources on automotive/wear.
         if (appPlatform != AppPlatform.Phone) return rawChapters
 
         // -1L primes combine so chapters emit immediately, before sample's first throttled tick.

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/ChapterManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/ChapterManagerImpl.kt
@@ -29,6 +29,8 @@ class ChapterManagerImpl @Inject constructor(
 
     override suspend fun hasChapters(episodeUuid: String) = chapterDao.countForEpisode(episodeUuid) > 0
 
+    override suspend fun hasGeneratedChapters(episodeUuid: String) = chapterDao.countGeneratedForEpisode(episodeUuid) > 0
+
     override fun observerChaptersForEpisode(episodeUuid: String) = combine(
         episodeManager.findEpisodeByUuidFlow(episodeUuid).distinctUntilChangedBy(BaseEpisode::deselectedChapters),
         chapterDao.observeChaptersForEpisode(episodeUuid),

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/DriftFilterTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/DriftFilterTest.kt
@@ -1,9 +1,12 @@
 package au.com.shiftyjelly.pocketcasts.repositories.fingerprint
 
+import android.content.Context
 import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.FingerprintTimingManager.TimeMappingEntry
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.ChapterManager
 import com.automattic.eventhorizon.EventHorizon
+import dagger.Lazy
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -26,6 +29,8 @@ class DriftFilterTest {
             playbackManager = playbackManager,
             referenceRetriever = mock(FingerprintReferenceRetriever::class.java),
             eventHorizon = mock(EventHorizon::class.java),
+            context = mock(Context::class.java),
+            chapterManager = Lazy { mock(ChapterManager::class.java) },
         )
         manager.debugTrackingEnabled = true
     }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManagerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManagerTest.kt
@@ -152,7 +152,10 @@ class FingerprintTimingManagerTest {
         FingerprintTimingManager.computeEager(
             hasGeneratedChapters = true,
             isDownloaded = true,
-            isUnmetered = { queriedNetwork = true; true },
+            isUnmetered = {
+                queriedNetwork = true
+                true
+            },
         )
         assertFalse(queriedNetwork)
     }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManagerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManagerTest.kt
@@ -2,7 +2,9 @@ package au.com.shiftyjelly.pocketcasts.repositories.fingerprint
 
 import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.FingerprintTimingManager.TimeMappingEntry
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class FingerprintTimingManagerTest {
@@ -102,6 +104,57 @@ class FingerprintTimingManagerTest {
             valueSelector = { it.referenceTime },
         )
         assertEquals(101.0, result!!, 0.001)
+    }
+
+    @Test
+    fun `computeEager runs for downloaded episode with generated chapters`() {
+        val eager = FingerprintTimingManager.computeEager(
+            hasGeneratedChapters = true,
+            isDownloaded = true,
+            isUnmetered = { false },
+        )
+        assertTrue(eager)
+    }
+
+    @Test
+    fun `computeEager runs for streaming episode on unmetered network`() {
+        val eager = FingerprintTimingManager.computeEager(
+            hasGeneratedChapters = true,
+            isDownloaded = false,
+            isUnmetered = { true },
+        )
+        assertTrue(eager)
+    }
+
+    @Test
+    fun `computeEager skips streaming episode on metered network`() {
+        val eager = FingerprintTimingManager.computeEager(
+            hasGeneratedChapters = true,
+            isDownloaded = false,
+            isUnmetered = { false },
+        )
+        assertFalse(eager)
+    }
+
+    @Test
+    fun `computeEager skips episode without generated chapters`() {
+        val eager = FingerprintTimingManager.computeEager(
+            hasGeneratedChapters = false,
+            isDownloaded = true,
+            isUnmetered = { true },
+        )
+        assertFalse(eager)
+    }
+
+    @Test
+    fun `computeEager does not query network for downloaded episode`() {
+        var queriedNetwork = false
+        FingerprintTimingManager.computeEager(
+            hasGeneratedChapters = true,
+            isDownloaded = true,
+            isUnmetered = { queriedNetwork = true; true },
+        )
+        assertFalse(queriedNetwork)
     }
 
     @Test

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/ChapterManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/ChapterManagerImplTest.kt
@@ -12,6 +12,7 @@ import au.com.shiftyjelly.pocketcasts.utils.AppPlatform
 import dagger.Lazy
 import java.util.Date
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
@@ -670,5 +671,90 @@ class ChapterManagerImplTest {
 
             awaitComplete()
         }
+    }
+
+    @Test
+    fun `align translates generated chapter times`() {
+        val chapters = Chapters(
+            listOf(
+                Chapter(title = "A", startTime = 0.seconds, endTime = 10.seconds, index = 0, uiIndex = 1, isGenerated = true),
+                Chapter(title = "B", startTime = 10.seconds, endTime = 20.seconds, index = 1, uiIndex = 2, isGenerated = true),
+            ),
+        )
+
+        // Simulate a 30s ad inserted before playback: every reference time shifts later by 30s.
+        val aligned = ChapterManagerImpl.alignGeneratedChapters(chapters) { it + 30.seconds }
+
+        assertEquals(
+            Chapters(
+                listOf(
+                    Chapter(title = "A", startTime = 30.seconds, endTime = 40.seconds, index = 0, uiIndex = 1, isGenerated = true),
+                    Chapter(title = "B", startTime = 40.seconds, endTime = 50.seconds, index = 1, uiIndex = 2, isGenerated = true),
+                ),
+            ),
+            aligned,
+        )
+    }
+
+    @Test
+    fun `align leaves embedded chapters untouched`() {
+        val chapters = Chapters(
+            listOf(
+                Chapter(title = "Embedded", startTime = 0.seconds, endTime = 10.seconds, index = 0, uiIndex = 1, isGenerated = false),
+                Chapter(title = "Generated", startTime = 10.seconds, endTime = 20.seconds, index = 1, uiIndex = 2, isGenerated = true),
+            ),
+        )
+
+        val aligned = ChapterManagerImpl.alignGeneratedChapters(chapters) { it + 30.seconds }
+
+        assertEquals(0.seconds, aligned[0].startTime)
+        assertEquals(10.seconds, aligned[0].endTime)
+        assertEquals(40.seconds, aligned[1].startTime)
+        assertEquals(50.seconds, aligned[1].endTime)
+    }
+
+    @Test
+    fun `align keeps original time when mapping returns null`() {
+        val chapters = Chapters(
+            listOf(
+                Chapter(title = "A", startTime = 5.seconds, endTime = 15.seconds, index = 0, uiIndex = 1, isGenerated = true),
+            ),
+        )
+
+        val aligned = ChapterManagerImpl.alignGeneratedChapters(chapters) { null }
+
+        assertEquals(5.seconds, aligned[0].startTime)
+        assertEquals(15.seconds, aligned[0].endTime)
+    }
+
+    @Test
+    fun `align drops collapsed chapters and re-derives uiIndex`() {
+        val chapters = Chapters(
+            listOf(
+                Chapter(title = "A", startTime = 0.seconds, endTime = 10.seconds, index = 0, uiIndex = 1, isGenerated = true),
+                Chapter(title = "B", startTime = 10.seconds, endTime = 20.seconds, index = 1, uiIndex = 2, isGenerated = true),
+            ),
+        )
+
+        // Collapse everything up to 10s onto a single instant; chapter A becomes zero-duration.
+        val aligned = ChapterManagerImpl.alignGeneratedChapters(chapters) { time -> if (time <= 10.seconds) 10.seconds else time }
+
+        assertEquals(1, aligned.size)
+        assertEquals("B", aligned[0].title)
+        assertEquals(1, aligned[0].index) // DB index preserved
+        assertEquals(1, aligned[0].uiIndex) // UI index re-derived
+    }
+
+    @Test
+    fun `align returns chapters unchanged when none are generated`() {
+        val chapters = Chapters(
+            listOf(
+                Chapter(title = "A", startTime = 0.seconds, endTime = 10.seconds, index = 0, uiIndex = 1, isGenerated = false),
+            ),
+        )
+
+        val aligned = ChapterManagerImpl.alignGeneratedChapters(chapters) { it + 30.seconds }
+
+        assertEquals(chapters, aligned)
     }
 }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/ChapterManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/ChapterManagerImplTest.kt
@@ -7,6 +7,9 @@ import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.Chapter
 import au.com.shiftyjelly.pocketcasts.models.to.Chapters
 import au.com.shiftyjelly.pocketcasts.models.to.DbChapter
+import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.FingerprintTimingManager
+import au.com.shiftyjelly.pocketcasts.utils.AppPlatform
+import dagger.Lazy
 import java.util.Date
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -22,7 +25,13 @@ class ChapterManagerImplTest {
     private val chapterDao = mock<ChapterDao>()
     private val episodeManager = mock<EpisodeManager>()
 
-    private val chapterManager = ChapterManagerImpl(chapterDao, episodeManager)
+    // Non-Phone platform keeps alignment off, so these tests observe the raw reference timeline.
+    private val chapterManager = ChapterManagerImpl(
+        chapterDao = chapterDao,
+        episodeManager = episodeManager,
+        fingerprintTimingManager = Lazy { mock<FingerprintTimingManager>() },
+        appPlatform = AppPlatform.Automotive,
+    )
 
     @Test
     fun `observe no chapters`() = runBlocking {


### PR DESCRIPTION
## Description
This PR attempts to eliminate drifts between the generated chapter timestamsp and the actual audio stream that may contain ads (hence messing up the timestamps + chapter positions).
In order to get the best results, we now traverse the entire audio stream eagerly (not just the small window ahead of current playhead). There's a caveat, though: because this pulls the whole stream up front, it only happens when doing so is cheap — the episode is already downloaded, or we're streaming on an unmetered (WiFi) connection.

Fixes POC-682 https://linear.app/a8c/issue/POC-682/match-chapter-timestamps-against-audio-fingerprints

## Testing Instructions
1. Make sure both `generated_summaries` and `synced_transcripts` FFs are enabled!
2. Open a podcast that has generated transcripts (like The american life)
3. Open an episode, select Chapters tab
4. Select a chapter and listen for a while
5. Open fullscreen player, use the < and > arrows to navigate between chapters
6. Observe playback content is correct


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.