### PR TITLE
[AI Chapters] Show indicator until fingerprinting settles

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersFragment.kt
@@ -69,6 +69,7 @@ class ChaptersFragment : BaseFragment() {
                     totalChaptersCount = state.chaptersCount,
                     isTogglingChapters = state.isTogglingChapters,
                     showSubscriptionIcon = state.showSubscriptionIcon,
+                    isAligningChapters = state.isAligningChapters,
                     onChapterClick = viewModel::playChapter,
                     onSkipChaptersClick = viewModel::enableTogglingOrUpsell,
                     onSelectionChange = viewModel::selectChapter,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersPage.kt
@@ -3,18 +3,23 @@ package au.com.shiftyjelly.pocketcasts.player.view.chapters
 import android.os.Build
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Divider
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -36,6 +41,7 @@ fun ChaptersPage(
     onSkipChaptersClick: (Boolean) -> Unit,
     isTogglingChapters: Boolean,
     showSubscriptionIcon: Boolean,
+    isAligningChapters: Boolean,
     modifier: Modifier = Modifier,
 ) {
     LazyColumn(
@@ -60,6 +66,11 @@ fun ChaptersPage(
                     isTogglingChapters = isTogglingChapters,
                     showSubscriptionIcon = showSubscriptionIcon,
                 )
+            }
+        }
+        if (isAligningChapters) {
+            item {
+                AligningChaptersRow()
             }
         }
         if (hasGeneratedChapters) {
@@ -91,5 +102,28 @@ fun ChaptersPage(
                 )
             }
         }
+    }
+}
+
+@Composable
+private fun AligningChaptersRow(
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp, vertical = 8.dp),
+    ) {
+        CircularProgressIndicator(
+            color = LocalChaptersTheme.current.headerTitle,
+            strokeWidth = 2.dp,
+            modifier = Modifier.size(16.dp),
+        )
+        TextP50(
+            text = stringResource(LR.string.chapters_aligning),
+            color = LocalChaptersTheme.current.headerTitle,
+        )
     }
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersViewModel.kt
@@ -89,8 +89,6 @@ class ChaptersViewModel @AssistedInject constructor(
         uiState.copy(isAligningChapters = isAligning && uiState.hasGeneratedChapters)
     }
 
-    // Generated chapters are re-timed from the fingerprint map (phone only). Surface the brief
-    // pre-alignment window so the unaligned timestamps aren't shown silently.
     private fun aligningFlow(episodeId: String): Flow<Boolean> = if (appPlatform != AppPlatform.Phone || !FeatureFlag.isEnabled(Feature.SYNCED_TRANSCRIPTS)) {
         flowOf(false)
     } else {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersViewModel.kt
@@ -11,10 +11,14 @@ import au.com.shiftyjelly.pocketcasts.models.to.toChapterOriginType
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.di.IoDispatcher
+import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.FingerprintTimingManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.ChapterManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import au.com.shiftyjelly.pocketcasts.utils.AppPlatform
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import com.automattic.eventhorizon.ChapterLinkClickedEvent
 import com.automattic.eventhorizon.ChaptersShownEvent
 import com.automattic.eventhorizon.ChaptersShownSource
@@ -33,6 +37,7 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -41,6 +46,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -53,6 +59,8 @@ class ChaptersViewModel @AssistedInject constructor(
     private val episodeManager: EpisodeManager,
     private val settings: Settings,
     private val eventHorizon: EventHorizon,
+    private val fingerprintTimingManager: FingerprintTimingManager,
+    private val appPlatform: AppPlatform,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
     private val isTogglingChapters = MutableStateFlow(false)
@@ -77,7 +85,22 @@ class ChaptersViewModel @AssistedInject constructor(
         settings.cachedSubscription.flow,
         isTogglingChapters,
         ::createUiState,
-    )
+    ).combine(aligningFlow(episodeId)) { uiState, isAligning ->
+        uiState.copy(isAligningChapters = isAligning && uiState.hasGeneratedChapters)
+    }
+
+    // Generated chapters are re-timed from the fingerprint map (phone only). Surface the brief
+    // pre-alignment window so the unaligned timestamps aren't shown silently.
+    private fun aligningFlow(episodeId: String): Flow<Boolean> = if (appPlatform != AppPlatform.Phone || !FeatureFlag.isEnabled(Feature.SYNCED_TRANSCRIPTS)) {
+        flowOf(false)
+    } else {
+        fingerprintTimingManager.stateFlow
+            .map { state ->
+                state is FingerprintTimingManager.State.Preparing &&
+                    fingerprintTimingManager.activeEpisodeUuid == episodeId
+            }
+            .distinctUntilChanged()
+    }
 
     private var playChapterJob: Job? = null
 
@@ -257,6 +280,7 @@ class ChaptersViewModel @AssistedInject constructor(
         val isTogglingChapters: Boolean = false,
         val canSkipChapters: Boolean = false,
         val showHeader: Boolean = false,
+        val isAligningChapters: Boolean = false,
     ) {
         val chaptersCount = allChapters.size
         val deselectedChaptersCount get() = allChapters.count { !it.chapter.selected }

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ChaptersViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ChaptersViewModelTest.kt
@@ -16,11 +16,16 @@ import au.com.shiftyjelly.pocketcasts.player.view.chapters.ChaptersViewModel
 import au.com.shiftyjelly.pocketcasts.player.view.chapters.ChaptersViewModel.Mode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
+import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.FingerprintTimingManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.ChapterManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import au.com.shiftyjelly.pocketcasts.sharedtest.InMemoryFeatureFlagRule
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import au.com.shiftyjelly.pocketcasts.utils.AppPlatform
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import com.automattic.eventhorizon.ChapterOriginType
 import com.automattic.eventhorizon.ChaptersShownEvent
 import com.automattic.eventhorizon.ChaptersShownSource
@@ -55,10 +60,14 @@ class ChaptersViewModelTest {
     @get:Rule
     val coroutineRule = MainCoroutineRule(testDispatcher)
 
+    @get:Rule
+    val featureFlagRule = InMemoryFeatureFlagRule()
+
     private val chapterManager = mock<ChapterManager>()
     private val playbackManager = mock<PlaybackManager>()
     private val episodeManager = mock<EpisodeManager>()
     private val settings = mock<Settings>()
+    private val fingerprintTimingManager = mock<FingerprintTimingManager>()
 
     private val episode = PodcastEpisode(uuid = "id", publishedDate = Date())
     private val chapters = Chapters(
@@ -66,6 +75,12 @@ class ChaptersViewModelTest {
             Chapter("1", 0.milliseconds, 100.milliseconds, selected = true, index = 0, uiIndex = 1),
             Chapter("2", 101.milliseconds, 200.milliseconds, selected = true, index = 1, uiIndex = 2),
             Chapter("3", 201.milliseconds, 300.milliseconds, selected = true, index = 2, uiIndex = 3),
+        ),
+    )
+
+    private val generatedChapters = Chapters(
+        listOf(
+            Chapter("1", 0.milliseconds, 100.milliseconds, selected = true, index = 0, uiIndex = 1, origin = ChapterOrigin.Generated),
         ),
     )
 
@@ -81,6 +96,7 @@ class ChaptersViewModelTest {
         giftDays = 0,
     )
     private val subscriptionFlow = MutableStateFlow<Subscription?>(plusSubscription)
+    private val fingerprintStateFlow = MutableStateFlow<FingerprintTimingManager.State>(FingerprintTimingManager.State.Idle)
 
     private val eventSink = TestEventSink()
 
@@ -94,6 +110,8 @@ class ChaptersViewModelTest {
         val userSetting = mock<UserSetting<Subscription?>>()
         whenever(userSetting.flow).thenReturn(subscriptionFlow)
         whenever(settings.cachedSubscription).thenReturn(userSetting)
+        whenever(fingerprintTimingManager.stateFlow).thenReturn(fingerprintStateFlow)
+        whenever(fingerprintTimingManager.activeEpisodeUuid).thenReturn("id")
 
         chaptersViewModel = ChaptersViewModel(
             mode = Mode.Episode(episode.uuid),
@@ -102,6 +120,8 @@ class ChaptersViewModelTest {
             episodeManager = episodeManager,
             settings = settings,
             eventHorizon = EventHorizon(eventSink),
+            fingerprintTimingManager = fingerprintTimingManager,
+            appPlatform = AppPlatform.Phone,
             ioDispatcher = testDispatcher,
         )
     }
@@ -254,6 +274,8 @@ class ChaptersViewModelTest {
             episodeManager = episodeManager,
             settings = settings,
             eventHorizon = EventHorizon(TestEventSink()),
+            fingerprintTimingManager = fingerprintTimingManager,
+            appPlatform = AppPlatform.Phone,
             ioDispatcher = testDispatcher,
         )
 
@@ -318,4 +340,67 @@ class ChaptersViewModelTest {
             assertEquals(Unit, awaitItem())
         }
     }
+
+    @Test
+    fun `shows aligning indicator while preparing generated chapters`() = runTest {
+        FeatureFlag.setEnabled(Feature.SYNCED_TRANSCRIPTS, true)
+        chaptersFlow.value = generatedChapters
+        fingerprintStateFlow.value = FingerprintTimingManager.State.Preparing
+        val viewModel = createViewModel(AppPlatform.Phone)
+
+        viewModel.uiState.test {
+            assertTrue(awaitItem().isAligningChapters)
+
+            fingerprintStateFlow.value = FingerprintTimingManager.State.Active(coverage = 2)
+            assertFalse(awaitItem().isAligningChapters)
+        }
+    }
+
+    @Test
+    fun `does not show aligning indicator for embedded chapters`() = runTest {
+        FeatureFlag.setEnabled(Feature.SYNCED_TRANSCRIPTS, true)
+        fingerprintStateFlow.value = FingerprintTimingManager.State.Preparing
+        val viewModel = createViewModel(AppPlatform.Phone)
+
+        viewModel.uiState.test {
+            assertFalse(awaitItem().isAligningChapters)
+        }
+    }
+
+    @Test
+    fun `does not show aligning indicator when fingerprinting a different episode`() = runTest {
+        FeatureFlag.setEnabled(Feature.SYNCED_TRANSCRIPTS, true)
+        chaptersFlow.value = generatedChapters
+        fingerprintStateFlow.value = FingerprintTimingManager.State.Preparing
+        whenever(fingerprintTimingManager.activeEpisodeUuid).thenReturn("other")
+        val viewModel = createViewModel(AppPlatform.Phone)
+
+        viewModel.uiState.test {
+            assertFalse(awaitItem().isAligningChapters)
+        }
+    }
+
+    @Test
+    fun `does not show aligning indicator on non-phone platforms`() = runTest {
+        FeatureFlag.setEnabled(Feature.SYNCED_TRANSCRIPTS, true)
+        chaptersFlow.value = generatedChapters
+        fingerprintStateFlow.value = FingerprintTimingManager.State.Preparing
+        val viewModel = createViewModel(AppPlatform.Automotive)
+
+        viewModel.uiState.test {
+            assertFalse(awaitItem().isAligningChapters)
+        }
+    }
+
+    private fun createViewModel(appPlatform: AppPlatform) = ChaptersViewModel(
+        mode = Mode.Episode(episode.uuid),
+        chapterManager = chapterManager,
+        playbackManager = playbackManager,
+        episodeManager = episodeManager,
+        settings = settings,
+        eventHorizon = EventHorizon(eventSink),
+        fingerprintTimingManager = fingerprintTimingManager,
+        appPlatform = appPlatform,
+        ioDispatcher = testDispatcher,
+    )
 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -911,6 +911,7 @@ class EpisodeFragment : BaseFragment() {
                                     onSkipChaptersClick = chaptersViewModel::enableTogglingOrUpsell,
                                     isTogglingChapters = chaptersState.isTogglingChapters,
                                     showSubscriptionIcon = chaptersState.showSubscriptionIcon,
+                                    isAligningChapters = chaptersState.isAligningChapters,
                                     modifier = Modifier
                                         .fillMaxWidth()
                                         .heightIn(max = screenHeight),

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -512,6 +512,7 @@
     <string name="number_of_chapters_summary_singular">1 chapter &#x2022; %d hidden</string>
     <string name="skip_chapters_plus_prompt">Preselect chapters and more with Pocket Casts Plus</string>
     <string name="chapters_generated_disclaimer">These chapters are automatically generated and may not be perfectly accurate.</string>
+    <string name="chapters_aligning">Aligning chapters…</string>
     <!-- %1$d is the current selected chapter. %2$d is the total number of chapters. -->
     <string name="chapter_count_summary">%1$d of %2$d</string>
     <plurals name="chapter">


### PR DESCRIPTION
## Description
This is a follow-up of #5445 
Now we show an indicator on the top of the chapters page until fingerprinting settles.

Fixes PCDROID-616 https://linear.app/a8c/issue/PCDROID-616/show-indicator-while-fingerprinting-is-in-progress

## Testing Instructions
1. Find a podcast episode with generated chapters (e.g. The Daily episodes)
2. Open an episode
3. Select the Chapters tab
4. Hit a chapter to play
5. Notice the indicator
6. Wait a bit until the fingerprinting finishes
7. Notice the indicator disappearing

## Screenshots or Screencast 
<img width="1080" height="2400" alt="Screenshot_20260622_160601" src="https://github.com/user-attachments/assets/00e5566c-4891-4067-8867-1c4b2304536c" />


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
 