### PR TITLE
[HeatMap] Aggregate data on query level for daily stats

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/EpisodeDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/EpisodeDaoTest.kt
@@ -10,6 +10,7 @@ import au.com.shiftyjelly.pocketcasts.models.di.addTypeConverters
 import au.com.shiftyjelly.pocketcasts.models.entity.EpisodeDownloadFailureStatistics
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.to.DailyListenedTime
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeDownloadStatus
 import au.com.shiftyjelly.pocketcasts.utils.extensions.escapeLike
 import com.squareup.moshi.Moshi
@@ -20,6 +21,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -209,5 +211,35 @@ class EpisodeDaoTest {
 
         val result = episodeDao.filteredPlaybackHistoryFlow(query.escapeLike('\\')).first()
         assertEquals(emptyList<PodcastEpisode>(), result)
+    }
+
+    @Test
+    fun dailyListenedTimeGroupsPlaybackByDay() = runTest {
+        val dayOne = Instant.parse("2024-06-15T12:00:00Z").toEpochMilli()
+        val dayTwo = Instant.parse("2024-06-17T12:00:00Z").toEpochMilli()
+        val beforeRange = Instant.parse("2024-06-10T12:00:00Z").toEpochMilli()
+        val episodes = listOf(
+            PodcastEpisode(uuid = "1", publishedDate = Date(), lastPlaybackInteraction = dayOne, playedUpTo = 100.0),
+            PodcastEpisode(uuid = "2", publishedDate = Date(), lastPlaybackInteraction = dayOne, playedUpTo = 50.0),
+            PodcastEpisode(uuid = "3", publishedDate = Date(), lastPlaybackInteraction = dayTwo, playedUpTo = 30.0),
+            PodcastEpisode(uuid = "4", publishedDate = Date(), lastPlaybackInteraction = beforeRange, playedUpTo = 999.0),
+        )
+        episodeDao.insertAllBlocking(episodes)
+
+        val result = episodeDao.dailyListenedTime(fromEpochMs = Instant.parse("2024-06-14T00:00:00Z").toEpochMilli())
+
+        assertEquals(2, result.size)
+        assertEquals(150.0, result[0].totalPlayedSeconds, 0.001)
+        assertEquals(30.0, result[1].totalPlayedSeconds, 0.001)
+        assertTrue(result[0].listenDate < result[1].listenDate)
+    }
+
+    @Test
+    fun dailyListenedTimeIsEmptyWithoutPlayback() = runTest {
+        episodeDao.insertBlocking(PodcastEpisode(uuid = "1", publishedDate = Date(), lastPlaybackInteraction = null))
+
+        val result = episodeDao.dailyListenedTime(fromEpochMs = 0)
+
+        assertEquals(emptyList<DailyListenedTime>(), result)
     }
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -17,6 +17,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.ChapterIndices
 import au.com.shiftyjelly.pocketcasts.models.entity.EpisodeDownloadFailureStatistics
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.to.DailyListenedTime
 import au.com.shiftyjelly.pocketcasts.models.to.EpisodeWithTitle
 import au.com.shiftyjelly.pocketcasts.models.type.DownloadStatusUpdate
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeDownloadStatus
@@ -741,4 +742,19 @@ abstract class EpisodeDao {
         """,
     )
     abstract suspend fun clearDownloadsWithoutTaskId(statuses: Collection<EpisodeDownloadStatus>)
+
+    @Query(
+        """
+        SELECT
+          date(last_playback_interaction_date / 1000, 'unixepoch', 'localtime') AS listen_date,
+          SUM(played_up_to) AS total_played_seconds
+        FROM podcast_episodes
+        WHERE
+          last_playback_interaction_date IS NOT NULL
+          AND last_playback_interaction_date >= :fromEpochMs
+        GROUP BY listen_date
+        ORDER BY listen_date ASC
+        """,
+    )
+    abstract suspend fun dailyListenedTime(fromEpochMs: Long): List<DailyListenedTime>
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/DailyListenedTime.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/DailyListenedTime.kt
@@ -1,0 +1,8 @@
+package au.com.shiftyjelly.pocketcasts.models.to
+
+import androidx.room.ColumnInfo
+
+data class DailyListenedTime(
+    @ColumnInfo(name = "listen_date") val listenDate: String,
+    @ColumnInfo(name = "total_played_seconds") val totalPlayedSeconds: Double,
+)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -4,6 +4,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.to.DailyListenedTime
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeDownloadStatus
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
@@ -126,6 +127,8 @@ interface EpisodeManager {
     suspend fun updatePlaybackInteractionDate(episode: BaseEpisode?)
     suspend fun findStaleDownloads(): List<PodcastEpisode>
     suspend fun calculatePlayedUptoSumInSecsWithinDays(days: Int): Double
+
+    suspend fun dailyListenedTime(fromEpochMs: Long): List<DailyListenedTime>
 
     suspend fun updateDownloadUrl(episode: PodcastEpisode): String?
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -12,6 +12,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.AutoArchiveAfterPlaying
+import au.com.shiftyjelly.pocketcasts.models.to.DailyListenedTime
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeDownloadStatus
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodesSortType
@@ -943,6 +944,10 @@ class EpisodeManagerImpl @Inject constructor(
             }
         }
         return totalPlaytime
+    }
+
+    override suspend fun dailyListenedTime(fromEpochMs: Long): List<DailyListenedTime> {
+        return episodeDao.dailyListenedTime(fromEpochMs)
     }
 
     /**


### PR DESCRIPTION
## Description
As title said it. Created a new query and helper entity to make us easier and quick to read listening stats from the database. Added tests as well.

Fixes PCDROID-646 https://linear.app/a8c/issue/PCDROID-646/aggregate-daily-stats

## Testing Instructions
Just review the changes please as the tests should cover correctness.


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
 