### PR TITLE
Automotive playback shutdown improvements

### DIFF
--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutoPlaybackService.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutoPlaybackService.kt
@@ -26,7 +26,11 @@ class AutoPlaybackService : PlaybackService() {
 
         // Promote to the Started state so the system reliably delivers onTaskRemoved()
         // even when the car only browses without playing. Does not call startForeground().
-        startService(Intent(this, javaClass))
+        try {
+            startService(Intent(this, javaClass))
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to promote AutoPlaybackService to started state")
+        }
     }
 
     override fun onTaskRemoved(rootIntent: Intent?) {

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutoPlaybackService.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutoPlaybackService.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts
 
+import android.content.Intent
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.coroutines.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackService
@@ -22,6 +23,17 @@ class AutoPlaybackService : PlaybackService() {
         RefreshPodcastsTask.runNow(this, applicationScope)
 
         Timber.d("Auto playback service created")
+
+        // Promote to the Started state so the system reliably delivers onTaskRemoved()
+        // even when the car only browses without playing. Does not call startForeground().
+        startService(Intent(this, javaClass))
+    }
+
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        // OEM automotive requirement: fully terminate on removal from recents.
+        stopMedia()
+        stopSelf()
+        super.onTaskRemoved(rootIntent)
     }
 
     override fun onDestroy() {
@@ -29,5 +41,9 @@ class AutoPlaybackService : PlaybackService() {
         Timber.d("Auto playback service destroyed")
 
         playbackManager.pause(transientLoss = false, sourceView = SourceView.AUTO_PAUSE)
+    }
+
+    private fun stopMedia() {
+        playbackManager.stopAsync(sourceView = SourceView.AUTO_PAUSE)
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -23,7 +23,6 @@ import androidx.media.utils.MediaConstants.PLAYBACK_STATE_EXTRAS_KEY_MEDIA_ID
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.session.CommandButton
 import androidx.media3.session.MediaLibraryService
-import androidx.media3.session.MediaSession
 import androidx.media3.session.SessionCommand
 import androidx.media3.session.SessionError
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
@@ -313,8 +312,14 @@ class MediaSessionManager(
             onSkipBack = { scope.launch { commandMutex.withLock { playbackManager.skipBackwardSuspend() } } },
             onStop = {
                 if (playbackManager.player !is CastPlayer) {
-                    LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Media3: stop → pause")
-                    scope.launch { commandMutex.withLock { playbackManager.pauseSuspend(sourceView = SourceView.MEDIA_BUTTON_BROADCAST_ACTION) } }
+                    if (isAutomotive) {
+                        // On Automotive a stop command must fully tear down playback, not just pause
+                        LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Media3: stop → stop (automotive)")
+                        playbackManager.stopAsync(sourceView = SourceView.MEDIA_BUTTON_BROADCAST_ACTION)
+                    } else {
+                        LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Media3: stop → pause")
+                        scope.launch { commandMutex.withLock { playbackManager.pauseSuspend(sourceView = SourceView.MEDIA_BUTTON_BROADCAST_ACTION) } }
+                    }
                 }
             },
             onPlay = {
@@ -926,6 +931,9 @@ class MediaSessionManager(
 
         if (playbackState.isPlaying || playbackState.transientLoss) {
             mediaSession?.isActive = true
+        } else if (playbackState.state == PlaybackState.State.STOPPED && Util.isAutomotive(context)) {
+            // On Automotive OS a stopped session must not stay active.
+            mediaSession?.isActive = false
         }
 
         if (playbackState.isEmpty || currentEpisode == null) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -315,7 +315,7 @@ class MediaSessionManager(
                     if (isAutomotive) {
                         // On Automotive a stop command must fully tear down playback, not just pause
                         LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Media3: stop → stop (automotive)")
-                        playbackManager.stopAsync(sourceView = SourceView.MEDIA_BUTTON_BROADCAST_ACTION)
+                        scope.launch { commandMutex.withLock { playbackManager.stopSuspend(sourceView = SourceView.MEDIA_BUTTON_BROADCAST_ACTION) } }
                     } else {
                         LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Media3: stop → pause")
                         scope.launch { commandMutex.withLock { playbackManager.pauseSuspend(sourceView = SourceView.MEDIA_BUTTON_BROADCAST_ACTION) } }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -582,6 +582,21 @@ class MediaSessionManager(
 
     @OptIn(UnstableApi::class)
     private fun observeForMedia3Updates() {
+        if (isAutomotive) {
+            playbackManager.playbackStateRelay
+                .map { it.isStopped || it.isError || it.isEmpty }
+                .distinctUntilChanged()
+                // Skip the BehaviorRelay's initial replay so we don't detach the session that
+                // PlaybackService.onCreate just attached; only react to genuine transitions after startup.
+                .skip(1)
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribeBy(
+                    onNext = { inactive -> setMedia3SessionAttached(!inactive) },
+                    onError = { Timber.e(it, "Error observing automotive active state") },
+                )
+                .addTo(disposables)
+        }
+
         val episodeAndState = playbackManager.playbackStateRelay
             .distinctUntilChanged { old, new ->
                 old.episodeUuid == new.episodeUuid &&
@@ -691,6 +706,25 @@ class MediaSessionManager(
                 onError = { Timber.e(it, "Error observing Up Next changes") },
             )
             .addTo(disposables)
+    }
+
+    @OptIn(UnstableApi::class)
+    private fun setMedia3SessionAttached(attached: Boolean) {
+        val session = media3Session ?: return
+        val service = media3Service ?: return
+        try {
+            if (attached) {
+                if (!service.sessions.contains(session)) {
+                    service.addSession(session)
+                }
+            } else {
+                if (service.sessions.contains(session)) {
+                    service.removeSession(session)
+                }
+            }
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to ${if (attached) "add" else "remove"} Media3 session")
+        }
     }
 
     @OptIn(UnstableApi::class)
@@ -931,9 +965,6 @@ class MediaSessionManager(
 
         if (playbackState.isPlaying || playbackState.transientLoss) {
             mediaSession?.isActive = true
-        } else if (playbackState.state == PlaybackState.State.STOPPED && Util.isAutomotive(context)) {
-            // On Automotive OS a stopped session must not stay active.
-            mediaSession?.isActive = false
         }
 
         if (playbackState.isEmpty || currentEpisode == null) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -865,16 +865,20 @@ open class PlaybackManager @Inject constructor(
 
     fun stopAsync(isAudioFocusFailed: Boolean = false, sourceView: SourceView = SourceView.UNKNOWN) {
         launch {
-            if (!isAudioFocusFailed) {
-                trackPlaybackEvent(sourceView) { source, contentType ->
-                    PlaybackStopEvent(
-                        source = source.analyticsValue,
-                        contentType = contentType,
-                    )
-                }
-            }
-            stop()
+            stopSuspend(isAudioFocusFailed, sourceView)
         }
+    }
+
+    suspend fun stopSuspend(isAudioFocusFailed: Boolean = false, sourceView: SourceView = SourceView.UNKNOWN) {
+        if (!isAudioFocusFailed) {
+            trackPlaybackEvent(sourceView) { source, contentType ->
+                PlaybackStopEvent(
+                    source = source.analyticsValue,
+                    contentType = contentType,
+                )
+            }
+        }
+        stop()
     }
 
     suspend fun stop() {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1781,6 +1781,16 @@ open class PlaybackManager @Inject constructor(
         if (player == null || player.isRemote) {
             return
         }
+
+        // On Automotive OS stop playback on a permanent focus loss to deactivate the MediaSession.
+        if (!transientLoss && Util.isAutomotive(application)) {
+            LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Focus lost permanently, stopping playback")
+            focusWasPlaying = null
+            focusManager.giveUpAudioFocus()
+            stopAsync(sourceView = SourceView.AUTO_PAUSE)
+            return
+        }
+
         // if we are playing but can't just reduce the volume then play when focus gained
         val playing = isPlaying()
         if ((playOverNotification == PlayOverNotificationSetting.NEVER) && playing) {


### PR DESCRIPTION
## Description

Improves how the Automotive (AAOS) app shuts down playback so it meets the OEM requirement to fully release audio and terminate the service. Three related changes, all scoped to Automotive (phone and Wear behavior is unchanged).

## Testing Instructions

Use an Android Automotive OS (AAOS) emulator with a `debug`/`debugProd` build. Run `adb logcat | grep -iE "playback"` to observe.

Smoke test the automotive playback. Checking that when the media session stop is issued `adb shell cmd media_session dispatch stop`, that playback stops with the logs message `Media3: stop → stop (automotive)`.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

#### I have tested any UI changes...
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
