### PR TITLE
[HLS] Persist alternate enclosures as server sends them

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AlternateEnclosureDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AlternateEnclosureDaoTest.kt
@@ -1,0 +1,89 @@
+package au.com.shiftyjelly.pocketcasts.models.db
+
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import au.com.shiftyjelly.pocketcasts.models.db.dao.AlternateEnclosureDao
+import au.com.shiftyjelly.pocketcasts.models.db.dao.EpisodeDao
+import au.com.shiftyjelly.pocketcasts.models.di.ModelModule
+import au.com.shiftyjelly.pocketcasts.models.di.addTypeConverters
+import au.com.shiftyjelly.pocketcasts.models.entity.AlternateEnclosureSource
+import au.com.shiftyjelly.pocketcasts.models.entity.EpisodeAlternateEnclosure
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import com.squareup.moshi.Moshi
+import java.util.Date
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AlternateEnclosureDaoTest {
+    private lateinit var testDb: AppDatabase
+    private lateinit var alternateEnclosureDao: AlternateEnclosureDao
+    private lateinit var episodeDao: EpisodeDao
+
+    @Before
+    fun setupDb() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        testDb = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .addTypeConverters(ModelModule.provideRoomConverters(Moshi.Builder().build()))
+            .build()
+        alternateEnclosureDao = testDb.alternateEnclosureDao()
+        episodeDao = testDb.episodeDao()
+    }
+
+    @After
+    fun closeDb() {
+        testDb.close()
+    }
+
+    @Test
+    fun replaceForEpisodeStoresSourcesAndPreservesOrder() = runTest {
+        episodeDao.insertBlocking(PodcastEpisode(uuid = "episode-1", publishedDate = Date()))
+
+        alternateEnclosureDao.replaceForEpisode(
+            "episode-1",
+            listOf(
+                enclosure(position = 1, type = "application/x-mpegURL", uri = "https://example.com/master.m3u8"),
+                enclosure(position = 0, type = "video/mp4", uri = "https://example.com/file-1080.mp4"),
+            ),
+        )
+
+        val stored = alternateEnclosureDao.findByEpisodeUuid("episode-1")
+        assertEquals(listOf(0, 1), stored.map { it.position })
+        assertEquals(listOf("video/mp4", "application/x-mpegURL"), stored.map { it.type })
+        assertEquals("https://example.com/master.m3u8", stored[1].sources.single().uri)
+    }
+
+    @Test
+    fun replaceForEpisodeReplacesPreviousRows() = runTest {
+        episodeDao.insertBlocking(PodcastEpisode(uuid = "episode-1", publishedDate = Date()))
+
+        alternateEnclosureDao.replaceForEpisode("episode-1", listOf(enclosure(0, "video/mp4", "https://example.com/a.mp4")))
+        alternateEnclosureDao.replaceForEpisode("episode-1", listOf(enclosure(0, "application/x-mpegURL", "https://example.com/b.m3u8")))
+
+        val stored = alternateEnclosureDao.findByEpisodeUuid("episode-1")
+        assertEquals(1, stored.size)
+        assertEquals("application/x-mpegURL", stored.single().type)
+    }
+
+    @Test
+    fun deletingEpisodeCascadesToEnclosures() = runTest {
+        episodeDao.insertBlocking(PodcastEpisode(uuid = "episode-1", publishedDate = Date()))
+        alternateEnclosureDao.replaceForEpisode("episode-1", listOf(enclosure(0, "video/mp4", "https://example.com/a.mp4")))
+
+        episodeDao.deleteBlocking(PodcastEpisode(uuid = "episode-1", publishedDate = Date()))
+
+        assertEquals(emptyList<EpisodeAlternateEnclosure>(), alternateEnclosureDao.findByEpisodeUuid("episode-1"))
+    }
+
+    private fun enclosure(position: Int, type: String, uri: String) = EpisodeAlternateEnclosure(
+        episodeUuid = "episode-1",
+        position = position,
+        type = type,
+        sources = listOf(AlternateEnclosureSource(uri = uri)),
+    )
+}

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AlternateEnclosureDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AlternateEnclosureDaoTest.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.models.db
 
+import androidx.media3.common.MimeTypes
 import androidx.room.Room
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
@@ -47,14 +48,14 @@ class AlternateEnclosureDaoTest {
         alternateEnclosureDao.replaceForEpisode(
             "episode-1",
             listOf(
-                enclosure(position = 1, type = "application/x-mpegURL", uri = "https://example.com/master.m3u8"),
+                enclosure(position = 1, type = MimeTypes.APPLICATION_M3U8, uri = "https://example.com/master.m3u8"),
                 enclosure(position = 0, type = "video/mp4", uri = "https://example.com/file-1080.mp4"),
             ),
         )
 
         val stored = alternateEnclosureDao.findByEpisodeUuid("episode-1")
         assertEquals(listOf(0, 1), stored.map { it.position })
-        assertEquals(listOf("video/mp4", "application/x-mpegURL"), stored.map { it.type })
+        assertEquals(listOf("video/mp4", MimeTypes.APPLICATION_M3U8), stored.map { it.type })
         assertEquals("https://example.com/master.m3u8", stored[1].sources.single().uri)
     }
 
@@ -63,11 +64,11 @@ class AlternateEnclosureDaoTest {
         episodeDao.insertBlocking(PodcastEpisode(uuid = "episode-1", publishedDate = Date()))
 
         alternateEnclosureDao.replaceForEpisode("episode-1", listOf(enclosure(0, "video/mp4", "https://example.com/a.mp4")))
-        alternateEnclosureDao.replaceForEpisode("episode-1", listOf(enclosure(0, "application/x-mpegURL", "https://example.com/b.m3u8")))
+        alternateEnclosureDao.replaceForEpisode("episode-1", listOf(enclosure(0, MimeTypes.APPLICATION_M3U8, "https://example.com/b.m3u8")))
 
         val stored = alternateEnclosureDao.findByEpisodeUuid("episode-1")
         assertEquals(1, stored.size)
-        assertEquals("application/x-mpegURL", stored.single().type)
+        assertEquals(MimeTypes.APPLICATION_M3U8, stored.single().type)
     }
 
     @Test

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabaseTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabaseTest.kt
@@ -26,6 +26,7 @@ class AppDatabaseTest {
     companion object {
         private const val TEST_DB = "migration-test"
         private const val MIGRATION_DB = "migration-test-132-133"
+        private const val MIGRATION_DB_133_134 = "migration-test-133-134"
     }
 
     @Rule @JvmField
@@ -144,6 +145,40 @@ class AppDatabaseTest {
         assertEquals("origin column should exist", true, columns.contains("origin"))
         assertEquals("is_embedded column should be dropped", false, columns.contains("is_embedded"))
         assertEquals("is_generated column should be dropped", false, columns.contains("is_generated"))
+    }
+
+    @Test
+    fun migrate133To134CreatesAlternateEnclosuresTable() {
+        migrationTestHelper.createDatabase(MIGRATION_DB_133_134, 133).close()
+
+        val db = migrationTestHelper.runMigrationsAndValidate(MIGRATION_DB_133_134, 134, true, AppDatabase.MIGRATION_133_134)
+
+        val columns = mutableListOf<String>()
+        db.query("PRAGMA table_info(episode_alternate_enclosures)").use { cursor ->
+            val nameIndex = cursor.getColumnIndex("name")
+            while (cursor.moveToNext()) {
+                columns.add(cursor.getString(nameIndex))
+            }
+        }
+        assertEquals(
+            "All enclosure columns should exist",
+            true,
+            columns.containsAll(
+                listOf("_id", "episode_uuid", "position", "type", "bitrate", "length", "height", "width", "lang", "title", "codecs", "is_default", "sources"),
+            ),
+        )
+
+        val indexes = mutableListOf<String>()
+        db.query("PRAGMA index_list(episode_alternate_enclosures)").use { cursor ->
+            val nameIndex = cursor.getColumnIndex("name")
+            while (cursor.moveToNext()) {
+                indexes.add(cursor.getString(nameIndex))
+            }
+        }
+        assertEquals("episode_uuid index should exist", true, indexes.contains("episode_alternate_enclosure_episode_uuid_index"))
+
+        db.execSQL("INSERT INTO episode_alternate_enclosures (episode_uuid, position, type, is_default, sources) VALUES ('episode-1', 0, 'application/x-mpegURL', 1, '[]')")
+        assertEquals(1, countRows(db, "episode_alternate_enclosures"))
     }
 
     private fun countWhere(db: SupportSQLiteDatabase?, tableName: String, where: String): Int {

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabaseTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabaseTest.kt
@@ -164,7 +164,7 @@ class AppDatabaseTest {
             "All enclosure columns should exist",
             true,
             columns.containsAll(
-                listOf("_id", "episode_uuid", "position", "type", "bitrate", "length", "height", "width", "lang", "title", "codecs", "is_default", "sources"),
+                listOf("_id", "episode_uuid", "position", "type", "bitrate", "length", "height", "width", "lang", "title", "codecs", "integrity_type", "integrity_value", "is_default", "sources"),
             ),
         )
 

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabaseTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabaseTest.kt
@@ -282,6 +282,7 @@ class AppDatabaseTest {
                 AppDatabase.MIGRATION_130_131,
                 AppDatabase.MIGRATION_131_132,
                 AppDatabase.MIGRATION_132_133,
+                AppDatabase.MIGRATION_133_134,
             )
             .build()
         // close the database and release any stream resources when the test finishes

--- a/modules/services/model/schemas/au.com.shiftyjelly.pocketcasts.models.db.AppDatabase/134.json
+++ b/modules/services/model/schemas/au.com.shiftyjelly.pocketcasts.models.db.AppDatabase/134.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 134,
-    "identityHash": "bfd49576cd9054a4388a4b598d6c2917",
+    "identityHash": "84388c13e7fd65678b5b16a9a3c1c0e2",
     "entities": [
       {
         "tableName": "bump_stats",
@@ -2242,7 +2242,7 @@
       },
       {
         "tableName": "episode_alternate_enclosures",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `episode_uuid` TEXT NOT NULL, `position` INTEGER NOT NULL, `type` TEXT, `bitrate` INTEGER, `length` INTEGER, `height` INTEGER, `width` INTEGER, `lang` TEXT, `title` TEXT, `codecs` TEXT, `is_default` INTEGER NOT NULL, `sources` TEXT NOT NULL)",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `episode_uuid` TEXT NOT NULL, `position` INTEGER NOT NULL, `type` TEXT, `bitrate` INTEGER, `length` INTEGER, `height` INTEGER, `width` INTEGER, `lang` TEXT, `title` TEXT, `codecs` TEXT, `is_default` INTEGER NOT NULL, `sources` TEXT NOT NULL, FOREIGN KEY(`episode_uuid`) REFERENCES `podcast_episodes`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE )",
         "fields": [
           {
             "fieldPath": "id",
@@ -2331,12 +2331,25 @@
             "orders": [],
             "createSql": "CREATE INDEX IF NOT EXISTS `episode_alternate_enclosure_episode_uuid_index` ON `${TABLE_NAME}` (`episode_uuid`)"
           }
+        ],
+        "foreignKeys": [
+          {
+            "table": "podcast_episodes",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "episode_uuid"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          }
         ]
       }
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'bfd49576cd9054a4388a4b598d6c2917')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '84388c13e7fd65678b5b16a9a3c1c0e2')"
     ]
   }
 }

--- a/modules/services/model/schemas/au.com.shiftyjelly.pocketcasts.models.db.AppDatabase/134.json
+++ b/modules/services/model/schemas/au.com.shiftyjelly.pocketcasts.models.db.AppDatabase/134.json
@@ -1,0 +1,2342 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 134,
+    "identityHash": "bfd49576cd9054a4388a4b598d6c2917",
+    "entities": [
+      {
+        "tableName": "bump_stats",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `event_time` INTEGER NOT NULL, `custom_event_props` TEXT NOT NULL, PRIMARY KEY(`name`, `event_time`, `custom_event_props`))",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventTime",
+            "columnName": "event_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customEventProps",
+            "columnName": "custom_event_props",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "name",
+            "event_time",
+            "custom_event_props"
+          ]
+        }
+      },
+      {
+        "tableName": "bookmarks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `podcast_uuid` TEXT NOT NULL, `episode_uuid` TEXT NOT NULL, `time` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, `title` TEXT NOT NULL, `title_modified` INTEGER, `deleted` INTEGER NOT NULL, `deleted_modified` INTEGER, `ai_title` TEXT, `ai_summary` TEXT, `ai_title_modified` INTEGER, `ai_summary_modified` INTEGER, `sync_status` INTEGER NOT NULL, `clean_title` TEXT NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcast_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeUuid",
+            "columnName": "episode_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timeSecs",
+            "columnName": "time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "titleModified",
+            "columnName": "title_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedModified",
+            "columnName": "deleted_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "aiTitle",
+            "columnName": "ai_title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "aiSummary",
+            "columnName": "ai_summary",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "aiTitleModified",
+            "columnName": "ai_title_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "aiSummaryModified",
+            "columnName": "ai_summary_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "sync_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cleanTitle",
+            "columnName": "clean_title",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "bookmarks_podcast_uuid",
+            "unique": false,
+            "columnNames": [
+              "podcast_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `bookmarks_podcast_uuid` ON `${TABLE_NAME}` (`podcast_uuid`)"
+          }
+        ]
+      },
+      {
+        "tableName": "podcast_episodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `episode_description` TEXT NOT NULL, `published_date` INTEGER NOT NULL, `title` TEXT NOT NULL, `size_in_bytes` INTEGER NOT NULL, `episode_status` INTEGER NOT NULL, `file_type` TEXT, `duration` REAL NOT NULL, `download_url` TEXT, `hls_url` TEXT, `downloaded_file_path` TEXT, `downloaded_error_details` TEXT, `play_error_details` TEXT, `played_up_to` REAL NOT NULL, `playing_status` INTEGER NOT NULL, `podcast_id` TEXT NOT NULL, `added_date` INTEGER NOT NULL, `auto_download_status` INTEGER NOT NULL, `starred` INTEGER NOT NULL, `thumbnail_status` INTEGER NOT NULL, `last_download_attempt_date` INTEGER, `playing_status_modified` INTEGER, `played_up_to_modified` INTEGER, `duration_modified` INTEGER, `starred_modified` INTEGER, `last_starred_date` INTEGER, `archived` INTEGER NOT NULL, `archived_modified` INTEGER, `season` INTEGER, `number` INTEGER, `type` TEXT, `last_playback_interaction_date` INTEGER, `last_playback_interaction_sync_status` INTEGER NOT NULL, `exclude_from_episode_limit` INTEGER NOT NULL, `download_task_id` TEXT, `last_archive_interaction_date` INTEGER, `image_url` TEXT, `deselected_chapters` TEXT NOT NULL, `deselected_chapters_modified` INTEGER, `slug` TEXT NOT NULL, `has_generated_transcript` INTEGER NOT NULL, `cleanTitle` TEXT, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeDescription",
+            "columnName": "episode_description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publishedDate",
+            "columnName": "published_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeInBytes",
+            "columnName": "size_in_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadStatus",
+            "columnName": "episode_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileType",
+            "columnName": "file_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadUrl",
+            "columnName": "download_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "hlsUrl",
+            "columnName": "hls_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadedFilePath",
+            "columnName": "downloaded_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadErrorDetails",
+            "columnName": "downloaded_error_details",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playErrorDetails",
+            "columnName": "play_error_details",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playedUpTo",
+            "columnName": "played_up_to",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playingStatus",
+            "columnName": "playing_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcast_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedDate",
+            "columnName": "added_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoDownloadStatus",
+            "columnName": "auto_download_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isStarred",
+            "columnName": "starred",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailStatus",
+            "columnName": "thumbnail_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDownloadAttemptDate",
+            "columnName": "last_download_attempt_date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "playingStatusModified",
+            "columnName": "playing_status_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "playedUpToModified",
+            "columnName": "played_up_to_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "durationModified",
+            "columnName": "duration_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "starredModified",
+            "columnName": "starred_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastStarredDate",
+            "columnName": "last_starred_date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isArchived",
+            "columnName": "archived",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "archivedModified",
+            "columnName": "archived_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "season",
+            "columnName": "season",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "number",
+            "columnName": "number",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastPlaybackInteraction",
+            "columnName": "last_playback_interaction_date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastPlaybackInteractionSyncStatus",
+            "columnName": "last_playback_interaction_sync_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "excludeFromEpisodeLimit",
+            "columnName": "exclude_from_episode_limit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadTaskId",
+            "columnName": "download_task_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastArchiveInteraction",
+            "columnName": "last_archive_interaction_date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "image_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "deselectedChapters",
+            "columnName": "deselected_chapters",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deselectedChaptersModified",
+            "columnName": "deselected_chapters_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "slug",
+            "columnName": "slug",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasGeneratedTranscript",
+            "columnName": "has_generated_transcript",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cleanTitle",
+            "columnName": "cleanTitle",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "episode_last_download_attempt_date",
+            "unique": false,
+            "columnNames": [
+              "last_download_attempt_date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `episode_last_download_attempt_date` ON `${TABLE_NAME}` (`last_download_attempt_date`)"
+          },
+          {
+            "name": "episode_podcast_id",
+            "unique": false,
+            "columnNames": [
+              "podcast_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `episode_podcast_id` ON `${TABLE_NAME}` (`podcast_id`)"
+          },
+          {
+            "name": "episode_published_date",
+            "unique": false,
+            "columnNames": [
+              "published_date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `episode_published_date` ON `${TABLE_NAME}` (`published_date`)"
+          }
+        ]
+      },
+      {
+        "tableName": "folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `name` TEXT NOT NULL, `color` INTEGER NOT NULL, `added_date` INTEGER NOT NULL, `sort_position` INTEGER NOT NULL, `podcasts_sort_type` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, `sync_modified` INTEGER NOT NULL, `clean_name` TEXT NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedDate",
+            "columnName": "added_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortPosition",
+            "columnName": "sort_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastsSortType",
+            "columnName": "podcasts_sort_type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncModified",
+            "columnName": "sync_modified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cleanName",
+            "columnName": "clean_name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        }
+      },
+      {
+        "tableName": "suggested_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`folder_name` TEXT NOT NULL, `podcast_uuid` TEXT NOT NULL, PRIMARY KEY(`folder_name`, `podcast_uuid`))",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "folder_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcast_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "folder_name",
+            "podcast_uuid"
+          ]
+        }
+      },
+      {
+        "tableName": "playlists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `title` TEXT NOT NULL, `iconId` INTEGER NOT NULL, `sortPosition` INTEGER, `sortId` INTEGER NOT NULL, `manual` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, `syncStatus` INTEGER NOT NULL, `autoDownload` INTEGER NOT NULL, `autoDownloadLimit` INTEGER NOT NULL, `unplayed` INTEGER NOT NULL, `partiallyPlayed` INTEGER NOT NULL, `finished` INTEGER NOT NULL, `downloaded` INTEGER NOT NULL, `notDownloaded` INTEGER NOT NULL, `audioVideo` INTEGER NOT NULL, `filterHours` INTEGER NOT NULL, `starred` INTEGER NOT NULL, `allPodcasts` INTEGER NOT NULL, `podcastUuids` TEXT, `filterDuration` INTEGER NOT NULL, `longerThan` INTEGER NOT NULL, `shorterThan` INTEGER NOT NULL, `showArchivedEpisodes` INTEGER NOT NULL, `clean_title` TEXT NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iconId",
+            "columnName": "iconId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortPosition",
+            "columnName": "sortPosition",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "sortType",
+            "columnName": "sortId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "manual",
+            "columnName": "manual",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "syncStatus",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoDownload",
+            "columnName": "autoDownload",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autodownloadLimit",
+            "columnName": "autoDownloadLimit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unplayed",
+            "columnName": "unplayed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "partiallyPlayed",
+            "columnName": "partiallyPlayed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "finished",
+            "columnName": "finished",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloaded",
+            "columnName": "downloaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notDownloaded",
+            "columnName": "notDownloaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioVideo",
+            "columnName": "audioVideo",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filterHours",
+            "columnName": "filterHours",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "starred",
+            "columnName": "starred",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "allPodcasts",
+            "columnName": "allPodcasts",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastUuids",
+            "columnName": "podcastUuids",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "filterDuration",
+            "columnName": "filterDuration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longerThan",
+            "columnName": "longerThan",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shorterThan",
+            "columnName": "shorterThan",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showArchivedEpisodes",
+            "columnName": "showArchivedEpisodes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cleanTitle",
+            "columnName": "clean_title",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        }
+      },
+      {
+        "tableName": "podcasts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `added_date` INTEGER, `thumbnail_url` TEXT, `title` TEXT NOT NULL, `podcast_url` TEXT, `podcast_description` TEXT NOT NULL, `podcast_html_description` TEXT NOT NULL, `podcast_category` TEXT NOT NULL, `podcast_language` TEXT NOT NULL, `media_type` TEXT, `latest_episode_uuid` TEXT, `author` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, `episodes_sort_order` INTEGER NOT NULL, `episodes_sort_order_modified` INTEGER, `latest_episode_date` INTEGER, `episodes_to_keep` INTEGER NOT NULL, `override_global_settings` INTEGER NOT NULL, `override_global_effects` INTEGER NOT NULL, `override_global_effects_modified` INTEGER, `start_from` INTEGER NOT NULL, `start_from_modified` INTEGER, `playback_speed` REAL NOT NULL, `playback_speed_modified` INTEGER, `volume_boosted` INTEGER NOT NULL, `volume_boosted_modified` INTEGER, `is_folder` INTEGER NOT NULL, `subscribed` INTEGER NOT NULL, `show_notifications` INTEGER NOT NULL, `show_notifications_modified` INTEGER, `auto_download_status` INTEGER NOT NULL, `auto_add_to_up_next` INTEGER NOT NULL, `auto_add_to_up_next_modified` INTEGER, `most_popular_color` INTEGER NOT NULL, `primary_color` INTEGER NOT NULL, `secondary_color` INTEGER NOT NULL, `light_overlay_color` INTEGER NOT NULL, `fab_for_light_bg` INTEGER NOT NULL, `link_for_dark_bg` INTEGER NOT NULL, `link_for_light_bg` INTEGER NOT NULL, `color_version` INTEGER NOT NULL, `color_last_downloaded` INTEGER NOT NULL, `sync_status` INTEGER NOT NULL, `exclude_from_auto_archive` INTEGER NOT NULL, `override_global_archive` INTEGER NOT NULL, `override_global_archive_modified` INTEGER, `auto_archive_played_after` INTEGER NOT NULL, `auto_archive_played_after_modified` INTEGER, `auto_archive_inactive_after` INTEGER NOT NULL, `auto_archive_inactive_after_modified` INTEGER, `auto_archive_episode_limit` INTEGER NOT NULL, `auto_archive_episode_limit_modified` INTEGER, `estimated_next_episode` INTEGER, `episode_frequency` TEXT, `grouping` INTEGER NOT NULL, `grouping_modified` INTEGER, `skip_last` INTEGER NOT NULL, `skip_last_modified` INTEGER, `show_archived` INTEGER NOT NULL, `show_archived_modified` INTEGER, `trim_silence_level` INTEGER NOT NULL, `trim_silence_level_modified` INTEGER, `refresh_available` INTEGER NOT NULL, `folder_uuid` TEXT, `licensing` INTEGER NOT NULL, `isPaid` INTEGER NOT NULL, `is_private` INTEGER NOT NULL, `is_header_expanded` INTEGER NOT NULL DEFAULT 1, `funding_url` TEXT, `slug` TEXT NOT NULL, `explicit` INTEGER, `web_feed` INTEGER NOT NULL DEFAULT 0, `clean_title` TEXT NOT NULL, `bundleuuid` TEXT, `bundlebundleUrl` TEXT, `bundlepaymentUrl` TEXT, `bundledescription` TEXT, `bundlepodcastUuid` TEXT, `bundlepaidType` TEXT, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedDate",
+            "columnName": "added_date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnail_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastUrl",
+            "columnName": "podcast_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "podcastDescription",
+            "columnName": "podcast_description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastHtmlDescription",
+            "columnName": "podcast_html_description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastCategory",
+            "columnName": "podcast_category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastLanguage",
+            "columnName": "podcast_language",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "media_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latestEpisodeUuid",
+            "columnName": "latest_episode_uuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortPosition",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodesSortType",
+            "columnName": "episodes_sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodesSortTypeModified",
+            "columnName": "episodes_sort_order_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "latestEpisodeDate",
+            "columnName": "latest_episode_date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "episodesToKeep",
+            "columnName": "episodes_to_keep",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "overrideGlobalSettings",
+            "columnName": "override_global_settings",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "overrideGlobalEffects",
+            "columnName": "override_global_effects",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "overrideGlobalEffectsModified",
+            "columnName": "override_global_effects_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "startFromSecs",
+            "columnName": "start_from",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startFromModified",
+            "columnName": "start_from_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "playbackSpeed",
+            "columnName": "playback_speed",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playbackSpeedModified",
+            "columnName": "playback_speed_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isVolumeBoosted",
+            "columnName": "volume_boosted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "volumeBoostedModified",
+            "columnName": "volume_boosted_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isFolder",
+            "columnName": "is_folder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSubscribed",
+            "columnName": "subscribed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isShowNotifications",
+            "columnName": "show_notifications",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showNotificationsModified",
+            "columnName": "show_notifications_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "autoDownloadStatus",
+            "columnName": "auto_download_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoAddToUpNext",
+            "columnName": "auto_add_to_up_next",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoAddToUpNextModified",
+            "columnName": "auto_add_to_up_next_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "backgroundColor",
+            "columnName": "most_popular_color",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tintColorForLightBg",
+            "columnName": "primary_color",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tintColorForDarkBg",
+            "columnName": "secondary_color",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fabColorForDarkBg",
+            "columnName": "light_overlay_color",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fabColorForLightBg",
+            "columnName": "fab_for_light_bg",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "linkColorForLightBg",
+            "columnName": "link_for_dark_bg",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "linkColorForDarkBg",
+            "columnName": "link_for_light_bg",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "colorVersion",
+            "columnName": "color_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "colorLastDownloaded",
+            "columnName": "color_last_downloaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "sync_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "excludeFromAutoArchive",
+            "columnName": "exclude_from_auto_archive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "overrideGlobalArchive",
+            "columnName": "override_global_archive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "overrideGlobalArchiveModified",
+            "columnName": "override_global_archive_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "rawAutoArchiveAfterPlaying",
+            "columnName": "auto_archive_played_after",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoArchiveAfterPlayingModified",
+            "columnName": "auto_archive_played_after_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "rawAutoArchiveInactive",
+            "columnName": "auto_archive_inactive_after",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoArchiveInactiveModified",
+            "columnName": "auto_archive_inactive_after_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "rawAutoArchiveEpisodeLimit",
+            "columnName": "auto_archive_episode_limit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoArchiveEpisodeLimitModified",
+            "columnName": "auto_archive_episode_limit_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "estimatedNextEpisode",
+            "columnName": "estimated_next_episode",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "episodeFrequency",
+            "columnName": "episode_frequency",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "grouping",
+            "columnName": "grouping",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "groupingModified",
+            "columnName": "grouping_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "skipLastSecs",
+            "columnName": "skip_last",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skipLastModified",
+            "columnName": "skip_last_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showArchived",
+            "columnName": "show_archived",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showArchivedModified",
+            "columnName": "show_archived_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "trimMode",
+            "columnName": "trim_silence_level",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trimModeModified",
+            "columnName": "trim_silence_level_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "refreshAvailable",
+            "columnName": "refresh_available",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rawFolderUuid",
+            "columnName": "folder_uuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "licensing",
+            "columnName": "licensing",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPaid",
+            "columnName": "isPaid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPrivate",
+            "columnName": "is_private",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isHeaderExpanded",
+            "columnName": "is_header_expanded",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "fundingUrl",
+            "columnName": "funding_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "slug",
+            "columnName": "slug",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "explicit",
+            "columnName": "explicit",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "webFeed",
+            "columnName": "web_feed",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "cleanTitle",
+            "columnName": "clean_title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "singleBundle.uuid",
+            "columnName": "bundleuuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "singleBundle.bundleUrl",
+            "columnName": "bundlebundleUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "singleBundle.paymentUrl",
+            "columnName": "bundlepaymentUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "singleBundle.description",
+            "columnName": "bundledescription",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "singleBundle.podcastUuid",
+            "columnName": "bundlepodcastUuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "singleBundle.paidType",
+            "columnName": "bundlepaidType",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        }
+      },
+      {
+        "tableName": "search_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT, `modified` INTEGER NOT NULL, `term` TEXT, `podcast_uuid` TEXT, `podcast_title` TEXT, `podcast_author` TEXT, `folder_uuid` TEXT, `folder_title` TEXT, `folder_color` INTEGER, `folder_podcastIds` TEXT, `episode_uuid` TEXT, `episode_title` TEXT, `episode_duration` REAL, `episode_podcastUuid` TEXT, `episode_podcastTitle` TEXT, `episode_artworkUrl` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "modified",
+            "columnName": "modified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "term",
+            "columnName": "term",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "podcast.uuid",
+            "columnName": "podcast_uuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "podcast.title",
+            "columnName": "podcast_title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "podcast.author",
+            "columnName": "podcast_author",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "folder.uuid",
+            "columnName": "folder_uuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "folder.title",
+            "columnName": "folder_title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "folder.color",
+            "columnName": "folder_color",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "folder.podcastIds",
+            "columnName": "folder_podcastIds",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "episode.uuid",
+            "columnName": "episode_uuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "episode.title",
+            "columnName": "episode_title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "episode.duration",
+            "columnName": "episode_duration",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "episode.podcastUuid",
+            "columnName": "episode_podcastUuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "episode.podcastTitle",
+            "columnName": "episode_podcastTitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "episode.artworkUrl",
+            "columnName": "episode_artworkUrl",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_search_history_term",
+            "unique": true,
+            "columnNames": [
+              "term"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_search_history_term` ON `${TABLE_NAME}` (`term`)"
+          },
+          {
+            "name": "index_search_history_podcast_uuid",
+            "unique": true,
+            "columnNames": [
+              "podcast_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_search_history_podcast_uuid` ON `${TABLE_NAME}` (`podcast_uuid`)"
+          },
+          {
+            "name": "index_search_history_folder_uuid",
+            "unique": true,
+            "columnNames": [
+              "folder_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_search_history_folder_uuid` ON `${TABLE_NAME}` (`folder_uuid`)"
+          },
+          {
+            "name": "index_search_history_episode_uuid",
+            "unique": true,
+            "columnNames": [
+              "episode_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_search_history_episode_uuid` ON `${TABLE_NAME}` (`episode_uuid`)"
+          }
+        ]
+      },
+      {
+        "tableName": "up_next_changes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT, `type` INTEGER NOT NULL, `uuid` TEXT, `uuids` TEXT, `modified` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "uuids",
+            "columnName": "uuids",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "modified",
+            "columnName": "modified",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        }
+      },
+      {
+        "tableName": "up_next_episodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT, `episodeUuid` TEXT NOT NULL, `position` INTEGER NOT NULL, `playlistId` INTEGER, `title` TEXT NOT NULL, `publishedDate` INTEGER, `downloadUrl` TEXT, `podcastUuid` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "episodeUuid",
+            "columnName": "episodeUuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publishedDate",
+            "columnName": "publishedDate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "downloadUrl",
+            "columnName": "downloadUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcastUuid",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "up_next_episode_episodeUuid",
+            "unique": false,
+            "columnNames": [
+              "episodeUuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `up_next_episode_episodeUuid` ON `${TABLE_NAME}` (`episodeUuid`)"
+          }
+        ]
+      },
+      {
+        "tableName": "user_episodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `published_date` INTEGER NOT NULL, `episode_description` TEXT NOT NULL, `title` TEXT NOT NULL, `size_in_bytes` INTEGER NOT NULL, `episode_status` INTEGER NOT NULL, `file_type` TEXT, `duration` REAL NOT NULL, `download_url` TEXT, `played_up_to` REAL NOT NULL, `playing_status` INTEGER NOT NULL, `added_date` INTEGER NOT NULL, `auto_download_status` INTEGER NOT NULL, `last_download_attempt_date` INTEGER, `archived` INTEGER NOT NULL, `download_task_id` TEXT, `downloaded_file_path` TEXT, `playing_status_modified` INTEGER, `played_up_to_modified` INTEGER, `artwork_url` TEXT, `play_error_details` TEXT, `server_status` INTEGER NOT NULL, `upload_error_details` TEXT, `downloaded_error_details` TEXT, `tint_color_index` INTEGER NOT NULL, `has_custom_image` INTEGER NOT NULL, `upload_task_id` TEXT, `deselected_chapters` TEXT NOT NULL, `deselected_chapters_modified` INTEGER, `clean_title` TEXT NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publishedDate",
+            "columnName": "published_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeDescription",
+            "columnName": "episode_description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeInBytes",
+            "columnName": "size_in_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadStatus",
+            "columnName": "episode_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileType",
+            "columnName": "file_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadUrl",
+            "columnName": "download_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playedUpTo",
+            "columnName": "played_up_to",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playingStatus",
+            "columnName": "playing_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedDate",
+            "columnName": "added_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoDownloadStatus",
+            "columnName": "auto_download_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDownloadAttemptDate",
+            "columnName": "last_download_attempt_date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isArchived",
+            "columnName": "archived",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadTaskId",
+            "columnName": "download_task_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadedFilePath",
+            "columnName": "downloaded_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playingStatusModified",
+            "columnName": "playing_status_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "playedUpToModified",
+            "columnName": "played_up_to_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "artworkUrl",
+            "columnName": "artwork_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playErrorDetails",
+            "columnName": "play_error_details",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "serverStatus",
+            "columnName": "server_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uploadErrorDetails",
+            "columnName": "upload_error_details",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadErrorDetails",
+            "columnName": "downloaded_error_details",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tintColorIndex",
+            "columnName": "tint_color_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasCustomImage",
+            "columnName": "has_custom_image",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uploadTaskId",
+            "columnName": "upload_task_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "deselectedChapters",
+            "columnName": "deselected_chapters",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deselectedChaptersModified",
+            "columnName": "deselected_chapters_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "cleanTitle",
+            "columnName": "clean_title",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "user_episode_last_download_attempt_date",
+            "unique": false,
+            "columnNames": [
+              "last_download_attempt_date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `user_episode_last_download_attempt_date` ON `${TABLE_NAME}` (`last_download_attempt_date`)"
+          },
+          {
+            "name": "user_episode_published_date",
+            "unique": false,
+            "columnNames": [
+              "published_date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `user_episode_published_date` ON `${TABLE_NAME}` (`published_date`)"
+          }
+        ]
+      },
+      {
+        "tableName": "podcast_ratings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`podcast_uuid` TEXT NOT NULL, `average` REAL, `total` INTEGER, PRIMARY KEY(`podcast_uuid`))",
+        "fields": [
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcast_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "average",
+            "columnName": "average",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "total",
+            "columnName": "total",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "podcast_uuid"
+          ]
+        }
+      },
+      {
+        "tableName": "episode_chapters",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`chapter_index` INTEGER NOT NULL, `episode_uuid` TEXT NOT NULL, `start_time` INTEGER NOT NULL, `end_time` INTEGER, `title` TEXT, `image_url` TEXT, `url` TEXT, `origin` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`episode_uuid`, `chapter_index`))",
+        "fields": [
+          {
+            "fieldPath": "index",
+            "columnName": "chapter_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeUuid",
+            "columnName": "episode_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTimeMs",
+            "columnName": "start_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endTimeMs",
+            "columnName": "end_time",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "image_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "origin",
+            "columnName": "origin",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "episode_uuid",
+            "chapter_index"
+          ]
+        },
+        "indices": [
+          {
+            "name": "chapter_episode_uuid_index",
+            "unique": false,
+            "columnNames": [
+              "episode_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `chapter_episode_uuid_index` ON `${TABLE_NAME}` (`episode_uuid`)"
+          }
+        ]
+      },
+      {
+        "tableName": "curated_podcasts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`list_id` TEXT NOT NULL, `list_title` TEXT NOT NULL, `podcast_id` TEXT NOT NULL, `podcast_title` TEXT NOT NULL, `podcast_description` TEXT, PRIMARY KEY(`list_id`, `podcast_id`))",
+        "fields": [
+          {
+            "fieldPath": "listId",
+            "columnName": "list_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listTitle",
+            "columnName": "list_title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastId",
+            "columnName": "podcast_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastTitle",
+            "columnName": "podcast_title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastDescription",
+            "columnName": "podcast_description",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "list_id",
+            "podcast_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "curated_podcasts_list_id_index",
+            "unique": false,
+            "columnNames": [
+              "list_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `curated_podcasts_list_id_index` ON `${TABLE_NAME}` (`list_id`)"
+          },
+          {
+            "name": "curated_podcasts_podcast_id_index",
+            "unique": false,
+            "columnNames": [
+              "podcast_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `curated_podcasts_podcast_id_index` ON `${TABLE_NAME}` (`podcast_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "episode_transcript",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`episode_uuid` TEXT NOT NULL, `url` TEXT NOT NULL, `type` TEXT NOT NULL, `is_generated` INTEGER NOT NULL, `language` TEXT, PRIMARY KEY(`episode_uuid`, `url`))",
+        "fields": [
+          {
+            "fieldPath": "episodeUuid",
+            "columnName": "episode_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isGenerated",
+            "columnName": "is_generated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "episode_uuid",
+            "url"
+          ]
+        }
+      },
+      {
+        "tableName": "user_podcast_ratings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`podcast_uuid` TEXT NOT NULL, `rating` INTEGER NOT NULL, `modified_at` INTEGER NOT NULL, PRIMARY KEY(`podcast_uuid`))",
+        "fields": [
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcast_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "podcast_uuid"
+          ]
+        }
+      },
+      {
+        "tableName": "up_next_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`episodeUuid` TEXT NOT NULL, `position` INTEGER NOT NULL, `playlistId` INTEGER, `title` TEXT NOT NULL, `publishedDate` INTEGER, `downloadUrl` TEXT, `podcastUuid` TEXT, `addedDate` INTEGER NOT NULL, PRIMARY KEY(`episodeUuid`, `addedDate`))",
+        "fields": [
+          {
+            "fieldPath": "episodeUuid",
+            "columnName": "episodeUuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publishedDate",
+            "columnName": "publishedDate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "downloadUrl",
+            "columnName": "downloadUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcastUuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addedDate",
+            "columnName": "addedDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "episodeUuid",
+            "addedDate"
+          ]
+        }
+      },
+      {
+        "tableName": "user_notifications",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`notification_id` INTEGER NOT NULL, `sent_this_week` INTEGER NOT NULL, `last_sent_at` INTEGER NOT NULL, `interacted_at` INTEGER, PRIMARY KEY(`notification_id`))",
+        "fields": [
+          {
+            "fieldPath": "notificationId",
+            "columnName": "notification_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sentThisWeek",
+            "columnName": "sent_this_week",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSentAt",
+            "columnName": "last_sent_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "interactedAt",
+            "columnName": "interacted_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "notification_id"
+          ]
+        }
+      },
+      {
+        "tableName": "user_category_visits",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`category_id` INTEGER NOT NULL, `total_visits` INTEGER NOT NULL, PRIMARY KEY(`category_id`))",
+        "fields": [
+          {
+            "fieldPath": "categoryId",
+            "columnName": "category_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalVisits",
+            "columnName": "total_visits",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "category_id"
+          ]
+        }
+      },
+      {
+        "tableName": "manual_playlist_episodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_uuid` TEXT NOT NULL, `episode_uuid` TEXT NOT NULL, `podcast_uuid` TEXT NOT NULL, `title` TEXT NOT NULL, `added_at` INTEGER NOT NULL, `published_at` INTEGER NOT NULL, `download_url` TEXT, `episode_slug` TEXT NOT NULL, `podcast_slug` TEXT NOT NULL, `sort_position` INTEGER NOT NULL, `is_synced` INTEGER NOT NULL, `clean_title` TEXT NOT NULL, PRIMARY KEY(`playlist_uuid`, `episode_uuid`))",
+        "fields": [
+          {
+            "fieldPath": "playlistUuid",
+            "columnName": "playlist_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeUuid",
+            "columnName": "episode_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcast_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publishedAt",
+            "columnName": "published_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadUrl",
+            "columnName": "download_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "episodeSlug",
+            "columnName": "episode_slug",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastSlug",
+            "columnName": "podcast_slug",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortPosition",
+            "columnName": "sort_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSynced",
+            "columnName": "is_synced",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cleanTitle",
+            "columnName": "clean_title",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_uuid",
+            "episode_uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "manual_playlist_episodes_playlist_uuid_index",
+            "unique": false,
+            "columnNames": [
+              "playlist_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `manual_playlist_episodes_playlist_uuid_index` ON `${TABLE_NAME}` (`playlist_uuid`)"
+          },
+          {
+            "name": "manual_playlist_episodes_episode_uuid_index",
+            "unique": false,
+            "columnNames": [
+              "episode_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `manual_playlist_episodes_episode_uuid_index` ON `${TABLE_NAME}` (`episode_uuid`)"
+          },
+          {
+            "name": "manual_playlist_episodes_podcast_uuid_index",
+            "unique": false,
+            "columnNames": [
+              "podcast_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `manual_playlist_episodes_podcast_uuid_index` ON `${TABLE_NAME}` (`podcast_uuid`)"
+          },
+          {
+            "name": "manual_playlist_episodes_playlist_uuid_is_synced_index",
+            "unique": false,
+            "columnNames": [
+              "playlist_uuid",
+              "is_synced"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `manual_playlist_episodes_playlist_uuid_is_synced_index` ON `${TABLE_NAME}` (`playlist_uuid`, `is_synced`)"
+          }
+        ]
+      },
+      {
+        "tableName": "blaze_ads",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `text` TEXT NOT NULL, `image_url` TEXT NOT NULL, `url_title` TEXT NOT NULL, `url` TEXT NOT NULL, `location` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "image_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "urlTitle",
+            "columnName": "url_title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "location",
+            "columnName": "location",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "playback_stats_events",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `episode_uuid` TEXT NOT NULL, `podcast_uuid` TEXT NOT NULL, `started_at_ms` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeUuid",
+            "columnName": "episode_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcast_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAtMs",
+            "columnName": "started_at_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "playback_stats_events_started_at_ms",
+            "unique": false,
+            "columnNames": [
+              "started_at_ms"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `playback_stats_events_started_at_ms` ON `${TABLE_NAME}` (`started_at_ms`)"
+          }
+        ]
+      },
+      {
+        "tableName": "episode_chats",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`episode_uuid` TEXT NOT NULL, `podcast_uuid` TEXT, `created_at` INTEGER NOT NULL, PRIMARY KEY(`episode_uuid`), FOREIGN KEY(`episode_uuid`) REFERENCES `podcast_episodes`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "episodeUuid",
+            "columnName": "episode_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcast_uuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "episode_uuid"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "podcast_episodes",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "episode_uuid"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "episode_chat_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `episode_uuid` TEXT NOT NULL, `text` TEXT NOT NULL, `role` TEXT NOT NULL, `created_at` INTEGER NOT NULL, `metadata` TEXT, PRIMARY KEY(`uuid`), FOREIGN KEY(`episode_uuid`) REFERENCES `episode_chats`(`episode_uuid`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeUuid",
+            "columnName": "episode_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadata",
+            "columnName": "metadata",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "episode_chat_messages_episode_uuid",
+            "unique": false,
+            "columnNames": [
+              "episode_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `episode_chat_messages_episode_uuid` ON `${TABLE_NAME}` (`episode_uuid`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "episode_chats",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "episode_uuid"
+            ],
+            "referencedColumns": [
+              "episode_uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "episode_alternate_enclosures",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `episode_uuid` TEXT NOT NULL, `position` INTEGER NOT NULL, `type` TEXT, `bitrate` INTEGER, `length` INTEGER, `height` INTEGER, `width` INTEGER, `lang` TEXT, `title` TEXT, `codecs` TEXT, `is_default` INTEGER NOT NULL, `sources` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeUuid",
+            "columnName": "episode_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bitrate",
+            "columnName": "bitrate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "length",
+            "columnName": "length",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "height",
+            "columnName": "height",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "width",
+            "columnName": "width",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lang",
+            "columnName": "lang",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "codecs",
+            "columnName": "codecs",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isDefault",
+            "columnName": "is_default",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sources",
+            "columnName": "sources",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "episode_alternate_enclosure_episode_uuid_index",
+            "unique": false,
+            "columnNames": [
+              "episode_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `episode_alternate_enclosure_episode_uuid_index` ON `${TABLE_NAME}` (`episode_uuid`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'bfd49576cd9054a4388a4b598d6c2917')"
+    ]
+  }
+}

--- a/modules/services/model/schemas/au.com.shiftyjelly.pocketcasts.models.db.AppDatabase/134.json
+++ b/modules/services/model/schemas/au.com.shiftyjelly.pocketcasts.models.db.AppDatabase/134.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 134,
-    "identityHash": "84388c13e7fd65678b5b16a9a3c1c0e2",
+    "identityHash": "cb8685c14833c99c9065eb4bc79d1fe2",
     "entities": [
       {
         "tableName": "bump_stats",
@@ -2242,7 +2242,7 @@
       },
       {
         "tableName": "episode_alternate_enclosures",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `episode_uuid` TEXT NOT NULL, `position` INTEGER NOT NULL, `type` TEXT, `bitrate` INTEGER, `length` INTEGER, `height` INTEGER, `width` INTEGER, `lang` TEXT, `title` TEXT, `codecs` TEXT, `is_default` INTEGER NOT NULL, `sources` TEXT NOT NULL, FOREIGN KEY(`episode_uuid`) REFERENCES `podcast_episodes`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `episode_uuid` TEXT NOT NULL, `position` INTEGER NOT NULL, `type` TEXT, `bitrate` INTEGER, `length` INTEGER, `height` INTEGER, `width` INTEGER, `lang` TEXT, `title` TEXT, `codecs` TEXT, `integrity_type` TEXT, `integrity_value` TEXT, `is_default` INTEGER NOT NULL, `sources` TEXT NOT NULL, FOREIGN KEY(`episode_uuid`) REFERENCES `podcast_episodes`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE )",
         "fields": [
           {
             "fieldPath": "id",
@@ -2303,6 +2303,16 @@
             "affinity": "TEXT"
           },
           {
+            "fieldPath": "integrityType",
+            "columnName": "integrity_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "integrityValue",
+            "columnName": "integrity_value",
+            "affinity": "TEXT"
+          },
+          {
             "fieldPath": "isDefault",
             "columnName": "is_default",
             "affinity": "INTEGER",
@@ -2349,7 +2359,7 @@
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '84388c13e7fd65678b5b16a9a3c1c0e2')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'cb8685c14833c99c9065eb4bc79d1fe2')"
     ]
   }
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/converter/AlternateEnclosureSourcesConverter.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/converter/AlternateEnclosureSourcesConverter.kt
@@ -1,0 +1,22 @@
+package au.com.shiftyjelly.pocketcasts.models.converter
+
+import androidx.room.ProvidedTypeConverter
+import androidx.room.TypeConverter
+import au.com.shiftyjelly.pocketcasts.models.entity.AlternateEnclosureSource
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
+
+@ProvidedTypeConverter
+class AlternateEnclosureSourcesConverter(
+    moshi: Moshi,
+) {
+    private val adapter = moshi.adapter<List<AlternateEnclosureSource>>(
+        Types.newParameterizedType(List::class.java, AlternateEnclosureSource::class.java),
+    )
+
+    @TypeConverter
+    fun toSources(value: String?): List<AlternateEnclosureSource> = value?.let { adapter.fromJson(it) }.orEmpty()
+
+    @TypeConverter
+    fun toJsonString(sources: List<AlternateEnclosureSource>): String = adapter.toJson(sources)
+}

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabase.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabase.kt
@@ -15,6 +15,7 @@ import androidx.room.TypeConverters
 import androidx.room.migration.AutoMigrationSpec
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
+import au.com.shiftyjelly.pocketcasts.models.converter.AlternateEnclosureSourcesConverter
 import au.com.shiftyjelly.pocketcasts.models.converter.AutoArchiveAfterPlayingTypeConverter
 import au.com.shiftyjelly.pocketcasts.models.converter.AutoArchiveInactiveTypeConverter
 import au.com.shiftyjelly.pocketcasts.models.converter.AutoArchiveLimitTypeConverter
@@ -36,6 +37,7 @@ import au.com.shiftyjelly.pocketcasts.models.converter.SafeDateTypeConverter
 import au.com.shiftyjelly.pocketcasts.models.converter.SyncStatusConverter
 import au.com.shiftyjelly.pocketcasts.models.converter.TrimModeTypeConverter
 import au.com.shiftyjelly.pocketcasts.models.converter.UserEpisodeServerStatusConverter
+import au.com.shiftyjelly.pocketcasts.models.db.dao.AlternateEnclosureDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.BlazeAdDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.BookmarkDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.BumpStatsDao
@@ -63,6 +65,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.BlazeAd
 import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
 import au.com.shiftyjelly.pocketcasts.models.entity.ChapterIndices
 import au.com.shiftyjelly.pocketcasts.models.entity.CuratedPodcast
+import au.com.shiftyjelly.pocketcasts.models.entity.EpisodeAlternateEnclosure
 import au.com.shiftyjelly.pocketcasts.models.entity.EpisodeChat
 import au.com.shiftyjelly.pocketcasts.models.entity.EpisodeChatMessage
 import au.com.shiftyjelly.pocketcasts.models.entity.Folder
@@ -115,8 +118,9 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
         PlaybackStatsEvent::class,
         EpisodeChat::class,
         EpisodeChatMessage::class,
+        EpisodeAlternateEnclosure::class,
     ],
-    version = 133,
+    version = 134,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 81, to = 82, spec = AppDatabase.Companion.DeleteSilenceRemovedMigration::class),
@@ -148,6 +152,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
     PlaylistEpisodeSortTypeConverter::class,
     InstantConverter::class,
     BlazeAdLocationConverter::class,
+    AlternateEnclosureSourcesConverter::class,
 )
 abstract class AppDatabase : RoomDatabase() {
     abstract fun podcastDao(): PodcastDao
@@ -172,6 +177,7 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun blazeAdDao(): BlazeAdDao
     abstract fun playbackStatsDao(): PlaybackStatsDao
     abstract fun episodeChatDao(): EpisodeChatDao
+    abstract fun alternateEnclosureDao(): AlternateEnclosureDao
 
     fun databaseFiles() = openHelper.readableDatabase.path?.let {
         listOf(
@@ -1476,6 +1482,11 @@ abstract class AppDatabase : RoomDatabase() {
             database.execSQL("CREATE INDEX IF NOT EXISTS `chapter_episode_uuid_index` ON `episode_chapters` (`episode_uuid`)")
         }
 
+        val MIGRATION_133_134 = addMigration(133, 134) { database ->
+            database.execSQL("CREATE TABLE IF NOT EXISTS `episode_alternate_enclosures` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `episode_uuid` TEXT NOT NULL, `position` INTEGER NOT NULL, `type` TEXT, `bitrate` INTEGER, `length` INTEGER, `height` INTEGER, `width` INTEGER, `lang` TEXT, `title` TEXT, `codecs` TEXT, `is_default` INTEGER NOT NULL, `sources` TEXT NOT NULL)")
+            database.execSQL("CREATE INDEX IF NOT EXISTS `episode_alternate_enclosure_episode_uuid_index` ON `episode_alternate_enclosures` (`episode_uuid`)")
+        }
+
         fun addMigrations(databaseBuilder: Builder<AppDatabase>, context: Context) {
             databaseBuilder.addMigrations(
                 addMigration(1, 2) { },
@@ -1898,6 +1909,7 @@ abstract class AppDatabase : RoomDatabase() {
                 MIGRATION_130_131,
                 MIGRATION_131_132,
                 MIGRATION_132_133,
+                MIGRATION_133_134,
             )
         }
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabase.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabase.kt
@@ -1483,7 +1483,7 @@ abstract class AppDatabase : RoomDatabase() {
         }
 
         val MIGRATION_133_134 = addMigration(133, 134) { database ->
-            database.execSQL("CREATE TABLE IF NOT EXISTS `episode_alternate_enclosures` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `episode_uuid` TEXT NOT NULL, `position` INTEGER NOT NULL, `type` TEXT, `bitrate` INTEGER, `length` INTEGER, `height` INTEGER, `width` INTEGER, `lang` TEXT, `title` TEXT, `codecs` TEXT, `is_default` INTEGER NOT NULL, `sources` TEXT NOT NULL, FOREIGN KEY(`episode_uuid`) REFERENCES `podcast_episodes`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE )")
+            database.execSQL("CREATE TABLE IF NOT EXISTS `episode_alternate_enclosures` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `episode_uuid` TEXT NOT NULL, `position` INTEGER NOT NULL, `type` TEXT, `bitrate` INTEGER, `length` INTEGER, `height` INTEGER, `width` INTEGER, `lang` TEXT, `title` TEXT, `codecs` TEXT, `integrity_type` TEXT, `integrity_value` TEXT, `is_default` INTEGER NOT NULL, `sources` TEXT NOT NULL, FOREIGN KEY(`episode_uuid`) REFERENCES `podcast_episodes`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE )")
             database.execSQL("CREATE INDEX IF NOT EXISTS `episode_alternate_enclosure_episode_uuid_index` ON `episode_alternate_enclosures` (`episode_uuid`)")
         }
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabase.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabase.kt
@@ -1483,7 +1483,7 @@ abstract class AppDatabase : RoomDatabase() {
         }
 
         val MIGRATION_133_134 = addMigration(133, 134) { database ->
-            database.execSQL("CREATE TABLE IF NOT EXISTS `episode_alternate_enclosures` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `episode_uuid` TEXT NOT NULL, `position` INTEGER NOT NULL, `type` TEXT, `bitrate` INTEGER, `length` INTEGER, `height` INTEGER, `width` INTEGER, `lang` TEXT, `title` TEXT, `codecs` TEXT, `is_default` INTEGER NOT NULL, `sources` TEXT NOT NULL)")
+            database.execSQL("CREATE TABLE IF NOT EXISTS `episode_alternate_enclosures` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `episode_uuid` TEXT NOT NULL, `position` INTEGER NOT NULL, `type` TEXT, `bitrate` INTEGER, `length` INTEGER, `height` INTEGER, `width` INTEGER, `lang` TEXT, `title` TEXT, `codecs` TEXT, `is_default` INTEGER NOT NULL, `sources` TEXT NOT NULL, FOREIGN KEY(`episode_uuid`) REFERENCES `podcast_episodes`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE )")
             database.execSQL("CREATE INDEX IF NOT EXISTS `episode_alternate_enclosure_episode_uuid_index` ON `episode_alternate_enclosures` (`episode_uuid`)")
         }
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/AlternateEnclosureDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/AlternateEnclosureDao.kt
@@ -28,4 +28,18 @@ abstract class AlternateEnclosureDao {
             insertAll(enclosures)
         }
     }
+
+    @Insert
+    protected abstract fun insertAllBlocking(enclosures: List<EpisodeAlternateEnclosure>)
+
+    @Query("DELETE FROM episode_alternate_enclosures WHERE episode_uuid IS :episodeUuid")
+    protected abstract fun deleteForEpisodeBlocking(episodeUuid: String)
+
+    @Transaction
+    open fun replaceForEpisodeBlocking(episodeUuid: String, enclosures: List<EpisodeAlternateEnclosure>) {
+        deleteForEpisodeBlocking(episodeUuid)
+        if (enclosures.isNotEmpty()) {
+            insertAllBlocking(enclosures)
+        }
+    }
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/AlternateEnclosureDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/AlternateEnclosureDao.kt
@@ -1,0 +1,31 @@
+package au.com.shiftyjelly.pocketcasts.models.db.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import androidx.room.Transaction
+import au.com.shiftyjelly.pocketcasts.models.entity.EpisodeAlternateEnclosure
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+abstract class AlternateEnclosureDao {
+    @Query("SELECT * FROM episode_alternate_enclosures WHERE episode_uuid IS :episodeUuid ORDER BY position ASC")
+    abstract suspend fun findByEpisodeUuid(episodeUuid: String): List<EpisodeAlternateEnclosure>
+
+    @Query("SELECT * FROM episode_alternate_enclosures WHERE episode_uuid IS :episodeUuid ORDER BY position ASC")
+    abstract fun observeByEpisodeUuid(episodeUuid: String): Flow<List<EpisodeAlternateEnclosure>>
+
+    @Insert
+    protected abstract suspend fun insertAll(enclosures: List<EpisodeAlternateEnclosure>)
+
+    @Query("DELETE FROM episode_alternate_enclosures WHERE episode_uuid IS :episodeUuid")
+    protected abstract suspend fun deleteForEpisode(episodeUuid: String)
+
+    @Transaction
+    open suspend fun replaceForEpisode(episodeUuid: String, enclosures: List<EpisodeAlternateEnclosure>) {
+        deleteForEpisode(episodeUuid)
+        if (enclosures.isNotEmpty()) {
+            insertAll(enclosures)
+        }
+    }
+}

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
@@ -535,6 +535,7 @@ abstract class PlaylistDao {
           podcast_episode.file_type AS p_file_type,
           podcast_episode.duration AS p_duration,
           podcast_episode.download_url AS p_download_url,
+          podcast_episode.hls_url AS p_hls_url,
           podcast_episode.downloaded_file_path AS p_downloaded_file_path,
           podcast_episode.downloaded_error_details AS p_downloaded_error_details,
           podcast_episode.play_error_details AS p_play_error_details,

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/di/ModelModule.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/di/ModelModule.kt
@@ -3,7 +3,9 @@ package au.com.shiftyjelly.pocketcasts.models.di
 import android.app.Application
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import au.com.shiftyjelly.pocketcasts.models.converter.AlternateEnclosureSourcesConverter
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
+import au.com.shiftyjelly.pocketcasts.models.db.dao.AlternateEnclosureDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.ChapterDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.EndOfYearDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.EpisodeChatDao
@@ -34,6 +36,7 @@ object ModelModule {
     fun provideRoomConverters(moshi: Moshi): List<Any> {
         return listOf(
             AnonymousBumpStat.CustomEventPropsTypeConverter(moshi),
+            AlternateEnclosureSourcesConverter(moshi),
         )
     }
 
@@ -87,6 +90,9 @@ object ModelModule {
 
     @Provides
     fun provideEpisodeChatDao(database: AppDatabase): EpisodeChatDao = database.episodeChatDao()
+
+    @Provides
+    fun provideAlternateEnclosureDao(database: AppDatabase): AlternateEnclosureDao = database.alternateEnclosureDao()
 }
 
 @Qualifier

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/BaseEpisode.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/BaseEpisode.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.models.entity
 
+import androidx.media3.common.MimeTypes
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeDownloadStatus
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
@@ -19,7 +20,7 @@ sealed interface BaseEpisode {
         }
 
         private fun isHlsMimeType(type: String?): Boolean {
-            return type.equals("application/x-mpegURL", ignoreCase = true) ||
+            return type.equals(MimeTypes.APPLICATION_M3U8, ignoreCase = true) ||
                 type.equals("application/vnd.apple.mpegurl", ignoreCase = true)
         }
 
@@ -186,7 +187,7 @@ sealed interface BaseEpisode {
             fileType.equals("audio/x-m4p", ignoreCase = true) -> return ".m4p"
             fileType.equals("audio/ogg", ignoreCase = true) -> return ".ogg"
             fileType.equals("audio/x-ms-wma", ignoreCase = true) -> return ".wma"
-            fileType.equals("application/x-mpegURL", ignoreCase = true) -> return ".m3u8"
+            fileType.equals(MimeTypes.APPLICATION_M3U8, ignoreCase = true) -> return ".m3u8"
             fileType.equals("application/vnd.apple.mpegurl", ignoreCase = true) -> return ".m3u8"
             else -> return if (fileType.startsWith("video/")) ".mp4" else ".mp3"
         }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/EpisodeAlternateEnclosure.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/EpisodeAlternateEnclosure.kt
@@ -1,0 +1,38 @@
+package au.com.shiftyjelly.pocketcasts.models.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+/** A Podcasting 2.0 `<podcast:alternateEnclosure>` as sent by the server, stored verbatim per episode. */
+@Entity(
+    tableName = "episode_alternate_enclosures",
+    indices = [
+        Index(name = "episode_alternate_enclosure_episode_uuid_index", value = ["episode_uuid"]),
+    ],
+)
+data class EpisodeAlternateEnclosure(
+    @PrimaryKey(autoGenerate = true) @ColumnInfo(name = "_id") val id: Long = 0,
+    @ColumnInfo(name = "episode_uuid") val episodeUuid: String,
+    @ColumnInfo(name = "position") val position: Int,
+    @ColumnInfo(name = "type") val type: String? = null,
+    @ColumnInfo(name = "bitrate") val bitrate: Long? = null,
+    @ColumnInfo(name = "length") val length: Long? = null,
+    @ColumnInfo(name = "height") val height: Int? = null,
+    @ColumnInfo(name = "width") val width: Int? = null,
+    @ColumnInfo(name = "lang") val lang: String? = null,
+    @ColumnInfo(name = "title") val title: String? = null,
+    @ColumnInfo(name = "codecs") val codecs: String? = null,
+    @ColumnInfo(name = "is_default") val isDefault: Boolean = false,
+    @ColumnInfo(name = "sources") val sources: List<AlternateEnclosureSource> = emptyList(),
+)
+
+/** One `<source>` of an [EpisodeAlternateEnclosure]; multiple sources mirror the same rendition. */
+@JsonClass(generateAdapter = true)
+data class AlternateEnclosureSource(
+    @Json(name = "uri") val uri: String,
+    @Json(name = "content_type") val contentType: String? = null,
+)

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/EpisodeAlternateEnclosure.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/EpisodeAlternateEnclosure.kt
@@ -35,6 +35,8 @@ data class EpisodeAlternateEnclosure(
     @ColumnInfo(name = "lang") val lang: String? = null,
     @ColumnInfo(name = "title") val title: String? = null,
     @ColumnInfo(name = "codecs") val codecs: String? = null,
+    @ColumnInfo(name = "integrity_type") val integrityType: String? = null,
+    @ColumnInfo(name = "integrity_value") val integrityValue: String? = null,
     @ColumnInfo(name = "is_default") val isDefault: Boolean = false,
     @ColumnInfo(name = "sources") val sources: List<AlternateEnclosureSource> = emptyList(),
 )

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/EpisodeAlternateEnclosure.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/EpisodeAlternateEnclosure.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.models.entity
 
 import androidx.room.ColumnInfo
 import androidx.room.Entity
+import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
 import com.squareup.moshi.Json
@@ -10,6 +11,14 @@ import com.squareup.moshi.JsonClass
 /** A Podcasting 2.0 `<podcast:alternateEnclosure>` as sent by the server, stored verbatim per episode. */
 @Entity(
     tableName = "episode_alternate_enclosures",
+    foreignKeys = [
+        ForeignKey(
+            entity = PodcastEpisode::class,
+            parentColumns = ["uuid"],
+            childColumns = ["episode_uuid"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
     indices = [
         Index(name = "episode_alternate_enclosure_episode_uuid_index", value = ["episode_uuid"]),
     ],

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/PodcastEpisode.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/PodcastEpisode.kt
@@ -123,6 +123,10 @@ data class PodcastEpisode(
     @Ignore
     override var playing: Boolean = false
 
+    /** Parsed from the server response and persisted separately into the episode_alternate_enclosures table. */
+    @Ignore
+    var alternateEnclosures: List<EpisodeAlternateEnclosure> = emptyList()
+
     val playedPercentage: Int
         get() {
             return if (isFinished) {

--- a/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/converter/AlternateEnclosureSourcesConverterTest.kt
+++ b/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/converter/AlternateEnclosureSourcesConverterTest.kt
@@ -1,0 +1,32 @@
+package au.com.shiftyjelly.pocketcasts.models.converter
+
+import au.com.shiftyjelly.pocketcasts.models.entity.AlternateEnclosureSource
+import com.squareup.moshi.Moshi
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AlternateEnclosureSourcesConverterTest {
+    private val converter = AlternateEnclosureSourcesConverter(Moshi.Builder().build())
+
+    @Test
+    fun `round trips sources`() {
+        val sources = listOf(
+            AlternateEnclosureSource(uri = "https://example.com/master.m3u8", contentType = "application/x-mpegURL"),
+            AlternateEnclosureSource(uri = "ipfs://QmManifest", contentType = null),
+        )
+
+        val restored = converter.toSources(converter.toJsonString(sources))
+
+        assertEquals(sources, restored)
+    }
+
+    @Test
+    fun `round trips empty list`() {
+        assertEquals(emptyList<AlternateEnclosureSource>(), converter.toSources(converter.toJsonString(emptyList())))
+    }
+
+    @Test
+    fun `null string maps to empty list`() {
+        assertEquals(emptyList<AlternateEnclosureSource>(), converter.toSources(null))
+    }
+}

--- a/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/converter/AlternateEnclosureSourcesConverterTest.kt
+++ b/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/converter/AlternateEnclosureSourcesConverterTest.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.models.converter
 
+import androidx.media3.common.MimeTypes
 import au.com.shiftyjelly.pocketcasts.models.entity.AlternateEnclosureSource
 import com.squareup.moshi.Moshi
 import org.junit.Assert.assertEquals
@@ -11,7 +12,7 @@ class AlternateEnclosureSourcesConverterTest {
     @Test
     fun `round trips sources`() {
         val sources = listOf(
-            AlternateEnclosureSource(uri = "https://example.com/master.m3u8", contentType = "application/x-mpegURL"),
+            AlternateEnclosureSource(uri = "https://example.com/master.m3u8", contentType = MimeTypes.APPLICATION_M3U8),
             AlternateEnclosureSource(uri = "ipfs://QmManifest", contentType = null),
         )
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SubscribeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SubscribeManager.kt
@@ -59,6 +59,7 @@ class SubscribeManager @Inject constructor(
     private val uuidsInQueue = HashSet<String>()
     private val podcastDao = appDatabase.podcastDao()
     private val episodeDao = appDatabase.episodeDao()
+    private val alternateEnclosureDao = appDatabase.alternateEnclosureDao()
 
     data class PodcastSubscribe(val podcastUuid: String, val sync: Boolean, val shouldAutoDownload: Boolean)
 
@@ -250,6 +251,12 @@ class SubscribeManager @Inject constructor(
         return Completable.fromAction {
             podcast.episodes.chunked(250).forEach { episodes ->
                 episodeDao.insertAllBlocking(episodes)
+            }
+            // Store alternate enclosures after the episode rows exist (cascading FK on episode_uuid).
+            podcast.episodes.forEach { episode ->
+                if (episode.alternateEnclosures.isNotEmpty()) {
+                    alternateEnclosureDao.replaceForEpisodeBlocking(episode.uuid, episode.alternateEnclosures)
+                }
             }
         }
             // make sure the podcast has the latest episode uuid

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
@@ -297,6 +297,7 @@ class RefreshPodcastsThread(
         val entryPoint = getEntryPoint()
         val podcastManager = entryPoint.podcastManager()
         val episodeManager = entryPoint.episodeManager()
+        val alternateEnclosureDao = entryPoint.appDatabase().alternateEnclosureDao()
 
         var newEpisodeCount = 0
 
@@ -316,6 +317,7 @@ class RefreshPodcastsThread(
             for (episode in episodes) {
                 episode.addedDate = addedDate
             }
+            val enclosuresByUuid = episodes.associate { it.uuid to it.alternateEnclosures }
             episodes = episodeManager.addBlocking(episodes, podcast.uuid, downloadMetaData)
 
             if (episodes.isEmpty()) {
@@ -328,6 +330,10 @@ class RefreshPodcastsThread(
                 podcastManager.updateLatestEpisodeBlocking(podcast, episodes[0])
                 for ((uuid) in episodes) {
                     episodeUuidsAdded.add(uuid)
+                    val enclosures = enclosuresByUuid[uuid].orEmpty()
+                    if (enclosures.isNotEmpty()) {
+                        alternateEnclosureDao.replaceForEpisodeBlocking(uuid, enclosures)
+                    }
                 }
 
                 // prepare to add to up next

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastRefresherImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastRefresherImpl.kt
@@ -25,6 +25,7 @@ class PodcastRefresherImpl @Inject constructor(
     private val crashLogging: CrashLogging,
 ) : PodcastRefresher {
     private val playlistDao = appDatabase.playlistDao()
+    private val alternateEnclosureDao = appDatabase.alternateEnclosureDao()
 
     override suspend fun refreshPodcast(existingPodcast: Podcast, playbackManager: PlaybackManager) {
         try {
@@ -41,6 +42,8 @@ class PodcastRefresherImpl @Inject constructor(
             val existingEpisodes = episodeManager.findEpisodesByPodcastOrderedByPublishDate(existingPodcast)
             val mostRecentEpisode = existingEpisodes.firstOrNull()
             val insertEpisodes = mutableListOf<PodcastEpisode>()
+            // Episodes that end up persisted (updated or inserted) whose alternate enclosures we should store.
+            val persistedEpisodes = mutableListOf<PodcastEpisode>()
             updatedPodcast.episodes.map { newEpisode ->
                 val existingEpisode = existingEpisodes.find { it.uuid == newEpisode.uuid }
                 if (existingEpisode != null) {
@@ -65,6 +68,7 @@ class PodcastRefresherImpl @Inject constructor(
                     if (originalEpisode != existingEpisode) {
                         episodeManager.update(existingEpisode)
                     }
+                    persistedEpisodes.add(newEpisode)
                 } else {
                     // don't add anything newer than the latest episode so it runs through the refresh logic (auto download, auto add to Up Next etc
                     if (!existingPodcast.isSubscribed || (mostRecentEpisode != null && newEpisode.publishedDate.before(mostRecentEpisode.publishedDate))) {
@@ -86,6 +90,7 @@ class PodcastRefresherImpl @Inject constructor(
                         newEpisode.addedDate = existingPodcast.addedDate ?: Date()
                         existingPodcast.addEpisode(newEpisode)
                         insertEpisodes.add(newEpisode)
+                        persistedEpisodes.add(newEpisode)
                     }
                 }
             }
@@ -95,6 +100,12 @@ class PodcastRefresherImpl @Inject constructor(
                     podcastUuid = existingPodcast.uuid,
                     downloadMetaData = false,
                 )
+            }
+            // Store alternate enclosures once the episode rows exist (the table has a cascading FK on episode_uuid).
+            persistedEpisodes.forEach { episode ->
+                if (episode.alternateEnclosures.isNotEmpty()) {
+                    alternateEnclosureDao.replaceForEpisode(episode.uuid, episode.alternateEnclosures)
+                }
             }
 
             val twoWeeksAgo = Calendar.getInstance()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastRefresherImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastRefresherImpl.kt
@@ -102,9 +102,14 @@ class PodcastRefresherImpl @Inject constructor(
                 )
             }
             // Store alternate enclosures once the episode rows exist (the table has a cascading FK on episode_uuid).
+            // Only rewrite when they actually changed so an unchanged feed doesn't churn delete+insert every refresh.
             persistedEpisodes.forEach { episode ->
-                if (episode.alternateEnclosures.isNotEmpty()) {
-                    alternateEnclosureDao.replaceForEpisode(episode.uuid, episode.alternateEnclosures)
+                val incoming = episode.alternateEnclosures
+                if (incoming.isNotEmpty()) {
+                    val stored = alternateEnclosureDao.findByEpisodeUuid(episode.uuid).map { it.copy(id = 0) }
+                    if (stored != incoming) {
+                        alternateEnclosureDao.replaceForEpisode(episode.uuid, incoming)
+                    }
                 }
             }
 

--- a/modules/services/servers/build.gradle.kts
+++ b/modules/services/servers/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
     implementation(projects.modules.services.localization)
     implementation(projects.modules.services.utils)
 
+    // compileOnly: we only reference MimeTypes.APPLICATION_M3U8, a const that inlines, so there's no runtime media3 dependency.
     compileOnly(libs.media3.common)
 
     testCompileOnly(libs.media3.common)

--- a/modules/services/servers/build.gradle.kts
+++ b/modules/services/servers/build.gradle.kts
@@ -43,6 +43,9 @@ dependencies {
     implementation(projects.modules.services.localization)
     implementation(projects.modules.services.utils)
 
+    compileOnly(libs.media3.common)
+
+    testCompileOnly(libs.media3.common)
     testImplementation(libs.coroutines.test)
     testImplementation(libs.junit)
     testImplementation(libs.okHttp.mockwebserver)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/AlternateEnclosures.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/AlternateEnclosures.kt
@@ -1,21 +1,18 @@
 package au.com.shiftyjelly.pocketcasts.servers
 
-/** Podcasting 2.0 `<podcast:alternateEnclosure>`, normalized to the [type] and source URIs we read. */
-internal class AlternateEnclosureData(
-    val type: String?,
-    val sourceUris: List<String>,
-)
+import au.com.shiftyjelly.pocketcasts.models.entity.EpisodeAlternateEnclosure
 
 // HLS is advertised as either of these MIME types (matches BaseEpisode.isHlsMimeType).
 private val HLS_MIME_TYPES = setOf("application/x-mpegurl", "application/vnd.apple.mpegurl")
 
 /** First HLS enclosure's first http(s) source URI, or null if none can be streamed. */
-internal fun List<AlternateEnclosureData>?.firstHlsStreamUrl(): String? {
+internal fun List<EpisodeAlternateEnclosure>?.firstHlsStreamUrl(): String? {
     val enclosures = this ?: return null
     return enclosures
         .firstOrNull { it.type?.lowercase() in HLS_MIME_TYPES }
-        ?.sourceUris
-        ?.firstOrNull { it.isPlayableHttpUri() }
+        ?.sources
+        ?.firstOrNull { it.uri.isPlayableHttpUri() }
+        ?.uri
 }
 
 private fun String.isPlayableHttpUri(): Boolean {

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/AlternateEnclosures.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/AlternateEnclosures.kt
@@ -1,9 +1,10 @@
 package au.com.shiftyjelly.pocketcasts.servers
 
+import androidx.media3.common.MimeTypes
 import au.com.shiftyjelly.pocketcasts.models.entity.EpisodeAlternateEnclosure
 
 // HLS is advertised as either of these MIME types (matches BaseEpisode.isHlsMimeType).
-private val HLS_MIME_TYPES = setOf("application/x-mpegurl", "application/vnd.apple.mpegurl")
+private val HLS_MIME_TYPES = setOf(MimeTypes.APPLICATION_M3U8.lowercase(), "application/vnd.apple.mpegurl")
 
 /** First HLS enclosure's first http(s) source URI, or null if none can be streamed. */
 internal fun List<EpisodeAlternateEnclosure>?.firstHlsStreamUrl(): String? {

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/DataParser.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/DataParser.kt
@@ -177,6 +177,7 @@ object DataParser {
                     }
                 }
             }
+            val integrity = enclosure.optJSONObject("integrity")
             EpisodeAlternateEnclosure(
                 episodeUuid = episodeUuid,
                 position = i,
@@ -188,6 +189,8 @@ object DataParser {
                 lang = getString(enclosure, "lang"),
                 title = getString(enclosure, "title"),
                 codecs = getString(enclosure, "codecs"),
+                integrityType = integrity?.let { getString(it, "type") },
+                integrityValue = integrity?.let { getString(it, "value") },
                 isDefault = enclosure.optBoolean("default", false),
                 sources = sources,
             )

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/DataParser.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/DataParser.kt
@@ -1,5 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.servers
 
+import au.com.shiftyjelly.pocketcasts.models.entity.AlternateEnclosureSource
+import au.com.shiftyjelly.pocketcasts.models.entity.EpisodeAlternateEnclosure
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.Share
@@ -146,7 +148,7 @@ object DataParser {
             title = getString(jsonEpisode, "title") ?: "",
             uuid = uuid,
             downloadUrl = getString(jsonEpisode, "url"),
-            hlsUrl = parseAlternateEnclosures(jsonEpisode).firstHlsStreamUrl(),
+            hlsUrl = parseAlternateEnclosures(jsonEpisode, uuid).firstHlsStreamUrl(),
             sizeInBytes = getLong(jsonEpisode, "size_in_bytes"),
             duration = getDouble(jsonEpisode, "duration_in_secs"),
             episodeDescription = getString(jsonEpisode, "description") ?: "",
@@ -157,19 +159,35 @@ object DataParser {
         )
     }
 
-    private fun parseAlternateEnclosures(jsonEpisode: JSONObject): List<AlternateEnclosureData> {
+    fun parseAlternateEnclosures(jsonEpisode: JSONObject, episodeUuid: String): List<EpisodeAlternateEnclosure> {
         val enclosures = jsonEpisode.optJSONArray("alternate_enclosures") ?: return emptyList()
         return (0 until enclosures.length()).mapNotNull { i ->
             val enclosure = enclosures.optJSONObject(i) ?: return@mapNotNull null
-            val sources = enclosure.optJSONArray("sources")
-            val sourceUris = if (sources == null) {
+            val sourcesJson = enclosure.optJSONArray("sources")
+            val sources = if (sourcesJson == null) {
                 emptyList()
             } else {
-                (0 until sources.length()).mapNotNull { j ->
-                    sources.optJSONObject(j)?.let { getString(it, "uri") }
+                (0 until sourcesJson.length()).mapNotNull { j ->
+                    val source = sourcesJson.optJSONObject(j) ?: return@mapNotNull null
+                    getString(source, "uri")?.let { uri ->
+                        AlternateEnclosureSource(uri = uri, contentType = getString(source, "content_type"))
+                    }
                 }
             }
-            AlternateEnclosureData(type = getString(enclosure, "type"), sourceUris = sourceUris)
+            EpisodeAlternateEnclosure(
+                episodeUuid = episodeUuid,
+                position = i,
+                type = getString(enclosure, "type"),
+                bitrate = getLongOrNull(enclosure, "bitrate"),
+                length = getLongOrNull(enclosure, "length"),
+                height = getIntOrNull(enclosure, "height"),
+                width = getIntOrNull(enclosure, "width"),
+                lang = getString(enclosure, "lang"),
+                title = getString(enclosure, "title"),
+                codecs = getString(enclosure, "codecs"),
+                isDefault = enclosure.optBoolean("default", false),
+                sources = sources,
+            )
         }
     }
 
@@ -187,6 +205,14 @@ object DataParser {
         } catch (e: Exception) {
             0
         }
+    }
+
+    private fun getLongOrNull(jsonObject: JSONObject, key: String): Long? {
+        return if (jsonObject.has(key) && !jsonObject.isNull(key)) jsonObject.optLong(key) else null
+    }
+
+    private fun getIntOrNull(jsonObject: JSONObject, key: String): Int? {
+        return if (jsonObject.has(key) && !jsonObject.isNull(key)) jsonObject.optInt(key) else null
     }
 
     private fun getDouble(jsonObject: JSONObject, key: String): Double {

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/DataParser.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/DataParser.kt
@@ -142,13 +142,14 @@ object DataParser {
         if (uuid == null || publishedAt == null || podcastUuidOrJson == null) {
             return null
         }
+        val enclosures = parseAlternateEnclosures(jsonEpisode, uuid)
         return PodcastEpisode(
             downloadStatus = EpisodeDownloadStatus.DownloadNotRequested,
             playingStatus = EpisodePlayingStatus.NOT_PLAYED,
             title = getString(jsonEpisode, "title") ?: "",
             uuid = uuid,
             downloadUrl = getString(jsonEpisode, "url"),
-            hlsUrl = parseAlternateEnclosures(jsonEpisode, uuid).firstHlsStreamUrl(),
+            hlsUrl = enclosures.firstHlsStreamUrl(),
             sizeInBytes = getLong(jsonEpisode, "size_in_bytes"),
             duration = getDouble(jsonEpisode, "duration_in_secs"),
             episodeDescription = getString(jsonEpisode, "description") ?: "",
@@ -156,10 +157,12 @@ object DataParser {
             publishedDate = publishedAt,
             podcastUuid = podcastUuidOrJson,
             addedDate = Date(),
-        )
+        ).apply {
+            alternateEnclosures = enclosures
+        }
     }
 
-    fun parseAlternateEnclosures(jsonEpisode: JSONObject, episodeUuid: String): List<EpisodeAlternateEnclosure> {
+    private fun parseAlternateEnclosures(jsonEpisode: JSONObject, episodeUuid: String): List<EpisodeAlternateEnclosure> {
         val enclosures = jsonEpisode.optJSONArray("alternate_enclosures") ?: return emptyList()
         return (0 until enclosures.length()).mapNotNull { i ->
             val enclosure = enclosures.optJSONObject(i) ?: return@mapNotNull null

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastResponse.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastResponse.kt
@@ -1,9 +1,10 @@
 package au.com.shiftyjelly.pocketcasts.servers.podcast
 
+import au.com.shiftyjelly.pocketcasts.models.entity.AlternateEnclosureSource
+import au.com.shiftyjelly.pocketcasts.models.entity.EpisodeAlternateEnclosure
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodesSortType
-import au.com.shiftyjelly.pocketcasts.servers.AlternateEnclosureData
 import au.com.shiftyjelly.pocketcasts.servers.firstHlsStreamUrl
 import au.com.shiftyjelly.pocketcasts.utils.extensions.parseIsoDate
 import com.squareup.moshi.Json
@@ -104,7 +105,7 @@ data class EpisodeInfo(
         return PodcastEpisode(
             uuid = uuid,
             downloadUrl = url,
-            hlsUrl = alternateEnclosures.toHlsUrl(),
+            hlsUrl = toAlternateEnclosures().firstHlsStreamUrl(),
             title = episodeTitle,
             fileType = fileType,
             sizeInBytes = fileSize ?: 0,
@@ -119,11 +120,38 @@ data class EpisodeInfo(
             hasGeneratedTranscript = hasGeneratedTranscript == true,
         )
     }
+
+    fun toAlternateEnclosures(): List<EpisodeAlternateEnclosure> = alternateEnclosures.orEmpty().mapIndexed { index, enclosure ->
+        EpisodeAlternateEnclosure(
+            episodeUuid = uuid,
+            position = index,
+            type = enclosure.type,
+            bitrate = enclosure.bitrate,
+            length = enclosure.length,
+            height = enclosure.height,
+            width = enclosure.width,
+            lang = enclosure.lang,
+            title = enclosure.title,
+            codecs = enclosure.codecs,
+            isDefault = enclosure.default == true,
+            sources = enclosure.sources?.mapNotNull { source ->
+                source.uri?.let { AlternateEnclosureSource(uri = it, contentType = source.contentType) }
+            }.orEmpty(),
+        )
+    }
 }
 
 @JsonClass(generateAdapter = true)
 data class AlternateEnclosure(
     @Json(name = "type") val type: String?,
+    @Json(name = "bitrate") val bitrate: Long?,
+    @Json(name = "length") val length: Long?,
+    @Json(name = "height") val height: Int?,
+    @Json(name = "width") val width: Int?,
+    @Json(name = "lang") val lang: String?,
+    @Json(name = "title") val title: String?,
+    @Json(name = "codecs") val codecs: String?,
+    @Json(name = "default") val default: Boolean?,
     @Json(name = "sources") val sources: List<AlternateSource>?,
 )
 
@@ -132,7 +160,3 @@ data class AlternateSource(
     @Json(name = "uri") val uri: String?,
     @Json(name = "content_type") val contentType: String?,
 )
-
-private fun List<AlternateEnclosure>?.toHlsUrl(): String? = this
-    ?.map { enclosure -> AlternateEnclosureData(enclosure.type, enclosure.sources?.mapNotNull(AlternateSource::uri).orEmpty()) }
-    .firstHlsStreamUrl()

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastResponse.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastResponse.kt
@@ -102,10 +102,11 @@ data class EpisodeInfo(
     fun toEpisode(podcastUuid: String): PodcastEpisode? {
         val publishedDate = published.parseIsoDate() ?: return null
         val episodeTitle = title.orEmpty()
+        val enclosures = toAlternateEnclosures()
         return PodcastEpisode(
             uuid = uuid,
             downloadUrl = url,
-            hlsUrl = toAlternateEnclosures().firstHlsStreamUrl(),
+            hlsUrl = enclosures.firstHlsStreamUrl(),
             title = episodeTitle,
             fileType = fileType,
             sizeInBytes = fileSize ?: 0,
@@ -118,7 +119,9 @@ data class EpisodeInfo(
             type = type,
             slug = slug.orEmpty(),
             hasGeneratedTranscript = hasGeneratedTranscript == true,
-        )
+        ).apply {
+            alternateEnclosures = enclosures
+        }
     }
 
     fun toAlternateEnclosures(): List<EpisodeAlternateEnclosure> = alternateEnclosures.orEmpty().mapIndexed { index, enclosure ->

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastResponse.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastResponse.kt
@@ -136,6 +136,8 @@ data class EpisodeInfo(
             lang = enclosure.lang,
             title = enclosure.title,
             codecs = enclosure.codecs,
+            integrityType = enclosure.integrity?.type,
+            integrityValue = enclosure.integrity?.value,
             isDefault = enclosure.default == true,
             sources = enclosure.sources?.mapNotNull { source ->
                 source.uri?.let { AlternateEnclosureSource(uri = it, contentType = source.contentType) }
@@ -154,6 +156,7 @@ data class AlternateEnclosure(
     @Json(name = "lang") val lang: String?,
     @Json(name = "title") val title: String?,
     @Json(name = "codecs") val codecs: String?,
+    @Json(name = "integrity") val integrity: AlternateEnclosureIntegrity?,
     @Json(name = "default") val default: Boolean?,
     @Json(name = "sources") val sources: List<AlternateSource>?,
 )
@@ -162,4 +165,10 @@ data class AlternateEnclosure(
 data class AlternateSource(
     @Json(name = "uri") val uri: String?,
     @Json(name = "content_type") val contentType: String?,
+)
+
+@JsonClass(generateAdapter = true)
+data class AlternateEnclosureIntegrity(
+    @Json(name = "type") val type: String?,
+    @Json(name = "value") val value: String?,
 )

--- a/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/AlternateEnclosuresTest.kt
+++ b/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/AlternateEnclosuresTest.kt
@@ -1,5 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.servers
 
+import au.com.shiftyjelly.pocketcasts.models.entity.AlternateEnclosureSource
+import au.com.shiftyjelly.pocketcasts.models.entity.EpisodeAlternateEnclosure
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
@@ -9,7 +11,7 @@ class AlternateEnclosuresTest {
     @Test
     fun `selects hls source`() {
         val enclosures = listOf(
-            AlternateEnclosureData("application/x-mpegURL", listOf("https://example.com/master.m3u8")),
+            enclosure("application/x-mpegURL", "https://example.com/master.m3u8"),
         )
         assertEquals("https://example.com/master.m3u8", enclosures.firstHlsStreamUrl())
     }
@@ -17,7 +19,7 @@ class AlternateEnclosuresTest {
     @Test
     fun `matches hls mime type case insensitively`() {
         val enclosures = listOf(
-            AlternateEnclosureData("APPLICATION/X-MPEGURL", listOf("https://example.com/master.m3u8")),
+            enclosure("APPLICATION/X-MPEGURL", "https://example.com/master.m3u8"),
         )
         assertEquals("https://example.com/master.m3u8", enclosures.firstHlsStreamUrl())
     }
@@ -25,7 +27,7 @@ class AlternateEnclosuresTest {
     @Test
     fun `matches apple vendor hls mime type`() {
         val enclosures = listOf(
-            AlternateEnclosureData("application/vnd.apple.mpegurl", listOf("https://example.com/master.m3u8")),
+            enclosure("application/vnd.apple.mpegurl", "https://example.com/master.m3u8"),
         )
         assertEquals("https://example.com/master.m3u8", enclosures.firstHlsStreamUrl())
     }
@@ -33,8 +35,8 @@ class AlternateEnclosuresTest {
     @Test
     fun `ignores non-hls enclosures and keeps hls`() {
         val enclosures = listOf(
-            AlternateEnclosureData("video/mp4", listOf("https://example.com/file-1080.mp4")),
-            AlternateEnclosureData("application/x-mpegURL", listOf("https://example.com/master.m3u8")),
+            enclosure("video/mp4", "https://example.com/file-1080.mp4"),
+            enclosure("application/x-mpegURL", "https://example.com/master.m3u8"),
         )
         assertEquals("https://example.com/master.m3u8", enclosures.firstHlsStreamUrl())
     }
@@ -42,10 +44,7 @@ class AlternateEnclosuresTest {
     @Test
     fun `skips non-http hls sources`() {
         val enclosures = listOf(
-            AlternateEnclosureData(
-                "application/x-mpegURL",
-                listOf("ipfs://QmManifest", "https://example.com/master.m3u8"),
-            ),
+            enclosure("application/x-mpegURL", "ipfs://QmManifest", "https://example.com/master.m3u8"),
         )
         assertEquals("https://example.com/master.m3u8", enclosures.firstHlsStreamUrl())
     }
@@ -53,7 +52,7 @@ class AlternateEnclosuresTest {
     @Test
     fun `returns null when hls enclosure has no playable source`() {
         val enclosures = listOf(
-            AlternateEnclosureData("application/x-mpegURL", listOf("ipfs://QmManifest")),
+            enclosure("application/x-mpegURL", "ipfs://QmManifest"),
         )
         assertNull(enclosures.firstHlsStreamUrl())
     }
@@ -61,7 +60,7 @@ class AlternateEnclosuresTest {
     @Test
     fun `returns null when hls enclosure has empty sources`() {
         val enclosures = listOf(
-            AlternateEnclosureData("application/x-mpegURL", emptyList()),
+            enclosure("application/x-mpegURL"),
         )
         assertNull(enclosures.firstHlsStreamUrl())
     }
@@ -69,14 +68,21 @@ class AlternateEnclosuresTest {
     @Test
     fun `returns null when no hls enclosure present`() {
         val enclosures = listOf(
-            AlternateEnclosureData("video/mp4", listOf("https://example.com/file-1080.mp4")),
+            enclosure("video/mp4", "https://example.com/file-1080.mp4"),
         )
         assertNull(enclosures.firstHlsStreamUrl())
     }
 
     @Test
     fun `returns null for empty or null list`() {
-        assertNull(emptyList<AlternateEnclosureData>().firstHlsStreamUrl())
+        assertNull(emptyList<EpisodeAlternateEnclosure>().firstHlsStreamUrl())
         assertNull(null.firstHlsStreamUrl())
     }
+
+    private fun enclosure(type: String, vararg uris: String) = EpisodeAlternateEnclosure(
+        episodeUuid = "episode-uuid",
+        position = 0,
+        type = type,
+        sources = uris.map { AlternateEnclosureSource(uri = it) },
+    )
 }

--- a/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/AlternateEnclosuresTest.kt
+++ b/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/AlternateEnclosuresTest.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.servers
 
+import androidx.media3.common.MimeTypes
 import au.com.shiftyjelly.pocketcasts.models.entity.AlternateEnclosureSource
 import au.com.shiftyjelly.pocketcasts.models.entity.EpisodeAlternateEnclosure
 import org.junit.Assert.assertEquals
@@ -11,7 +12,7 @@ class AlternateEnclosuresTest {
     @Test
     fun `selects hls source`() {
         val enclosures = listOf(
-            enclosure("application/x-mpegURL", "https://example.com/master.m3u8"),
+            enclosure(MimeTypes.APPLICATION_M3U8, "https://example.com/master.m3u8"),
         )
         assertEquals("https://example.com/master.m3u8", enclosures.firstHlsStreamUrl())
     }
@@ -36,7 +37,7 @@ class AlternateEnclosuresTest {
     fun `ignores non-hls enclosures and keeps hls`() {
         val enclosures = listOf(
             enclosure("video/mp4", "https://example.com/file-1080.mp4"),
-            enclosure("application/x-mpegURL", "https://example.com/master.m3u8"),
+            enclosure(MimeTypes.APPLICATION_M3U8, "https://example.com/master.m3u8"),
         )
         assertEquals("https://example.com/master.m3u8", enclosures.firstHlsStreamUrl())
     }
@@ -44,7 +45,7 @@ class AlternateEnclosuresTest {
     @Test
     fun `skips non-http hls sources`() {
         val enclosures = listOf(
-            enclosure("application/x-mpegURL", "ipfs://QmManifest", "https://example.com/master.m3u8"),
+            enclosure(MimeTypes.APPLICATION_M3U8, "ipfs://QmManifest", "https://example.com/master.m3u8"),
         )
         assertEquals("https://example.com/master.m3u8", enclosures.firstHlsStreamUrl())
     }
@@ -52,7 +53,7 @@ class AlternateEnclosuresTest {
     @Test
     fun `returns null when hls enclosure has no playable source`() {
         val enclosures = listOf(
-            enclosure("application/x-mpegURL", "ipfs://QmManifest"),
+            enclosure(MimeTypes.APPLICATION_M3U8, "ipfs://QmManifest"),
         )
         assertNull(enclosures.firstHlsStreamUrl())
     }
@@ -60,7 +61,7 @@ class AlternateEnclosuresTest {
     @Test
     fun `returns null when hls enclosure has empty sources`() {
         val enclosures = listOf(
-            enclosure("application/x-mpegURL"),
+            enclosure(MimeTypes.APPLICATION_M3U8),
         )
         assertNull(enclosures.firstHlsStreamUrl())
     }

--- a/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/podcast/EpisodeInfoTest.kt
+++ b/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/podcast/EpisodeInfoTest.kt
@@ -54,6 +54,48 @@ class EpisodeInfoTest {
     }
 
     @Test
+    fun `captures full alternate enclosure metadata`() {
+        val episodeInfo = adapter.fromJson(
+            """
+            {
+              "uuid": "episode-uuid",
+              "url": "https://example.com/episode.mp3",
+              "published": "2026-06-11T00:00:00Z",
+              "alternate_enclosures": [
+                {
+                  "type": "video/mp4",
+                  "bitrate": 681484,
+                  "length": 123456,
+                  "height": 1080,
+                  "width": 1920,
+                  "lang": "en",
+                  "title": "1080p",
+                  "codecs": "avc1.640028",
+                  "default": true,
+                  "sources": [{ "uri": "https://example.com/file-1080.mp4", "content_type": "video/mp4" }]
+                }
+              ]
+            }
+            """.trimIndent(),
+        )
+
+        val enclosure = episodeInfo!!.toAlternateEnclosures().single()
+        assertEquals("episode-uuid", enclosure.episodeUuid)
+        assertEquals(0, enclosure.position)
+        assertEquals("video/mp4", enclosure.type)
+        assertEquals(681484L, enclosure.bitrate)
+        assertEquals(123456L, enclosure.length)
+        assertEquals(1080, enclosure.height)
+        assertEquals(1920, enclosure.width)
+        assertEquals("en", enclosure.lang)
+        assertEquals("1080p", enclosure.title)
+        assertEquals("avc1.640028", enclosure.codecs)
+        assertEquals(true, enclosure.isDefault)
+        assertEquals("https://example.com/file-1080.mp4", enclosure.sources.single().uri)
+        assertEquals("video/mp4", enclosure.sources.single().contentType)
+    }
+
+    @Test
     fun `parse episode without alternate enclosures`() {
         val episodeInfo = adapter.fromJson(
             """{"uuid":"episode-uuid","url":"https://example.com/episode.mp3","published":"2026-06-11T00:00:00Z"}""",

--- a/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/podcast/EpisodeInfoTest.kt
+++ b/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/podcast/EpisodeInfoTest.kt
@@ -55,6 +55,7 @@ class EpisodeInfoTest {
 
     @Test
     fun `captures full alternate enclosure metadata`() {
+        // Mirrors the exact payload shape the backend emits.
         val episodeInfo = adapter.fromJson(
             """
             {
@@ -63,36 +64,64 @@ class EpisodeInfoTest {
               "published": "2026-06-11T00:00:00Z",
               "alternate_enclosures": [
                 {
+                  "type": "application/x-mpegURL",
+                  "length": 0,
+                  "sources": [{ "uri": "https://example.com/master.m3u8" }]
+                },
+                {
                   "type": "video/mp4",
+                  "length": 10562995,
                   "bitrate": 681484,
-                  "length": 123456,
                   "height": 1080,
-                  "width": 1920,
-                  "lang": "en",
                   "title": "1080p",
-                  "codecs": "avc1.640028",
+                  "codecs": "avc1.640028,mp4a.40.2",
                   "default": true,
-                  "sources": [{ "uri": "https://example.com/file-1080.mp4", "content_type": "video/mp4" }]
+                  "sources": [
+                    { "uri": "https://example.com/file-1080.mp4" },
+                    { "uri": "ipfs://Qm..." },
+                    { "uri": "https://example.com/file-1080.torrent", "content_type": "application/x-bittorrent" }
+                  ],
+                  "integrity": {
+                    "type": "sri",
+                    "value": "sha384-ExVqijgYHm15PqQqdXfW95x+Rs6C+d6E/ICxyQOeFevnxNLR/wtJNrNYTjIysUBo"
+                  }
                 }
               ]
             }
             """.trimIndent(),
         )
 
-        val enclosure = episodeInfo!!.toAlternateEnclosures().single()
-        assertEquals("episode-uuid", enclosure.episodeUuid)
-        assertEquals(0, enclosure.position)
-        assertEquals("video/mp4", enclosure.type)
-        assertEquals(681484L, enclosure.bitrate)
-        assertEquals(123456L, enclosure.length)
-        assertEquals(1080, enclosure.height)
-        assertEquals(1920, enclosure.width)
-        assertEquals("en", enclosure.lang)
-        assertEquals("1080p", enclosure.title)
-        assertEquals("avc1.640028", enclosure.codecs)
-        assertEquals(true, enclosure.isDefault)
-        assertEquals("https://example.com/file-1080.mp4", enclosure.sources.single().uri)
-        assertEquals("video/mp4", enclosure.sources.single().contentType)
+        val episode = episodeInfo!!.toEpisode("podcast-uuid")
+        // The HLS enclosure is selected for the streaming fast-path.
+        assertEquals("https://example.com/master.m3u8", episode?.hlsUrl)
+
+        val enclosures = episodeInfo.toAlternateEnclosures()
+        assertEquals(2, enclosures.size)
+
+        val hls = enclosures[0]
+        assertEquals("episode-uuid", hls.episodeUuid)
+        assertEquals(0, hls.position)
+        assertEquals("application/x-mpegURL", hls.type)
+        assertEquals(0L, hls.length)
+        assertEquals("https://example.com/master.m3u8", hls.sources.single().uri)
+
+        val mp4 = enclosures[1]
+        assertEquals(1, mp4.position)
+        assertEquals("video/mp4", mp4.type)
+        assertEquals(681484L, mp4.bitrate)
+        assertEquals(10562995L, mp4.length)
+        assertEquals(1080, mp4.height)
+        assertNull(mp4.width)
+        assertEquals("1080p", mp4.title)
+        assertEquals("avc1.640028,mp4a.40.2", mp4.codecs)
+        assertEquals(true, mp4.isDefault)
+        assertEquals("sri", mp4.integrityType)
+        assertEquals("sha384-ExVqijgYHm15PqQqdXfW95x+Rs6C+d6E/ICxyQOeFevnxNLR/wtJNrNYTjIysUBo", mp4.integrityValue)
+        assertEquals(3, mp4.sources.size)
+        assertEquals("https://example.com/file-1080.mp4", mp4.sources[0].uri)
+        assertNull(mp4.sources[0].contentType)
+        assertEquals("ipfs://Qm...", mp4.sources[1].uri)
+        assertEquals("application/x-bittorrent", mp4.sources[2].contentType)
     }
 
     @Test

--- a/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/podcast/EpisodeInfoTest.kt
+++ b/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/podcast/EpisodeInfoTest.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.servers.podcast
 
+import androidx.media3.common.MimeTypes
 import com.squareup.moshi.Moshi
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -101,7 +102,7 @@ class EpisodeInfoTest {
         val hls = enclosures[0]
         assertEquals("episode-uuid", hls.episodeUuid)
         assertEquals(0, hls.position)
-        assertEquals("application/x-mpegURL", hls.type)
+        assertEquals(MimeTypes.APPLICATION_M3U8, hls.type)
         assertEquals(0L, hls.length)
         assertEquals("https://example.com/master.m3u8", hls.sources.single().uri)
 


### PR DESCRIPTION
## Description
This PR makes changes to our database schemas as we're now storing the alternate enclosures array as the server sends it for future purposes -- it's quite probable that we'll want to have an option on the ui to let users select which stream to be played.

Fixes PCDROID-617 https://linear.app/a8c/issue/PCDROID-617/persist-alternate-enclosures

## Testing Instructions
Just make sure the CI is green

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
 