### PR TITLE
Fix conditions to fetch summary that includes chapters

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
@@ -253,7 +253,9 @@ class PlayerContainerFragment :
 
         viewModel.listDataLive.observe(viewLifecycleOwner) {
             adapter.updateNotes(addNotes = !it.podcastHeader.isUserEpisode)
-            if (FeatureFlag.isEnabled(Feature.AI_SUMMARIES) && !it.podcastHeader.isUserEpisode) {
+            val isSummaryOrChaptersEnabled =
+                FeatureFlag.isEnabled(Feature.AI_SUMMARIES) || FeatureFlag.isEnabled(Feature.GENERATED_CHAPTERS)
+            if (isSummaryOrChaptersEnabled && !it.podcastHeader.isUserEpisode) {
                 summaryViewModel.loadSummary(it.podcastHeader.episodeUuid)
             } else {
                 summaryViewModel.clearSummary()

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
@@ -325,7 +325,7 @@ class EpisodeFragmentViewModel @Inject constructor(
                 _pageState.update { state ->
                     state.withSummary(result)
                 }
-                if (result != null) {
+                if (result != null || !isSummaryEnabled) {
                     lastSummaryEpisodeUuid = episodeUuid
                 }
             }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
@@ -312,7 +312,9 @@ class EpisodeFragmentViewModel @Inject constructor(
             }
         }
 
-        if (FeatureFlag.isEnabled(Feature.AI_SUMMARIES) && lastSummaryEpisodeUuid != episodeUuid) {
+        val isSummaryEnabled = FeatureFlag.isEnabled(Feature.AI_SUMMARIES)
+        val isChaptersEnabled = FeatureFlag.isEnabled(Feature.GENERATED_CHAPTERS)
+        if ((isSummaryEnabled || isChaptersEnabled) && lastSummaryEpisodeUuid != episodeUuid) {
             _pageState.update { state ->
                 state.withSummary(null)
             }
@@ -327,7 +329,7 @@ class EpisodeFragmentViewModel @Inject constructor(
                     lastSummaryEpisodeUuid = episodeUuid
                 }
             }
-        } else if (!FeatureFlag.isEnabled(Feature.AI_SUMMARIES)) {
+        } else if (!isSummaryEnabled) {
             _pageState.update { state ->
                 state.withSummary(null)
             }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/ChapterManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/ChapterManagerImpl.kt
@@ -8,6 +8,8 @@ import au.com.shiftyjelly.pocketcasts.models.to.Chapters
 import au.com.shiftyjelly.pocketcasts.models.to.DbChapter
 import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.FingerprintTimingManager
 import au.com.shiftyjelly.pocketcasts.utils.AppPlatform
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import dagger.Lazy
 import javax.inject.Inject
 import kotlin.time.Duration
@@ -48,7 +50,15 @@ class ChapterManagerImpl @Inject constructor(
         val rawChapters = combine(
             episodeManager.findEpisodeByUuidFlow(episodeUuid).distinctUntilChangedBy(BaseEpisode::deselectedChapters),
             chapterDao.observeChaptersForEpisode(episodeUuid),
-        ) { episode, dbChapters -> Chapters(dbChapters.fixChapterTimestamps(episode)) }
+        ) { episode, dbChapters ->
+            // Already-saved generated chapters must stay hidden while the feature is off.
+            val visibleChapters = if (FeatureFlag.isEnabled(Feature.GENERATED_CHAPTERS)) {
+                dbChapters
+            } else {
+                dbChapters.filterNot { it.origin == ChapterOrigin.Generated }
+            }
+            Chapters(visibleChapters.fixChapterTimestamps(episode))
+        }
 
         // Generated chapter timestamps are in the server reference timeline; align them to the real audio
         // stream via the fingerprint map. Phone only, to spare resources on automotive/wear.

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/TranscriptManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/TranscriptManagerImpl.kt
@@ -143,6 +143,10 @@ class TranscriptManagerImpl @Inject constructor(
     }
 
     override suspend fun loadSummaryText(episodeUuid: String): String? {
+        val isChaptersEnabled = FeatureFlag.isEnabled(Feature.GENERATED_CHAPTERS)
+        val isSummaryEnabled = FeatureFlag.isEnabled(Feature.AI_SUMMARIES)
+        if (!isChaptersEnabled && !isSummaryEnabled) return null
+
         return try {
             val generatedTranscript = loadLocalTranscripts(episodeUuid)
                 .firstOrNull { it.isGenerated } ?: return null
@@ -152,11 +156,15 @@ class TranscriptManagerImpl @Inject constructor(
             response.use { body ->
                 val meta = metaAdapter.fromJson(body.source()) ?: return@use null
 
-                if (FeatureFlag.isEnabled(Feature.GENERATED_CHAPTERS)) {
+                if (isChaptersEnabled) {
                     saveAiChaptersIfNeeded(episodeUuid, meta.chapters)
                 }
 
-                meta.summary?.takeIf { it.isNotBlank() }
+                if (isSummaryEnabled) {
+                    meta.summary?.takeIf { it.isNotBlank() }
+                } else {
+                    null
+                }
             }
         } catch (e: CancellationException) {
             throw e

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/ChapterManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/ChapterManagerImplTest.kt
@@ -9,7 +9,10 @@ import au.com.shiftyjelly.pocketcasts.models.to.ChapterOrigin
 import au.com.shiftyjelly.pocketcasts.models.to.Chapters
 import au.com.shiftyjelly.pocketcasts.models.to.DbChapter
 import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.FingerprintTimingManager
+import au.com.shiftyjelly.pocketcasts.sharedtest.InMemoryFeatureFlagRule
 import au.com.shiftyjelly.pocketcasts.utils.AppPlatform
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import dagger.Lazy
 import java.util.Date
 import kotlin.time.Duration.Companion.milliseconds
@@ -19,11 +22,15 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.junit.Assert.assertEquals
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
 class ChapterManagerImplTest {
+    @get:Rule
+    val featureFlagRule = InMemoryFeatureFlagRule()
+
     private val chapterDao = mock<ChapterDao>()
     private val episodeManager = mock<EpisodeManager>()
 
@@ -779,5 +786,43 @@ class ChapterManagerImplTest {
         val aligned = ChapterManagerImpl.alignGeneratedChapters(chapters) { it + 30.seconds }
 
         assertEquals(chapters, aligned)
+    }
+
+    @Test
+    fun `observe hides already-saved generated chapters when feature is off`() = runBlocking {
+        FeatureFlag.setEnabled(Feature.GENERATED_CHAPTERS, false)
+        val episode = PodcastEpisode("id", publishedDate = Date(), duration = 0.002)
+        val dbChapters = listOf(
+            DbChapter(index = 0, episodeUuid = "id", startTimeMs = 0, endTimeMs = 1, title = "Embedded", origin = ChapterOrigin.PodcastIndex),
+            DbChapter(index = 1, episodeUuid = "id", startTimeMs = 1, endTimeMs = 2, title = "Generated", origin = ChapterOrigin.Generated),
+        )
+
+        whenever(chapterDao.observeChaptersForEpisode("id")).thenReturn(flowOf(dbChapters))
+        whenever(episodeManager.findEpisodeByUuidFlow("id")).thenReturn(flowOf(episode))
+
+        chapterManager.observerChaptersForEpisode("id").test {
+            val chapters = awaitItem()
+            assertEquals(listOf("Embedded"), chapters.map { it.title })
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `observe keeps generated chapters when feature is on`() = runBlocking {
+        FeatureFlag.setEnabled(Feature.GENERATED_CHAPTERS, true)
+        val episode = PodcastEpisode("id", publishedDate = Date(), duration = 0.002)
+        val dbChapters = listOf(
+            DbChapter(index = 0, episodeUuid = "id", startTimeMs = 0, endTimeMs = 1, title = "Embedded", origin = ChapterOrigin.PodcastIndex),
+            DbChapter(index = 1, episodeUuid = "id", startTimeMs = 1, endTimeMs = 2, title = "Generated", origin = ChapterOrigin.Generated),
+        )
+
+        whenever(chapterDao.observeChaptersForEpisode("id")).thenReturn(flowOf(dbChapters))
+        whenever(episodeManager.findEpisodeByUuidFlow("id")).thenReturn(flowOf(episode))
+
+        chapterManager.observerChaptersForEpisode("id").test {
+            val chapters = awaitItem()
+            assertEquals(listOf("Embedded", "Generated"), chapters.map { it.title })
+            awaitComplete()
+        }
     }
 }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/TranscriptManagerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/TranscriptManagerTest.kt
@@ -36,6 +36,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -511,6 +512,79 @@ class TranscriptManagerTest {
         assertEquals("Just a summary", summary)
         verify(chapterManager, never()).updateChapters(any(), any())
     }
+
+    @Test
+    fun `save ai chapters but withhold summary when only generated chapters enabled`() = runTest {
+        FeatureFlag.setEnabled(Feature.GENERATED_CHAPTERS, true)
+        FeatureFlag.setEnabled(Feature.AI_SUMMARIES, false)
+        localTranscriptsFlow.value = listOf(generatedVttTranscript)
+        service.metaJsonResponse = META_JSON_WITH_CHAPTERS
+
+        val summary = transcriptManager.loadSummaryText("episode-id")
+
+        assertNull(summary)
+        verify(chapterManager).updateChapters(
+            "episode-id",
+            listOf(
+                DbChapter(index = 0, episodeUuid = "episode-id", startTimeMs = 15000, title = "Introduction", origin = ChapterOrigin.Generated),
+                DbChapter(index = 1, episodeUuid = "episode-id", startTimeMs = 73000, title = "Main Topic", origin = ChapterOrigin.Generated),
+                DbChapter(index = 2, episodeUuid = "episode-id", startTimeMs = 180000, title = "Wrap Up", origin = ChapterOrigin.Generated),
+            ),
+        )
+    }
+
+    @Test
+    fun `do not return summary when summaries disabled`() = runTest {
+        FeatureFlag.setEnabled(Feature.GENERATED_CHAPTERS, true)
+        FeatureFlag.setEnabled(Feature.AI_SUMMARIES, false)
+        localTranscriptsFlow.value = listOf(generatedVttTranscript)
+        service.metaJsonResponse = META_JSON_WITH_CHAPTERS
+
+        val summary = transcriptManager.loadSummaryText("episode-id")
+
+        assertNull(summary)
+    }
+
+    @Test
+    fun `do not save ai chapters when generated chapters disabled`() = runTest {
+        FeatureFlag.setEnabled(Feature.GENERATED_CHAPTERS, false)
+        FeatureFlag.setEnabled(Feature.AI_SUMMARIES, true)
+        localTranscriptsFlow.value = listOf(generatedVttTranscript)
+        service.metaJsonResponse = META_JSON_WITH_CHAPTERS
+
+        val summary = transcriptManager.loadSummaryText("episode-id")
+
+        assertEquals("A great episode.", summary)
+        verify(chapterManager, never()).updateChapters(any(), any())
+    }
+
+    @Test
+    fun `do not fetch meta when both ai features disabled`() = runTest {
+        FeatureFlag.setEnabled(Feature.GENERATED_CHAPTERS, false)
+        FeatureFlag.setEnabled(Feature.AI_SUMMARIES, false)
+        localTranscriptsFlow.value = listOf(generatedVttTranscript)
+        service.metaJsonResponse = META_JSON_WITH_CHAPTERS
+
+        val summary = transcriptManager.loadSummaryText("episode-id")
+
+        assertNull(summary)
+        assertEquals(0, service.metaRequestCount)
+        verify(chapterManager, never()).updateChapters(any(), any())
+    }
+
+    @Test
+    fun `fetch meta only once for chapters and summary`() = runTest {
+        FeatureFlag.setEnabled(Feature.GENERATED_CHAPTERS, true)
+        FeatureFlag.setEnabled(Feature.AI_SUMMARIES, true)
+        localTranscriptsFlow.value = listOf(generatedVttTranscript)
+        service.metaJsonResponse = META_JSON_WITH_CHAPTERS
+
+        val summary = transcriptManager.loadSummaryText("episode-id")
+
+        assertEquals("A great episode.", summary)
+        assertEquals(1, service.metaRequestCount)
+        verify(chapterManager).updateChapters(eq("episode-id"), any())
+    }
 }
 
 private class TestParser(
@@ -533,11 +607,13 @@ private class TestTranscriptService : TranscriptService {
     var shouldThrow = false
     var responseBody: String = "Ok"
     var metaJsonResponse: String? = null
+    var metaRequestCount = 0
 
     override suspend fun getTranscriptOrThrow(url: String, cacheControl: CacheControl?): ResponseBody {
         return if (shouldThrow) {
             error("Test exception")
         } else if (url.endsWith("-meta.json") && metaJsonResponse != null) {
+            metaRequestCount++
             metaJsonResponse!!.toResponseBody()
         } else {
             responseBody.toResponseBody()


### PR DESCRIPTION
## Description
The summary fetching logic (that actually pulls chapters as well) had a fatal flaw introduced by this commit: 1a70a0f85607414b793ae15d5543ad8e4e8b6d0a. If the `ai_summaries` feature flag is OFF, we won't fetch chapters at all. 
This PR addresses that and runs the fetch job either when `ai_summaries` or `generated_chapters` are on.
It worth noting that non-generated chapters were not affected by this plague.

Fixes PCDROID-637 https://linear.app/a8c/issue/PCDROID-637/bug-generated-chapters-are-not-fetched-when-ai-summaries-flag-is-off

## Testing Instructions
1. Build debugProd
2. Open developer settings
3. Turn off AI summaries (`ai_summaries` flag)
4. Open a podcast with generated chapters (like The Daily)
5. Open an episode, wait until data loads
6. Notice that Chapters tab is available on top
7. Verify chapter operations (tap to seek, preselect, etc) work
8. Now disable `generated_summaries`) as well
9. Find another episode with generated summaries and open it
10. Notice no Chapters tab
11. Find another podcast, this time with curated chapters (e.g. Changelog Master Feed)
12. Open an episode
13. Notice regular chapters are still dispalyed
14. Verify chapter operations work

## Screenshots or Screencast 

https://github.com/user-attachments/assets/c21d48fd-c32b-4f39-a2cc-a1078c3e130b



## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
 