### PR TITLE
[HeatMap] Create mapping from values to `HeatLevel`s

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/EpisodeDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/EpisodeDaoTest.kt
@@ -10,6 +10,7 @@ import au.com.shiftyjelly.pocketcasts.models.di.addTypeConverters
 import au.com.shiftyjelly.pocketcasts.models.entity.EpisodeDownloadFailureStatistics
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.to.DailyListenedTime
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeDownloadStatus
 import au.com.shiftyjelly.pocketcasts.utils.extensions.escapeLike
 import com.squareup.moshi.Moshi
@@ -20,6 +21,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -209,5 +211,35 @@ class EpisodeDaoTest {
 
         val result = episodeDao.filteredPlaybackHistoryFlow(query.escapeLike('\\')).first()
         assertEquals(emptyList<PodcastEpisode>(), result)
+    }
+
+    @Test
+    fun dailyListenedTimeGroupsPlaybackByDay() = runTest {
+        val dayOne = Instant.parse("2024-06-15T12:00:00Z").toEpochMilli()
+        val dayTwo = Instant.parse("2024-06-17T12:00:00Z").toEpochMilli()
+        val beforeRange = Instant.parse("2024-06-10T12:00:00Z").toEpochMilli()
+        val episodes = listOf(
+            PodcastEpisode(uuid = "1", publishedDate = Date(), lastPlaybackInteraction = dayOne, playedUpTo = 100.0),
+            PodcastEpisode(uuid = "2", publishedDate = Date(), lastPlaybackInteraction = dayOne, playedUpTo = 50.0),
+            PodcastEpisode(uuid = "3", publishedDate = Date(), lastPlaybackInteraction = dayTwo, playedUpTo = 30.0),
+            PodcastEpisode(uuid = "4", publishedDate = Date(), lastPlaybackInteraction = beforeRange, playedUpTo = 999.0),
+        )
+        episodeDao.insertAllBlocking(episodes)
+
+        val result = episodeDao.dailyListenedTime(fromEpochMs = Instant.parse("2024-06-14T00:00:00Z").toEpochMilli())
+
+        assertEquals(2, result.size)
+        assertEquals(150.0, result[0].totalPlayedSeconds, 0.001)
+        assertEquals(30.0, result[1].totalPlayedSeconds, 0.001)
+        assertTrue(result[0].listenDate < result[1].listenDate)
+    }
+
+    @Test
+    fun dailyListenedTimeIsEmptyWithoutPlayback() = runTest {
+        episodeDao.insertBlocking(PodcastEpisode(uuid = "1", publishedDate = Date(), lastPlaybackInteraction = null))
+
+        val result = episodeDao.dailyListenedTime(fromEpochMs = 0)
+
+        assertEquals(emptyList<DailyListenedTime>(), result)
     }
 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/stats/ListeningHeatmap.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/stats/ListeningHeatmap.kt
@@ -1,0 +1,53 @@
+package au.com.shiftyjelly.pocketcasts.settings.stats
+
+import au.com.shiftyjelly.pocketcasts.compose.stats.HeatLevel
+import au.com.shiftyjelly.pocketcasts.models.to.DailyListenedTime
+import java.time.LocalDate
+import kotlin.math.ceil
+import kotlin.math.floor
+
+fun listeningHeatLevels(
+    dailyListenedTime: List<DailyListenedTime>,
+    start: LocalDate,
+    end: LocalDate,
+): Map<LocalDate, HeatLevel> {
+    val secondsByDate = dailyListenedTime
+        .mapNotNull { entry -> entry.listenDate.toLocalDateOrNull()?.let { date -> date to entry.totalPlayedSeconds } }
+        .filter { (date, _) -> date in start..end }
+        .toMap()
+
+    val sortedNonZero = secondsByDate.values.filter { it > 0 }.sorted()
+    if (sortedNonZero.isEmpty()) {
+        return emptyMap()
+    }
+
+    val q1 = quantile(sortedNonZero, 0.25)
+    val q2 = quantile(sortedNonZero, 0.5)
+    val q3 = quantile(sortedNonZero, 0.75)
+
+    return secondsByDate
+        .mapValues { (_, seconds) -> heatLevelFor(seconds, q1, q2, q3) }
+        .filterValues { it != HeatLevel.None }
+}
+
+private fun heatLevelFor(seconds: Double, q1: Double, q2: Double, q3: Double) = when {
+    seconds <= 0 -> HeatLevel.None
+    seconds <= q1 -> HeatLevel.Low
+    seconds <= q2 -> HeatLevel.Medium
+    seconds <= q3 -> HeatLevel.High
+    else -> HeatLevel.Max
+}
+
+private fun quantile(sortedValues: List<Double>, fraction: Double): Double {
+    val position = fraction * (sortedValues.size - 1)
+    val lowerIndex = floor(position).toInt()
+    val upperIndex = ceil(position).toInt()
+    val lower = sortedValues[lowerIndex]
+    if (lowerIndex == upperIndex) {
+        return lower
+    }
+    val upper = sortedValues[upperIndex]
+    return lower + (position - lowerIndex) * (upper - lower)
+}
+
+private fun String.toLocalDateOrNull() = runCatching { LocalDate.parse(this) }.getOrNull()

--- a/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/stats/ListeningHeatmapTest.kt
+++ b/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/stats/ListeningHeatmapTest.kt
@@ -1,0 +1,59 @@
+package au.com.shiftyjelly.pocketcasts.settings.stats
+
+import au.com.shiftyjelly.pocketcasts.compose.stats.HeatLevel
+import au.com.shiftyjelly.pocketcasts.models.to.DailyListenedTime
+import java.time.LocalDate
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ListeningHeatmapTest {
+    private val start = LocalDate.parse("2024-06-01")
+    private val end = LocalDate.parse("2024-06-30")
+
+    @Test
+    fun mapsQuartilesToHeatLevels() {
+        val data = listOf(
+            DailyListenedTime("2024-06-02", 10.0),
+            DailyListenedTime("2024-06-03", 20.0),
+            DailyListenedTime("2024-06-04", 30.0),
+            DailyListenedTime("2024-06-05", 40.0),
+        )
+
+        val result = listeningHeatLevels(data, start, end)
+
+        assertEquals(HeatLevel.Low, result[LocalDate.parse("2024-06-02")])
+        assertEquals(HeatLevel.Medium, result[LocalDate.parse("2024-06-03")])
+        assertEquals(HeatLevel.High, result[LocalDate.parse("2024-06-04")])
+        assertEquals(HeatLevel.Max, result[LocalDate.parse("2024-06-05")])
+        assertEquals(4, result.size)
+    }
+
+    @Test
+    fun excludesZeroOutOfRangeAndUnparsableDays() {
+        val data = listOf(
+            DailyListenedTime("2024-06-04", 30.0),
+            DailyListenedTime("2024-06-06", 0.0),
+            DailyListenedTime("2024-05-30", 99.0),
+            DailyListenedTime("not-a-date", 50.0),
+        )
+
+        val result = listeningHeatLevels(data, start, end)
+
+        assertEquals(setOf(LocalDate.parse("2024-06-04")), result.keys)
+    }
+
+    @Test
+    fun returnsEmptyWhenNoListening() {
+        assertEquals(emptyMap<LocalDate, HeatLevel>(), listeningHeatLevels(emptyList(), start, end))
+    }
+
+    @Test
+    fun returnsEmptyWhenAllDaysZero() {
+        val data = listOf(
+            DailyListenedTime("2024-06-02", 0.0),
+            DailyListenedTime("2024-06-03", 0.0),
+        )
+
+        assertEquals(emptyMap<LocalDate, HeatLevel>(), listeningHeatLevels(data, start, end))
+    }
+}

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -17,6 +17,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.ChapterIndices
 import au.com.shiftyjelly.pocketcasts.models.entity.EpisodeDownloadFailureStatistics
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.to.DailyListenedTime
 import au.com.shiftyjelly.pocketcasts.models.to.EpisodeWithTitle
 import au.com.shiftyjelly.pocketcasts.models.type.DownloadStatusUpdate
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeDownloadStatus
@@ -741,4 +742,19 @@ abstract class EpisodeDao {
         """,
     )
     abstract suspend fun clearDownloadsWithoutTaskId(statuses: Collection<EpisodeDownloadStatus>)
+
+    @Query(
+        """
+        SELECT
+          date(last_playback_interaction_date / 1000, 'unixepoch', 'localtime') AS listen_date,
+          SUM(played_up_to) AS total_played_seconds
+        FROM podcast_episodes
+        WHERE
+          last_playback_interaction_date IS NOT NULL
+          AND last_playback_interaction_date >= :fromEpochMs
+        GROUP BY listen_date
+        ORDER BY listen_date ASC
+        """,
+    )
+    abstract suspend fun dailyListenedTime(fromEpochMs: Long): List<DailyListenedTime>
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/DailyListenedTime.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/DailyListenedTime.kt
@@ -1,0 +1,8 @@
+package au.com.shiftyjelly.pocketcasts.models.to
+
+import androidx.room.ColumnInfo
+
+data class DailyListenedTime(
+    @ColumnInfo(name = "listen_date") val listenDate: String,
+    @ColumnInfo(name = "total_played_seconds") val totalPlayedSeconds: Double,
+)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -4,6 +4,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.to.DailyListenedTime
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeDownloadStatus
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
@@ -126,6 +127,8 @@ interface EpisodeManager {
     suspend fun updatePlaybackInteractionDate(episode: BaseEpisode?)
     suspend fun findStaleDownloads(): List<PodcastEpisode>
     suspend fun calculatePlayedUptoSumInSecsWithinDays(days: Int): Double
+
+    suspend fun dailyListenedTime(fromEpochMs: Long): List<DailyListenedTime>
 
     suspend fun updateDownloadUrl(episode: PodcastEpisode): String?
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -12,6 +12,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.AutoArchiveAfterPlaying
+import au.com.shiftyjelly.pocketcasts.models.to.DailyListenedTime
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeDownloadStatus
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodesSortType
@@ -943,6 +944,10 @@ class EpisodeManagerImpl @Inject constructor(
             }
         }
         return totalPlaytime
+    }
+
+    override suspend fun dailyListenedTime(fromEpochMs: Long): List<DailyListenedTime> {
+        return episodeDao.dailyListenedTime(fromEpochMs)
     }
 
     /**


### PR DESCRIPTION
## Description
This PR builds upon the previous one and uses the aggregated daily stats to map values to `HeatLevel`s that could be fed the the preexisting component to render them on screen.

Fixes PCDROID-648 https://linear.app/a8c/issue/PCDROID-648/create-mapping-to-heatlevels

## Testing Instructions
Just review the code, please.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
 