### PR TITLE
Fixes from our bug audit

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/UpdateEpisodeDetailsTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/UpdateEpisodeDetailsTask.kt
@@ -101,27 +101,27 @@ class UpdateEpisodeDetailsTask @AssistedInject constructor(
 
                 try {
                     val client = withContext(Dispatchers.Default) { httpClient.get() }
-                    val response = client.newCall(request).await()
-
-                    val contentType = response.header("Content-Type")
-                    if (!contentType.isNullOrBlank()) {
-                        if ((episode.fileType.isNullOrBlank() && (contentType.startsWith("audio") || contentType.startsWith("video"))) || contentType.startsWith("video")) {
-                            episodeManager.updateFileTypeBlocking(episode, contentType)
-                            episode.fileType = contentType
-                        }
-                    }
-
-                    val contentLengthHeader = response.header("Content-Length")
-                    if (!contentLengthHeader.isNullOrBlank()) {
-                        try {
-                            val contentLength = java.lang.Long.parseLong(contentLengthHeader)
-                            val sizeInBytes = episode.sizeInBytes
-                            if ((sizeInBytes == 0L || sizeInBytes != contentLength) && contentLength > 153600) {
-                                episodeManager.updateSizeInBytesBlocking(episode, contentLength)
-                                episode.sizeInBytes = contentLength
+                    client.newCall(request).await().use { response ->
+                        val contentType = response.header("Content-Type")
+                        if (!contentType.isNullOrBlank()) {
+                            if ((episode.fileType.isNullOrBlank() && (contentType.startsWith("audio") || contentType.startsWith("video"))) || contentType.startsWith("video")) {
+                                episodeManager.updateFileTypeBlocking(episode, contentType)
+                                episode.fileType = contentType
                             }
-                        } catch (nfe: NumberFormatException) {
-                            Timber.i(nfe, "Unable to read content length.")
+                        }
+
+                        val contentLengthHeader = response.header("Content-Length")
+                        if (!contentLengthHeader.isNullOrBlank()) {
+                            try {
+                                val contentLength = java.lang.Long.parseLong(contentLengthHeader)
+                                val sizeInBytes = episode.sizeInBytes
+                                if ((sizeInBytes == 0L || sizeInBytes != contentLength) && contentLength > 153600) {
+                                    episodeManager.updateSizeInBytesBlocking(episode, contentLength)
+                                    episode.sizeInBytes = contentLength
+                                }
+                            } catch (nfe: NumberFormatException) {
+                                Timber.i(nfe, "Unable to read content length.")
+                            }
                         }
                     }
                 } catch (ioException: IOException) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/UpdateEpisodeDetailsTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/UpdateEpisodeDetailsTask.kt
@@ -26,7 +26,6 @@ import kotlinx.coroutines.withContext
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.OkHttpClient
 import okhttp3.Request
-import timber.log.Timber
 
 @HiltWorker
 class UpdateEpisodeDetailsTask @AssistedInject constructor(
@@ -110,17 +109,12 @@ class UpdateEpisodeDetailsTask @AssistedInject constructor(
                             }
                         }
 
-                        val contentLengthHeader = response.header("Content-Length")
-                        if (!contentLengthHeader.isNullOrBlank()) {
-                            try {
-                                val contentLength = java.lang.Long.parseLong(contentLengthHeader)
-                                val sizeInBytes = episode.sizeInBytes
-                                if ((sizeInBytes == 0L || sizeInBytes != contentLength) && contentLength > 153600) {
-                                    episodeManager.updateSizeInBytesBlocking(episode, contentLength)
-                                    episode.sizeInBytes = contentLength
-                                }
-                            } catch (nfe: NumberFormatException) {
-                                Timber.i(nfe, "Unable to read content length.")
+                        val contentLength = response.header("Content-Length")?.toLongOrNull()
+                        if (contentLength != null) {
+                            val sizeInBytes = episode.sizeInBytes
+                            if ((sizeInBytes == 0L || sizeInBytes != contentLength) && contentLength > 153600) {
+                                episodeManager.updateSizeInBytesBlocking(episode, contentLength)
+                                episode.sizeInBytes = contentLength
                             }
                         }
                     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SubscribeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SubscribeManager.kt
@@ -73,12 +73,18 @@ class SubscribeManager @Inject constructor(
             .flatMap({ info ->
                 // shouldAutoDownload = true because the user manually subscribed to the podcast,
                 // so we want to automatically download episodes at this moment.
-                addPodcastRxSingle(info.podcastUuid, sync = info.sync, subscribed = true, shouldAutoDownload = info.shouldAutoDownload).toObservable()
+                addPodcastRxSingle(podcastUuid = info.podcastUuid, sync = info.sync, subscribed = true, shouldAutoDownload = info.shouldAutoDownload)
+                    .doOnError { throwable ->
+                        LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, throwable, "Could not subscribe to podcast ${info.podcastUuid}")
+                    }
+                    .doFinally {
+                        uuidsInQueue.remove(info.podcastUuid)
+                    }
+                    .toObservable()
             }, true, 5)
             .doOnError { throwable -> LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, throwable, "Could not subscribe to podcast") }
             .subscribeBy(
                 onNext = { podcast ->
-                    uuidsInQueue.remove(podcast.uuid)
                     Timber.i("Subscribed successfully to podcast ${podcast.uuid}")
                     subscriptionChangedRelay.accept(podcast.uuid)
                 },

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SubscribeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SubscribeManager.kt
@@ -36,6 +36,7 @@ import io.reactivex.functions.Function4
 import io.reactivex.rxkotlin.subscribeBy
 import io.reactivex.schedulers.Schedulers
 import java.util.Date
+import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.rx2.rxCompletable
@@ -56,7 +57,7 @@ class SubscribeManager @Inject constructor(
     private val subscribeRelay: PublishRelay<PodcastSubscribe> by lazy { setupSubscribeRelay() }
     val subscriptionChangedRelay: PublishRelay<String> = PublishRelay.create()
 
-    private val uuidsInQueue = HashSet<String>()
+    private val uuidsInQueue = ConcurrentHashMap.newKeySet<String>()
     private val podcastDao = appDatabase.podcastDao()
     private val episodeDao = appDatabase.episodeDao()
     private val alternateEnclosureDao = appDatabase.alternateEnclosureDao()
@@ -89,10 +90,9 @@ class SubscribeManager @Inject constructor(
      * Subscribe to a podcast on a background queue.
      */
     fun subscribeOnQueue(podcastUuid: String, sync: Boolean = false, shouldAutoDownload: Boolean) {
-        if (uuidsInQueue.contains(podcastUuid)) {
+        if (!uuidsInQueue.add(podcastUuid)) {
             return
         }
-        uuidsInQueue.add(podcastUuid)
         subscribeRelay.accept(PodcastSubscribe(podcastUuid, sync, shouldAutoDownload))
     }
 
@@ -148,7 +148,7 @@ class SubscribeManager @Inject constructor(
     }
 
     fun getSubscribingPodcastUuids(): Set<String> {
-        return uuidsInQueue
+        return uuidsInQueue.toSet()
     }
 
     private fun subscribeToExistingOrServerPodcastRxSingle(podcastUuid: String, sync: Boolean, subscribed: Boolean, shouldAutoDownload: Boolean): Single<Podcast> {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
@@ -62,6 +62,7 @@ import dagger.hilt.EntryPoints
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import java.util.Date
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
@@ -130,7 +131,7 @@ class RefreshPodcastsThread(
             }
 
             if (!tryAcquireRefreshSlot(runNow)) {
-                LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Not refreshing as too soon")
+                LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Not refreshing as too soon or already in progress")
                 try {
                     // sleep for half a second to give the user a feeling of "oh the app is refreshing"
                     Thread.sleep(500)
@@ -141,7 +142,11 @@ class RefreshPodcastsThread(
                 return ListenableWorker.Result.success()
             }
 
-            refresh()
+            try {
+                refresh()
+            } finally {
+                releaseRefreshSlot()
+            }
 
             return ListenableWorker.Result.success()
         } catch (e: Exception) {
@@ -393,6 +398,7 @@ class RefreshPodcastsThread(
         private const val INITIAL_LAST_REFRESH_ALLOWED_TIME_MS = -10000L
         private val THROTTLE_RUN_NOW_MS: Long = if (BuildConfig.DEBUG) 0 else 15.seconds.inWholeMilliseconds
         private val THROTTLE_PERIODIC_MS: Long = if (BuildConfig.DEBUG) 0 else 5.minutes.inWholeMilliseconds
+        private val refreshInProgress = AtomicBoolean(false)
         private val lastRefreshAllowedTime = AtomicLong(INITIAL_LAST_REFRESH_ALLOWED_TIME_MS)
 
         fun clearLastRefreshTime() {
@@ -400,20 +406,32 @@ class RefreshPodcastsThread(
         }
 
         private fun tryAcquireRefreshSlot(throttleMs: Long, now: Long): Boolean {
-            while (true) {
-                val lastRefreshTime = lastRefreshAllowedTime.get()
-                if (now <= lastRefreshTime + throttleMs) {
-                    return false
-                }
-                if (lastRefreshAllowedTime.compareAndSet(lastRefreshTime, now)) {
-                    return true
-                }
+            if (!refreshInProgress.compareAndSet(false, true)) {
+                return false
             }
+
+            val lastRefreshTime = lastRefreshAllowedTime.get()
+            if (now <= lastRefreshTime + throttleMs) {
+                releaseRefreshSlot()
+                return false
+            }
+
+            lastRefreshAllowedTime.set(now)
+            return true
+        }
+
+        private fun releaseRefreshSlot() {
+            refreshInProgress.set(false)
         }
 
         @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
         internal fun tryAcquireRefreshSlotForTesting(throttleMs: Long, now: Long): Boolean {
             return tryAcquireRefreshSlot(throttleMs = throttleMs, now = now)
+        }
+
+        @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+        internal fun releaseRefreshSlotForTesting() {
+            releaseRefreshSlot()
         }
 
         fun updateNotifications(lastSeen: Date?, settings: Settings, podcastManager: PodcastManager, episodeManager: EpisodeManager, notificationHelper: NotificationHelper, context: Context) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
@@ -9,6 +9,7 @@ import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import android.os.SystemClock
 import android.text.TextUtils
+import androidx.annotation.VisibleForTesting
 import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
@@ -61,6 +62,7 @@ import dagger.hilt.EntryPoints
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import java.util.Date
+import java.util.concurrent.atomic.AtomicLong
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.measureTime
@@ -99,9 +101,9 @@ class RefreshPodcastsThread(
     @Volatile
     private var taskHasBeenCancelled = false
 
-    private fun isAllowedToRun(runNow: Boolean = false): Boolean {
-        val now = System.currentTimeMillis()
-        return now > lastRefreshAllowedTime + if (runNow) THROTTLE_RUN_NOW_MS else THROTTLE_PERIODIC_MS
+    private fun tryAcquireRefreshSlot(runNow: Boolean = false): Boolean {
+        val throttleMs = if (runNow) THROTTLE_RUN_NOW_MS else THROTTLE_PERIODIC_MS
+        return tryAcquireRefreshSlot(throttleMs = throttleMs, now = System.currentTimeMillis())
     }
 
     fun getEntryPoint(): RefreshPodcastsThreadEntryPoint {
@@ -127,7 +129,7 @@ class RefreshPodcastsThread(
                 return ListenableWorker.Result.retry()
             }
 
-            if (!isAllowedToRun(runNow)) {
+            if (!tryAcquireRefreshSlot(runNow)) {
                 LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Not refreshing as too soon")
                 try {
                     // sleep for half a second to give the user a feeling of "oh the app is refreshing"
@@ -138,7 +140,6 @@ class RefreshPodcastsThread(
                 dispatchCurrentRefreshedState()
                 return ListenableWorker.Result.success()
             }
-            lastRefreshAllowedTime = System.currentTimeMillis()
 
             refresh()
 
@@ -389,12 +390,30 @@ class RefreshPodcastsThread(
 
         private const val GROUP_NEW_EPISODES = "group_new_episodes"
 
+        private const val INITIAL_LAST_REFRESH_ALLOWED_TIME_MS = -10000L
         private val THROTTLE_RUN_NOW_MS: Long = if (BuildConfig.DEBUG) 0 else 15.seconds.inWholeMilliseconds
         private val THROTTLE_PERIODIC_MS: Long = if (BuildConfig.DEBUG) 0 else 5.minutes.inWholeMilliseconds
-        private var lastRefreshAllowedTime: Long = -10000
+        private val lastRefreshAllowedTime = AtomicLong(INITIAL_LAST_REFRESH_ALLOWED_TIME_MS)
 
         fun clearLastRefreshTime() {
-            lastRefreshAllowedTime = -10000
+            lastRefreshAllowedTime.set(INITIAL_LAST_REFRESH_ALLOWED_TIME_MS)
+        }
+
+        private fun tryAcquireRefreshSlot(throttleMs: Long, now: Long): Boolean {
+            while (true) {
+                val lastRefreshTime = lastRefreshAllowedTime.get()
+                if (now <= lastRefreshTime + throttleMs) {
+                    return false
+                }
+                if (lastRefreshAllowedTime.compareAndSet(lastRefreshTime, now)) {
+                    return true
+                }
+            }
+        }
+
+        @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+        internal fun tryAcquireRefreshSlotForTesting(throttleMs: Long, now: Long): Boolean {
+            return tryAcquireRefreshSlot(throttleMs = throttleMs, now = now)
         }
 
         fun updateNotifications(lastSeen: Date?, settings: Settings, podcastManager: PodcastManager, episodeManager: EpisodeManager, notificationHelper: NotificationHelper, context: Context) {

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThreadTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThreadTest.kt
@@ -15,6 +15,7 @@ class RefreshPodcastsThreadTest {
 
     @After
     fun tearDown() {
+        RefreshPodcastsThread.releaseRefreshSlotForTesting()
         RefreshPodcastsThread.clearLastRefreshTime()
     }
 
@@ -28,12 +29,41 @@ class RefreshPodcastsThreadTest {
                 now = 10.minutes.inWholeMilliseconds,
             ),
         )
+        RefreshPodcastsThread.releaseRefreshSlotForTesting()
+
         assertFalse(
             RefreshPodcastsThread.tryAcquireRefreshSlotForTesting(
                 throttleMs = throttleMs,
                 now = 14.minutes.inWholeMilliseconds,
             ),
         )
+        assertTrue(
+            RefreshPodcastsThread.tryAcquireRefreshSlotForTesting(
+                throttleMs = throttleMs,
+                now = 16.minutes.inWholeMilliseconds,
+            ),
+        )
+    }
+
+    @Test
+    fun `refresh slot is blocked while refresh is already in progress`() {
+        val throttleMs = 5.minutes.inWholeMilliseconds
+
+        assertTrue(
+            RefreshPodcastsThread.tryAcquireRefreshSlotForTesting(
+                throttleMs = throttleMs,
+                now = 10.minutes.inWholeMilliseconds,
+            ),
+        )
+        assertFalse(
+            RefreshPodcastsThread.tryAcquireRefreshSlotForTesting(
+                throttleMs = throttleMs,
+                now = 16.minutes.inWholeMilliseconds,
+            ),
+        )
+
+        RefreshPodcastsThread.releaseRefreshSlotForTesting()
+
         assertTrue(
             RefreshPodcastsThread.tryAcquireRefreshSlotForTesting(
                 throttleMs = throttleMs,

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThreadTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThreadTest.kt
@@ -1,0 +1,77 @@
+package au.com.shiftyjelly.pocketcasts.repositories.refresh
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.minutes
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RefreshPodcastsThreadTest {
+
+    @After
+    fun tearDown() {
+        RefreshPodcastsThread.clearLastRefreshTime()
+    }
+
+    @Test
+    fun `refresh slot is blocked inside throttle window`() {
+        val throttleMs = 5.minutes.inWholeMilliseconds
+
+        assertTrue(
+            RefreshPodcastsThread.tryAcquireRefreshSlotForTesting(
+                throttleMs = throttleMs,
+                now = 10.minutes.inWholeMilliseconds,
+            ),
+        )
+        assertFalse(
+            RefreshPodcastsThread.tryAcquireRefreshSlotForTesting(
+                throttleMs = throttleMs,
+                now = 14.minutes.inWholeMilliseconds,
+            ),
+        )
+        assertTrue(
+            RefreshPodcastsThread.tryAcquireRefreshSlotForTesting(
+                throttleMs = throttleMs,
+                now = 16.minutes.inWholeMilliseconds,
+            ),
+        )
+    }
+
+    @Test
+    fun `refresh slot is claimed by only one concurrent caller`() {
+        val callerCount = 32
+        val executor = Executors.newFixedThreadPool(callerCount)
+        val start = CountDownLatch(1)
+        val done = CountDownLatch(callerCount)
+        val allowedCount = AtomicInteger()
+
+        try {
+            repeat(callerCount) {
+                executor.execute {
+                    start.await()
+                    if (
+                        RefreshPodcastsThread.tryAcquireRefreshSlotForTesting(
+                            throttleMs = 5.minutes.inWholeMilliseconds,
+                            now = 10.minutes.inWholeMilliseconds,
+                        )
+                    ) {
+                        allowedCount.incrementAndGet()
+                    }
+                    done.countDown()
+                }
+            }
+
+            start.countDown()
+
+            assertTrue("Timed out waiting for refresh slot callers", done.await(5, TimeUnit.SECONDS))
+            assertEquals(1, allowedCount.get())
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+}


### PR DESCRIPTION
## Description

This pull request contains multiple fixes from our bug audit of the code base. I will comment in the code to explain each one. 

- Fix leaked connections when refreshing episode details
- Prevent duplicate podcast refreshes
- Fix crashes while subscribing to multiple podcasts

## Testing Instructions

Test the areas of app around the issues above.

- Find an podcast that is missing the episode file sizes such as "Pocket Casts Test Feed".
- Open the app, tap the refresh button, check the logs for `Not refreshing as too soon`.
- Sign into your account, at the same time subscribe to lots of podcasts.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
 