### PR TITLE
Wear OS performance improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
     *   Fix crash when scrolling to the top of a long Up Next queue
         ([#5320](https://github.com/Automattic/pocket-casts-android/pull/5320))
     *   Wear OS performance improvements
-        ([#5320](https://github.com/Automattic/pocket-casts-android/pull/5446))
+        ([#5446](https://github.com/Automattic/pocket-casts-android/pull/5446))
 
 8.14
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 *   Bug Fixes
     *   Fix crash when scrolling to the top of a long Up Next queue
         ([#5320](https://github.com/Automattic/pocket-casts-android/pull/5320))
+    *   Wear OS performance improvements
+        ([#5320](https://github.com/Automattic/pocket-casts-android/pull/5446))
 
 8.14
 -----

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
@@ -101,6 +101,7 @@ class PocketCastsWearApplication :
 
         notificationHelper.setupNotificationChannels()
         appLifecycleObserver.setup()
+        PlaybackServiceToggle.ensureCorrectServiceEnabled(application)
 
         // Apply migrations before the UI starts, so the app never reads pre-migration state.
         VersionMigrationsWorker.performMigrations(
@@ -111,8 +112,6 @@ class PocketCastsWearApplication :
 
         // Defer the expensive playback/storage setup and monitors off the main thread to avoid blocking onCreate (ANRs).
         applicationScope.launch {
-            PlaybackServiceToggle.ensureCorrectServiceEnabled(application)
-
             playbackManager.setup()
             val storageChoice = settings.getStorageChoice()
             if (storageChoice == null) {

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
@@ -6,6 +6,7 @@ import androidx.work.Configuration
 import au.com.shiftyjelly.pocketcasts.BuildConfig
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsController
 import au.com.shiftyjelly.pocketcasts.analytics.experiments.ExperimentProvider
+import au.com.shiftyjelly.pocketcasts.coroutines.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.crashlogging.InitializeRemoteLogging
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadStatusObserver
@@ -30,9 +31,8 @@ import dagger.hilt.android.HiltAndroidApp
 import java.io.File
 import java.util.concurrent.Executors
 import javax.inject.Inject
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import timber.log.Timber
 
 @HiltAndroidApp
@@ -70,6 +70,9 @@ class PocketCastsWearApplication :
 
     @Inject lateinit var connectivityLogger: ConnectivityLogger
 
+    @Inject @ApplicationScope
+    lateinit var applicationScope: CoroutineScope
+
     override fun onCreate() {
         super.onCreate()
         RxJavaUncaughtExceptionHandling.setUp()
@@ -94,39 +97,41 @@ class PocketCastsWearApplication :
     }
 
     private fun setupApp() {
-        runBlocking {
-            notificationHelper.setupNotificationChannels()
-            appLifecycleObserver.setup()
+        val application = this
 
-            PlaybackServiceToggle.ensureCorrectServiceEnabled(this@PocketCastsWearApplication)
+        notificationHelper.setupNotificationChannels()
+        appLifecycleObserver.setup()
 
-            withContext(Dispatchers.Default) {
-                playbackManager.setup()
-                val storageChoice = settings.getStorageChoice()
-                if (storageChoice == null) {
-                    val folder = StorageOptions()
-                        .getFolderLocations(this@PocketCastsWearApplication)
-                        .firstOrNull()
-                    if (folder != null) {
-                        settings.setStorageChoice(folder.filePath, folder.label)
-                    } else {
-                        settings.setStorageCustomFolder(this@PocketCastsWearApplication.filesDir.absolutePath)
-                    }
+        // Apply migrations before the UI starts, so the app never reads pre-migration state.
+        VersionMigrationsWorker.performMigrations(
+            context = application,
+            settings = settings,
+            moshi = moshi,
+        )
+
+        // Defer the expensive playback/storage setup and monitors off the main thread to avoid blocking onCreate (ANRs).
+        applicationScope.launch {
+            PlaybackServiceToggle.ensureCorrectServiceEnabled(application)
+
+            playbackManager.setup()
+            val storageChoice = settings.getStorageChoice()
+            if (storageChoice == null) {
+                val folder = StorageOptions()
+                    .getFolderLocations(application)
+                    .firstOrNull()
+                if (folder != null) {
+                    settings.setStorageChoice(folder.filePath, folder.label)
+                } else {
+                    settings.setStorageCustomFolder(application.filesDir.absolutePath)
                 }
             }
 
-            VersionMigrationsWorker.performMigrations(
-                context = this@PocketCastsWearApplication,
-                settings = settings,
-                moshi = moshi,
-            )
+            userManager.beginMonitoringAccountManager(playbackManager)
+            downloadStatusObserver.monitorDownloadStatus()
+
+            PlaybackStatsSyncWorker.scheduleOneTimeWork(application)
+            PlaybackStatsSyncWorker.schedulePeriodicWork(application)
         }
-
-        userManager.beginMonitoringAccountManager(playbackManager)
-        downloadStatusObserver.monitorDownloadStatus()
-
-        PlaybackStatsSyncWorker.scheduleOneTimeWork(this)
-        PlaybackStatsSyncWorker.schedulePeriodicWork(this)
     }
 
     private fun setupAnalytics() {

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
@@ -25,12 +25,14 @@ import au.com.shiftyjelly.pocketcasts.utils.TimberDebugTree
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.utils.log.RxJavaUncaughtExceptionHandling
 import au.com.shiftyjelly.pocketcasts.wear.networking.ConnectivityLogger
+import com.automattic.android.tracks.crashlogging.CrashLogging
 import com.google.firebase.FirebaseApp
 import com.squareup.moshi.Moshi
 import dagger.hilt.android.HiltAndroidApp
 import java.io.File
 import java.util.concurrent.Executors
 import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -69,6 +71,8 @@ class PocketCastsWearApplication :
     @Inject lateinit var initializeRemoteLogging: InitializeRemoteLogging
 
     @Inject lateinit var connectivityLogger: ConnectivityLogger
+
+    @Inject lateinit var crashLogging: CrashLogging
 
     @Inject @ApplicationScope
     lateinit var applicationScope: CoroutineScope
@@ -112,24 +116,41 @@ class PocketCastsWearApplication :
 
         // Defer the expensive playback/storage setup and monitors off the main thread to avoid blocking onCreate (ANRs).
         applicationScope.launch {
-            playbackManager.setup()
-            val storageChoice = settings.getStorageChoice()
-            if (storageChoice == null) {
-                val folder = StorageOptions()
-                    .getFolderLocations(application)
-                    .firstOrNull()
-                if (folder != null) {
-                    settings.setStorageChoice(folder.filePath, folder.label)
-                } else {
-                    settings.setStorageCustomFolder(application.filesDir.absolutePath)
+            runStartupStep("playback setup and account monitoring") {
+                playbackManager.setup()
+                userManager.beginMonitoringAccountManager(playbackManager)
+            }
+            runStartupStep("storage setup") {
+                if (settings.getStorageChoice() == null) {
+                    val folder = StorageOptions()
+                        .getFolderLocations(application)
+                        .firstOrNull()
+                    if (folder != null) {
+                        settings.setStorageChoice(folder.filePath, folder.label)
+                    } else {
+                        settings.setStorageCustomFolder(application.filesDir.absolutePath)
+                    }
                 }
             }
+            runStartupStep("download monitoring") {
+                downloadStatusObserver.monitorDownloadStatus()
+            }
+            runStartupStep("playback stats scheduling") {
+                PlaybackStatsSyncWorker.scheduleOneTimeWork(application)
+                PlaybackStatsSyncWorker.schedulePeriodicWork(application)
+            }
+        }
+    }
 
-            userManager.beginMonitoringAccountManager(playbackManager)
-            downloadStatusObserver.monitorDownloadStatus()
-
-            PlaybackStatsSyncWorker.scheduleOneTimeWork(application)
-            PlaybackStatsSyncWorker.schedulePeriodicWork(application)
+    /** Runs a deferred startup step, reporting failures to the log buffer and Sentry without skipping later steps. */
+    private inline fun runStartupStep(name: String, block: () -> Unit) {
+        try {
+            block()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, e, "${WearLogging.PREFIX} Deferred startup step failed: $name")
+            crashLogging.sendReport(e, message = "${WearLogging.PREFIX} Deferred startup step failed: $name")
         }
     }
 

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/WearMainActivityViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/WearMainActivityViewModel.kt
@@ -54,7 +54,7 @@ class WearMainActivityViewModel @Inject constructor(
         val showLoggingInScreen: Boolean = false,
         val signInState: SignInState = SignInState.SignedOut,
         val syncState: WatchSyncState = WatchSyncState.Syncing,
-        val isConnected: Boolean = false,
+        val isConnected: Boolean = true,
     )
 
     private val _state = MutableStateFlow(State())
@@ -117,7 +117,7 @@ class WearMainActivityViewModel @Inject constructor(
                             onResult = { result -> onLoginFromPhoneResult(result) },
                             onAlreadyLoggedIn = {
                                 LogBuffer.i(TAG, "Already logged in - treating as sync success")
-                                _state.update { it.copy(syncState = WatchSyncState.Success, showLoggingInScreen = true) }
+                                _state.update { it.copy(syncState = WatchSyncState.Success) }
                                 syncJob?.cancel()
                             },
                         )

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/networking/ConnectivityStateManager.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/networking/ConnectivityStateManager.kt
@@ -26,6 +26,6 @@ class ConnectivityStateManager @Inject constructor(
         .stateIn(
             scope = coroutineScope,
             started = SharingStarted.Eagerly,
-            initialValue = false,
+            initialValue = true,
         )
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.ui.text.font.FontWeight.Companion.W700
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.core.text.parseAsHtml
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.wear.compose.foundation.lazy.items
 import androidx.wear.compose.material.Icon
@@ -37,7 +36,6 @@ import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeDownloadStatus
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.podcasts.view.episode.DownloadButtonState
-import au.com.shiftyjelly.pocketcasts.servers.shownotes.ShowNotesState
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.ExpandableText
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.WatchListChip
@@ -190,11 +188,12 @@ fun EpisodeScreen(
         }
 
         item {
-            if (state.showNotesState is ShowNotesState.Loaded) {
+            val showNotesText = state.showNotesText
+            if (showNotesText != null) {
                 val coroutineScope = rememberCoroutineScope()
                 Column {
                     ExpandableText(
-                        text = state.showNotesState.showNotes.parseAsHtml().toString(),
+                        text = showNotesText,
                         style = MaterialTheme.typography.caption2,
                         textAlign = TextAlign.Center,
                         onClick = { isExpanded ->

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeViewModel.kt
@@ -205,10 +205,8 @@ class EpisodeViewModel @Inject constructor(
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), State.Empty)
     }
 
-    private fun parseShowNotes(showNotesState: ShowNotesState): String? = if (showNotesState is ShowNotesState.Loaded) {
-        showNotesState.showNotes.parseAsHtml().toString()
-    } else {
-        null
+    private fun parseShowNotes(showNotesState: ShowNotesState): String? {
+        return (showNotesState as? ShowNotesState.Loaded)?.showNotes?.parseAsHtml()?.toString()
     }
 
     private fun getErrorData(episode: BaseEpisode): State.Loaded.ErrorData? {

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeViewModel.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.compose.ui.graphics.Color
+import androidx.core.text.parseAsHtml
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
@@ -19,6 +20,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeDownloadStatus
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.profile.cloud.AddFileActivity
+import au.com.shiftyjelly.pocketcasts.repositories.di.DefaultDispatcher
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadProgressCache
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadQueue
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadType
@@ -50,6 +52,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -63,6 +66,7 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
@@ -90,6 +94,7 @@ class EpisodeViewModel @Inject constructor(
     @ApplicationScope private val applicationScope: CoroutineScope,
     private val audioOutputSelectorHelper: AudioOutputSelectorHelper,
     private val userEpisodeManager: UserEpisodeManager,
+    @DefaultDispatcher private val backgroundDispatcher: CoroutineDispatcher,
 ) : AndroidViewModel(appContext as Application) {
     private var playAttempt: Job? = null
     private val sourceView = SourceView.EPISODE_DETAILS
@@ -102,7 +107,7 @@ class EpisodeViewModel @Inject constructor(
             val inUpNext: Boolean,
             val tintColor: Color?,
             val downloadProgress: Float? = null,
-            val showNotesState: ShowNotesState,
+            val showNotesText: String?,
             val errorData: ErrorData?,
         ) : State() {
             data class ErrorData(
@@ -161,7 +166,7 @@ class EpisodeViewModel @Inject constructor(
             .map { progress -> (progress?.percentage?.toFloat() ?: 0f) / 100 }
             .distinctUntilChanged()
 
-        val showNotesFlow = episodeFlow
+        val showNotesTextFlow = episodeFlow
             .flatMapLatest {
                 when (it) {
                     is PodcastEpisode -> showNotesManager.loadShowNotesFlow(
@@ -173,6 +178,9 @@ class EpisodeViewModel @Inject constructor(
                     is UserEpisode -> flowOf(ShowNotesState.NotFound)
                 }
             }
+            // Parse the show notes HTML off the main thread, and only when the notes change, to avoid blocking the UI.
+            .map { showNotesState -> parseShowNotes(showNotesState) }
+            .flowOn(backgroundDispatcher)
 
         stateFlow = combine(
             episodeFlow,
@@ -181,8 +189,8 @@ class EpisodeViewModel @Inject constructor(
             isPlayingEpisodeFlow.onStart { emit(false) },
             inUpNextFlow,
             downloadProgressFlow,
-            showNotesFlow,
-        ) { episode, podcast, isPlayingEpisode, upNext, downloadProgress, showNotesState ->
+            showNotesTextFlow,
+        ) { episode, podcast, isPlayingEpisode, upNext, downloadProgress, showNotesText ->
 
             State.Loaded(
                 episode = episode,
@@ -191,10 +199,16 @@ class EpisodeViewModel @Inject constructor(
                 downloadProgress = downloadProgress,
                 inUpNext = isInUpNext(upNext, episode),
                 tintColor = getTintColor(episode, podcast, theme),
-                showNotesState = showNotesState,
+                showNotesText = showNotesText,
                 errorData = getErrorData(episode),
             )
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), State.Empty)
+    }
+
+    private fun parseShowNotes(showNotesState: ShowNotesState): String? = if (showNotesState is ShowNotesState.Loaded) {
+        showNotesState.showNotes.parseAsHtml().toString()
+    } else {
+        null
     }
 
     private fun getErrorData(episode: BaseEpisode): State.Loaded.ErrorData? {

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcast/PodcastViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcast/PodcastViewModel.kt
@@ -6,15 +6,18 @@ import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.di.DefaultDispatcher
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 
@@ -25,6 +28,7 @@ class PodcastViewModel @Inject constructor(
     private val podcastManager: PodcastManager,
     private val theme: Theme,
     settings: Settings,
+    @DefaultDispatcher private val backgroundDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
 
     private val podcastUuid: String = savedStateHandle[PodcastScreen.ARGUMENT] ?: ""
@@ -61,9 +65,11 @@ class PodcastViewModel @Inject constructor(
                     },
             )
         }
-    }.stateIn(
-        scope = viewModelScope,
-        started = SharingStarted.WhileSubscribed(1000),
-        initialValue = UiState.Empty,
-    )
+    }
+        .flowOn(backgroundDispatcher)
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(1000),
+            initialValue = UiState.Empty,
+        )
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/SettingsScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/SettingsScreen.kt
@@ -184,8 +184,7 @@ private fun Content(
         }
 
         item {
-            val signInState = state.signInState
-            when (signInState) {
+            when (val signInState = state.signInState) {
                 is SignInState.SignedIn -> {
                     WatchListChip(
                         title = stringResource(LR.string.log_out),
@@ -202,6 +201,9 @@ private fun Content(
                         onClick = signInClick,
                     )
                 }
+
+                // Not yet known; the sign-in chip appears once the state flow emits.
+                null -> Unit
             }
         }
 

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/SettingsViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/SettingsViewModel.kt
@@ -16,7 +16,6 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.reactive.asFlow
-import kotlinx.coroutines.rx2.asFlow
 
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
@@ -28,7 +27,7 @@ class SettingsViewModel @Inject constructor(
 
     data class State(
         val refreshState: RefreshState?,
-        val signInState: SignInState,
+        val signInState: SignInState?,
         val showDataWarning: Boolean,
         val refreshInBackground: Boolean,
     )
@@ -36,7 +35,7 @@ class SettingsViewModel @Inject constructor(
     private val _state = MutableStateFlow(
         State(
             refreshState = null,
-            signInState = userManager.getSignInState().blockingFirst(),
+            signInState = null,
             showDataWarning = settings.warnOnMeteredNetwork.value,
             refreshInBackground = settings.backgroundRefreshPodcasts.value,
         ),

--- a/wear/src/test/kotlin/au/com/shiftyjelly/pocketcasts/wear/networking/ConnectivityStateManagerTest.kt
+++ b/wear/src/test/kotlin/au/com/shiftyjelly/pocketcasts/wear/networking/ConnectivityStateManagerTest.kt
@@ -48,6 +48,7 @@ class ConnectivityStateManagerTest {
             networks = emptyList(),
         )
         val connectivityStateManager = createConnectivityStateManager()
+        testScheduler.runCurrent()
 
         connectivityStateManager.isConnected.test {
             assertEquals(false, awaitItem())
@@ -139,6 +140,7 @@ class ConnectivityStateManagerTest {
     @Test
     fun `isConnected changes from false to true when WiFi connects`() = testScope.runTest {
         val connectivityStateManager = createConnectivityStateManager()
+        testScheduler.runCurrent()
 
         connectivityStateManager.isConnected.test {
             assertEquals(false, awaitItem())

--- a/wear/src/test/kotlin/au/com/shiftyjelly/pocketcasts/wear/networking/ConnectivityStateManagerTest.kt
+++ b/wear/src/test/kotlin/au/com/shiftyjelly/pocketcasts/wear/networking/ConnectivityStateManagerTest.kt
@@ -47,9 +47,9 @@ class ConnectivityStateManagerTest {
             activeNetwork = null,
             networks = emptyList(),
         )
-        val connectivityStateManager = createConnectivityStateManager()
-        testScheduler.runCurrent()
-
+val connectivityStateManager = createConnectivityStateManager()
+assertEquals(true, connectivityStateManager.isConnected.value)
+testScheduler.runCurrent()
         connectivityStateManager.isConnected.test {
             assertEquals(false, awaitItem())
             cancel()
@@ -139,9 +139,9 @@ class ConnectivityStateManagerTest {
 
     @Test
     fun `isConnected changes from false to true when WiFi connects`() = testScope.runTest {
-        val connectivityStateManager = createConnectivityStateManager()
-        testScheduler.runCurrent()
-
+val connectivityStateManager = createConnectivityStateManager()
+assertEquals(true, connectivityStateManager.isConnected.value)
+testScheduler.runCurrent()
         connectivityStateManager.isConnected.test {
             assertEquals(false, awaitItem())
 

--- a/wear/src/test/kotlin/au/com/shiftyjelly/pocketcasts/wear/networking/ConnectivityStateManagerTest.kt
+++ b/wear/src/test/kotlin/au/com/shiftyjelly/pocketcasts/wear/networking/ConnectivityStateManagerTest.kt
@@ -47,9 +47,9 @@ class ConnectivityStateManagerTest {
             activeNetwork = null,
             networks = emptyList(),
         )
-val connectivityStateManager = createConnectivityStateManager()
-assertEquals(true, connectivityStateManager.isConnected.value)
-testScheduler.runCurrent()
+        val connectivityStateManager = createConnectivityStateManager()
+        assertEquals(true, connectivityStateManager.isConnected.value)
+        testScheduler.runCurrent()
         connectivityStateManager.isConnected.test {
             assertEquals(false, awaitItem())
             cancel()
@@ -139,9 +139,9 @@ testScheduler.runCurrent()
 
     @Test
     fun `isConnected changes from false to true when WiFi connects`() = testScope.runTest {
-val connectivityStateManager = createConnectivityStateManager()
-assertEquals(true, connectivityStateManager.isConnected.value)
-testScheduler.runCurrent()
+        val connectivityStateManager = createConnectivityStateManager()
+        assertEquals(true, connectivityStateManager.isConnected.value)
+        testScheduler.runCurrent()
         connectivityStateManager.isConnected.test {
             assertEquals(false, awaitItem())
 

--- a/wear/src/test/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcast/PodcastViewModelTest.kt
+++ b/wear/src/test/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcast/PodcastViewModelTest.kt
@@ -148,6 +148,7 @@ class PodcastViewModelTest {
             podcastManager = podcastManager,
             theme = theme,
             settings = settings,
+            backgroundDispatcher = coroutineRule.testDispatcher,
         )
     }
 


### PR DESCRIPTION
## Description

This PR addresses ANRs and UI jank in the Wear OS app by moving expensive work off the main thread and removing blocking calls during startup and screen rendering.

**Startup (`PocketCastsWearApplication`)**
- Replaced the `runBlocking { ... }` block in `setupApp()` with non-blocking work. Notification channels, the app lifecycle observer, the playback-service toggle, and version migrations still run synchronously (migrations must complete before the UI reads any state), but the expensive playback/storage setup, account/download monitors, and stats workers are now deferred onto an injected `@ApplicationScope` coroutine instead of blocking `onCreate()`.
- This is the primary ANR fix — `onCreate()` no longer blocks on playback manager setup and storage option enumeration.

**Show notes parsing (`EpisodeViewModel` / `EpisodeScreen`)**
- HTML show notes were being parsed (`parseAsHtml()`) on the main thread inside the composable on every render. Parsing now happens once in the ViewModel flow via `.map { ... }.flowOn(DefaultDispatcher)` when the notes change, and the screen consumes a plain `String?` (`showNotesText`) instead of `ShowNotesState`.

**Podcast screen (`PodcastViewModel`)**
- Moved the episode/podcast flow computation onto `DefaultDispatcher` with `.flowOn(...)` so it no longer runs on the main thread.

**Settings & connectivity (`SettingsViewModel`, `ConnectivityStateManager`, `WearMainActivityViewModel`)**
- Removed the blocking `userManager.getSignInState().blockingFirst()` call from `SettingsViewModel`'s initial state; `signInState` is now nullable and populated reactively, with the UI rendering nothing until the first emission.
- Changed the default `isConnected` value to `true` (in both `ConnectivityStateManager` and `WearMainActivityViewModel`) so the UI doesn't briefly flash an offline/disconnected state before the real connectivity status arrives.
- Stopped forcing `showLoggingInScreen = true` on the already-logged-in sync path.

## Testing Instructions

1. Build and install the Wear OS app on a watch (or emulator)
2. Cold-start the app and confirm it launches correctly when logged in and out.
3. Confirm playback still works (start an episode, ensure the playback service starts and audio plays).
4. Open an episode detail screen with HTML show notes and confirm the notes render correctly and scrolling/expanding is smooth.
5. Open a podcast screen and confirm episodes load.
6. Open Settings and confirm the sign-in/log-out chip appears once state loads, and the data warning / background refresh toggles reflect the correct values.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

#### I have tested any UI changes...
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
