### PR TITLE
Disable HLS remote flag

### DIFF
--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -365,7 +365,7 @@ enum class Feature(
         title = "Prefer HLS stream when available",
         defaultValue = isDebugOrPrototypeBuild,
         tier = FeatureTier.Free,
-        hasFirebaseRemoteFlag = true,
+        hasFirebaseRemoteFlag = false,
         hasDevToggle = true,
         addedOn = LocalDate.parse("2026-06-11"),
     ),


### PR DESCRIPTION
## Description

Disables the Firebase Remote Config flag for the `HLS_STREAMING` feature by setting `hasFirebaseRemoteFlag = false`.

There didn't seem to be the flag `hls_streaming` in the console yet, so if we add this again we will need to add it in the Console as well.

## Testing Instructions

A review of the code should be enough

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

