### PR TITLE
[HeatMap] Integrate data and display it on UI

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/EpisodeDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/EpisodeDaoTest.kt
@@ -10,6 +10,7 @@ import au.com.shiftyjelly.pocketcasts.models.di.addTypeConverters
 import au.com.shiftyjelly.pocketcasts.models.entity.EpisodeDownloadFailureStatistics
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.to.DailyListenedTime
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeDownloadStatus
 import au.com.shiftyjelly.pocketcasts.utils.extensions.escapeLike
 import com.squareup.moshi.Moshi
@@ -20,6 +21,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -209,5 +211,35 @@ class EpisodeDaoTest {
 
         val result = episodeDao.filteredPlaybackHistoryFlow(query.escapeLike('\\')).first()
         assertEquals(emptyList<PodcastEpisode>(), result)
+    }
+
+    @Test
+    fun dailyListenedTimeGroupsPlaybackByDay() = runTest {
+        val dayOne = Instant.parse("2024-06-15T12:00:00Z").toEpochMilli()
+        val dayTwo = Instant.parse("2024-06-17T12:00:00Z").toEpochMilli()
+        val beforeRange = Instant.parse("2024-06-10T12:00:00Z").toEpochMilli()
+        val episodes = listOf(
+            PodcastEpisode(uuid = "1", publishedDate = Date(), lastPlaybackInteraction = dayOne, playedUpTo = 100.0),
+            PodcastEpisode(uuid = "2", publishedDate = Date(), lastPlaybackInteraction = dayOne, playedUpTo = 50.0),
+            PodcastEpisode(uuid = "3", publishedDate = Date(), lastPlaybackInteraction = dayTwo, playedUpTo = 30.0),
+            PodcastEpisode(uuid = "4", publishedDate = Date(), lastPlaybackInteraction = beforeRange, playedUpTo = 999.0),
+        )
+        episodeDao.insertAllBlocking(episodes)
+
+        val result = episodeDao.dailyListenedTime(fromEpochMs = Instant.parse("2024-06-14T00:00:00Z").toEpochMilli())
+
+        assertEquals(2, result.size)
+        assertEquals(150.0, result[0].totalPlayedSeconds, 0.001)
+        assertEquals(30.0, result[1].totalPlayedSeconds, 0.001)
+        assertTrue(result[0].listenDate < result[1].listenDate)
+    }
+
+    @Test
+    fun dailyListenedTimeIsEmptyWithoutPlayback() = runTest {
+        episodeDao.insertBlocking(PodcastEpisode(uuid = "1", publishedDate = Date(), lastPlaybackInteraction = null))
+
+        val result = episodeDao.dailyListenedTime(fromEpochMs = 0)
+
+        assertEquals(emptyList<DailyListenedTime>(), result)
     }
 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/stats/ListeningHeatmap.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/stats/ListeningHeatmap.kt
@@ -1,0 +1,53 @@
+package au.com.shiftyjelly.pocketcasts.settings.stats
+
+import au.com.shiftyjelly.pocketcasts.compose.stats.HeatLevel
+import au.com.shiftyjelly.pocketcasts.models.to.DailyListenedTime
+import java.time.LocalDate
+import kotlin.math.ceil
+import kotlin.math.floor
+
+fun listeningHeatLevels(
+    dailyListenedTime: List<DailyListenedTime>,
+    start: LocalDate,
+    end: LocalDate,
+): Map<LocalDate, HeatLevel> {
+    val secondsByDate = dailyListenedTime
+        .mapNotNull { entry -> entry.listenDate.toLocalDateOrNull()?.let { date -> date to entry.totalPlayedSeconds } }
+        .filter { (date, _) -> date in start..end }
+        .toMap()
+
+    val sortedNonZero = secondsByDate.values.filter { it > 0 }.sorted()
+    if (sortedNonZero.isEmpty()) {
+        return emptyMap()
+    }
+
+    val q1 = quantile(sortedNonZero, 0.25)
+    val q2 = quantile(sortedNonZero, 0.5)
+    val q3 = quantile(sortedNonZero, 0.75)
+
+    return secondsByDate
+        .mapValues { (_, seconds) -> heatLevelFor(seconds, q1, q2, q3) }
+        .filterValues { it != HeatLevel.None }
+}
+
+private fun heatLevelFor(seconds: Double, q1: Double, q2: Double, q3: Double) = when {
+    seconds <= 0 -> HeatLevel.None
+    seconds <= q1 -> HeatLevel.Low
+    seconds <= q2 -> HeatLevel.Medium
+    seconds <= q3 -> HeatLevel.High
+    else -> HeatLevel.Max
+}
+
+private fun quantile(sortedValues: List<Double>, fraction: Double): Double {
+    val position = fraction * (sortedValues.size - 1)
+    val lowerIndex = floor(position).toInt()
+    val upperIndex = ceil(position).toInt()
+    val lower = sortedValues[lowerIndex]
+    if (lowerIndex == upperIndex) {
+        return lower
+    }
+    val upper = sortedValues[upperIndex]
+    return lower + (position - lowerIndex) * (upper - lower)
+}
+
+private fun String.toLocalDateOrNull() = runCatching { LocalDate.parse(this) }.getOrNull()

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/stats/StatsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/stats/StatsFragment.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -51,6 +52,7 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.compose.extensions.contentWithoutConsumedInsets
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.compose.stats.CalendarHeatMap
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.localization.helper.StatsHelper
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -59,6 +61,8 @@ import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.extensions.getActivity
 import au.com.shiftyjelly.pocketcasts.utils.extensions.pxToDp
 import au.com.shiftyjelly.pocketcasts.utils.extensions.toLocalizedFormatLongStyle
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import com.automattic.eventhorizon.EventHorizon
 import com.automattic.eventhorizon.StatsDismissedEvent
@@ -190,6 +194,20 @@ private fun StatsPageLoaded(
         item {
             TextP40(state.funnyText)
             Spacer(Modifier.height(24.dp))
+        }
+        if (FeatureFlag.isEnabled(Feature.STATS_HEATMAP)) {
+            item {
+                val heatmapDescription = stringResource(LR.string.profile_stats_listening_activity_content_description)
+                TextC70(stringResource(LR.string.profile_stats_listening_activity))
+                Spacer(Modifier.height(6.dp))
+                CalendarHeatMap(
+                    start = state.heatmapStart,
+                    end = state.heatmapEnd,
+                    heatLevels = state.heatLevels,
+                    modifier = Modifier.semantics { contentDescription = heatmapDescription },
+                )
+                Spacer(Modifier.height(24.dp))
+            }
         }
         item {
             TextC70(stringResource(LR.string.profile_stats_time_saved_by))

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/stats/StatsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/stats/StatsViewModel.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.compose.stats.HeatLevel
 import au.com.shiftyjelly.pocketcasts.models.to.StatsBundle
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.di.IoDispatcher
@@ -11,9 +12,13 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.StatsManager
 import au.com.shiftyjelly.pocketcasts.settings.util.FunnyTimeConverter
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.timeIntervalSinceNow
 import au.com.shiftyjelly.pocketcasts.views.review.InAppReviewHelper
 import dagger.hilt.android.lifecycle.HiltViewModel
+import java.time.LocalDate
+import java.time.ZoneId
 import java.util.Date
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
@@ -48,6 +53,9 @@ class StatsViewModel @Inject constructor(
             val totalSaved: Long,
             val funnyText: String,
             val startedAt: Date?,
+            val heatmapStart: LocalDate = LocalDate.now(),
+            val heatmapEnd: LocalDate = LocalDate.now(),
+            val heatLevels: Map<LocalDate, HeatLevel> = emptyMap(),
             val showAppReviewDialog: Boolean = false,
         ) : State()
     }
@@ -77,6 +85,18 @@ class StatsViewModel @Inject constructor(
 
                 val funnyText = FunnyTimeConverter().timeSecsToFunnyText(totalListened, application.resources)
 
+                val zone = ZoneId.systemDefault()
+                val heatmapEnd = LocalDate.now(zone)
+                val heatmapStart = heatmapEnd.minusDays(HEATMAP_DAYS)
+                val heatLevels = if (FeatureFlag.isEnabled(Feature.STATS_HEATMAP)) {
+                    withContext(ioDispatcher) {
+                        val fromEpochMs = heatmapStart.atStartOfDay(zone).toInstant().toEpochMilli()
+                        listeningHeatLevels(episodeManager.dailyListenedTime(fromEpochMs), heatmapStart, heatmapEnd)
+                    }
+                } else {
+                    emptyMap()
+                }
+
                 mutableState.value = State.Loaded(
                     totalListened = totalListened,
                     skipping = skipping,
@@ -86,6 +106,9 @@ class StatsViewModel @Inject constructor(
                     totalSaved = skipping + variableSpeed + trimSilence + autoSkipping,
                     funnyText = funnyText,
                     startedAt = serverStats?.startedAt,
+                    heatmapStart = heatmapStart,
+                    heatmapEnd = heatmapEnd,
+                    heatLevels = heatLevels,
                 )
                 withContext(ioDispatcher) {
                     serverStats?.startedAt?.let { showAppReviewDialogIfPossible(it) }
@@ -135,5 +158,6 @@ class StatsViewModel @Inject constructor(
         private const val DAYS_LIMIT_FOR_PLAYED_UPTO = 7
         private const val MIN_DAYS_STATS_STARTED = 7
         private const val IN_APP_REVIEW_LAUNCH_DELAY_IN_MS = 1000L
+        private const val HEATMAP_DAYS = 364L
     }
 }

--- a/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/stats/ListeningHeatmapTest.kt
+++ b/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/stats/ListeningHeatmapTest.kt
@@ -1,0 +1,59 @@
+package au.com.shiftyjelly.pocketcasts.settings.stats
+
+import au.com.shiftyjelly.pocketcasts.compose.stats.HeatLevel
+import au.com.shiftyjelly.pocketcasts.models.to.DailyListenedTime
+import java.time.LocalDate
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ListeningHeatmapTest {
+    private val start = LocalDate.parse("2024-06-01")
+    private val end = LocalDate.parse("2024-06-30")
+
+    @Test
+    fun mapsQuartilesToHeatLevels() {
+        val data = listOf(
+            DailyListenedTime("2024-06-02", 10.0),
+            DailyListenedTime("2024-06-03", 20.0),
+            DailyListenedTime("2024-06-04", 30.0),
+            DailyListenedTime("2024-06-05", 40.0),
+        )
+
+        val result = listeningHeatLevels(data, start, end)
+
+        assertEquals(HeatLevel.Low, result[LocalDate.parse("2024-06-02")])
+        assertEquals(HeatLevel.Medium, result[LocalDate.parse("2024-06-03")])
+        assertEquals(HeatLevel.High, result[LocalDate.parse("2024-06-04")])
+        assertEquals(HeatLevel.Max, result[LocalDate.parse("2024-06-05")])
+        assertEquals(4, result.size)
+    }
+
+    @Test
+    fun excludesZeroOutOfRangeAndUnparsableDays() {
+        val data = listOf(
+            DailyListenedTime("2024-06-04", 30.0),
+            DailyListenedTime("2024-06-06", 0.0),
+            DailyListenedTime("2024-05-30", 99.0),
+            DailyListenedTime("not-a-date", 50.0),
+        )
+
+        val result = listeningHeatLevels(data, start, end)
+
+        assertEquals(setOf(LocalDate.parse("2024-06-04")), result.keys)
+    }
+
+    @Test
+    fun returnsEmptyWhenNoListening() {
+        assertEquals(emptyMap<LocalDate, HeatLevel>(), listeningHeatLevels(emptyList(), start, end))
+    }
+
+    @Test
+    fun returnsEmptyWhenAllDaysZero() {
+        val data = listOf(
+            DailyListenedTime("2024-06-02", 0.0),
+            DailyListenedTime("2024-06-03", 0.0),
+        )
+
+        assertEquals(emptyMap<LocalDate, HeatLevel>(), listeningHeatLevels(data, start, end))
+    }
+}

--- a/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/stats/StatsViewModelTest.kt
+++ b/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/stats/StatsViewModelTest.kt
@@ -2,14 +2,19 @@ package au.com.shiftyjelly.pocketcasts.settings.stats
 
 import android.app.Application
 import android.content.res.Resources
+import au.com.shiftyjelly.pocketcasts.models.to.DailyListenedTime
 import au.com.shiftyjelly.pocketcasts.models.to.StatsBundle
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.StatsManager
+import au.com.shiftyjelly.pocketcasts.sharedtest.InMemoryFeatureFlagRule
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.review.InAppReviewHelper
 import java.time.Instant
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.util.Date
@@ -17,6 +22,7 @@ import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -26,6 +32,7 @@ import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
@@ -34,6 +41,9 @@ import org.mockito.kotlin.whenever
 class StatsViewModelTest {
     @get:Rule
     val coroutineRule = MainCoroutineRule()
+
+    @get:Rule
+    val featureFlagRule = InMemoryFeatureFlagRule()
 
     @Mock
     private lateinit var settings: Settings
@@ -61,6 +71,7 @@ class StatsViewModelTest {
         whenever(mockResources.getString(anyInt())).thenReturn("")
         whenever(application.resources).thenReturn(mockResources)
         whenever(syncManager.isLoggedIn()).thenReturn(true)
+        FeatureFlag.setEnabled(Feature.STATS_HEATMAP, false)
     }
 
     @Test
@@ -115,6 +126,34 @@ class StatsViewModelTest {
         viewModel.loadStats()
 
         assertFalse((viewModel.state.value as StatsViewModel.State.Loaded).showAppReviewDialog)
+    }
+
+    @Test
+    fun `given heatmap flag enabled, when stats are loaded, then heat levels are populated`() = runTest {
+        FeatureFlag.setEnabled(Feature.STATS_HEATMAP, true)
+        whenever(episodeManager.dailyListenedTime(any())).thenReturn(
+            listOf(
+                DailyListenedTime(LocalDate.now().toString(), 100.0),
+                DailyListenedTime(LocalDate.now().minusDays(1).toString(), 50.0),
+            ),
+        )
+        initViewModel()
+
+        viewModel.loadStats()
+
+        val state = viewModel.state.value as StatsViewModel.State.Loaded
+        assertEquals(2, state.heatLevels.size)
+    }
+
+    @Test
+    fun `given heatmap flag disabled, when stats are loaded, then heat levels are empty`() = runTest {
+        FeatureFlag.setEnabled(Feature.STATS_HEATMAP, false)
+        initViewModel()
+
+        viewModel.loadStats()
+
+        val state = viewModel.state.value as StatsViewModel.State.Loaded
+        assertTrue(state.heatLevels.isEmpty())
     }
 
     private suspend fun initViewModel(

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1301,6 +1301,8 @@
     </plurals>
     <string name="profile_stats_auto_skipping">Auto Skipping</string>
     <string name="profile_stats_listened_for">You\'ve listened for</string>
+    <string name="profile_stats_listening_activity">Listening Activity</string>
+    <string name="profile_stats_listening_activity_content_description">Listening activity heatmap</string>
     <string name="profile_stats_trim_silence">Trim Silence</string>
     <string name="profile_stats_share_to">Share to ...</string>
     <string name="profile_stats_since_listened_for">Since %s you\'ve listened for</string>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -17,6 +17,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.ChapterIndices
 import au.com.shiftyjelly.pocketcasts.models.entity.EpisodeDownloadFailureStatistics
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.to.DailyListenedTime
 import au.com.shiftyjelly.pocketcasts.models.to.EpisodeWithTitle
 import au.com.shiftyjelly.pocketcasts.models.type.DownloadStatusUpdate
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeDownloadStatus
@@ -741,4 +742,19 @@ abstract class EpisodeDao {
         """,
     )
     abstract suspend fun clearDownloadsWithoutTaskId(statuses: Collection<EpisodeDownloadStatus>)
+
+    @Query(
+        """
+        SELECT
+          date(last_playback_interaction_date / 1000, 'unixepoch', 'localtime') AS listen_date,
+          SUM(played_up_to) AS total_played_seconds
+        FROM podcast_episodes
+        WHERE
+          last_playback_interaction_date IS NOT NULL
+          AND last_playback_interaction_date >= :fromEpochMs
+        GROUP BY listen_date
+        ORDER BY listen_date ASC
+        """,
+    )
+    abstract suspend fun dailyListenedTime(fromEpochMs: Long): List<DailyListenedTime>
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/DailyListenedTime.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/DailyListenedTime.kt
@@ -1,0 +1,8 @@
+package au.com.shiftyjelly.pocketcasts.models.to
+
+import androidx.room.ColumnInfo
+
+data class DailyListenedTime(
+    @ColumnInfo(name = "listen_date") val listenDate: String,
+    @ColumnInfo(name = "total_played_seconds") val totalPlayedSeconds: Double,
+)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -4,6 +4,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.to.DailyListenedTime
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeDownloadStatus
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
@@ -126,6 +127,8 @@ interface EpisodeManager {
     suspend fun updatePlaybackInteractionDate(episode: BaseEpisode?)
     suspend fun findStaleDownloads(): List<PodcastEpisode>
     suspend fun calculatePlayedUptoSumInSecsWithinDays(days: Int): Double
+
+    suspend fun dailyListenedTime(fromEpochMs: Long): List<DailyListenedTime>
 
     suspend fun updateDownloadUrl(episode: PodcastEpisode): String?
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -12,6 +12,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.AutoArchiveAfterPlaying
+import au.com.shiftyjelly.pocketcasts.models.to.DailyListenedTime
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeDownloadStatus
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodesSortType
@@ -943,6 +944,10 @@ class EpisodeManagerImpl @Inject constructor(
             }
         }
         return totalPlaytime
+    }
+
+    override suspend fun dailyListenedTime(fromEpochMs: Long): List<DailyListenedTime> {
+        return episodeDao.dailyListenedTime(fromEpochMs)
     }
 
     /**

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -374,7 +374,7 @@ enum class Feature(
         title = "Show listening activity heatmap on Stats",
         defaultValue = isDebugOrPrototypeBuild,
         tier = FeatureTier.Free,
-        hasFirebaseRemoteFlag = true,
+        hasFirebaseRemoteFlag = false,
         hasDevToggle = true,
         addedOn = LocalDate.parse("2026-07-02"),
     ),

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -369,6 +369,15 @@ enum class Feature(
         hasDevToggle = true,
         addedOn = LocalDate.parse("2026-06-11"),
     ),
+    STATS_HEATMAP(
+        key = "stats_heatmap",
+        title = "Show listening activity heatmap on Stats",
+        defaultValue = isDebugOrPrototypeBuild,
+        tier = FeatureTier.Free,
+        hasFirebaseRemoteFlag = true,
+        hasDevToggle = true,
+        addedOn = LocalDate.parse("2026-07-02"),
+    ),
 }
 
 sealed class FeatureTier {


### PR DESCRIPTION
## Description
This is the next step in the HeatMap saga. This time we wired up data to the stats screen and show the heatmap component when the feature flag `stats_heatmap` is enabled.

Fixes PCDROID-649 https://linear.app/a8c/issue/PCDROID-649/integrate-data-and-show-the-heatmap-on-stats-screen

P2: pdeCcb-cse-p2

## Testing Instructions
1. Make sure `stats_heatmap` is enabled 
2. Log in with an acocunt that has listening history
3. Open Profile > Stats
4. Observe
5. Test with multiple themes

## Screenshots or Screencast 
| Light theme | Dark theme |
| --- | --- | 
| <img width="1080" height="2400" alt="Screenshot_20260703_143716" src="https://github.com/user-attachments/assets/2a0b6845-4fa6-454e-ae84-539f0fffa9aa" /> | <img width="1080" height="2400" alt="Screenshot_20260703_143734" src="https://github.com/user-attachments/assets/bfec0639-3639-476c-9647-a89f1c52ccb4" /> |

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack