### PR TITLE
[Hyundai] Reset player to empty state when playback completes (#5488)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@
         ([#5446](https://github.com/Automattic/pocket-casts-android/pull/5446))
     *   Improved Automotive sign up screen
         ([#5487](https://github.com/Automattic/pocket-casts-android/pull/5487))
+    *   Fix overlapping text issue on Automotive after orientation change
+        ([#5477](https://github.com/Automattic/pocket-casts-android/pull/5477))
+    *   Fix link screen's text overlap on Automotive
+        ([#5475](https://github.com/Automattic/pocket-casts-android/pull/5475))
+*   Updates
+    *   Reset player after playback finished on Automotive
+        ([#5488](https://github.com/Automattic/pocket-casts-android/pull/5488))
 
 8.14
 -----

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3AutomotiveStrategy.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3AutomotiveStrategy.kt
@@ -22,8 +22,13 @@ internal class Media3AutomotiveStrategy(
         context: Context,
         buildCustomActionButton: (MediaNotificationControls, BaseEpisode?) -> CommandButton?,
     ): AutomotiveSessionStrategy.ButtonLayout {
-        val buttons = mutableListOf<CommandButton>()
         val currentEpisode = playbackManager.getCurrentEpisode()
+
+        if (currentEpisode == null) {
+            return AutomotiveSessionStrategy.ButtonLayout(primaryButtons = emptyList(), overflowButtons = emptyList())
+        }
+
+        val buttons = mutableListOf<CommandButton>()
 
         if (useCustomSkipButtons()) {
             buttons.add(

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -344,6 +344,7 @@ class MediaSessionManager(
                     true
                 }
             },
+            isAutomotive = isAutomotive,
         )
 
         media3Callback = Media3SessionCallback(
@@ -435,6 +436,20 @@ class MediaSessionManager(
         Timber.i("Media3 session player swapped")
     }
 
+    @OptIn(UnstableApi::class)
+    @MainThread
+    private fun resetToEmptyState() {
+        val currentPlayer = forwardingPlayer ?: return
+        if (currentPlayer.wrappedPlayer is SeedStatePlayer) return
+        val seed = SeedStatePlayer(Looper.getMainLooper())
+        val swapped = currentPlayer.swapPlayer(seed)
+        swapped.clearMetadata()
+        forwardingPlayer = swapped
+        media3Session?.player = swapped
+        placeholderPlayer?.release()
+        placeholderPlayer = seed
+    }
+
     /**
      * Creates a [CastStatePlayer] and installs it into the Media3 session so that
      * notifications and lock screen controls reflect cast playback state.
@@ -483,6 +498,7 @@ class MediaSessionManager(
             onSkipForward = { scope.launch { commandMutex.withLock { playbackManager.skipForwardSuspend() } } },
             onSkipBack = { scope.launch { commandMutex.withLock { playbackManager.skipBackwardSuspend() } } },
             playGuard = currentPlayer.playGuard,
+            isAutomotive = isAutomotive,
         ).also {
             it.currentMediaItem = currentPlayer.currentMediaItem
             it.previousMediaId = currentPlayer.previousMediaId
@@ -584,14 +600,14 @@ class MediaSessionManager(
     private fun observeForMedia3Updates() {
         if (isAutomotive) {
             playbackManager.playbackStateRelay
-                .map { it.isStopped || it.isError || it.isEmpty }
+                .map { it.isError }
                 .distinctUntilChanged()
                 // Skip the BehaviorRelay's initial replay so we don't detach the session that
                 // PlaybackService.onCreate just attached; only react to genuine transitions after startup.
                 .skip(1)
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribeBy(
-                    onNext = { inactive -> setMedia3SessionAttached(!inactive) },
+                    onNext = { hasError -> setMedia3SessionAttached(!hasError) },
                     onError = { Timber.e(it, "Error observing automotive active state") },
                 )
                 .addTo(disposables)
@@ -663,7 +679,12 @@ class MediaSessionManager(
                     val player = forwardingPlayer ?: return@subscribeBy
                     val data = dataOpt.get()
                     if (data == null) {
-                        player.clearMetadata()
+                        if (isAutomotive) {
+                            resetToEmptyState()
+                            updateMedia3CustomLayout()
+                        } else {
+                            player.clearMetadata()
+                        }
                         return@subscribeBy
                     }
                     val wrappedUri = if (data.showArtwork) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsForwardingPlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsForwardingPlayer.kt
@@ -43,7 +43,11 @@ class PocketCastsForwardingPlayer(
     private val onPause: (() -> Unit)? = null,
     private val onSeekTo: ((Long) -> Unit)? = null,
     internal val playGuard: (() -> Boolean) = { true },
+    private val isAutomotive: Boolean = false,
 ) : ForwardingPlayer(wrappedPlayer) {
+
+    private val isEmptyState: Boolean
+        get() = isAutomotive && super.getCurrentTimeline().isEmpty
 
     internal var currentMediaItem: MediaItem = MediaItem.EMPTY
     internal var previousMediaId: String? = null
@@ -68,7 +72,7 @@ class PocketCastsForwardingPlayer(
     @MainThread
     fun swapPlayer(newPlayer: Player): PocketCastsForwardingPlayer {
         checkMainThread()
-        return PocketCastsForwardingPlayer(newPlayer, onSkipForward, onSkipBack, onStop, onPlay, onPause, onSeekTo, playGuard).also {
+        return PocketCastsForwardingPlayer(newPlayer, onSkipForward, onSkipBack, onStop, onPlay, onPause, onSeekTo, playGuard, isAutomotive).also {
             it.currentMediaItem = this.currentMediaItem
             it.previousMediaId = this.previousMediaId
             it.isTransientLoss = this.isTransientLoss
@@ -154,11 +158,20 @@ class PocketCastsForwardingPlayer(
         dispatchEvents(Player.EVENT_MEDIA_METADATA_CHANGED)
     }
 
-    override fun getCurrentMediaItem(): MediaItem = currentMediaItem
+    override fun getCurrentMediaItem(): MediaItem? = if (isEmptyState) null else currentMediaItem
 
     override fun getMediaMetadata(): MediaMetadata = currentMediaItem.mediaMetadata
 
     override fun getAvailableCommands(): Player.Commands {
+        if (isEmptyState) {
+            return Player.Commands.Builder()
+                .addAll(
+                    Player.COMMAND_SET_MEDIA_ITEM,
+                    Player.COMMAND_GET_CURRENT_MEDIA_ITEM,
+                    Player.COMMAND_GET_METADATA,
+                )
+                .build()
+        }
         return Player.Commands.Builder()
             .addAll(
                 Player.COMMAND_PLAY_PAUSE,

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3AutomotiveStrategyTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3AutomotiveStrategyTest.kt
@@ -1,0 +1,34 @@
+package au.com.shiftyjelly.pocketcasts.repositories.playback
+
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.session.CommandButton
+import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
+import au.com.shiftyjelly.pocketcasts.preferences.Settings.MediaNotificationControls
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@UnstableApi
+@RunWith(RobolectricTestRunner::class)
+class Media3AutomotiveStrategyTest {
+
+    private val context = RuntimeEnvironment.getApplication()
+    private val noButton: (MediaNotificationControls, BaseEpisode?) -> CommandButton? = { _, _ -> null }
+
+    @Test
+    fun `returns empty layout when there is no current episode`() {
+        val playbackManager = mock<PlaybackManager> {
+            on { getCurrentEpisode() } doReturn null
+        }
+        val strategy = Media3AutomotiveStrategy(useCustomSkipButtons = { true })
+
+        val layout = strategy.buildLayout(playbackManager, mock(), context, noButton)
+
+        assertTrue(layout.primaryButtons.isEmpty())
+        assertTrue(layout.overflowButtons.isEmpty())
+    }
+}

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsForwardingPlayerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PocketCastsForwardingPlayerTest.kt
@@ -7,6 +7,7 @@ import androidx.media3.common.HeartRating
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import androidx.media3.common.Player
+import androidx.media3.common.Timeline
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
@@ -187,6 +188,44 @@ class PocketCastsForwardingPlayerTest {
     }
 
     @Test
+    fun `automotive empty timeline drops transport commands but keeps SET_MEDIA_ITEM`() {
+        val player = mock<Player> {
+            on { applicationLooper } doReturn Looper.getMainLooper()
+            on { currentTimeline } doReturn Timeline.EMPTY
+        }
+        val commands = PocketCastsForwardingPlayer(player, isAutomotive = true).availableCommands
+
+        assertFalse(commands.contains(Player.COMMAND_PLAY_PAUSE))
+        assertFalse(commands.contains(Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM))
+        assertFalse(commands.contains(Player.COMMAND_STOP))
+        assertTrue(commands.contains(Player.COMMAND_SET_MEDIA_ITEM))
+        assertTrue(commands.contains(Player.COMMAND_GET_CURRENT_MEDIA_ITEM))
+        assertTrue(commands.contains(Player.COMMAND_GET_METADATA))
+    }
+
+    @Test
+    fun `automotive empty timeline reports null current media item`() {
+        val player = mock<Player> {
+            on { applicationLooper } doReturn Looper.getMainLooper()
+            on { currentTimeline } doReturn Timeline.EMPTY
+        }
+        val forwarding: Player = PocketCastsForwardingPlayer(player, isAutomotive = true)
+
+        assertNull(forwarding.currentMediaItem)
+    }
+
+    @Test
+    fun `non-automotive keeps full commands even with empty timeline`() {
+        val player = mock<Player> {
+            on { applicationLooper } doReturn Looper.getMainLooper()
+            on { currentTimeline } doReturn Timeline.EMPTY
+        }
+        val commands = PocketCastsForwardingPlayer(player, isAutomotive = false).availableCommands
+
+        assertTrue(commands.contains(Player.COMMAND_PLAY_PAUSE))
+    }
+
+    @Test
     fun `duration falls back to metadata when player reports unset`() {
         val episode = createPodcastEpisode(uuid = "ep-1", title = "Test", durationMs = 120_000)
         forwardingPlayer.updateMetadata(episode, null)
@@ -233,6 +272,23 @@ class PocketCastsForwardingPlayerTest {
         assertEquals("ep-1", swapped.currentMediaItem.mediaId)
         assertEquals("Preserved", swapped.mediaMetadata.title)
         assertTrue(swapped.isTransientLoss)
+    }
+
+    @Test
+    fun `swapPlayer preserves isAutomotive so swapped-in empty player shows empty state`() {
+        val emptyPlayer = mock<Player> {
+            on { applicationLooper } doReturn Looper.getMainLooper()
+            on { currentTimeline } doReturn Timeline.EMPTY
+        }
+        val player = PocketCastsForwardingPlayer(mockPlayer, isAutomotive = true)
+        val swapped: Player = player.swapPlayer(emptyPlayer)
+
+        assertNull(swapped.currentMediaItem)
+        val commands = swapped.availableCommands
+        assertFalse(commands.contains(Player.COMMAND_PLAY_PAUSE))
+        assertFalse(commands.contains(Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM))
+        assertFalse(commands.contains(Player.COMMAND_STOP))
+        assertTrue(commands.contains(Player.COMMAND_SET_MEDIA_ITEM))
     }
 
     @Test


### PR DESCRIPTION
## Description
This PR cherry-picks e1bd18b501c762d6e184ce44254accc9b658d930 from #5488
This has been reviewed on the release branch.

## Testing Instructions
Just make sure CI is 🟢 

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
