### PR TITLE
Sort Up Next by time remaining instead of duration

### DIFF
--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/UpNextSortType.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/UpNextSortType.kt
@@ -60,9 +60,6 @@ enum class UpNextSortType(
     ;
 
     private companion object {
-        private val BaseEpisode.hasNoDuration get() = duration <= 0
-
-        // Time remaining accounts for how much of the episode has already been played.
-        private val BaseEpisode.timeRemaining get() = duration - playedUpTo
+        private val BaseEpisode.timeRemaining get() = if (hasNoDuration) 0.0 else (duration - playedUpTo).coerceAtLeast(0.0)
     }
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/UpNextSortType.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/UpNextSortType.kt
@@ -37,7 +37,7 @@ enum class UpNextSortType(
     ) {
         // Episodes without a known duration always sort to the bottom.
         private val comparatorDelegate = compareBy<BaseEpisode> { it.hasNoDuration }
-            .thenBy { it.duration }
+            .thenBy { it.timeRemaining }
             .thenBy { it.addedDate }
 
         override fun compare(o1: BaseEpisode, o2: BaseEpisode): Int {
@@ -50,7 +50,7 @@ enum class UpNextSortType(
     ) {
         // Episodes without a known duration always sort to the bottom.
         private val comparatorDelegate = compareBy<BaseEpisode> { it.hasNoDuration }
-            .thenByDescending { it.duration }
+            .thenByDescending { it.timeRemaining }
             .thenBy { it.addedDate }
 
         override fun compare(o1: BaseEpisode, o2: BaseEpisode): Int {
@@ -61,5 +61,8 @@ enum class UpNextSortType(
 
     private companion object {
         private val BaseEpisode.hasNoDuration get() = duration <= 0
+
+        // Time remaining accounts for how much of the episode has already been played.
+        private val BaseEpisode.timeRemaining get() = duration - playedUpTo
     }
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/UpNextSortType.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/UpNextSortType.kt
@@ -60,6 +60,9 @@ enum class UpNextSortType(
     ;
 
     private companion object {
+        private val BaseEpisode.hasNoDuration get() = duration <= 0
+
+        // Time remaining accounts for how much of the episode has already been played.
         private val BaseEpisode.timeRemaining get() = if (hasNoDuration) 0.0 else (duration - playedUpTo).coerceAtLeast(0.0)
     }
 }

--- a/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/type/UpNextSortTypeTest.kt
+++ b/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/type/UpNextSortTypeTest.kt
@@ -111,7 +111,7 @@ class UpNextSortTypeTest {
     }
 
     @Test
-    fun `sort shortest to longest`() {
+    fun `sort shortest to longest by time remaining`() {
         val episodes = listOf(
             PodcastEpisode(
                 uuid = "2",
@@ -172,7 +172,7 @@ class UpNextSortTypeTest {
     }
 
     @Test
-    fun `sort longest to shortest`() {
+    fun `sort longest to shortest by time remaining`() {
         val episodes = listOf(
             PodcastEpisode(
                 uuid = "2",
@@ -228,6 +228,72 @@ class UpNextSortTypeTest {
                     addedDate = Date(2),
                 ),
             ),
+            episodes.sortedWith(UpNextSortType.LongestToShortest),
+        )
+    }
+
+    @Test
+    fun `sort by time remaining accounts for already played time`() {
+        // A long episode that's almost finished has less time remaining than a
+        // short, unplayed one, so it sorts first when shortest to longest.
+        val longAlmostDone = PodcastEpisode(
+            uuid = "longAlmostDone",
+            duration = 3000.0,
+            playedUpTo = 2900.0, // 100 remaining
+            publishedDate = Date(0),
+            addedDate = Date(0),
+        )
+        val shortUnplayed = PodcastEpisode(
+            uuid = "shortUnplayed",
+            duration = 600.0,
+            playedUpTo = 0.0, // 600 remaining
+            publishedDate = Date(0),
+            addedDate = Date(0),
+        )
+        val midHalfPlayed = PodcastEpisode(
+            uuid = "midHalfPlayed",
+            duration = 1800.0,
+            playedUpTo = 900.0, // 900 remaining
+            publishedDate = Date(0),
+            addedDate = Date(0),
+        )
+        val episodes = listOf(longAlmostDone, shortUnplayed, midHalfPlayed)
+
+        assertEquals(
+            listOf(longAlmostDone, shortUnplayed, midHalfPlayed),
+            episodes.sortedWith(UpNextSortType.ShortestToLongest),
+        )
+        assertEquals(
+            listOf(midHalfPlayed, shortUnplayed, longAlmostDone),
+            episodes.sortedWith(UpNextSortType.LongestToShortest),
+        )
+    }
+
+    @Test
+    fun `sort by time remaining breaks ties by added date`() {
+        // Both have 1000 remaining, so the earlier added episode sorts first.
+        val addedEarlier = PodcastEpisode(
+            uuid = "addedEarlier",
+            duration = 1000.0,
+            playedUpTo = 0.0, // 1000 remaining
+            publishedDate = Date(0),
+            addedDate = Date(1),
+        )
+        val addedLater = PodcastEpisode(
+            uuid = "addedLater",
+            duration = 2000.0,
+            playedUpTo = 1000.0, // 1000 remaining
+            publishedDate = Date(0),
+            addedDate = Date(2),
+        )
+        val episodes = listOf(addedLater, addedEarlier)
+
+        assertEquals(
+            listOf(addedEarlier, addedLater),
+            episodes.sortedWith(UpNextSortType.ShortestToLongest),
+        )
+        assertEquals(
+            listOf(addedEarlier, addedLater),
             episodes.sortedWith(UpNextSortType.LongestToShortest),
         )
     }


### PR DESCRIPTION
## Description

Follow-up to #5399, which added the **Shortest to longest** / **Longest to shortest** Up Next sort options ordering by an episode's full duration. To match the [iOS implementation](https://github.com/Automattic/pocket-casts-ios) (`Change to sort by time remaining`), these options now sort by the episode's **time remaining** (`duration - playedUpTo`) rather than its total duration.

Why: time remaining better reflects a play queue — a long episode that's almost finished now sorts ahead of a short, unplayed one, consistent with iOS.

## Testing Instructions

1. Use either the `debug` or `debugProd` variant (the `up_next_duration` flag defaults on for these builds).
2. Add several episodes to Up Next with differing durations, and partially play some so they have different amounts of time remaining (include at least one episode with an unknown/zero duration — the Pocket Casts test podcast has one).
3. Open the Up Next screen and tap the sort option.
4. Select **Shortest to longest** and confirm episodes are ordered by ascending time remaining (a nearly-finished long episode appears before a short unplayed one).
5. Select **Longest to shortest** and confirm the reverse ordering.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

#### I have tested any UI changes...
<!-- No UI changes; ordering logic only. -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
