### PR TITLE
Make search result podcast titles nullable but don't include them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 *   Bug Fixes
     *   Fix crash when scrolling to the top of a long Up Next queue
         ([#5320](https://github.com/Automattic/pocket-casts-android/pull/5320))
+    *   Make sure titles of search results nullable, but don't include such items on results
+        ([#5451](https://github.com/Automattic/pocket-casts-android/pull/5451))
 
 8.14
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 *   Bug Fixes
     *   Fix crash when scrolling to the top of a long Up Next queue
         ([#5320](https://github.com/Automattic/pocket-casts-android/pull/5320))
-    *   Make sure titles of search results nullable, but don't include such items on results
+    *   Improve handling of search results where the podcast title is missing
         ([#5451](https://github.com/Automattic/pocket-casts-android/pull/5451))
 
 8.14

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/search/ImprovedSearchManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/search/ImprovedSearchManagerImpl.kt
@@ -32,15 +32,18 @@ class ImprovedSearchManagerImpl @Inject constructor(
 
     override suspend fun combinedSearch(term: String): List<ImprovedSearchResultItem> {
         val response = combinedSearchService.combinedSearch(CombinedSearchRequest(term))
-        return response.results.map {
+        return response.results.mapNotNull {
             when (it) {
-                is CombinedResult.PodcastResult -> ImprovedSearchResultItem.PodcastItem(
-                    uuid = it.uuid,
-                    title = it.title,
-                    author = it.author.orEmpty(),
-                    isFollowed = false,
-                    isExplicit = it.explicit == true,
-                )
+                is CombinedResult.PodcastResult -> {
+                    val title = it.title?.takeIf { title -> title.isNotBlank() } ?: return@mapNotNull null
+                    ImprovedSearchResultItem.PodcastItem(
+                        uuid = it.uuid,
+                        title = title,
+                        author = it.author.orEmpty(),
+                        isFollowed = false,
+                        isExplicit = it.explicit == true,
+                    )
+                }
 
                 is CombinedResult.EpisodeResult -> ImprovedSearchResultItem.EpisodeItem(
                     uuid = it.uuid,

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/search/ImprovedSearchManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/search/ImprovedSearchManagerImplTest.kt
@@ -1,0 +1,66 @@
+package au.com.shiftyjelly.pocketcasts.repositories.search
+
+import au.com.shiftyjelly.pocketcasts.models.to.ImprovedSearchResultItem
+import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheService
+import au.com.shiftyjelly.pocketcasts.servers.search.AutoCompleteSearchService
+import au.com.shiftyjelly.pocketcasts.servers.search.CombinedResult
+import au.com.shiftyjelly.pocketcasts.servers.search.CombinedSearchResponse
+import java.util.Date
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class ImprovedSearchManagerImplTest {
+    private val autoCompleteSearchService = mock<AutoCompleteSearchService>()
+    private val combinedSearchService = mock<PodcastCacheService>()
+    private val manager = ImprovedSearchManagerImpl(
+        autoCompleteSearchService = autoCompleteSearchService,
+        combinedSearchService = combinedSearchService,
+    )
+
+    @Test
+    fun `combined search drops podcasts with a null title and keeps the rest`() = runTest {
+        whenever(combinedSearchService.combinedSearch(any())) doReturn CombinedSearchResponse(
+            results = listOf(
+                CombinedResult.EpisodeResult(
+                    uuid = "episode-uuid",
+                    title = "Big Sugar",
+                    publishedDate = Date(0),
+                    url = "https://example.com/audio.mp3",
+                    duration = 1114,
+                    podcastUuid = "podcast-uuid",
+                    podcastTitle = "Business Daily",
+                    podcastSlug = "business-daily",
+                ),
+                CombinedResult.PodcastResult(
+                    uuid = "podcast-uuid",
+                    title = "Big Sugar",
+                    author = "Weekday Fun Productions",
+                    slug = "big-sugar",
+                    explicit = false,
+                ),
+                // The offending result from the bug report: a podcast with a null title.
+                CombinedResult.PodcastResult(
+                    uuid = "null-title-uuid",
+                    title = null,
+                    author = "WGTE Public Media",
+                    slug = "untitled",
+                    explicit = false,
+                ),
+            ),
+        )
+
+        val results = manager.combinedSearch("big sugar")
+
+        assertEquals(
+            listOf("episode-uuid", "podcast-uuid"),
+            results.map { it.uuid },
+        )
+        assertTrue(results.none { it is ImprovedSearchResultItem.PodcastItem && it.uuid == "null-title-uuid" })
+    }
+}

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/search/CombinedSearchResponse.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/search/CombinedSearchResponse.kt
@@ -14,7 +14,7 @@ sealed interface CombinedResult {
     @JsonClass(generateAdapter = true)
     data class PodcastResult(
         val uuid: String,
-        val title: String,
+        val title: String? = null,
         val author: String? = "",
         val slug: String,
         val explicit: Boolean? = null,


### PR DESCRIPTION
## Description
It's been reported that search results showing the "Search Failed" screen despite the API responds with HTTP 200. Upon further investigation, it turned out that the `title` propery of some items in the response was `null` that broke our contracts and the app silently threw a `JsonFormatException`.
It's been addressed on the backend since then, but this PR does countermeasures to prevent this ever happening again. Now the title field is nullable, but we filter out results with null titles.

Context: p1781711826353259-slack-C02A333D8LQ

## Testing Instructions
Just review the code please since it's been fixed on the backend

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
