### PR TITLE
[Synced Transcripts] Fix gaps in highlighting compared to iOS

### DIFF
--- a/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/TranscriptViewModel.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/TranscriptViewModel.kt
@@ -171,11 +171,17 @@ class TranscriptViewModel @AssistedInject constructor(
         }
     }
 
-    fun seekToTranscriptEntry(entry: TranscriptEntry) {
-        val textEntry = entry as? TranscriptEntry.Text ?: return
-        if (textEntry.startTimeMs < 0) return
+    /**
+     * Seeks playback to the tapped transcript [entry]. Returns the playback position (ms) sought
+     * to, or `null` if the entry is untimed, syncing is inactive, or no mapping is available. The
+     * caller uses the returned position to drive the highlight directly rather than re-deriving it
+     * from the (lossy) playback position.
+     */
+    fun seekToTranscriptEntry(entry: TranscriptEntry): Int? {
+        val textEntry = entry as? TranscriptEntry.Text ?: return null
+        if (textEntry.startTimeMs < 0) return null
         val currentState = _uiState.value
-        if (!currentState.isSyncedActive) return
+        if (!currentState.isSyncedActive) return null
 
         val refTimeSec = textEntry.startTimeMs / 1000.0
         val seekTimeMs = fingerprintTimingManager.playbackTimeMs(forReferenceTime = refTimeSec)
@@ -189,7 +195,7 @@ class TranscriptViewModel @AssistedInject constructor(
                     source = source,
                 )
             }
-            return
+            return null
         }
 
         val fromPositionSeconds = currentPlaybackPositionMs / 1000L
@@ -203,6 +209,7 @@ class TranscriptViewModel @AssistedInject constructor(
                 source = source,
             )
         }
+        return seekTimeMs
     }
 
     override fun onCleared() {

--- a/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptCueHelper.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptCueHelper.kt
@@ -31,8 +31,7 @@ internal object TranscriptCueHelper {
             }
             return HighlightOutcome.Show(entryIndex = idx, wordIndex = wordIdx)
         }
-        // No cue contains the time — we're in a gap between sentences. Mirror iOS: keep the
-        // previous highlight rather than clearing, unless playback is before the first cue.
+        // In a gap between cues: hold the previous highlight unless we're before the first cue.
         return if (isBeforeFirstCue(entries, refTimeMs)) HighlightOutcome.Clear else HighlightOutcome.Keep
     }
 
@@ -117,8 +116,7 @@ internal object TranscriptCueHelper {
                 }
             }
         }
-        // Strict containment: no cue's [startTimeMs, endTimeMs] range contains the time.
-        // Mirrors iOS `currentCue()` returning nil so the caller can hold the previous highlight.
+        // No cue's [startTimeMs, endTimeMs] contains the time.
         return null
     }
 

--- a/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptCueHelper.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptCueHelper.kt
@@ -1,7 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.transcripts.ui
 
 import au.com.shiftyjelly.pocketcasts.models.to.TranscriptEntry
-import kotlin.math.abs
 
 internal sealed interface HighlightOutcome {
     data class Show(val entryIndex: Int, val wordIndex: Int?) : HighlightOutcome
@@ -32,7 +31,17 @@ internal object TranscriptCueHelper {
             }
             return HighlightOutcome.Show(entryIndex = idx, wordIndex = wordIdx)
         }
-        return HighlightOutcome.Clear
+        // No cue contains the time — we're in a gap between sentences. Mirror iOS: keep the
+        // previous highlight rather than clearing, unless playback is before the first cue.
+        return if (isBeforeFirstCue(entries, refTimeMs)) HighlightOutcome.Clear else HighlightOutcome.Keep
+    }
+
+    private fun isBeforeFirstCue(
+        entries: List<TranscriptEntry>,
+        refTimeMs: Long,
+    ): Boolean {
+        val firstCue = entries.firstOrNull { it is TranscriptEntry.Text && it.startTimeMs >= 0 } as? TranscriptEntry.Text
+        return firstCue != null && refTimeMs < firstCue.startTimeMs
     }
 
     fun findCueIndex(
@@ -108,33 +117,9 @@ internal object TranscriptCueHelper {
                 }
             }
         }
-        return findClosestTimedEntry(entries, refTimeMs, lo.coerceIn(0, entries.size - 1))
-    }
-
-    fun findClosestTimedEntry(
-        entries: List<TranscriptEntry>,
-        refTimeMs: Long,
-        around: Int,
-    ): Int? {
-        var bestIndex: Int? = null
-        var bestDistance = Long.MAX_VALUE
-        val scanRadius = 5
-        val start = maxOf(0, around - scanRadius)
-        val end = minOf(entries.size - 1, around + scanRadius)
-        for (i in start..end) {
-            val entry = entries[i]
-            if (entry is TranscriptEntry.Text && entry.startTimeMs >= 0) {
-                val dist = minOf(
-                    abs(refTimeMs - entry.startTimeMs),
-                    abs(refTimeMs - entry.endTimeMs),
-                )
-                if (dist < bestDistance) {
-                    bestDistance = dist
-                    bestIndex = i
-                }
-            }
-        }
-        return if (bestDistance <= NEAREST_CUE_THRESHOLD_MS) bestIndex else null
+        // Strict containment: no cue's [startTimeMs, endTimeMs] range contains the time.
+        // Mirrors iOS `currentCue()` returning nil so the caller can hold the previous highlight.
+        return null
     }
 
     fun findNearestTimedEntry(
@@ -174,6 +159,4 @@ internal object TranscriptCueHelper {
         }
         return lastPassedIndex
     }
-
-    const val NEAREST_CUE_THRESHOLD_MS = 5000L
 }

--- a/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptCueHelper.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptCueHelper.kt
@@ -3,7 +3,37 @@ package au.com.shiftyjelly.pocketcasts.transcripts.ui
 import au.com.shiftyjelly.pocketcasts.models.to.TranscriptEntry
 import kotlin.math.abs
 
+internal sealed interface HighlightOutcome {
+    data class Show(val entryIndex: Int, val wordIndex: Int?) : HighlightOutcome
+
+    data object Clear : HighlightOutcome
+
+    data object Keep : HighlightOutcome
+}
+
 internal object TranscriptCueHelper {
+
+    /**
+     * Resolves what the highlight should do for a given reference time. Pure so it can be
+     * shared between the playing frame loop and the paused recompute, and unit tested.
+     */
+    fun resolveHighlight(
+        entries: List<TranscriptEntry>,
+        refTimeMs: Long,
+        cachedIndex: Int,
+    ): HighlightOutcome {
+        val idx = findCueIndex(entries, refTimeMs, cachedIndex)
+        if (idx != null) {
+            val entry = entries[idx]
+            val wordIdx = if (entry is TranscriptEntry.Text && entry.words.isNotEmpty()) {
+                findWordIndex(entry, refTimeMs)
+            } else {
+                null
+            }
+            return HighlightOutcome.Show(entryIndex = idx, wordIndex = wordIdx)
+        }
+        return HighlightOutcome.Clear
+    }
 
     fun findCueIndex(
         entries: List<TranscriptEntry>,

--- a/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptCueHelper.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptCueHelper.kt
@@ -3,7 +3,7 @@ package au.com.shiftyjelly.pocketcasts.transcripts.ui
 import au.com.shiftyjelly.pocketcasts.models.to.TranscriptEntry
 
 internal sealed interface HighlightOutcome {
-    data class Show(val entryIndex: Int, val wordIndex: Int?) : HighlightOutcome
+    data class Show(val entryIndex: Int) : HighlightOutcome
 
     data object Clear : HighlightOutcome
 
@@ -23,13 +23,7 @@ internal object TranscriptCueHelper {
     ): HighlightOutcome {
         val idx = findCueIndex(entries, refTimeMs, cachedIndex)
         if (idx != null) {
-            val entry = entries[idx]
-            val wordIdx = if (entry is TranscriptEntry.Text && entry.words.isNotEmpty()) {
-                findWordIndex(entry, refTimeMs)
-            } else {
-                null
-            }
-            return HighlightOutcome.Show(entryIndex = idx, wordIndex = wordIdx)
+            return HighlightOutcome.Show(entryIndex = idx)
         }
         // No cue contains the time — we're in a gap between sentences. Mirror iOS: keep the
         // previous highlight rather than clearing, unless playback is before the first cue.
@@ -143,20 +137,5 @@ internal object TranscriptCueHelper {
             }
         }
         return null
-    }
-
-    fun findWordIndex(
-        entry: TranscriptEntry.Text,
-        refTimeMs: Long,
-    ): Int? {
-        if (entry.words.isEmpty()) return null
-        var lastPassedIndex: Int? = null
-        for ((index, word) in entry.words.withIndex()) {
-            if (word.startTimeMs < 0) continue
-            if (refTimeMs < word.startTimeMs) return lastPassedIndex
-            if (refTimeMs < word.endTimeMs) return index
-            lastPassedIndex = index
-        }
-        return lastPassedIndex
     }
 }

--- a/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptCueHelper.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptCueHelper.kt
@@ -3,7 +3,7 @@ package au.com.shiftyjelly.pocketcasts.transcripts.ui
 import au.com.shiftyjelly.pocketcasts.models.to.TranscriptEntry
 
 internal sealed interface HighlightOutcome {
-    data class Show(val entryIndex: Int) : HighlightOutcome
+    data class Show(val entryIndex: Int, val wordIndex: Int?) : HighlightOutcome
 
     data object Clear : HighlightOutcome
 
@@ -23,7 +23,13 @@ internal object TranscriptCueHelper {
     ): HighlightOutcome {
         val idx = findCueIndex(entries, refTimeMs, cachedIndex)
         if (idx != null) {
-            return HighlightOutcome.Show(entryIndex = idx)
+            val entry = entries[idx]
+            val wordIdx = if (entry is TranscriptEntry.Text && entry.words.isNotEmpty()) {
+                findWordIndex(entry, refTimeMs)
+            } else {
+                null
+            }
+            return HighlightOutcome.Show(entryIndex = idx, wordIndex = wordIdx)
         }
         // No cue contains the time — we're in a gap between sentences. Mirror iOS: keep the
         // previous highlight rather than clearing, unless playback is before the first cue.
@@ -137,5 +143,20 @@ internal object TranscriptCueHelper {
             }
         }
         return null
+    }
+
+    fun findWordIndex(
+        entry: TranscriptEntry.Text,
+        refTimeMs: Long,
+    ): Int? {
+        if (entry.words.isEmpty()) return null
+        var lastPassedIndex: Int? = null
+        for ((index, word) in entry.words.withIndex()) {
+            if (word.startTimeMs < 0) continue
+            if (refTimeMs < word.startTimeMs) return lastPassedIndex
+            if (refTimeMs < word.endTimeMs) return index
+            lastPassedIndex = index
+        }
+        return lastPassedIndex
     }
 }

--- a/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptLines.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptLines.kt
@@ -28,7 +28,6 @@ import androidx.compose.ui.draw.BlurredEdgeTreatment
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
@@ -173,7 +172,6 @@ private fun TranscriptLine(
 ) {
     val entryText = entry.text()
     val isEntryHighlighted = entryIndex == highlightState.entryIndex
-    val wordTimings = (entry as? TranscriptEntry.Text)?.words.orEmpty()
 
     val searchHighlights = remember(entryIndex, entryText, searchState) {
         val searchTermLength = searchState.searchTerm.length
@@ -185,22 +183,11 @@ private fun TranscriptLine(
             .orEmpty()
     }
 
-    val textColor = if (isEntryHighlighted && wordTimings.isEmpty()) theme.highlightText else theme.primaryText
+    val textColor = if (isEntryHighlighted) theme.highlightText else theme.primaryText
 
     Text(
         text = buildAnnotatedString {
             append(entryText)
-            if (isEntryHighlighted && wordTimings.isNotEmpty() && highlightState.wordIndex != null) {
-                val wordIdx = highlightState.wordIndex.coerceAtMost(wordTimings.lastIndex)
-                val word = wordTimings[wordIdx]
-                if (word.charOffsetStart >= 0 && word.charOffsetEnd <= entryText.length) {
-                    addStyle(
-                        SpanStyle(color = theme.highlightText),
-                        word.charOffsetStart,
-                        word.charOffsetEnd,
-                    )
-                }
-            }
             searchHighlights.forEach { (startIndex, endIndex) ->
                 val highlightCoordinates = SearchCoordinates(line = entryIndex, match = startIndex)
                 val style = if (highlightCoordinates == searchState.matches.selectedCoordinate) {

--- a/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptLines.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptLines.kt
@@ -185,10 +185,8 @@ private fun TranscriptLine(
             .orEmpty()
     }
 
-    // Highlight the current fragment within the sentence (iOS-style partial highlight). When
-    // the entry is current but no fragment resolves (no word timings, before the first
-    // fragment, or invalid offsets) fall back to lighting the whole entry so a current
-    // sentence never goes dark.
+    // Highlight the current word within the sentence, falling back to the whole entry when no
+    // fragment resolves so a current sentence never goes dark.
     val wordIndex = highlightState.wordIndex
     val highlightWord = if (isEntryHighlighted && wordIndex != null && wordTimings.isNotEmpty()) {
         wordTimings[wordIndex.coerceAtMost(wordTimings.lastIndex)]

--- a/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptLines.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptLines.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.draw.BlurredEdgeTreatment
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
@@ -172,6 +173,7 @@ private fun TranscriptLine(
 ) {
     val entryText = entry.text()
     val isEntryHighlighted = entryIndex == highlightState.entryIndex
+    val wordTimings = (entry as? TranscriptEntry.Text)?.words.orEmpty()
 
     val searchHighlights = remember(entryIndex, entryText, searchState) {
         val searchTermLength = searchState.searchTerm.length
@@ -183,11 +185,29 @@ private fun TranscriptLine(
             .orEmpty()
     }
 
-    val textColor = if (isEntryHighlighted) theme.highlightText else theme.primaryText
+    // Highlight the current fragment within the sentence (iOS-style partial highlight). When
+    // the entry is current but no fragment resolves (no word timings, before the first
+    // fragment, or invalid offsets) fall back to lighting the whole entry so a current
+    // sentence never goes dark.
+    val wordIndex = highlightState.wordIndex
+    val highlightWord = if (isEntryHighlighted && wordIndex != null && wordTimings.isNotEmpty()) {
+        wordTimings[wordIndex.coerceAtMost(wordTimings.lastIndex)]
+            .takeIf { it.charOffsetStart in 0..<it.charOffsetEnd && it.charOffsetEnd <= entryText.length }
+    } else {
+        null
+    }
+    val textColor = if (isEntryHighlighted && highlightWord == null) theme.highlightText else theme.primaryText
 
     Text(
         text = buildAnnotatedString {
             append(entryText)
+            if (highlightWord != null) {
+                addStyle(
+                    SpanStyle(color = theme.highlightText),
+                    highlightWord.charOffsetStart,
+                    highlightWord.charOffsetEnd,
+                )
+            }
             searchHighlights.forEach { (startIndex, endIndex) ->
                 val highlightCoordinates = SearchCoordinates(line = entryIndex, match = startIndex)
                 val style = if (highlightCoordinates == searchState.matches.selectedCoordinate) {

--- a/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptPage.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptPage.kt
@@ -297,7 +297,7 @@ private fun HighlightEffect(
                     when (val outcome = resolveHighlight(transcript.entries, posMs, fingerprintTimingManager, cueIndexHolder[0])) {
                         is HighlightOutcome.Show -> {
                             cueIndexHolder[0] = outcome.entryIndex
-                            latestOnHighlightChanged(HighlightState(entryIndex = outcome.entryIndex, wordIndex = outcome.wordIndex))
+                            latestOnHighlightChanged(HighlightState(entryIndex = outcome.entryIndex))
                             wasHighlighting = true
                         }
 
@@ -322,7 +322,7 @@ private fun HighlightEffect(
             when (val outcome = resolveHighlight(transcript.entries, posMs, fingerprintTimingManager, cueIndexHolder[0])) {
                 is HighlightOutcome.Show -> {
                     cueIndexHolder[0] = outcome.entryIndex
-                    latestOnHighlightChanged(HighlightState(entryIndex = outcome.entryIndex, wordIndex = outcome.wordIndex))
+                    latestOnHighlightChanged(HighlightState(entryIndex = outcome.entryIndex))
                 }
 
                 HighlightOutcome.Clear -> latestOnHighlightChanged(HighlightState())
@@ -425,7 +425,6 @@ private fun KeepScreenOnEffect(keepOn: Boolean) {
 
 internal data class HighlightState(
     val entryIndex: Int? = null,
-    val wordIndex: Int? = null,
 )
 
 private const val AUTO_SCROLL_BACK_DELAY_MS = 5000L

--- a/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptPage.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptPage.kt
@@ -282,37 +282,33 @@ private fun HighlightEffect(
     }.collectAsState(initial = null)
     val isPlaying = playbackState?.isPlaying == true
 
+    // Shared between the playing loop and the paused recompute as the cue lookup hint.
+    // A plain holder (not Compose state) so updating it per frame doesn't recompose.
+    val cueIndexHolder = remember(transcript.entries) { intArrayOf(0) }
+
     if (isPlaying && isSyncedActive) {
         LaunchedEffect(transcript.entries) {
-            var cachedIndex = 0
+            cueIndexHolder[0] = 0
             var wasHighlighting = false
             latestOnHighlightChanged(HighlightState())
             while (true) {
                 withFrameNanos { _ ->
                     val posMs = playbackState?.positionMs ?: return@withFrameNanos
-                    val currentRefTime = fingerprintTimingManager.matchedReferenceTime(forPlaybackTimeMs = posMs)
-                    if (currentRefTime == null) {
-                        if (wasHighlighting) {
-                            latestOnHighlightChanged(HighlightState())
-                            wasHighlighting = false
+                    when (val outcome = resolveHighlight(transcript.entries, posMs, fingerprintTimingManager, cueIndexHolder[0])) {
+                        is HighlightOutcome.Show -> {
+                            cueIndexHolder[0] = outcome.entryIndex
+                            latestOnHighlightChanged(HighlightState(entryIndex = outcome.entryIndex, wordIndex = outcome.wordIndex))
+                            wasHighlighting = true
                         }
-                        return@withFrameNanos
-                    }
-                    val currentRefTimeMs = (currentRefTime * 1000).toLong()
-                    val idx = TranscriptCueHelper.findCueIndex(transcript.entries, currentRefTimeMs, cachedIndex)
-                    if (idx != null) {
-                        cachedIndex = idx
-                        val entry = transcript.entries[idx]
-                        val wordIdx = if (entry is TranscriptEntry.Text && entry.words.isNotEmpty()) {
-                            TranscriptCueHelper.findWordIndex(entry, currentRefTimeMs)
-                        } else {
-                            null
+
+                        HighlightOutcome.Clear -> {
+                            if (wasHighlighting) {
+                                latestOnHighlightChanged(HighlightState())
+                                wasHighlighting = false
+                            }
                         }
-                        latestOnHighlightChanged(HighlightState(entryIndex = idx, wordIndex = wordIdx))
-                        wasHighlighting = true
-                    } else if (wasHighlighting) {
-                        latestOnHighlightChanged(HighlightState())
-                        wasHighlighting = false
+
+                        HighlightOutcome.Keep -> Unit
                     }
                 }
             }
@@ -320,6 +316,23 @@ private fun HighlightEffect(
     } else if (!isSyncedActive) {
         LaunchedEffect(Unit) { latestOnHighlightChanged(HighlightState()) }
     }
+}
+
+/**
+ * Maps the current playback position to a highlight outcome. Returns [HighlightOutcome.Clear]
+ * when playback is off matched content (ads / unmatched / outside the mapped range), otherwise
+ * delegates the cue decision to [TranscriptCueHelper.resolveHighlight].
+ */
+private fun resolveHighlight(
+    entries: List<TranscriptEntry>,
+    posMs: Int,
+    fingerprintTimingManager: FingerprintTimingManager,
+    cachedIndex: Int,
+): HighlightOutcome {
+    val refTime = fingerprintTimingManager.matchedReferenceTime(forPlaybackTimeMs = posMs)
+        ?: return HighlightOutcome.Clear
+    val refTimeMs = (refTime * 1000).toLong()
+    return TranscriptCueHelper.resolveHighlight(entries, refTimeMs, cachedIndex)
 }
 
 @Composable

--- a/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptPage.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptPage.kt
@@ -39,6 +39,7 @@ import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.search.SearchCoordinates
 import kotlin.math.roundToInt
+import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.flowOf
@@ -73,6 +74,8 @@ fun TranscriptPage(
     var highlightState by remember { mutableStateOf(HighlightState()) }
     var hasInitiallyScrolled by remember { mutableStateOf(false) }
     var isAutoScrollSuppressed by remember { mutableStateOf(false) }
+    var pendingSeekPositionMs by remember { mutableStateOf<Int?>(null) }
+    var forceScrollIndex by remember { mutableStateOf<Int?>(null) }
     val playbackState by remember(playbackManager) {
         playbackManager?.playbackStateFlow ?: flowOf(null)
     }.collectAsState(initial = null)
@@ -106,7 +109,18 @@ fun TranscriptPage(
             ) {
                 val tapToSeekHandler: ((TranscriptEntry, Int) -> Unit)? =
                     if (uiState.isSyncedActive && viewModel != null) {
-                        { entry, _ -> viewModel.seekToTranscriptEntry(entry) }
+                        { entry, index ->
+                            val seekTarget = viewModel.seekToTranscriptEntry(entry)
+                            if (seekTarget != null) {
+                                // Highlight the tapped index directly: re-deriving it from the seeked
+                                // position truncates and resolves to the previous contiguous row.
+                                highlightState = HighlightState(entryIndex = index)
+                                if (!isPlaying) {
+                                    pendingSeekPositionMs = seekTarget
+                                    forceScrollIndex = index
+                                }
+                            }
+                        }
                     } else {
                         null
                     }
@@ -161,6 +175,8 @@ fun TranscriptPage(
         uiState = uiState,
         fingerprintTimingManager = fingerprintTimingManager,
         playbackManager = playbackManager,
+        pendingSeekPositionMs = pendingSeekPositionMs,
+        onConsumePendingSeek = { pendingSeekPositionMs = null },
         onHighlightChange = { highlightState = it },
     )
 
@@ -171,6 +187,8 @@ fun TranscriptPage(
         isPlaying = isPlaying,
         isAutoScrollSuppressed = isAutoScrollSuppressed,
         animate = hasInitiallyScrolled,
+        forceScrollIndex = forceScrollIndex,
+        onConsumeForceScroll = { forceScrollIndex = null },
         onScroll = { hasInitiallyScrolled = true },
     )
 
@@ -269,6 +287,8 @@ private fun HighlightEffect(
     uiState: UiState,
     fingerprintTimingManager: FingerprintTimingManager?,
     playbackManager: PlaybackManager?,
+    pendingSeekPositionMs: Int?,
+    onConsumePendingSeek: () -> Unit,
     onHighlightChange: (HighlightState) -> Unit,
 ) {
     if (fingerprintTimingManager == null || playbackManager == null) return
@@ -276,24 +296,22 @@ private fun HighlightEffect(
     val transcript = (uiState.transcriptState as? TranscriptState.Loaded)?.transcript as? Transcript.Text ?: return
     val isSyncedActive = uiState.isSyncedActive
     val latestOnHighlightChanged by rememberUpdatedState(onHighlightChange)
+    val latestPendingSeek by rememberUpdatedState(pendingSeekPositionMs)
+    val latestOnConsumePendingSeek by rememberUpdatedState(onConsumePendingSeek)
 
     val playbackState by remember(playbackManager) {
         playbackManager.playbackStateFlow
     }.collectAsState(initial = null)
     val isPlaying = playbackState?.isPlaying == true
 
-    // Shared between the playing loop and the paused recompute as the cue lookup hint.
-    // A plain holder (not Compose state) so updating it per frame doesn't recompose.
     val cueIndexHolder = remember(transcript.entries) { intArrayOf(0) }
 
     if (isPlaying && isSyncedActive) {
         LaunchedEffect(transcript.entries) {
             cueIndexHolder[0] = 0
+            latestOnConsumePendingSeek()
             var wasHighlighting = false
             latestOnHighlightChanged(HighlightState())
-            // Drive the highlight from the live player position (like iOS reads currentTime()
-            // each tick) rather than playbackState.positionMs, which the player only refreshes
-            // every ~1s — sampling the stale value at 60Hz makes the highlight lag and jump.
             val episode = playbackManager.getCurrentEpisode()
             while (true) {
                 withFrameNanos { }
@@ -321,11 +339,14 @@ private fun HighlightEffect(
             }
         }
     } else if (isSyncedActive) {
-        // Paused but synced: there's no frame loop, so recompute once whenever the position
-        // changes. A tap-to-seek while paused moves the position, so the tapped sentence
-        // highlights immediately — matching iOS, which forces one update while paused.
+        // Paused but synced: no frame loop, so recompute once per position change. Skip the seek
+        // from a paused tap (its row is already highlighted); recompute any other change.
         LaunchedEffect(transcript.entries, playbackState?.positionMs) {
             val posMs = playbackState?.positionMs ?: return@LaunchedEffect
+            if (posMs == latestPendingSeek) {
+                return@LaunchedEffect
+            }
+            latestOnConsumePendingSeek()
             when (val outcome = resolveHighlight(transcript.entries, posMs, fingerprintTimingManager, cueIndexHolder[0])) {
                 is HighlightOutcome.Show -> {
                     cueIndexHolder[0] = outcome.entryIndex
@@ -367,9 +388,12 @@ private fun AutoScrollEffect(
     isPlaying: Boolean,
     isAutoScrollSuppressed: Boolean,
     animate: Boolean,
+    forceScrollIndex: Int?,
+    onConsumeForceScroll: () -> Unit,
     onScroll: () -> Unit,
 ) {
     val latestOnScroll by rememberUpdatedState(onScroll)
+    val latestOnConsumeForceScroll by rememberUpdatedState(onConsumeForceScroll)
     if (highlightIndex != null && isPlaying && !isSearching && !isAutoScrollSuppressed) {
         LaunchedEffect(highlightIndex) {
             if (highlightIndex >= listState.layoutInfo.totalItemsCount) return@LaunchedEffect
@@ -381,6 +405,17 @@ private fun AutoScrollEffect(
                 listState.scrollToItem(highlightIndex, -scrollOffset)
             }
             latestOnScroll()
+        }
+    }
+
+    if (forceScrollIndex != null && !isSearching) {
+        LaunchedEffect(forceScrollIndex) {
+            if (forceScrollIndex < listState.layoutInfo.totalItemsCount) {
+                val viewportHeight = listState.layoutInfo.viewportSize.height
+                val scrollOffset = (viewportHeight * 0.3f).roundToInt()
+                listState.animateScrollToItem(forceScrollIndex, -scrollOffset)
+            }
+            latestOnConsumeForceScroll()
         }
     }
 }
@@ -409,7 +444,7 @@ private fun UserScrollDetectionEffect(
                     dragStartMs = null
                     resumeJob?.cancel()
                     resumeJob = launch {
-                        delay(AUTO_SCROLL_BACK_DELAY_MS)
+                        delay(AUTO_SCROLL_BACK_DELAY_MS.milliseconds)
                         latestOnResumeScroll(manualScrollDurationMs)
                     }
                 }

--- a/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptPage.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptPage.kt
@@ -313,7 +313,24 @@ private fun HighlightEffect(
                 }
             }
         }
-    } else if (!isSyncedActive) {
+    } else if (isSyncedActive) {
+        // Paused but synced: there's no frame loop, so recompute once whenever the position
+        // changes. A tap-to-seek while paused moves the position, so the tapped sentence
+        // highlights immediately — matching iOS, which forces one update while paused.
+        LaunchedEffect(transcript.entries, playbackState?.positionMs) {
+            val posMs = playbackState?.positionMs ?: return@LaunchedEffect
+            when (val outcome = resolveHighlight(transcript.entries, posMs, fingerprintTimingManager, cueIndexHolder[0])) {
+                is HighlightOutcome.Show -> {
+                    cueIndexHolder[0] = outcome.entryIndex
+                    latestOnHighlightChanged(HighlightState(entryIndex = outcome.entryIndex, wordIndex = outcome.wordIndex))
+                }
+
+                HighlightOutcome.Clear -> latestOnHighlightChanged(HighlightState())
+
+                HighlightOutcome.Keep -> Unit
+            }
+        }
+    } else {
         LaunchedEffect(Unit) { latestOnHighlightChanged(HighlightState()) }
     }
 }

--- a/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptPage.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptPage.kt
@@ -297,7 +297,7 @@ private fun HighlightEffect(
                     when (val outcome = resolveHighlight(transcript.entries, posMs, fingerprintTimingManager, cueIndexHolder[0])) {
                         is HighlightOutcome.Show -> {
                             cueIndexHolder[0] = outcome.entryIndex
-                            latestOnHighlightChanged(HighlightState(entryIndex = outcome.entryIndex))
+                            latestOnHighlightChanged(HighlightState(entryIndex = outcome.entryIndex, wordIndex = outcome.wordIndex))
                             wasHighlighting = true
                         }
 
@@ -322,7 +322,7 @@ private fun HighlightEffect(
             when (val outcome = resolveHighlight(transcript.entries, posMs, fingerprintTimingManager, cueIndexHolder[0])) {
                 is HighlightOutcome.Show -> {
                     cueIndexHolder[0] = outcome.entryIndex
-                    latestOnHighlightChanged(HighlightState(entryIndex = outcome.entryIndex))
+                    latestOnHighlightChanged(HighlightState(entryIndex = outcome.entryIndex, wordIndex = outcome.wordIndex))
                 }
 
                 HighlightOutcome.Clear -> latestOnHighlightChanged(HighlightState())
@@ -425,6 +425,7 @@ private fun KeepScreenOnEffect(keepOn: Boolean) {
 
 internal data class HighlightState(
     val entryIndex: Int? = null,
+    val wordIndex: Int? = null,
 )
 
 private const val AUTO_SCROLL_BACK_DELAY_MS = 5000L

--- a/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptPage.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptPage.kt
@@ -291,25 +291,32 @@ private fun HighlightEffect(
             cueIndexHolder[0] = 0
             var wasHighlighting = false
             latestOnHighlightChanged(HighlightState())
+            // Drive the highlight from the live player position (like iOS reads currentTime()
+            // each tick) rather than playbackState.positionMs, which the player only refreshes
+            // every ~1s — sampling the stale value at 60Hz makes the highlight lag and jump.
+            val episode = playbackManager.getCurrentEpisode()
             while (true) {
-                withFrameNanos { _ ->
-                    val posMs = playbackState?.positionMs ?: return@withFrameNanos
-                    when (val outcome = resolveHighlight(transcript.entries, posMs, fingerprintTimingManager, cueIndexHolder[0])) {
-                        is HighlightOutcome.Show -> {
-                            cueIndexHolder[0] = outcome.entryIndex
-                            latestOnHighlightChanged(HighlightState(entryIndex = outcome.entryIndex, wordIndex = outcome.wordIndex))
-                            wasHighlighting = true
-                        }
-
-                        HighlightOutcome.Clear -> {
-                            if (wasHighlighting) {
-                                latestOnHighlightChanged(HighlightState())
-                                wasHighlighting = false
-                            }
-                        }
-
-                        HighlightOutcome.Keep -> Unit
+                withFrameNanos { }
+                val posMs = if (episode != null) {
+                    playbackManager.getCurrentTimeMs(episode)
+                } else {
+                    playbackState?.positionMs ?: continue
+                }
+                when (val outcome = resolveHighlight(transcript.entries, posMs, fingerprintTimingManager, cueIndexHolder[0])) {
+                    is HighlightOutcome.Show -> {
+                        cueIndexHolder[0] = outcome.entryIndex
+                        latestOnHighlightChanged(HighlightState(entryIndex = outcome.entryIndex, wordIndex = outcome.wordIndex))
+                        wasHighlighting = true
                     }
+
+                    HighlightOutcome.Clear -> {
+                        if (wasHighlighting) {
+                            latestOnHighlightChanged(HighlightState())
+                            wasHighlighting = false
+                        }
+                    }
+
+                    HighlightOutcome.Keep -> Unit
                 }
             }
         }

--- a/modules/features/transcripts/src/test/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/TranscriptViewModelTest.kt
+++ b/modules/features/transcripts/src/test/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/TranscriptViewModelTest.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.yield
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -319,8 +320,9 @@ class TranscriptViewModelTest {
         awaitSyncedActive()
         drainEvents()
 
-        viewModel.seekToTranscriptEntry(TranscriptEntry.Text("Line", startTimeMs = 30_000))
+        val seekTarget = viewModel.seekToTranscriptEntry(TranscriptEntry.Text("Line", startTimeMs = 30_000))
 
+        assertEquals(20_000, seekTarget)
         assertEquals(
             SyncedTranscriptsSeekUsedEvent(
                 fromPositionSeconds = 10L,
@@ -345,8 +347,9 @@ class TranscriptViewModelTest {
         awaitSyncedActive()
         drainEvents()
 
-        viewModel.seekToTranscriptEntry(TranscriptEntry.Text("Line", startTimeMs = 30_000))
+        val seekTarget = viewModel.seekToTranscriptEntry(TranscriptEntry.Text("Line", startTimeMs = 30_000))
 
+        assertNull(seekTarget)
         assertEquals(
             SyncedTranscriptsSeekFailedEvent(
                 reason = "mapping_unavailable",

--- a/modules/features/transcripts/src/test/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptCueHelperTest.kt
+++ b/modules/features/transcripts/src/test/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptCueHelperTest.kt
@@ -11,100 +11,6 @@ class TranscriptCueHelperTest {
 
     private fun speaker(name: String = "Speaker") = TranscriptEntry.Speaker(name = name)
 
-    // --- findWordIndex ---
-
-    @Test
-    fun `findWordIndex returns null for empty words`() {
-        val entry = TranscriptEntry.Text("Hello world.", startTimeMs = 0, endTimeMs = 2000)
-        assertNull(TranscriptCueHelper.findWordIndex(entry, 500))
-    }
-
-    @Test
-    fun `findWordIndex finds word within time range`() {
-        val entry = TranscriptEntry.Text(
-            "Hello world.",
-            startTimeMs = 0,
-            endTimeMs = 2000,
-            words = listOf(
-                TranscriptEntry.WordTiming("Hello", 0, 1000, 0, 5),
-                TranscriptEntry.WordTiming("world.", 1000, 2000, 6, 12),
-            ),
-        )
-        assertEquals(0, TranscriptCueHelper.findWordIndex(entry, 500))
-        assertEquals(1, TranscriptCueHelper.findWordIndex(entry, 1500))
-    }
-
-    @Test
-    fun `findWordIndex returns last word when past all words`() {
-        val entry = TranscriptEntry.Text(
-            "Hello world.",
-            startTimeMs = 0,
-            endTimeMs = 2000,
-            words = listOf(
-                TranscriptEntry.WordTiming("Hello", 0, 1000, 0, 5),
-                TranscriptEntry.WordTiming("world.", 1000, 2000, 6, 12),
-            ),
-        )
-        assertEquals(1, TranscriptCueHelper.findWordIndex(entry, 2500))
-    }
-
-    @Test
-    fun `findWordIndex returns word at exact start time`() {
-        val entry = TranscriptEntry.Text(
-            "Hello world.",
-            startTimeMs = 0,
-            endTimeMs = 2000,
-            words = listOf(
-                TranscriptEntry.WordTiming("Hello", 0, 1000, 0, 5),
-                TranscriptEntry.WordTiming("world.", 1000, 2000, 6, 12),
-            ),
-        )
-        assertEquals(0, TranscriptCueHelper.findWordIndex(entry, 0))
-        assertEquals(1, TranscriptCueHelper.findWordIndex(entry, 1000))
-    }
-
-    @Test
-    fun `findWordIndex skips words without timing`() {
-        val entry = TranscriptEntry.Text(
-            "Hello world.",
-            startTimeMs = 0,
-            endTimeMs = 2000,
-            words = listOf(
-                TranscriptEntry.WordTiming("Hello", -1, -1, 0, 5),
-                TranscriptEntry.WordTiming("world.", 1000, 2000, 6, 12),
-            ),
-        )
-        assertEquals(1, TranscriptCueHelper.findWordIndex(entry, 1500))
-    }
-
-    @Test
-    fun `findWordIndex returns null when before all words`() {
-        val entry = TranscriptEntry.Text(
-            "Hello world.",
-            startTimeMs = 1000,
-            endTimeMs = 3000,
-            words = listOf(
-                TranscriptEntry.WordTiming("Hello", 1000, 2000, 0, 5),
-                TranscriptEntry.WordTiming("world.", 2000, 3000, 6, 12),
-            ),
-        )
-        assertNull(TranscriptCueHelper.findWordIndex(entry, 500))
-    }
-
-    @Test
-    fun `findWordIndex returns last passed word in gap between words`() {
-        val entry = TranscriptEntry.Text(
-            "Hello world.",
-            startTimeMs = 0,
-            endTimeMs = 3000,
-            words = listOf(
-                TranscriptEntry.WordTiming("Hello", 0, 1000, 0, 5),
-                TranscriptEntry.WordTiming("world.", 2000, 3000, 6, 12),
-            ),
-        )
-        assertEquals(0, TranscriptCueHelper.findWordIndex(entry, 1500))
-    }
-
     // --- findCueIndex ---
 
     @Test
@@ -293,26 +199,7 @@ class TranscriptCueHelperTest {
             text(2001, 3000),
         )
         assertEquals(
-            HighlightOutcome.Show(entryIndex = 1, wordIndex = null),
-            TranscriptCueHelper.resolveHighlight(entries, refTimeMs = 1500, cachedIndex = 0),
-        )
-    }
-
-    @Test
-    fun `resolveHighlight includes the word index when the cue has word timings`() {
-        val entries = listOf(
-            TranscriptEntry.Text(
-                "Hello world.",
-                startTimeMs = 0,
-                endTimeMs = 2000,
-                words = listOf(
-                    TranscriptEntry.WordTiming("Hello", 0, 1000, 0, 5),
-                    TranscriptEntry.WordTiming("world.", 1000, 2000, 6, 12),
-                ),
-            ),
-        )
-        assertEquals(
-            HighlightOutcome.Show(entryIndex = 0, wordIndex = 1),
+            HighlightOutcome.Show(entryIndex = 1),
             TranscriptCueHelper.resolveHighlight(entries, refTimeMs = 1500, cachedIndex = 0),
         )
     }

--- a/modules/features/transcripts/src/test/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptCueHelperTest.kt
+++ b/modules/features/transcripts/src/test/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptCueHelperTest.kt
@@ -315,4 +315,50 @@ class TranscriptCueHelperTest {
         )
         assertNull(TranscriptCueHelper.findNearestTimedEntry(entries, mid = 1, lo = 0, hi = 2))
     }
+
+    // --- resolveHighlight ---
+
+    @Test
+    fun `resolveHighlight shows the cue containing the reference time`() {
+        val entries = listOf(
+            text(0, 1000),
+            text(1001, 2000),
+            text(2001, 3000),
+        )
+        assertEquals(
+            HighlightOutcome.Show(entryIndex = 1, wordIndex = null),
+            TranscriptCueHelper.resolveHighlight(entries, refTimeMs = 1500, cachedIndex = 0),
+        )
+    }
+
+    @Test
+    fun `resolveHighlight includes the word index when the cue has word timings`() {
+        val entries = listOf(
+            TranscriptEntry.Text(
+                "Hello world.",
+                startTimeMs = 0,
+                endTimeMs = 2000,
+                words = listOf(
+                    TranscriptEntry.WordTiming("Hello", 0, 1000, 0, 5),
+                    TranscriptEntry.WordTiming("world.", 1000, 2000, 6, 12),
+                ),
+            ),
+        )
+        assertEquals(
+            HighlightOutcome.Show(entryIndex = 0, wordIndex = 1),
+            TranscriptCueHelper.resolveHighlight(entries, refTimeMs = 1500, cachedIndex = 0),
+        )
+    }
+
+    @Test
+    fun `resolveHighlight clears when no cue is near the reference time`() {
+        val entries = listOf(
+            text(0, 1000),
+            text(1001, 2000),
+        )
+        assertEquals(
+            HighlightOutcome.Clear,
+            TranscriptCueHelper.resolveHighlight(entries, refTimeMs = 100_000, cachedIndex = 0),
+        )
+    }
 }

--- a/modules/features/transcripts/src/test/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptCueHelperTest.kt
+++ b/modules/features/transcripts/src/test/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptCueHelperTest.kt
@@ -11,6 +11,100 @@ class TranscriptCueHelperTest {
 
     private fun speaker(name: String = "Speaker") = TranscriptEntry.Speaker(name = name)
 
+    // --- findWordIndex ---
+
+    @Test
+    fun `findWordIndex returns null for empty words`() {
+        val entry = TranscriptEntry.Text("Hello world.", startTimeMs = 0, endTimeMs = 2000)
+        assertNull(TranscriptCueHelper.findWordIndex(entry, 500))
+    }
+
+    @Test
+    fun `findWordIndex finds word within time range`() {
+        val entry = TranscriptEntry.Text(
+            "Hello world.",
+            startTimeMs = 0,
+            endTimeMs = 2000,
+            words = listOf(
+                TranscriptEntry.WordTiming("Hello", 0, 1000, 0, 5),
+                TranscriptEntry.WordTiming("world.", 1000, 2000, 6, 12),
+            ),
+        )
+        assertEquals(0, TranscriptCueHelper.findWordIndex(entry, 500))
+        assertEquals(1, TranscriptCueHelper.findWordIndex(entry, 1500))
+    }
+
+    @Test
+    fun `findWordIndex returns last word when past all words`() {
+        val entry = TranscriptEntry.Text(
+            "Hello world.",
+            startTimeMs = 0,
+            endTimeMs = 2000,
+            words = listOf(
+                TranscriptEntry.WordTiming("Hello", 0, 1000, 0, 5),
+                TranscriptEntry.WordTiming("world.", 1000, 2000, 6, 12),
+            ),
+        )
+        assertEquals(1, TranscriptCueHelper.findWordIndex(entry, 2500))
+    }
+
+    @Test
+    fun `findWordIndex returns word at exact start time`() {
+        val entry = TranscriptEntry.Text(
+            "Hello world.",
+            startTimeMs = 0,
+            endTimeMs = 2000,
+            words = listOf(
+                TranscriptEntry.WordTiming("Hello", 0, 1000, 0, 5),
+                TranscriptEntry.WordTiming("world.", 1000, 2000, 6, 12),
+            ),
+        )
+        assertEquals(0, TranscriptCueHelper.findWordIndex(entry, 0))
+        assertEquals(1, TranscriptCueHelper.findWordIndex(entry, 1000))
+    }
+
+    @Test
+    fun `findWordIndex skips words without timing`() {
+        val entry = TranscriptEntry.Text(
+            "Hello world.",
+            startTimeMs = 0,
+            endTimeMs = 2000,
+            words = listOf(
+                TranscriptEntry.WordTiming("Hello", -1, -1, 0, 5),
+                TranscriptEntry.WordTiming("world.", 1000, 2000, 6, 12),
+            ),
+        )
+        assertEquals(1, TranscriptCueHelper.findWordIndex(entry, 1500))
+    }
+
+    @Test
+    fun `findWordIndex returns null when before all words`() {
+        val entry = TranscriptEntry.Text(
+            "Hello world.",
+            startTimeMs = 1000,
+            endTimeMs = 3000,
+            words = listOf(
+                TranscriptEntry.WordTiming("Hello", 1000, 2000, 0, 5),
+                TranscriptEntry.WordTiming("world.", 2000, 3000, 6, 12),
+            ),
+        )
+        assertNull(TranscriptCueHelper.findWordIndex(entry, 500))
+    }
+
+    @Test
+    fun `findWordIndex returns last passed word in gap between words`() {
+        val entry = TranscriptEntry.Text(
+            "Hello world.",
+            startTimeMs = 0,
+            endTimeMs = 3000,
+            words = listOf(
+                TranscriptEntry.WordTiming("Hello", 0, 1000, 0, 5),
+                TranscriptEntry.WordTiming("world.", 2000, 3000, 6, 12),
+            ),
+        )
+        assertEquals(0, TranscriptCueHelper.findWordIndex(entry, 1500))
+    }
+
     // --- findCueIndex ---
 
     @Test
@@ -199,7 +293,26 @@ class TranscriptCueHelperTest {
             text(2001, 3000),
         )
         assertEquals(
-            HighlightOutcome.Show(entryIndex = 1),
+            HighlightOutcome.Show(entryIndex = 1, wordIndex = null),
+            TranscriptCueHelper.resolveHighlight(entries, refTimeMs = 1500, cachedIndex = 0),
+        )
+    }
+
+    @Test
+    fun `resolveHighlight includes the word index when the cue has word timings`() {
+        val entries = listOf(
+            TranscriptEntry.Text(
+                "Hello world.",
+                startTimeMs = 0,
+                endTimeMs = 2000,
+                words = listOf(
+                    TranscriptEntry.WordTiming("Hello", 0, 1000, 0, 5),
+                    TranscriptEntry.WordTiming("world.", 1000, 2000, 6, 12),
+                ),
+            ),
+        )
+        assertEquals(
+            HighlightOutcome.Show(entryIndex = 0, wordIndex = 1),
             TranscriptCueHelper.resolveHighlight(entries, refTimeMs = 1500, cachedIndex = 0),
         )
     }

--- a/modules/features/transcripts/src/test/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptCueHelperTest.kt
+++ b/modules/features/transcripts/src/test/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptCueHelperTest.kt
@@ -233,13 +233,13 @@ class TranscriptCueHelperTest {
     }
 
     @Test
-    fun `findCueBinarySearch falls back to closest entry when no exact range match`() {
+    fun `findCueBinarySearch returns null when refTime falls in a gap between cues`() {
         val entries = listOf(
             text(0, 1000),
             text(5000, 6000),
         )
-        // refTime 4500 is in a gap — should find closest entry within threshold
-        assertEquals(1, TranscriptCueHelper.findCueBinarySearch(entries, 4500))
+        // refTime 4500 is in a gap between cues — strict containment returns null
+        assertNull(TranscriptCueHelper.findCueBinarySearch(entries, 4500))
     }
 
     @Test
@@ -249,39 +249,6 @@ class TranscriptCueHelperTest {
             text(1001, 2000),
         )
         assertNull(TranscriptCueHelper.findCueBinarySearch(entries, 100_000))
-    }
-
-    // --- findClosestTimedEntry ---
-
-    @Test
-    fun `findClosestTimedEntry returns closest entry within threshold`() {
-        val entries = listOf(
-            text(0, 1000),
-            text(2000, 3000),
-            text(5000, 6000),
-        )
-        // refTime 4500 is 1500ms from entry[1].end and 500ms from entry[2].start
-        assertEquals(2, TranscriptCueHelper.findClosestTimedEntry(entries, 4500, around = 1))
-    }
-
-    @Test
-    fun `findClosestTimedEntry returns null when all entries beyond threshold`() {
-        val entries = listOf(
-            text(0, 1000),
-        )
-        // refTime 20000 is 19000ms away — well beyond 5000ms threshold
-        assertNull(TranscriptCueHelper.findClosestTimedEntry(entries, 20_000, around = 0))
-    }
-
-    @Test
-    fun `findClosestTimedEntry skips Speaker entries`() {
-        val entries = listOf(
-            speaker(),
-            speaker(),
-            text(1000, 2000),
-            speaker(),
-        )
-        assertEquals(2, TranscriptCueHelper.findClosestTimedEntry(entries, 1500, around = 1))
     }
 
     // --- findNearestTimedEntry ---
@@ -351,14 +318,40 @@ class TranscriptCueHelperTest {
     }
 
     @Test
-    fun `resolveHighlight clears when no cue is near the reference time`() {
+    fun `resolveHighlight keeps the previous highlight in a gap between cues`() {
+        val entries = listOf(
+            text(0, 1000),
+            text(5000, 6000),
+        )
+        // refTime 4500 sits in the gap between the two cues — hold the previous highlight.
+        assertEquals(
+            HighlightOutcome.Keep,
+            TranscriptCueHelper.resolveHighlight(entries, refTimeMs = 4500, cachedIndex = 0),
+        )
+    }
+
+    @Test
+    fun `resolveHighlight keeps the previous highlight after the last cue`() {
         val entries = listOf(
             text(0, 1000),
             text(1001, 2000),
         )
         assertEquals(
-            HighlightOutcome.Clear,
+            HighlightOutcome.Keep,
             TranscriptCueHelper.resolveHighlight(entries, refTimeMs = 100_000, cachedIndex = 0),
+        )
+    }
+
+    @Test
+    fun `resolveHighlight clears before the first cue`() {
+        val entries = listOf(
+            text(1000, 2000),
+            text(2001, 3000),
+        )
+        // refTime 500 is before the first cue starts — nothing to highlight yet.
+        assertEquals(
+            HighlightOutcome.Clear,
+            TranscriptCueHelper.resolveHighlight(entries, refTimeMs = 500, cachedIndex = 0),
         )
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/TranscripSanitization.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/TranscripSanitization.kt
@@ -82,10 +82,13 @@ private fun List<TranscriptEntry>.joinSplitSentences(): List<TranscriptEntry> {
             val (index, punctuation) = midSentence
 
             val midSentenceText = text.substring(0, index + punctuation.length)
-            val sentence = buildFullSentence(midSentenceText, startTimeMs, endTimeMs)
-
             val leftOverText = text.drop(midSentenceText.length)
-            appendToAccumulator(leftOverText, startTimeMs, endTimeMs)
+
+            // Split the time range at the sentence boundary so the two halves don't overlap.
+            val splitTimeMs = splitTimeMs(startTimeMs, endTimeMs, midSentenceText.length, text.length)
+            val sentence = buildFullSentence(midSentenceText, startTimeMs, splitTimeMs)
+
+            appendToAccumulator(leftOverText, splitTimeMs, endTimeMs)
 
             sentence
         } else {
@@ -215,6 +218,14 @@ private val MidSentencePunctuation = listOf(
 private val MidSentenceQuotationPunctuation = MidSentencePunctuation.flatMap { punctuation ->
     val quotationMarks = listOf("\"", "”", "'", "’")
     quotationMarks.map { quotationMark -> "$punctuation$quotationMark" }
+}
+
+// Splits a cue's time range proportionally at a character position, falling back to [endTimeMs]
+// for untimed/degenerate cues.
+private fun splitTimeMs(startTimeMs: Long, endTimeMs: Long, splitIndex: Int, totalLength: Int): Long {
+    if (startTimeMs < 0 || endTimeMs <= startTimeMs || totalLength <= 0) return endTimeMs
+    val offset = (endTimeMs - startTimeMs) * splitIndex / totalLength
+    return (startTimeMs + offset).coerceIn(startTimeMs, endTimeMs)
 }
 
 private fun TranscriptEntry.Text.recalculateWordOffsets(): TranscriptEntry.Text {

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/TranscriptSanitizationTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/TranscriptSanitizationTest.kt
@@ -257,8 +257,8 @@ class TranscriptSanitizationTest {
 
             assertEquals(
                 buildTranscript {
-                    text("Period.", startTimeMs = 0, endTimeMs = 1000)
-                    text("Unfinished sentence.", startTimeMs = 0, endTimeMs = 2000)
+                    text("Period.", startTimeMs = 0, endTimeMs = 388)
+                    text("Unfinished sentence.", startTimeMs = 388, endTimeMs = 2000)
                 },
                 output.withoutWords(),
             )
@@ -276,7 +276,7 @@ class TranscriptSanitizationTest {
             val secondEntry = output[1] as TranscriptEntry.Text
             assertEquals(
                 listOf(
-                    TranscriptEntry.WordTiming("Unfinished", 0, 1000, 0, 10),
+                    TranscriptEntry.WordTiming("Unfinished", 388, 1000, 0, 10),
                     TranscriptEntry.WordTiming("sentence.", 1000, 2000, 11, 20),
                 ),
                 secondEntry.words,


### PR DESCRIPTION
## Description
This PR aims to bring more closer highlighting to follow the actual audio stream. Some issues have been found during beta testing (pdeCcb-cwm-p2#comment-9187) and I've did a close review and identied some areas of improvement. For example we had a bug on android in the highlighting logic when the cue reached over multiple transcript paragraphs -- that's fixed now. The sampling frequency has been reduced as well so we are now closely following the playback and fingerprints -- similarly to iOS. Lastly, we now highlight the tapped paragraph when the playback is paused.

Fixes PCDROID-613 https://linear.app/a8c/issue/PCDROID-613/improve-android-behavior

## Testing Instructions
1. Open an episode with pre/mid/post-ads (like The Daily)
2. Start listening to the episode with transcripts open and observe highlighting, you should see no (at least much more less gaps) in highlighting as long as ads aren't playing
3. Pause playback
4. Scroll down in transcripts
5. Tap on a paragraph
6. Notice the paragraph gets highlighted
7. Also do a smoke test around highlighting

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
