### PR TITLE
[Hyundai] Attempt to fix overlapping text on Link page

### DIFF
--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveLinkFragment.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveLinkFragment.kt
@@ -2,7 +2,6 @@ package au.com.shiftyjelly.pocketcasts
 
 import android.os.Bundle
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
@@ -17,12 +16,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.fragment.app.Fragment
 import au.com.shiftyjelly.pocketcasts.compose.AutomotiveTheme
+import au.com.shiftyjelly.pocketcasts.compose.extensions.contentWithoutConsumedInsets
 import au.com.shiftyjelly.pocketcasts.qr.rememberQrPainter
 
 /**
@@ -42,14 +41,13 @@ class AutomotiveLinkFragment : Fragment() {
         }
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        val url = arguments?.getString(ARGUMENT_URL).orEmpty()
-        return ComposeView(requireContext()).apply {
-            setContent {
-                AutomotiveTheme {
-                    LinkPage(url = url)
-                }
-            }
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ) = contentWithoutConsumedInsets {
+        AutomotiveTheme {
+            LinkPage(url = arguments?.getString(ARGUMENT_URL).orEmpty())
         }
     }
 

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveLinkFragment.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveLinkFragment.kt
@@ -60,6 +60,7 @@ class AutomotiveLinkFragment : Fragment() {
             Text(
                 text = url,
                 fontSize = 32.sp,
+                lineHeight = 40.sp,
                 textAlign = TextAlign.Center,
                 color = Color.White,
             )


### PR DESCRIPTION
## Description
Although I never been able to reproduce this issue with the current main branch, I took claude's advice and changed how we create the page content -- now we're using `contentWithoutConsumedInsets` wrapper instead of directly creating a `ComposeView`.

Fixes PCDROID-619 https://linear.app/a8c/issue/PCDROID-619/hyundai-prt-554-text-overlap-on-qr-screen-after-navigation

## Testing Instructions
1. Install Pleos emulator and configure it
2. Disable chromium `adb shell pm disable-user --user 10 org.chromium.chrome.stable
3. Install our app
4. Launch it `adb shell am start --user 10 -n au.com.shiftyjelly.pocketcasts.debug/au.com.shiftyjelly.pocketcasts.AutomotiveSettingsActivity`
5. Navigate to Privacy Policy
6. Notice no overlap
7. Launch another app
8. Return to our app
9. Notice no overlap

## Screenshots or Screencast 
See: https://linear.app/a8c/issue/PCDROID-619/hyundai-prt-554-text-overlap-on-qr-screen-after-navigation#comment-6290defd


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
 