### PR TITLE
[Hyundai] Keep automotive Now Playing card alive and replayable at end of playback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 8.16
 -----
-
+*   Bug Fixes
+    *   Keep the Automotive Now Playing card alive and replayable when playback ends with Autoplay next off
+        ([#5480](https://github.com/Automattic/pocket-casts-android/pull/5480))
 
 8.15
 -----

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1518,6 +1518,17 @@ open class PlaybackManager @Inject constructor(
                 LogBuffer.e(LogBuffer.TAG_PLAYBACK, "OnCompletion uuid does not match playback state current episode, ignoring onComplete event.")
                 return
             }
+
+            // Automotive: keep the Now Playing card alive and replayable at the end of playback.
+            if (Util.isAutomotive(application) &&
+                !hadSleepAfterEpisode &&
+                upNextQueue.queueEpisodes.isEmpty() &&
+                !settings.autoPlayNextEpisodeOnEmpty.value
+            ) {
+                pauseFinishedEpisodeForAutomotive(episode)
+                return
+            }
+
             eventHorizon.track(
                 PlayerEpisodeCompletedEvent(
                     podcastUuid = episode.podcastOrSubstituteUuid,
@@ -1587,6 +1598,19 @@ open class PlaybackManager @Inject constructor(
         } else {
             loadCurrentEpisode(play = autoPlay, sourceView = SourceView.AUTO_PLAY)
         }
+    }
+
+    private suspend fun pauseFinishedEpisodeForAutomotive(episode: BaseEpisode) {
+        LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Automotive: episode finished with auto play off, reloading paused to keep Now Playing card")
+
+        // Rewind so the reloaded episode is paused at the start and replays from the beginning.
+        episodeManager.updatePlayedUpToBlocking(episode, 0.0, forceUpdate = true)
+
+        // Release the finished player so the reload rebuilds it paused instead of resuming the ended player.
+        player?.stop()
+
+        // Reload the still-queued episode paused: rebuilds metadata and session state so the card stays alive.
+        loadCurrentEpisode(play = false, sourceView = SourceView.AUTO_PAUSE)
     }
 
     private suspend fun autoSelectNextEpisode(): BaseEpisode? {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1603,6 +1603,15 @@ open class PlaybackManager @Inject constructor(
     private suspend fun pauseFinishedEpisodeForAutomotive(episode: BaseEpisode) {
         LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Automotive: episode finished with auto play off, reloading paused to keep Now Playing card")
 
+        // The player finished the episode, so still record the completion for analytics even though
+        // we keep the episode in the queue and skip the rest of the normal completion handling.
+        eventHorizon.track(
+            PlayerEpisodeCompletedEvent(
+                podcastUuid = episode.podcastOrSubstituteUuid,
+                episodeUuid = episode.uuid,
+            ),
+        )
+
         // Rewind so the reloaded episode is paused at the start and replays from the beginning.
         episodeManager.updatePlayedUpToBlocking(episode, 0.0, forceUpdate = true)
 


### PR DESCRIPTION
## Description
Our automotive partner at Hyundai has reported that the Now playing card gets cleared when the playback ends and the Autoplay next setting is Off on automotive.
This was a real issue that I had to address. Now I won't clear and clean up the media session, so the Now Playing card will show the last played media and give an option to replay it.

Fixes PCDROID-620 https://linear.app/a8c/issue/PCDROID-620/hyundai-prt-556-media-information-not-retained-after-playback-ends

## Testing Instructions
1. Disable Autoplay next setting
2. Play an episode, seek to close to end
3. Wait until playback completes
4. Press home
5. Verify you're still seeing the Now Playing 

## Screenshots or Screencast 

https://github.com/user-attachments/assets/6687112f-ae2e-44d8-849c-452023b86812



## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
 