### PR TITLE
Fix/automotive settings rotate overlap

### DIFF
--- a/automotive/src/androidTest/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsActivityRecreateTest.kt
+++ b/automotive/src/androidTest/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsActivityRecreateTest.kt
@@ -1,0 +1,40 @@
+package au.com.shiftyjelly.pocketcasts
+
+import android.widget.FrameLayout
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AutomotiveSettingsActivityRecreateTest {
+
+    @Test
+    fun backAfterRecreateDoesNotLeaveOverlappingFragments() {
+        ActivityScenario.launch(AutomotiveSettingsActivity::class.java).use { scenario ->
+            // Settings -> About -> Acknowledgements
+            scenario.onActivity { activity ->
+                activity.addFragment(AutomotiveAboutFragment())
+                activity.addFragment(AutomotiveLicensesFragment())
+                activity.supportFragmentManager.executePendingTransactions()
+            }
+
+            // Simulate the configuration change (e.g. rotation to portrait)
+            scenario.recreate()
+
+            // Tap Back
+            scenario.onActivity { activity ->
+                activity.supportFragmentManager.popBackStack()
+                activity.supportFragmentManager.executePendingTransactions()
+
+                val frameMain = activity.findViewById<FrameLayout>(R.id.frameMain)
+                assertEquals("frameMain should hold a single fragment after back", 1, frameMain.childCount)
+
+                val visible = activity.supportFragmentManager.findFragmentById(R.id.frameMain)
+                assertTrue("expected the About fragment, not an orphaned settings fragment", visible is AutomotiveAboutFragment)
+            }
+        }
+    }
+}

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsActivity.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsActivity.kt
@@ -33,8 +33,10 @@ class AutomotiveSettingsActivity :
             },
         )
 
-        val settingsFragment = AutomotiveSettingsFragment()
-        supportFragmentManager.beginTransaction().replace(R.id.frameMain, settingsFragment).commitNowAllowingStateLoss()
+        if (savedInstanceState == null) {
+            val settingsFragment = AutomotiveSettingsFragment()
+            supportFragmentManager.beginTransaction().replace(R.id.frameMain, settingsFragment).commitNowAllowingStateLoss()
+        }
 
         val btnClose = findViewById<ImageView>(PR.id.btnClose)
         btnClose?.setImageResource(IR.drawable.ic_arrow_back)


### PR DESCRIPTION
## Description
Our partners at Hyundai have reported that they noticed overlapping texts on automotive's Acknowledgements screen when they switched between landscape and portrait. I never managed to reproduce this with their emulator as it won't change the actual orientation to `adb shell settings put system user_rotation 1` commands, just rotates itself.
It didn't occur on the original Google automotive emulator either, as the emulator changed orientation I didn't see anything overlapping.
Claude's advice was implemented eventually.

Fixes PCDROID-622 https://linear.app/a8c/issue/PCDROID-622/hyundai-prt-558-text-and-ui-overlap-after-returning-from-portrait-mode

## Testing Instructions
1. Open the Settings > Privacy Policy screen
2. Hit Acknowledgements
3. send command `adb shell settings put system user_rortation 1` to go portrait
4. Hit back
5. Notice no overlapping texts
6. Hit Acknowledgements again
7. send previous comand with `0` arg to go back to landscape
8. Hit back again
9. Notice still no overlap

## Screenshots or Screencast 

https://github.com/user-attachments/assets/562c0d2f-89d2-4364-9b50-28dedd3a9bdb



## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
 