### PR TITLE
Turn on Up Next sort by duration feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 8.16
 -----
-
-8.15
------
 *   New Features
     *   Up Next sort by duration
         ([#5399](https://github.com/Automattic/pocket-casts-android/pull/5399))
+
+8.15
+-----
 *   Bug Fixes
     *   Fix crash when scrolling to the top of a long Up Next queue
         ([#5320](https://github.com/Automattic/pocket-casts-android/pull/5320))

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextSortFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextSortFragment.kt
@@ -30,7 +30,7 @@ internal class UpNextSortFragment : BaseDialogFragment() {
             fillMaxHeight = false,
             modifier = Modifier.nestedScroll(rememberNestedScrollInteropConnection()),
         ) {
-            val options = if (FeatureFlag.isEnabled(Feature.UP_NEXT_DURATION)) {
+            val options = if (FeatureFlag.isEnabled(Feature.UP_NEXT_SORT)) {
                 UpNextSortType.entries
             } else {
                 UpNextSortType.entries.filterNot {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/UpNextViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/UpNextViewModel.kt
@@ -38,7 +38,7 @@ class UpNextViewModel @Inject constructor(
         settings.showUpNextSortDurationTooltip.flow,
         _isUpNextVisible,
     ) { shouldShowTooltip, isUpNextVisible ->
-        shouldShowTooltip && isUpNextVisible && FeatureFlag.isEnabled(Feature.UP_NEXT_DURATION)
+        shouldShowTooltip && isUpNextVisible && FeatureFlag.isEnabled(Feature.UP_NEXT_SORT)
     }.stateIn(viewModelScope, SharingStarted.Eagerly, false)
 
     init {

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -333,12 +333,12 @@ enum class Feature(
         hasDevToggle = true,
         addedOn = LocalDate.parse("2026-05-29"),
     ),
-    UP_NEXT_DURATION(
-        key = "up_next_duration",
-        title = "Up Next Duration",
+    UP_NEXT_SORT(
+        key = "up_next_sort",
+        title = "Up Next sort by duration",
         defaultValue = isDebugOrPrototypeBuild,
         tier = FeatureTier.Free,
-        hasFirebaseRemoteFlag = false,
+        hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
         addedOn = LocalDate.parse("2026-06-09"),
     ),


### PR DESCRIPTION
## Description

Turns on the "Up Next sort by duration" feature flag for a rollout in 8.16. This pull request also renames the feature flag and Firebase Remote Config so that it matches the iOS version of the `up_next_sort`.

## Testing Instructions
1. Check the feature flag "Up Next sort by duration" is turned on
2. Add at least one episode
3. Go to Settings -> Developer -> Tap "Reset Up Next sort tooltip"
4. Verify the tooltip appears on the Up Next tab
5. Turn off the feature flag
6. Repeat the steps and make sure the tooltip doesn't appear

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

