### PR TITLE
Speed up the Spotless task

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -151,14 +151,25 @@ spotless {
             target(spotlessPreCommitKotlinFiles)
         } else {
             target(
-                "app/src/**/*.kt",
-                "automotive/src/**/*.kt",
-                "modules/**/src/**/*.kt",
-                "tv/src/**/*.kt",
-                "wear/src/**/*.kt",
+                fileTree(rootDir) {
+                    include(
+                        "app/src/**/*.kt",
+                        "automotive/src/**/*.kt",
+                        "modules/**/src/**/*.kt",
+                        "tv/src/**/*.kt",
+                        "wear/src/**/*.kt",
+                    )
+                    exclude(
+                        "**/build/**",
+                        "**/uniffi/**",
+                        "vendor/**",
+                        ".git/**",
+                        ".gradle/**",
+                        ".idea/**",
+                    )
+                },
             )
         }
-        targetExclude("**/uniffi/**/*.kt")
         ktlint(ktlintVersion)
             .editorConfigOverride(ktLintConfigOverride + ktLintConfigComposeOverride)
             .customRuleSets(listOf(ktlintComposeRules))


### PR DESCRIPTION
## Description

The Git pre-commit was painfully slow so the aim of this change was to speed up the process. 

Scenario | Before | After
-- | -- | --
Full spotlessCheck, everything re-formatted | 6m55s | 28s
Full spotlessCheck, no changes | ~3min (still walked) | 2s
Pre-commit with 2-file list | 3m43s | 1-2s!!!

The `spotlessCheck` / `spotlessApply` Kotlin target was configured with plain glob strings (e.g. `modules/**/src/**/*.kt`). Spotless resolves these globs by walking the matching directories, which means it also descends into large generated/build directories before filtering. On a repo this size that walk is a meaningful chunk of the task's runtime. 

This change switches the target to an explicit `fileTree(rootDir)` with the same `include` patterns plus an `exclude` list for directories that should never be formatted:

- `**/build/**` — generated build output
- `**/uniffi/**` — generated UniFFI bindings (previously handled by a separate `targetExclude`)
- `vendor/**`, `.git/**`, `.gradle/**`, `.idea/**` — VCS/tooling directories

By pruning these directories up front via the `fileTree`, Spotless avoids walking and considering thousands of irrelevant files, which speeds up the task. The previous standalone `targetExclude("**/uniffi/**/*.kt")` is now folded into the `fileTree` exclude list, so behavior for the actual set of formatted files is unchanged.

## Testing Instructions

1. Run `./gradlew spotlessCheck` and confirm it passes with no formatting errors.
2. Run `./gradlew spotlessApply` and confirm it completes successfully and does not attempt to format files under `build/`, `uniffi/`, `vendor/`, `.git/`, `.gradle/`, or `.idea/`.
3. Introduce a deliberate formatting violation in a real source file (e.g. add extra blank lines) and confirm `spotlessCheck` flags it and `spotlessApply` fixes it.
4. (Optional) Compare task wall-clock time before/after (e.g. `./gradlew spotlessCheck --rerun-tasks`) to confirm the speed-up.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
