### PR TITLE
[Build] Add Missing Fake `google-services.json` to `tv` Module and Revert #5432

### DIFF
--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -6,12 +6,6 @@ fi
 
 "$(dirname "${BASH_SOURCE[0]}")/restore-cache.sh"
 
-echo "--- :rubygems: Setting up Gems"
-install_gems
-
-echo "--- :closed_lock_with_key: Installing Secrets"
-bundle exec fastlane run configure_apply
-
 echo "--- 🧪 Testing"
 
 ./gradlew testDebugUnitTest

--- a/.buildkite/schedules/dependency-analysis.yml
+++ b/.buildkite/schedules/dependency-analysis.yml
@@ -8,13 +8,6 @@ steps:
   - label: "dependency analysis"
     command: |
       .buildkite/commands/restore-cache.sh
-
-      echo "--- :rubygems: Setting up Gems"
-      install_gems
-
-      echo "--- :closed_lock_with_key: Installing Secrets"
-      bundle exec fastlane run configure_apply
-
       echo "--- 📊 Analyzing"
       ./gradlew buildHealth
     plugins: [$CI_TOOLKIT]

--- a/tv/src/debug/google-services.json
+++ b/tv/src/debug/google-services.json
@@ -1,0 +1,39 @@
+{
+  "project_info": {
+    "project_number": "219484810371",
+    "project_id": "pocket-casts-debug",
+    "storage_bucket": "pocket-casts-debug.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:219484810371:android:7502b372956eb312fc3fb6",
+        "android_client_info": {
+          "package_name": "au.com.shiftyjelly.pocketcasts.debug"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "219484810371-dq2i74pgo8p71n072hjj1fk63mt1vap4.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyBguqVfwriVWjnSqRg50XPfZZH5r1VumNM"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "219484810371-dq2i74pgo8p71n072hjj1fk63mt1vap4.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/tv/src/debugProd/google-services.json
+++ b/tv/src/debugProd/google-services.json
@@ -1,0 +1,39 @@
+{
+  "project_info": {
+    "project_number": "219484810371",
+    "project_id": "pocket-casts-debug",
+    "storage_bucket": "pocket-casts-debug.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:219484810371:android:7502b372956eb312fc3fb6",
+        "android_client_info": {
+          "package_name": "au.com.shiftyjelly.pocketcasts.debug"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "219484810371-dq2i74pgo8p71n072hjj1fk63mt1vap4.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyBguqVfwriVWjnSqRg50XPfZZH5r1VumNM"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "219484810371-dq2i74pgo8p71n072hjj1fk63mt1vap4.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}


### PR DESCRIPTION
Closes: [AINFRA-2502](https://linear.app/a8c/issue/AINFRA-2502)

---

## Description

This is the proper fix for [AINFRA-2502](https://linear.app/a8c/issue/AINFRA-2502), and it supersedes the previously merged [#5432](https://github.com/Automattic/pocket-casts-android/pull/5432), whose root-cause analysis was incorrect (thanks @wzieba for [catching it](https://github.com/Automattic/pocket-casts-android/pull/5432#issuecomment-4741000360)).

### What was actually wrong

The `app`, `automotive`, and `wear` modules each commit a **fake, debug-only** `google-services.json` under their `src/debug` and `src/debugProd` source sets, so the project builds from a fresh clone without any secrets. The `tv` module (added in [#5389](https://github.com/Automattic/pocket-casts-android/pull/5389)) applies the `com.google.gms.google-services` plugin but was **missing** those fakes. As a result, `:tv:processDebugGoogleServices` fails with `File google-services.json is missing.` on any debug build that is not served from the build cache — which is why (cc @sztomek as an fyi):

- the scheduled **Dependency Analysis** job failed (it ran on a cache miss), and
- the project could no longer be built from a **fresh clone**, breaking the open-source contributor experience.

### Why #5432 was wrong

[#5432](https://github.com/Automattic/pocket-casts-android/pull/5432) misattributed the failure to the remote build cache and worked around it by running `configure_apply` (provisioning the real secrets) in the dependency-analysis job. That turned CI green but masked the real cause and made the job depend on secrets, which it conceptually should not — dependency analysis should not require secrets. The same reasoning had earlier been applied to the unit-tests job in #5389.

### What this PR does

1. **Adds the missing fake `google-services.json` to `tv`** (`src/debug` + `src/debugProd`), copied from `app`. `tv` shares the same base `applicationId`, so the `package_name` matches and the Google Services task is satisfied. The project builds from a fresh clone without secrets again. 6aa7f621a6101314ca20d6bb5ff016bed02d9c77
2. **Reverts #5432** — removes `configure_apply` from `.buildkite/schedules/dependency-analysis.yml`. It is no longer needed. 0808f5344bcb76e3e2ca2d9d5947cb9440c8bdb2
3. **Reverts the related #5389 CI addition** — removes `configure_apply` from `.buildkite/commands/run-unit-tests.sh`. That job runs `testDebugUnitTest` (the **debug** variant), now satisfied by the fake config. 1df12ee2966f0a024d57c3faede8659b4c2af725

---

## Testing Instructions

The reliable proof is a fresh clone with no secrets and no build cache:

1. **Fresh-clone build (the real fix):** on a clean checkout without secrets (`configure_apply` not run), build the debug variant:
    ```
    ./gradlew assembleDebug
    ```
    It should succeed, and `:tv:processDebugGoogleServices` should no longer report `File google-services.json is missing.`
2. **Dependency analysis:** run `./gradlew buildHealth` locally and confirm it completes. Then test the scheduled job via the `New Build` button for [PCAndroid](https://buildkite.com/automattic/pocket-casts-android): _(Last successful test run: [17220](https://buildkite.com/automattic/pocket-casts-android/builds/17220))_
    - **Message:** `Trigger Standalone "Dependency Analysis" Job`
    - **Commit:** `HEAD`
    - **Branch:** `build/add-missing-fake-google-services-to-tv-module`
    - **Environment Variables:** `PIPELINE=schedules/dependency-analysis.yml`
    - **Clean Checkout:** unchecked
    - Confirm it passes **without** `configure_apply`.
3. **Unit tests:** confirm the unit-tests CI job (and `./gradlew testDebugUnitTest`) still passes without secrets.

---

## Screenshots or Screencast

N/A — CI and build-configuration change with no user-facing or UI impact.

---

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md _(N/A — CI/build-config change)_
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes _(N/A — pipeline/build config)_
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml` _(N/A)_
- [ ] Any jetpack compose components I added or changed are covered by compose previews _(N/A)_
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics. _(N/A — no analytics changes)_

#### I have tested any UI changes...
_(N/A — this PR contains no UI changes)_