### PR TITLE
Fix Podcasts tab sort scroll drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 8.19
 -----
 
+*   Bug Fixes
+    *   Keep the Podcasts tab pinned to the top when changing sort order from the top of the list
+        ([#5516](https://github.com/Automattic/pocket-casts-android/pull/5516))
 
 8.18
 -----

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/FolderAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/FolderAdapter.kt
@@ -139,9 +139,9 @@ class FolderAdapter(
         notifyDataSetChanged()
     }
 
-    fun setFolderItems(items: List<FolderItem>) {
+    fun setFolderItems(items: List<FolderItem>, commitCallback: (() -> Unit)? = null) {
         applyBadgesToNewPodcasts(items.mapNotNull { (it as? FolderItem.Podcast)?.podcast })
-        submitList(items)
+        submitList(items, commitCallback?.let { callback -> Runnable { callback() } })
     }
 
     private fun applyBadgesToExistingPodcasts() {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -172,6 +172,7 @@ class PodcastsFragment :
     private var lastOrientationRefreshed = LAST_ORIENTATION_NOT_SET
     private var lastWidthPx: Int = 0
     private var listState: Parcelable? = null
+    private var sortTypeToKeepAtTop: PodcastsSortType? = null
 
     private val folderUuid: String?
         get() = arguments?.getString(ARG_FOLDER_UUID)
@@ -286,7 +287,15 @@ class PodcastsFragment :
                     toolbar.menu.findItem(R.id.create_folder)?.isVisible = rootFolder && isSignedInAsPlusOrPatron
                     toolbar.menu.findItem(R.id.search_podcasts)?.isVisible = rootFolder
 
-                    folderAdapter?.setFolderItems(uiState.items)
+                    val pendingSortType = sortTypeToKeepAtTop
+                    val currentSortType = uiState.folder?.podcastsSortType ?: uiState.sortType
+                    val shouldScrollToTop = pendingSortType == currentSortType
+                    folderAdapter?.setFolderItems(uiState.items) {
+                        if (shouldScrollToTop) {
+                            scrollRecyclerViewToTop()
+                            this@PodcastsFragment.sortTypeToKeepAtTop = null
+                        }
+                    }
 
                     val isEmpty = uiState.items.isEmpty()
                     binding.emptyView.isVisible = isEmpty && !uiState.isLoadingItems
@@ -374,6 +383,7 @@ class PodcastsFragment :
 
     override fun onDestroyView() {
         listState = binding.recyclerView.layoutManager?.onSaveInstanceState()
+        sortTypeToKeepAtTop = null
         binding.recyclerView.adapter = null
         super.onDestroyView()
         realBinding = null
@@ -424,6 +434,9 @@ class PodcastsFragment :
                 )
             }
             val onSortTypeChanged = { sort: PodcastsSortType ->
+                if (sort != folder.podcastsSortType) {
+                    keepRecyclerViewAtTopAfterSort(sort)
+                }
                 eventHorizon.track(
                     FolderSortByChangedEvent(
                         sortOrder = sort.analyticsValue,
@@ -455,7 +468,14 @@ class PodcastsFragment :
                 show()
             }
         } else {
-            podcastOptionsDialog = PodcastsOptionsDialog(this, settings, eventHorizon).apply {
+            podcastOptionsDialog = PodcastsOptionsDialog(
+                fragment = this,
+                settings = settings,
+                eventHorizon = eventHorizon,
+                onSortTypeChanged = { sort ->
+                    keepRecyclerViewAtTopAfterSort(sort)
+                },
+            ).apply {
                 show()
             }
         }
@@ -666,6 +686,20 @@ class PodcastsFragment :
         val canScroll = binding.recyclerView.canScrollVertically(-1)
         binding.recyclerView.quickScrollToTop()
         return canScroll
+    }
+
+    private fun scrollRecyclerViewToTop() {
+        val recyclerView = realBinding?.recyclerView ?: return
+        (recyclerView.layoutManager as? LinearLayoutManager)?.scrollToPositionWithOffset(0, 0)
+            ?: recyclerView.scrollToPosition(0)
+    }
+
+    private fun keepRecyclerViewAtTopAfterSort(sortType: PodcastsSortType) {
+        sortTypeToKeepAtTop = if (realBinding?.recyclerView?.canScrollVertically(-1) == false) {
+            sortType
+        } else {
+            null
+        }
     }
 
     private fun showTooltip() {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -293,7 +293,9 @@ class PodcastsFragment :
                     folderAdapter?.setFolderItems(uiState.items) {
                         if (shouldScrollToTop) {
                             scrollRecyclerViewToTop()
-                            this@PodcastsFragment.sortTypeToKeepAtTop = null
+                            if (sortTypeToKeepAtTop == pendingSortType) {
+                                sortTypeToKeepAtTop = null
+                            }
                         }
                     }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -175,6 +175,13 @@ class PodcastsFragment :
     private var lastWidthPx: Int = 0
     private var listState: Parcelable? = null
     private var scrollToTopRequest: ScrollToTopRequest? = null
+    private val cancelPendingScrollToTopListener = object : RecyclerView.OnScrollListener() {
+        override fun onScrollStateChanged(recyclerView: RecyclerView, newState: Int) {
+            if (newState == RecyclerView.SCROLL_STATE_DRAGGING) {
+                scrollToTopRequest = null
+            }
+        }
+    }
 
     private val folderUuid: String?
         get() = arguments?.getString(ARG_FOLDER_UUID)
@@ -214,6 +221,7 @@ class PodcastsFragment :
         binding.recyclerView.let {
             it.adapter = adapter
             it.addItemDecoration(SpaceItemDecoration())
+            it.addOnScrollListener(cancelPendingScrollToTopListener)
             ItemTouchHelper(dragAndDropCallback).attachToRecyclerView(it)
         }
 
@@ -390,6 +398,7 @@ class PodcastsFragment :
     override fun onDestroyView() {
         listState = binding.recyclerView.layoutManager?.onSaveInstanceState()
         scrollToTopRequest = null
+        binding.recyclerView.removeOnScrollListener(cancelPendingScrollToTopListener)
         binding.recyclerView.adapter = null
         super.onDestroyView()
         realBinding = null
@@ -696,8 +705,10 @@ class PodcastsFragment :
 
     private fun scrollRecyclerViewToTop() {
         val recyclerView = realBinding?.recyclerView ?: return
-        (recyclerView.layoutManager as? LinearLayoutManager)?.scrollToPositionWithOffset(0, 0)
-            ?: recyclerView.scrollToPosition(0)
+        when (val layoutManager = recyclerView.layoutManager) {
+            is LinearLayoutManager -> layoutManager.scrollToPositionWithOffset(0, 0)
+            else -> recyclerView.scrollToPosition(0)
+        }
     }
 
     private fun keepRecyclerViewAtTopAfterSort(sortType: PodcastsSortType) {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -145,6 +145,8 @@ class PodcastsFragment :
         }
     }
 
+    private class ScrollToTopRequest(val sortType: PodcastsSortType)
+
     @Inject
     lateinit var settings: Settings
 
@@ -172,7 +174,7 @@ class PodcastsFragment :
     private var lastOrientationRefreshed = LAST_ORIENTATION_NOT_SET
     private var lastWidthPx: Int = 0
     private var listState: Parcelable? = null
-    private var sortTypeToKeepAtTop: PodcastsSortType? = null
+    private var scrollToTopRequest: ScrollToTopRequest? = null
 
     private val folderUuid: String?
         get() = arguments?.getString(ARG_FOLDER_UUID)
@@ -287,15 +289,17 @@ class PodcastsFragment :
                     toolbar.menu.findItem(R.id.create_folder)?.isVisible = rootFolder && isSignedInAsPlusOrPatron
                     toolbar.menu.findItem(R.id.search_podcasts)?.isVisible = rootFolder
 
-                    val pendingSortType = sortTypeToKeepAtTop
+                    val pendingScrollToTopRequest = scrollToTopRequest
                     val currentSortType = uiState.folder?.podcastsSortType ?: uiState.sortType
-                    val shouldScrollToTop = pendingSortType == currentSortType
-                    folderAdapter?.setFolderItems(uiState.items) {
-                        if (shouldScrollToTop) {
+                    val submittedFolderAdapter = folderAdapter
+                    submittedFolderAdapter?.setFolderItems(uiState.items) {
+                        if (
+                            pendingScrollToTopRequest?.sortType == currentSortType &&
+                            scrollToTopRequest === pendingScrollToTopRequest &&
+                            folderAdapter === submittedFolderAdapter
+                        ) {
+                            scrollToTopRequest = null
                             scrollRecyclerViewToTop()
-                            if (sortTypeToKeepAtTop == pendingSortType) {
-                                sortTypeToKeepAtTop = null
-                            }
                         }
                     }
 
@@ -385,7 +389,7 @@ class PodcastsFragment :
 
     override fun onDestroyView() {
         listState = binding.recyclerView.layoutManager?.onSaveInstanceState()
-        sortTypeToKeepAtTop = null
+        scrollToTopRequest = null
         binding.recyclerView.adapter = null
         super.onDestroyView()
         realBinding = null
@@ -697,8 +701,8 @@ class PodcastsFragment :
     }
 
     private fun keepRecyclerViewAtTopAfterSort(sortType: PodcastsSortType) {
-        sortTypeToKeepAtTop = if (realBinding?.recyclerView?.canScrollVertically(-1) == false) {
-            sortType
+        scrollToTopRequest = if (realBinding?.recyclerView?.canScrollVertically(-1) == false) {
+            ScrollToTopRequest(sortType)
         } else {
             null
         }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -449,9 +449,7 @@ class PodcastsFragment :
                 )
             }
             val onSortTypeChanged = { sort: PodcastsSortType ->
-                if (sort != folder.podcastsSortType) {
-                    keepRecyclerViewAtTopAfterSort(sort)
-                }
+                keepRecyclerViewAtTopAfterSort(sort)
                 eventHorizon.track(
                     FolderSortByChangedEvent(
                         sortOrder = sort.analyticsValue,
@@ -712,6 +710,15 @@ class PodcastsFragment :
     }
 
     private fun keepRecyclerViewAtTopAfterSort(sortType: PodcastsSortType) {
+        val currentSortType = if (folderUuid == null) {
+            settings.podcastsSortType.value
+        } else {
+            viewModel.uiState.value.folder?.podcastsSortType
+        }
+        if (sortType == currentSortType) {
+            scrollToTopRequest = scrollToTopRequest?.takeIf { request -> request.sortType == sortType }
+            return
+        }
         scrollToTopRequest = if (realBinding?.recyclerView?.canScrollVertically(-1) == false) {
             ScrollToTopRequest(sortType)
         } else {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -710,13 +710,13 @@ class PodcastsFragment :
     }
 
     private fun keepRecyclerViewAtTopAfterSort(sortType: PodcastsSortType) {
-        val currentSortType = if (folderUuid == null) {
+        // A pending request is the latest selection while folder UI state may still reflect the previous sort.
+        val currentSortType = scrollToTopRequest?.sortType ?: if (folderUuid == null) {
             settings.podcastsSortType.value
         } else {
             viewModel.uiState.value.folder?.podcastsSortType
         }
         if (sortType == currentSortType) {
-            scrollToTopRequest = scrollToTopRequest?.takeIf { request -> request.sortType == sortType }
             return
         }
         scrollToTopRequest = if (realBinding?.recyclerView?.canScrollVertically(-1) == false) {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsOptionsDialog.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsOptionsDialog.kt
@@ -24,6 +24,7 @@ class PodcastsOptionsDialog(
     val fragment: Fragment,
     val settings: Settings,
     private val eventHorizon: EventHorizon,
+    private val onSortTypeChanged: (PodcastsSortType) -> Unit,
 ) {
     private var showDialog: OptionsDialog? = null
     private var sortDialog: OptionsDialog? = null
@@ -113,6 +114,9 @@ class PodcastsOptionsDialog(
                 titleId = order.labelId,
                 checked = order.clientId == sortOrder.clientId,
                 click = {
+                    if (order.clientId != sortOrder.clientId) {
+                        onSortTypeChanged(order)
+                    }
                     settings.podcastsSortType.set(order, updateModifiedAt = true)
                     trackSortByChanged(order)
                 },

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsOptionsDialog.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsOptionsDialog.kt
@@ -114,9 +114,7 @@ class PodcastsOptionsDialog(
                 titleId = order.labelId,
                 checked = order.clientId == sortOrder.clientId,
                 click = {
-                    if (order.clientId != sortOrder.clientId) {
-                        onSortTypeChanged(order)
-                    }
+                    onSortTypeChanged(order)
                     settings.podcastsSortType.set(order, updateModifiedAt = true)
                     trackSortByChanged(order)
                 },

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
@@ -99,7 +99,7 @@ class PodcastsViewModel @AssistedInject constructor(
                 when (sortType) {
                     PodcastsSortType.RECENTLY_PLAYED -> podcastManager.observePodcastsBySortedRecentlyPlayed()
                     else -> podcastManager.observePodcastsSortedByLatestEpisode()
-                }
+                }.map { podcasts -> sortType to podcasts }
             }
 
         val foldersFlow: Flow<List<FolderItem.Folder>> = folderManager.observeFolders()
@@ -124,9 +124,8 @@ class PodcastsViewModel @AssistedInject constructor(
         return combine(
             podcastsFlow,
             foldersFlow,
-            settings.podcastsSortType.flow,
             userManager.getSignInState().asFlow(),
-        ) { podcasts, folders, sortType, signInState ->
+        ) { (sortType, podcasts), folders, signInState ->
             withContext(Dispatchers.Default) {
                 buildUiState(podcasts, folders, sortType, signInState)
             }
@@ -139,6 +138,7 @@ class PodcastsViewModel @AssistedInject constructor(
         sortType: PodcastsSortType,
         signInState: SignInState,
     ) = UiState(
+        sortType = sortType,
         items = when {
             signInState.isNoAccountOrFree -> buildPodcastItems(podcasts, sortType)
 
@@ -319,6 +319,7 @@ class PodcastsViewModel @AssistedInject constructor(
 
     data class UiState(
         val isLoadingItems: Boolean = false,
+        val sortType: PodcastsSortType = PodcastsSortType.default,
         val items: List<FolderItem> = emptyList(),
         val folder: Folder? = null,
         val isSignedInAsPlusOrPatron: Boolean = false,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
@@ -11,6 +11,7 @@ import au.com.shiftyjelly.pocketcasts.podcasts.view.folders.SuggestedFoldersPopu
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.model.BadgeType
 import au.com.shiftyjelly.pocketcasts.repositories.ads.BlazeAdsManager
+import au.com.shiftyjelly.pocketcasts.repositories.di.DefaultDispatcher
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationHelper
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.FolderManager
@@ -29,7 +30,7 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
@@ -60,6 +61,7 @@ class PodcastsViewModel @AssistedInject constructor(
     private val suggestedFoldersPopupPolicy: SuggestedFoldersPopupPolicy,
     private val userManager: UserManager,
     private val notificationHelper: NotificationHelper,
+    @DefaultDispatcher private val computationDispatcher: CoroutineDispatcher,
     blazeAdsManager: BlazeAdsManager,
     @Assisted private val folderUuid: String?,
 ) : ViewModel() {
@@ -126,7 +128,7 @@ class PodcastsViewModel @AssistedInject constructor(
             foldersFlow,
             userManager.getSignInState().asFlow(),
         ) { (sortType, podcasts), folders, signInState ->
-            withContext(Dispatchers.Default) {
+            withContext(computationDispatcher) {
                 buildUiState(podcasts, folders, sortType, signInState)
             }
         }
@@ -231,7 +233,7 @@ class PodcastsViewModel @AssistedInject constructor(
         // Wait until the UI state is synchronized with the ordered items.
         // This ensures smoother transitions — items won’t jump around
         // if an intermediate state is emitted during ordering.
-        return withContext(Dispatchers.Default) {
+        return withContext(computationDispatcher) {
             val sortedUuids = items.map(FolderItem::uuid)
             uiState
                 .map { state -> state.items.map(FolderItem::uuid) }

--- a/modules/features/podcasts/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModelTest.kt
+++ b/modules/features/podcasts/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModelTest.kt
@@ -1,0 +1,146 @@
+package au.com.shiftyjelly.pocketcasts.podcasts.viewmodel
+
+import app.cash.turbine.test
+import au.com.shiftyjelly.pocketcasts.analytics.testing.TestEventSink
+import au.com.shiftyjelly.pocketcasts.models.entity.BlazeAd
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.entity.SuggestedFolder
+import au.com.shiftyjelly.pocketcasts.models.to.RefreshState
+import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
+import au.com.shiftyjelly.pocketcasts.models.type.SignInState
+import au.com.shiftyjelly.pocketcasts.podcasts.view.folders.SuggestedFoldersPopupPolicy
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
+import au.com.shiftyjelly.pocketcasts.preferences.model.BadgeType
+import au.com.shiftyjelly.pocketcasts.preferences.model.PodcastGridLayoutType
+import au.com.shiftyjelly.pocketcasts.repositories.ads.BlazeAdsManager
+import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationHelper
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.FolderManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.SuggestedFoldersManager
+import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
+import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import com.automattic.eventhorizon.EventHorizon
+import io.reactivex.Flowable
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PodcastsViewModelTest {
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
+
+    @Test
+    fun `changing to recently played waits for recently played podcasts before updating sort type`() = runTest {
+        val sortTypeFlow = MutableStateFlow(PodcastsSortType.DATE_ADDED_NEWEST_TO_OLDEST)
+        val latestEpisodePodcasts = MutableSharedFlow<List<Podcast>>(replay = 1)
+        val recentlyPlayedPodcasts = MutableSharedFlow<List<Podcast>>()
+        latestEpisodePodcasts.emit(listOf(podcast("latest-episode-podcast")))
+
+        val viewModel = createViewModel(
+            sortTypeFlow = sortTypeFlow,
+            latestEpisodePodcasts = latestEpisodePodcasts,
+            recentlyPlayedPodcasts = recentlyPlayedPodcasts,
+        )
+
+        viewModel.uiState.test {
+            var initialState = awaitItem()
+            while (initialState.items.isEmpty()) {
+                initialState = awaitItem()
+            }
+            assertEquals(PodcastsSortType.DATE_ADDED_NEWEST_TO_OLDEST, initialState.sortType)
+            assertEquals(listOf("latest-episode-podcast"), initialState.items.map { it.uuid })
+
+            sortTypeFlow.value = PodcastsSortType.RECENTLY_PLAYED
+            expectNoEvents()
+
+            recentlyPlayedPodcasts.emit(listOf(podcast("recently-played-podcast")))
+
+            val recentlyPlayedState = awaitItem()
+            assertEquals(PodcastsSortType.RECENTLY_PLAYED, recentlyPlayedState.sortType)
+            assertEquals(listOf("recently-played-podcast"), recentlyPlayedState.items.map { it.uuid })
+        }
+    }
+
+    private fun createViewModel(
+        sortTypeFlow: MutableStateFlow<PodcastsSortType>,
+        latestEpisodePodcasts: MutableSharedFlow<List<Podcast>>,
+        recentlyPlayedPodcasts: MutableSharedFlow<List<Podcast>>,
+    ): PodcastsViewModel {
+        val sortTypeSetting = mock<UserSetting<PodcastsSortType>> {
+            on { flow } doReturn sortTypeFlow
+            on { value } doReturn sortTypeFlow.value
+        }
+        val notificationsPromptAcknowledgedSetting = mock<UserSetting<Boolean>> {
+            on { flow } doReturn MutableStateFlow(false)
+        }
+        val podcastBadgeTypeSetting = mock<UserSetting<BadgeType>> {
+            on { flow } doReturn MutableStateFlow(BadgeType.OFF)
+            on { value } doReturn BadgeType.OFF
+        }
+        val podcastGridLayoutSetting = mock<UserSetting<PodcastGridLayoutType>> {
+            on { flow } doReturn MutableStateFlow(PodcastGridLayoutType.LARGE_ARTWORK)
+            on { value } doReturn PodcastGridLayoutType.LARGE_ARTWORK
+        }
+        val showRecentlyPlayedTooltip = mock<UserSetting<Boolean>> {
+            on { value } doReturn false
+        }
+        val settings = mock<Settings> {
+            on { podcastsSortType } doReturn sortTypeSetting
+            on { notificationsPromptAcknowledged } doReturn notificationsPromptAcknowledgedSetting
+            on { podcastBadgeType } doReturn podcastBadgeTypeSetting
+            on { podcastGridLayout } doReturn podcastGridLayoutSetting
+            on { refreshStateFlow } doReturn MutableStateFlow<RefreshState>(RefreshState.Never)
+            on { showPodcastsRecentlyPlayedSortOrderTooltip } doReturn showRecentlyPlayedTooltip
+        }
+
+        val podcastManager = mock<PodcastManager>()
+        whenever(podcastManager.observePodcastsSortedByLatestEpisode()).thenReturn(latestEpisodePodcasts)
+        whenever(podcastManager.observePodcastsBySortedRecentlyPlayed()).thenReturn(recentlyPlayedPodcasts)
+
+        val folderManager = mock<FolderManager>()
+        whenever(folderManager.observeFolders()).thenReturn(flowOf(emptyList()))
+
+        val suggestedFoldersManager = mock<SuggestedFoldersManager>()
+        whenever(suggestedFoldersManager.observeSuggestedFolders()).thenReturn(flowOf(emptyList<SuggestedFolder>()))
+
+        val userManager = mock<UserManager>()
+        whenever(userManager.getSignInState()).thenReturn(Flowable.just(SignInState.SignedOut))
+
+        val notificationHelper = mock<NotificationHelper>()
+        whenever(notificationHelper.hasNotificationsPermission()).thenReturn(true)
+
+        val blazeAdsManager = mock<BlazeAdsManager>()
+        whenever(blazeAdsManager.findPodcastListAd()).thenReturn(flowOf<BlazeAd?>(null))
+
+        return PodcastsViewModel(
+            podcastManager = podcastManager,
+            episodeManager = mock<EpisodeManager>(),
+            folderManager = folderManager,
+            settings = settings,
+            eventHorizon = EventHorizon(TestEventSink()),
+            suggestedFoldersManager = suggestedFoldersManager,
+            suggestedFoldersPopupPolicy = mock<SuggestedFoldersPopupPolicy>(),
+            userManager = userManager,
+            notificationHelper = notificationHelper,
+            blazeAdsManager = blazeAdsManager,
+            folderUuid = null,
+        )
+    }
+
+    private fun podcast(uuid: String) = Podcast(
+        uuid = uuid,
+        title = uuid,
+        isSubscribed = true,
+    )
+}

--- a/modules/features/podcasts/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModelTest.kt
+++ b/modules/features/podcasts/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModelTest.kt
@@ -27,10 +27,12 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
@@ -62,6 +64,7 @@ class PodcastsViewModelTest {
             assertEquals(listOf("latest-episode-podcast"), initialState.items.map { it.uuid })
 
             sortTypeFlow.value = PodcastsSortType.RECENTLY_PLAYED
+            advanceUntilIdle()
             expectNoEvents()
 
             recentlyPlayedPodcasts.emit(listOf(podcast("recently-played-podcast")))
@@ -79,7 +82,7 @@ class PodcastsViewModelTest {
     ): PodcastsViewModel {
         val sortTypeSetting = mock<UserSetting<PodcastsSortType>> {
             on { flow } doReturn sortTypeFlow
-            on { value } doReturn sortTypeFlow.value
+            on { value } doAnswer { sortTypeFlow.value }
         }
         val notificationsPromptAcknowledgedSetting = mock<UserSetting<Boolean>> {
             on { flow } doReturn MutableStateFlow(false)
@@ -133,6 +136,7 @@ class PodcastsViewModelTest {
             suggestedFoldersPopupPolicy = mock<SuggestedFoldersPopupPolicy>(),
             userManager = userManager,
             notificationHelper = notificationHelper,
+            computationDispatcher = coroutineRule.testDispatcher,
             blazeAdsManager = blazeAdsManager,
             folderUuid = null,
         )

--- a/modules/features/podcasts/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModelTest.kt
+++ b/modules/features/podcasts/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModelTest.kt
@@ -46,7 +46,7 @@ class PodcastsViewModelTest {
     fun `changing to recently played waits for recently played podcasts before updating sort type`() = runTest {
         val sortTypeFlow = MutableStateFlow(PodcastsSortType.DATE_ADDED_NEWEST_TO_OLDEST)
         val latestEpisodePodcasts = MutableSharedFlow<List<Podcast>>(replay = 1)
-        val recentlyPlayedPodcasts = MutableSharedFlow<List<Podcast>>()
+        val recentlyPlayedPodcasts = MutableSharedFlow<List<Podcast>>(replay = 1)
         latestEpisodePodcasts.emit(listOf(podcast("latest-episode-podcast")))
 
         val viewModel = createViewModel(
@@ -60,19 +60,37 @@ class PodcastsViewModelTest {
             while (initialState.items.isEmpty()) {
                 initialState = awaitItem()
             }
-            assertEquals(PodcastsSortType.DATE_ADDED_NEWEST_TO_OLDEST, initialState.sortType)
-            assertEquals(listOf("latest-episode-podcast"), initialState.items.map { it.uuid })
+            assertSortAndPodcasts(
+                state = initialState,
+                sortType = PodcastsSortType.DATE_ADDED_NEWEST_TO_OLDEST,
+                podcastUuids = listOf("latest-episode-podcast"),
+            )
 
             sortTypeFlow.value = PodcastsSortType.RECENTLY_PLAYED
             advanceUntilIdle()
+            // A UI state must never pair a sort type with podcasts produced for another sort.
             expectNoEvents()
 
             recentlyPlayedPodcasts.emit(listOf(podcast("recently-played-podcast")))
 
             val recentlyPlayedState = awaitItem()
-            assertEquals(PodcastsSortType.RECENTLY_PLAYED, recentlyPlayedState.sortType)
-            assertEquals(listOf("recently-played-podcast"), recentlyPlayedState.items.map { it.uuid })
+            assertSortAndPodcasts(
+                state = recentlyPlayedState,
+                sortType = PodcastsSortType.RECENTLY_PLAYED,
+                podcastUuids = listOf("recently-played-podcast"),
+            )
         }
+    }
+
+    private fun assertSortAndPodcasts(
+        state: PodcastsViewModel.UiState,
+        sortType: PodcastsSortType,
+        podcastUuids: List<String>,
+    ) {
+        assertEquals(
+            sortType to podcastUuids,
+            state.sortType to state.items.map { item -> item.uuid },
+        )
     }
 
     private fun createViewModel(


### PR DESCRIPTION
## Description
Fixes the Podcasts tab sort-change scroll drift by preserving the top position only when the user starts at the top of the list. The RecyclerView is pinned back to offset 0 after the sorted adapter update commits, and the PodcastsViewModel now pairs each emitted podcast list with the sort type that produced it so Recently Played cannot briefly show mismatched state.

Fixes #2121

## Testing Instructions
1. Open the Podcasts tab and make sure the list is at the top.
2. Open the Podcasts sort options.
3. Change sorting from Date Added to Episode Release Date.
4. Verify the first row remains aligned at the top and the list does not appear silently scrolled down.
5. Scroll down in the Podcasts tab, change the sort order again, and verify the app does not force-scroll you to the top.
6. Run `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :modules:features:podcasts:testDebugUnitTest`.
7. Run `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew spotlessCheck`.

## Screenshots

| Before (`7865da77b`) | After (`c30fba5`) |
| --- | --- |
| <img width="360" alt="Before: baseline scrolls down after sorting, clipping the first visible row" src="https://github.com/user-attachments/assets/38a70b32-f1c1-4c06-a045-5111c2b78792" /> | <img width="360" alt="After: PR keeps the sorted list aligned at the top" src="https://github.com/user-attachments/assets/4cee160b-0ba5-4b76-a215-d487cbff6bca" /> |

Same seeded 24-podcast library on a Pixel 9 Pro XL emulator, portrait, large-grid layout. Both captures start at the top and switch from Date Added to Episode Release Date. The baseline lands six items down with a clipped first row; the PR keeps item 0 fully aligned at the top.

### Physical device verification

| Before (physical, pre-fix `8.17-rc-1`) | After (physical, current main + PR code) |
| --- | --- |
| <img width="360" alt="Physical before: pre-fix build jumps down and clips the first visible row" src="https://github.com/user-attachments/assets/037db5cc-00a9-4259-a569-795ed1ff6205" /> | <img width="360" alt="Physical after: PR code keeps the reordered library fully aligned at the top" src="https://github.com/user-attachments/assets/3e932688-1dac-4e3b-ac86-12e14664ae12" /> |

Same Samsung SM-G990E (Android 16), portrait, large-grid layout, with a reversible 26-podcast test library. Both captures start at the top and switch from Date Added to Episode Release Date. The installed pre-fix debug build (`8.17-rc-1` / `9442`) jumps deep into the reordered library and clips the first visible row; a current-main candidate (`fe78e776` + PR source commits `2ce7cb9` and `5227bed`; changelog-only commit omitted) keeps item 0 fully aligned at the top. The candidate also passed list-layout top preservation and retained a deliberately scrolled-down position.

### Verification
- [x] Physical Samsung SM-G990E verification passes in large-grid and list layouts; sorting while scrolled remains scrolled.
- [x] Exact merge-base APK reproduces the scroll drift.
- [x] PR head keeps the top position in large-grid and list layouts.
- [x] Sorting while already scrolled does not force-scroll to the top.
- [x] Podcasts feature unit tests pass (49 tests).
- [x] `spotlessCheck` and `:app:assembleDebugProd` pass locally.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
