### PR TITLE
Update GitHub PR template to use Event Horizon

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,7 +18,7 @@ Fixes # <!-- issue number, if applicable -->
 - [ ] I have considered whether it makes sense to add tests for my changes
 - [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
 - [ ] Any jetpack compose components I added or changed are covered by compose previews
-- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
+- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
  
 #### I have tested any UI changes...
 <!-- If this PR does not contain UI changes, ignore these items -->


### PR DESCRIPTION
## Description

Updates the analytics reminder in the GitHub pull request template to point at the new [Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) instead of the old Google Sheets spreadsheet. Analytics definitions have moved to Event Horizon, so this keeps the checklist link accurate and points contributors to the right place when adding or changing analytics events.

## Testing Instructions

1. Open a new pull request (or preview the template) and verify the checklist line reads "I have updated (or requested that someone edit) the Event Horizon schema...".
2. Confirm the link resolves to the Event Horizon schema repo.

## Screenshots or Screencast

Not applicable — documentation/template change only.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

#### I have tested any UI changes...
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
