### PR TITLE
Bump compileSdkVersion to 37

### DIFF
--- a/dependencies.gradle.kts
+++ b/dependencies.gradle.kts
@@ -74,7 +74,7 @@ project.apply {
         set("targetSdkVersionWear", 36)
         set("targetSdkVersionAutomotive", 35)
         set("targetSdkVersionTv", 36)
-        set("compileSdkVersion", 36)
+        set("compileSdkVersion", 37)
         set("testInstrumentationRunner", "androidx.test.runner.AndroidJUnitRunner")
 
         // App Signing


### PR DESCRIPTION
## Description

Now that our CI support it this bumps the `compileSdkVersion` from 36 to 37 in `dependencies.gradle.kts`, so all modules (app, automotive, wear) compile against the Android SDK 37 platform. This keeps the project current with the latest SDK and unblocks use of new APIs and updated lint checks. `targetSdkVersion` values are intentionally left unchanged.

## Testing Instructions

Smoke test the app to confirm no runtime regressions

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

#### I have tested any UI changes...
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack