### PR TITLE
New skill: cherry-pick-to-release

### DIFF
--- a/.agents/skills/cherry-pick-main-to-release/SKILL.md
+++ b/.agents/skills/cherry-pick-main-to-release/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: cherry-pick-to-release
+name: cherry-pick-main-to-release
 description: Cherry-pick a merged pull request's commit(s) from `main` onto the current release branch and open a draft PR.
 disable-model-invocation: true
 allowed-tools: Read, Bash(which gh), Bash(git fetch *), Bash(git branch *), Bash(git branch -r *), Bash(git checkout *), Bash(git switch *), Bash(git cherry-pick *), Bash(git status *), Bash(git log *), Bash(git show *), Bash(git rev-list *), Bash(git push *), Bash(grep *), Bash(sed *), Bash(sort *), Bash(tail *), Bash(gh pr view *), Bash(gh pr create --repo Automattic/pocket-casts-android *), Bash(gh pr edit --repo Automattic/pocket-casts-android *), Bash(gh pr list --repo Automattic/pocket-casts-android *)
@@ -7,9 +7,11 @@ allowed-tools: Read, Bash(which gh), Bash(git fetch *), Bash(git branch *), Bash
 
 # Cherry-pick a PR to the release branch
 
-Take a merged pull request, cherry-pick its commit(s) onto a fresh branch off the **current release branch**, and open a **draft** PR targeting that release branch.
+Take a merged pull request, cherry-pick its commit(s) onto a fresh branch off the **current release branch**, and open a **draft** PR
+targeting that release branch.
 
-The workflow this supports: fixes are developed and merged on `main`, then cherry-picked to the release branch. That keeps the release branch limited to exactly the commits it needs, so merging it back into `main` later is clean and unambiguous (see the Git Workflow section of AGENTS.md).
+The workflow this supports: fixes are developed and merged on `main`, then cherry-picked to the release branch. That keeps the release branch
+limited to exactly the commits it needs, so merging it back into `main` later is clean and unambiguous (see the Git Workflow section of AGENTS.md).
 
 ## Requirements
 
@@ -27,7 +29,8 @@ gh pr view <pr-url-or-number> --repo Automattic/pocket-casts-android \
   --json number,title,url,state,mergedAt,mergeCommit,headRefName,author,labels,body
 ```
 
-- If `state` is not `MERGED`, warn the user: cherry-picking is meant for changes already reviewed and merged on `main`. Ask whether to continue anyway before proceeding.
+- If `state` is not `MERGED`, warn the user: cherry-picking is meant for changes already reviewed and merged on `main`. Ask whether to continue
+  anyway before proceeding.
 - Note the `mergeCommit.oid` (the commit that landed on `main`). This is what you will cherry-pick.
 
 ### 2. Determine the current release branch
@@ -39,11 +42,14 @@ git fetch origin --prune
 git branch -r | grep -oE 'origin/release/[0-9]+\.[0-9]+' | sed 's|origin/release/||' | sort -V | tail -1
 ```
 
-This prints the latest release version (e.g. `8.15`), giving the branch `release/<ver>`. **Confirm the target branch with the user** before continuing, in case a new release branch has been cut or an older one is intended.
+This prints the latest release version (e.g. `8.15`), giving the branch `release/<ver>`. There is normally only one active release branch, so use
+the one you find without asking. Only pause to confirm with the user if the command returns **more than one** release branch, in which case ask
+which to target.
 
 ### 3. Identify the commit(s) to cherry-pick
 
-The repository squash-merges PRs, so the merge commit is usually a single commit containing the whole change. Handle both squash and true merge commits by checking the parent count:
+The repository squash-merges PRs, so the merge commit is usually a single commit containing the whole change. Handle both squash and true merge
+commits by checking the parent count:
 
 ```bash
 git rev-list --parents -n 1 <mergeCommit.oid>
@@ -58,7 +64,9 @@ git rev-list --parents -n 1 <mergeCommit.oid>
   git cherry-pick -m 1 <mergeCommit.oid>
   ```
 
-If `mergeCommit` is null (rare, e.g. the PR was merged in an unusual way), or the PR was rebase-merged (each commit is replayed onto `main`, so `mergeCommit.oid` is only the last of them and cherry-picking it alone would silently drop the earlier commits), fall back to the PR's own commits from `gh pr view --json commits` and cherry-pick them in order, oldest first. Tell the user this is what you are doing.
+If `mergeCommit` is null (rare, e.g. the PR was merged in an unusual way), or the PR was rebase-merged (each commit is replayed onto `main`, so
+`mergeCommit.oid` is only the last of them and cherry-picking it alone would silently drop the earlier commits), fall back to the PR's own commits
+from `gh pr view --json commits` and cherry-pick them in order, oldest first. Tell the user this is what you are doing.
 
 ### 4. Create the branch off the release branch
 
@@ -73,7 +81,9 @@ git checkout -b cherry-pick/<ver>/pr-<number> origin/release/<ver>
 Run the cherry-pick command chosen in step 3.
 
 - **On success**, verify with `git log --oneline -n 3` that the commit landed.
-- **On conflict**, stop. Show the conflicting files (`git status`) and hand back to the user to resolve. Do not force or guess a resolution. Once they have staged the fixes, continue with `git cherry-pick --continue`. Resolving conflicts carefully matters here because the release branch and `main` may have diverged.
+- **On conflict**, stop. Show the conflicting files (`git status`) and hand back to the user to resolve. Do not force or guess a resolution. Once
+  they have staged the fixes, continue with `git cherry-pick --continue`. Resolving conflicts carefully matters here because the release branch and
+  `main` may have diverged.
 
 ### 6. Push and open the draft PR
 
@@ -101,14 +111,16 @@ gh pr create --repo Automattic/pocket-casts-android --draft \
 
 ## PR body template
 
-Fill in every field. The body must make clear this is an already-reviewed change being cherry-picked, while still asking reviewers/CI to confirm it applies cleanly, because the release branch may have diverged from `main`.
+Fill in every field. The body must make clear this is an already-reviewed change being cherry-picked, while still asking reviewers/CI to confirm it
+applies cleanly, because the release branch may have diverged from `main`.
 
 ```markdown
 ## Description
 
 Cherry-pick of #<original-number> into `release/<ver>`.
 
-> **This change was already reviewed and merged on `main`.** This PR exists to land it in the upcoming release. CI and a quick review should still run to confirm the cherry-pick applies cleanly and introduces no issues on the release branch, since `release/<ver>` may have diverged from `main`.
+> **This change was already reviewed and merged on `main`.** This PR exists to land it in the upcoming release. CI and a quick review should still
+> run to confirm the cherry-pick applies cleanly and introduces no issues on the release branch, since `release/<ver>` may have diverged from `main`.
 
 - Original PR: <original-url>
 - Cherry-picked commit: `<mergeCommit.oid short sha>`

--- a/.agents/skills/cherry-pick-to-release/SKILL.md
+++ b/.agents/skills/cherry-pick-to-release/SKILL.md
@@ -2,7 +2,7 @@
 name: cherry-pick-to-release
 description: Cherry-pick a merged pull request's commit(s) from `main` onto the current release branch and open a draft PR.
 disable-model-invocation: true
-allowed-tools: Read, Bash(which gh), Bash(git fetch *), Bash(git branch *), Bash(git branch -r *), Bash(git checkout *), Bash(git switch *), Bash(git cherry-pick *), Bash(git status *), Bash(git log *), Bash(git show *), Bash(git rev-list *), Bash(git push *), Bash(gh pr view *), Bash(gh pr create --repo Automattic/pocket-casts-android *), Bash(gh pr edit --repo Automattic/pocket-casts-android *), Bash(gh pr list --repo Automattic/pocket-casts-android *)
+allowed-tools: Read, Bash(which gh), Bash(git fetch *), Bash(git branch *), Bash(git branch -r *), Bash(git checkout *), Bash(git switch *), Bash(git cherry-pick *), Bash(git status *), Bash(git log *), Bash(git show *), Bash(git rev-list *), Bash(git push *), Bash(grep *), Bash(sed *), Bash(sort *), Bash(tail *), Bash(gh pr view *), Bash(gh pr create --repo Automattic/pocket-casts-android *), Bash(gh pr edit --repo Automattic/pocket-casts-android *), Bash(gh pr list --repo Automattic/pocket-casts-android *)
 ---
 
 # Cherry-pick a PR to the release branch
@@ -49,7 +49,7 @@ The repository squash-merges PRs, so the merge commit is usually a single commit
 git rev-list --parents -n 1 <mergeCommit.oid>
 ```
 
-- **One parent** (squash or rebase merge): cherry-pick the commit directly.
+- **One parent** (squash merge, the repo default): cherry-pick the commit directly.
   ```bash
   git cherry-pick <mergeCommit.oid>
   ```
@@ -58,7 +58,7 @@ git rev-list --parents -n 1 <mergeCommit.oid>
   git cherry-pick -m 1 <mergeCommit.oid>
   ```
 
-If `mergeCommit` is null (rare, e.g. the PR was merged in an unusual way), fall back to the PR's own commits from `gh pr view --json commits` and cherry-pick them in order, oldest first. Tell the user this is what you are doing.
+If `mergeCommit` is null (rare, e.g. the PR was merged in an unusual way), or the PR was rebase-merged (each commit is replayed onto `main`, so `mergeCommit.oid` is only the last of them and cherry-picking it alone would silently drop the earlier commits), fall back to the PR's own commits from `gh pr view --json commits` and cherry-pick them in order, oldest first. Tell the user this is what you are doing.
 
 ### 4. Create the branch off the release branch
 
@@ -95,7 +95,7 @@ gh pr create --repo Automattic/pocket-casts-android --draft \
 
 - Copy the `[Type]` and `[Area]` labels from the source PR onto the new one:
   ```bash
-  gh pr edit <new-pr-number> --repo Automattic/pocket-casts-android --add-label "<label>"
+  gh pr edit --repo Automattic/pocket-casts-android <new-pr-number> --add-label "<label>"
   ```
 - Output the new PR URL.
 

--- a/.agents/skills/cherry-pick-to-release/SKILL.md
+++ b/.agents/skills/cherry-pick-to-release/SKILL.md
@@ -115,13 +115,5 @@ Cherry-pick of #<original-number> into `release/<ver>`.
 
 ## Testing Instructions
 
-See the original PR (<original-url>) for full testing steps. In addition:
-
-1. Confirm CI passes on this branch.
-2. Verify the change behaves as described on top of `release/<ver>`.
-
-## Checklist
-
-- [ ] The cherry-pick applied without unresolved conflicts
-- [ ] CI is green on this branch
+See the original PR (<original-url>) for full testing steps. In addition, verify the change behaves as described on top of `release/<ver>`.
 ```

--- a/.agents/skills/cherry-pick-to-release/SKILL.md
+++ b/.agents/skills/cherry-pick-to-release/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: cherry-pick-to-release
+description: Cherry-pick a merged pull request's commit(s) from `main` onto the current release branch and open a draft PR.
+disable-model-invocation: true
+allowed-tools: Read, Bash(which gh), Bash(git fetch *), Bash(git branch *), Bash(git branch -r *), Bash(git checkout *), Bash(git switch *), Bash(git cherry-pick *), Bash(git status *), Bash(git log *), Bash(git show *), Bash(git rev-list *), Bash(git push *), Bash(gh pr view *), Bash(gh pr create --repo Automattic/pocket-casts-android *), Bash(gh pr edit --repo Automattic/pocket-casts-android *), Bash(gh pr list --repo Automattic/pocket-casts-android *)
+---
+
+# Cherry-pick a PR to the release branch
+
+Take a merged pull request, cherry-pick its commit(s) onto a fresh branch off the **current release branch**, and open a **draft** PR targeting that release branch.
+
+The workflow this supports: fixes are developed and merged on `main`, then cherry-picked to the release branch. That keeps the release branch limited to exactly the commits it needs, so merging it back into `main` later is clean and unambiguous (see the Git Workflow section of AGENTS.md).
+
+## Requirements
+
+- [GitHub CLI (`gh`)](https://cli.github.com/) installed and authenticated. Verify with `which gh`; if missing, stop and tell the user to install it.
+- The PR URL (or number) to cherry-pick. If the user did not provide one, ask for it.
+
+## Steps
+
+### 1. Read the source PR
+
+Run:
+
+```bash
+gh pr view <pr-url-or-number> --repo Automattic/pocket-casts-android \
+  --json number,title,url,state,mergedAt,mergeCommit,headRefName,author,labels,body
+```
+
+- If `state` is not `MERGED`, warn the user: cherry-picking is meant for changes already reviewed and merged on `main`. Ask whether to continue anyway before proceeding.
+- Note the `mergeCommit.oid` (the commit that landed on `main`). This is what you will cherry-pick.
+
+### 2. Determine the current release branch
+
+There should be only one active release branch. Fetch and find the highest version:
+
+```bash
+git fetch origin --prune
+git branch -r | grep -oE 'origin/release/[0-9]+\.[0-9]+' | sed 's|origin/release/||' | sort -V | tail -1
+```
+
+This prints the latest release version (e.g. `8.15`), giving the branch `release/<ver>`. **Confirm the target branch with the user** before continuing, in case a new release branch has been cut or an older one is intended.
+
+### 3. Identify the commit(s) to cherry-pick
+
+The repository squash-merges PRs, so the merge commit is usually a single commit containing the whole change. Handle both squash and true merge commits by checking the parent count:
+
+```bash
+git rev-list --parents -n 1 <mergeCommit.oid>
+```
+
+- **One parent** (squash or rebase merge): cherry-pick the commit directly.
+  ```bash
+  git cherry-pick <mergeCommit.oid>
+  ```
+- **Two parents** (true merge commit): cherry-pick relative to the first parent.
+  ```bash
+  git cherry-pick -m 1 <mergeCommit.oid>
+  ```
+
+If `mergeCommit` is null (rare, e.g. the PR was merged in an unusual way), fall back to the PR's own commits from `gh pr view --json commits` and cherry-pick them in order, oldest first. Tell the user this is what you are doing.
+
+### 4. Create the branch off the release branch
+
+Branch **from the release branch**, never from `main`. Use a descriptive name that ties it to the source PR:
+
+```bash
+git checkout -b cherry-pick/<ver>/pr-<number> origin/release/<ver>
+```
+
+### 5. Cherry-pick
+
+Run the cherry-pick command chosen in step 3.
+
+- **On success**, verify with `git log --oneline -n 3` that the commit landed.
+- **On conflict**, stop. Show the conflicting files (`git status`) and hand back to the user to resolve. Do not force or guess a resolution. Once they have staged the fixes, continue with `git cherry-pick --continue`. Resolving conflicts carefully matters here because the release branch and `main` may have diverged.
+
+### 6. Push and open the draft PR
+
+```bash
+git push -u origin cherry-pick/<ver>/pr-<number>
+```
+
+Create a **draft** PR targeting the release branch, filling in the template below:
+
+```bash
+gh pr create --repo Automattic/pocket-casts-android --draft \
+  --base release/<ver> \
+  --head cherry-pick/<ver>/pr-<number> \
+  --title "<original title> (cherry-pick to <ver>)" \
+  --body "<filled-in body>"
+```
+
+### 7. Carry over labels and report
+
+- Copy the `[Type]` and `[Area]` labels from the source PR onto the new one:
+  ```bash
+  gh pr edit <new-pr-number> --repo Automattic/pocket-casts-android --add-label "<label>"
+  ```
+- Output the new PR URL.
+
+## PR body template
+
+Fill in every field. The body must make clear this is an already-reviewed change being cherry-picked, while still asking reviewers/CI to confirm it applies cleanly, because the release branch may have diverged from `main`.
+
+```markdown
+## Description
+
+Cherry-pick of #<original-number> into `release/<ver>`.
+
+> **This change was already reviewed and merged on `main`.** This PR exists to land it in the upcoming release. CI and a quick review should still run to confirm the cherry-pick applies cleanly and introduces no issues on the release branch, since `release/<ver>` may have diverged from `main`.
+
+- Original PR: <original-url>
+- Cherry-picked commit: `<mergeCommit.oid short sha>`
+
+## Testing Instructions
+
+See the original PR (<original-url>) for full testing steps. In addition:
+
+1. Confirm CI passes on this branch.
+2. Verify the change behaves as described on top of `release/<ver>`.
+
+## Checklist
+
+- [ ] The cherry-pick applied without unresolved conflicts
+- [ ] CI is green on this branch
+```


### PR DESCRIPTION
Adds a new AI-assistant skill, `cherry-pick-to-release`, under `.agents/skills/`. The skill codifies the repository's cherry-pick workflow documented in AGENTS.md: take a PR that has already been reviewed and merged on `main`, cherry-pick its commit(s) onto a fresh branch off the current release branch, and open a draft PR targeting that release branch.

The skill walks through reading the source PR, determining the current release branch, handling both squash and true-merge commits, creating the branch off the release branch (never `main`), cherry-picking with conflict guidance, pushing, and opening a draft PR with labels carried over. It is scoped with `disable-model-invocation: true` and an explicit `allowed-tools` allowlist, so it only runs when a user invokes it.
