### PR TITLE
Prevent endless transcript meta fetch/cancel loop in SummaryViewModel

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/SummaryViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/SummaryViewModel.kt
@@ -75,6 +75,7 @@ class SummaryViewModel @Inject constructor(
     fun loadSummary(episodeUuid: String) {
         if (currentEpisodeUuid == episodeUuid && _state.value is SummaryState.Loaded) return
         if (currentEpisodeUuid == episodeUuid && _state.value is SummaryState.Upsell) return
+        if (currentEpisodeUuid == episodeUuid && loadJob?.isActive == true) return
         currentEpisodeUuid = episodeUuid
         loadedText = null
         loadJob?.cancel()

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/SummaryViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/SummaryViewModelTest.kt
@@ -12,6 +12,7 @@ import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.transcript.TranscriptManager
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import java.time.Instant
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
@@ -22,6 +23,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
@@ -149,6 +151,22 @@ class SummaryViewModelTest {
         viewModel.loadSummary("episode-1")
         viewModel.loadSummary("episode-1")
 
+        verify(transcriptManager).loadSummaryText("episode-1")
+    }
+
+    @Test
+    fun `loading same episode does not re-fetch while a load is still in flight`() = runTest {
+        val gate = CompletableDeferred<String?>()
+        whenever(transcriptManager.loadSummaryText("episode-1")).doSuspendableAnswer { gate.await() }
+        val viewModel = createViewModel()
+
+        viewModel.loadSummary("episode-1")
+        assertEquals(SummaryState.Loading, viewModel.state.value)
+
+        viewModel.loadSummary("episode-1")
+
+        gate.complete("Summary text")
+        assertEquals(SummaryState.Loaded("Summary text"), viewModel.state.value)
         verify(transcriptManager).loadSummaryText("episode-1")
     }
 


### PR DESCRIPTION
## Description

While an episode is playing, the AI summary feature was firing the transcript `…-meta.json` request in an endless fetch/cancel loop until the summary was loaded. In the logs there is a stream of `HTTP FAILED: java.io.IOException: Canceled` for `shownotes.pocketcasts.com/generated_transcripts/…-meta.json`.

Root cause: `PlayerContainerFragment` observes `listDataLive`, which is derived from `playbackStateObservable` and therefore re-emits on every playback position update (~once per second). Each emission calls `SummaryViewModel.loadSummary(episodeUuid)` with the same episode UUID. `loadSummary` only returned early for the `Loaded` and `Upsell` terminal states — while a load was still in flight (`Loading`), it cancelled the in-flight `loadJob` (and with it the OkHttp request) and restarted it. Because the next position update arrived before the request could settle into a terminal state, the request was cancelled and refetched indefinitely.

The fix adds an early return when a load for the same episode is already active, so position updates no longer interrupt an in-flight request. A genuine episode change still cancels and reloads as before, since the UUID won't match.

## Testing Instructions

1. Ensure the AI Summaries feature flag is enabled.
2. Play an episode of a podcast that has a generated transcript/summary, such as The Daily.
3. Open the full-screen player and watch Logcat (filter on `meta.json`).
4. Confirm the request is made once and completes, rather than repeatedly logging `HTTP FAILED: … Canceled` on every playback tick.
5. Skip to a different episode and confirm the summary reloads for the new episode.

## Screenshots 

<img width="1797" height="959" alt="Screenshot 2026-06-25 at 10 02 24 am" src="https://github.com/user-attachments/assets/6de0880d-e6f6-4429-a201-ee67ed4feeec" />

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

#### I have tested any UI changes...
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
