### PR TITLE
Add support for the Flightcast transcript format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 8.17
 -----
-
+*   New Features
+    *   Add support for Flightcast transcripts
+        ([#5544](https://github.com/Automattic/pocket-casts-android/pull/5544))
 
 8.16
 -----

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/converter/TranscriptJsonConverter.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/converter/TranscriptJsonConverter.kt
@@ -8,16 +8,27 @@ import javax.inject.Inject
 
 @JsonClass(generateAdapter = true)
 data class TranscriptSegments(
-    @Json(name = "segments") val segments: List<TranscriptCue>,
+    @Json(name = "segments") val segments: List<TranscriptCue> = emptyList(),
+    // Flightcast transcripts embed a WEBVTT document alongside the segments.
+    @Json(name = "vtt") val vtt: String? = null,
 )
 
 @JsonClass(generateAdapter = true)
 data class TranscriptCue(
-    @Json(name = "body") val body: String,
-    @Json(name = "startTime") val startTime: Double?,
-    @Json(name = "endTime") val endTime: Double?,
-    @Json(name = "speaker") val speaker: String?,
-)
+    // Podcast Index transcripts use "body"; Flightcast transcripts use "text".
+    @Json(name = "body") val body: String? = null,
+    @Json(name = "text") val text: String? = null,
+    // Podcast Index uses "startTime"/"endTime"; Flightcast uses "start"/"end".
+    @Json(name = "startTime") val startTime: Double? = null,
+    @Json(name = "endTime") val endTime: Double? = null,
+    @Json(name = "start") val start: Double? = null,
+    @Json(name = "end") val end: Double? = null,
+    @Json(name = "speaker") val speaker: String? = null,
+) {
+    val content: String? get() = body ?: text
+    val startSeconds: Double? get() = startTime ?: start
+    val endSeconds: Double? get() = endTime ?: end
+}
 
 class TranscriptJsonConverter @Inject constructor(
     private val moshi: Moshi,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/TranscriptParser.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/TranscriptParser.kt
@@ -153,9 +153,13 @@ internal class JsonParser(
                 segments.flatMap(::toEntries)
             }
 
-            // Flightcast style: prefer the embedded WEBVTT document when present.
+            // Flightcast style: prefer the embedded WEBVTT document when present,
+            // but fall back to the segments if it is missing or fails to parse.
             vtt != null && vtt.contains("WEBVTT") -> {
-                vttParser.parse(Buffer().writeUtf8(vtt)).getOrThrow()
+                vttParser.parse(Buffer().writeUtf8(vtt))
+                    .getOrNull()
+                    ?.takeIf { it.isNotEmpty() }
+                    ?: segments.flatMap(::toEntries)
             }
 
             // Fallback: segments carrying plain text (Flightcast) or body-only entries.

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/TranscriptParser.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/TranscriptParser.kt
@@ -152,10 +152,12 @@ internal class JsonParser(
             firstSegment?.speaker != null && firstSegment.body != null -> {
                 segments.flatMap(::toEntries)
             }
+
             // Flightcast style: prefer the embedded WEBVTT document when present.
             vtt != null && vtt.contains("WEBVTT") -> {
                 vttParser.parse(Buffer().writeUtf8(vtt)).getOrThrow()
             }
+
             // Fallback: segments carrying plain text (Flightcast) or body-only entries.
             else -> segments.flatMap(::toEntries)
         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/TranscriptParser.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/TranscriptParser.kt
@@ -18,6 +18,7 @@ import au.com.shiftyjelly.pocketcasts.models.to.TranscriptEntry
 import au.com.shiftyjelly.pocketcasts.models.to.TranscriptType
 import com.squareup.moshi.Moshi
 import kotlin.math.roundToLong
+import okio.Buffer
 import okio.BufferedSource
 import okio.use
 import androidx.media3.extractor.text.SubtitleParser as Media3SubtitleParser
@@ -138,19 +139,35 @@ internal class JsonParser(
     override val type get() = TranscriptType.Json
 
     private val adapter = moshi.adapter(TranscriptSegments::class.java)
+    private val vttParser by lazy { WebVttParser() }
 
     override fun parse(source: BufferedSource) = runCatching {
-        requireNotNull(adapter.fromJson(source))
-            .segments
-            .flatMap(::toEntries)
+        val data = requireNotNull(adapter.fromJson(source))
+        val segments = data.segments
+        val firstSegment = segments.firstOrNull()
+        val vtt = data.vtt
+
+        when {
+            // Podcast Index style: segments carry a speaker and a body.
+            firstSegment?.speaker != null && firstSegment.body != null -> {
+                segments.flatMap(::toEntries)
+            }
+            // Flightcast style: prefer the embedded WEBVTT document when present.
+            vtt != null && vtt.contains("WEBVTT") -> {
+                vttParser.parse(Buffer().writeUtf8(vtt)).getOrThrow()
+            }
+            // Fallback: segments carrying plain text (Flightcast) or body-only entries.
+            else -> segments.flatMap(::toEntries)
+        }
     }
 
     private fun toEntries(cue: TranscriptCue) = buildList<TranscriptEntry> {
         cue.speaker?.let { speaker ->
             add(TranscriptEntry.Speaker(speaker))
         }
-        val startTimeMs = cue.startTime?.let { (it * 1000).roundToLong() } ?: -1L
-        val endTimeMs = cue.endTime?.let { (it * 1000).roundToLong() } ?: -1L
-        add(TranscriptEntry.Text(cue.body, startTimeMs = startTimeMs, endTimeMs = endTimeMs))
+        val content = cue.content ?: return@buildList
+        val startTimeMs = cue.startSeconds?.let { (it * 1000).roundToLong() } ?: -1L
+        val endTimeMs = cue.endSeconds?.let { (it * 1000).roundToLong() } ?: -1L
+        add(TranscriptEntry.Text(content, startTimeMs = startTimeMs, endTimeMs = endTimeMs))
     }
 }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/JsonParserTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/JsonParserTest.kt
@@ -122,6 +122,28 @@ class JsonParserTest {
     }
 
     @Test
+    fun `parse flightcast json falls back to text segments when embedded vtt is malformed`() {
+        val subtitles = """
+            |{
+            |  "segments": [
+            |    { "start": 0.0, "end": 1.0, "text": "Fallback segment text" }
+            |  ],
+            |  "vtt": "WEBVTT\n\nthis is not a valid cue"
+            |}
+        """.trimMargin()
+        val source = Buffer().writeUtf8(subtitles)
+
+        val entries = parser.parse(source).getOrThrow()
+
+        assertEquals(
+            listOf(
+                TranscriptEntry.Text("Fallback segment text", startTimeMs = 0, endTimeMs = 1000),
+            ),
+            entries,
+        )
+    }
+
+    @Test
     fun `parse podcast index json prefers speaker and body over embedded vtt`() {
         val subtitles = """
             |{

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/JsonParserTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/JsonParserTest.kt
@@ -5,7 +5,12 @@ import com.squareup.moshi.Moshi
 import okio.Buffer
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
+@Config(manifest = Config.NONE)
+@RunWith(RobolectricTestRunner::class)
 class JsonParserTest {
     private val parser = JsonParser(Moshi.Builder().build())
 
@@ -67,6 +72,73 @@ class JsonParserTest {
                 TranscriptEntry.Text("Timed text", startTimeMs = 1500, endTimeMs = 3750),
                 TranscriptEntry.Text("No timing", startTimeMs = -1, endTimeMs = -1),
                 TranscriptEntry.Text("Partial timing", startTimeMs = 10000, endTimeMs = -1),
+            ),
+            entries,
+        )
+    }
+
+    @Test
+    fun `parse flightcast json using embedded vtt`() {
+        val subtitles = """
+            |{
+            |  "text": "Hello world from flightcast",
+            |  "segments": [
+            |    { "start": 0.03, "end": 2.35, "text": "Hello world from flightcast" }
+            |  ],
+            |  "vtt": "WEBVTT\n\n1\n00:00:00.031 --> 00:00:02.356\nHello world from flightcast\n"
+            |}
+        """.trimMargin()
+        val source = Buffer().writeUtf8(subtitles)
+
+        val entries = parser.parse(source).getOrThrow()
+
+        assertEquals(
+            listOf(
+                TranscriptEntry.Text("Hello world from flightcast", startTimeMs = 31, endTimeMs = 2356),
+            ),
+            entries,
+        )
+    }
+
+    @Test
+    fun `parse flightcast json from text segments when no vtt is present`() {
+        val subtitles = """
+            |{
+            |  "segments": [
+            |    { "start": 0.0, "end": 1.0, "text": "Only segment text here" }
+            |  ]
+            |}
+        """.trimMargin()
+        val source = Buffer().writeUtf8(subtitles)
+
+        val entries = parser.parse(source).getOrThrow()
+
+        assertEquals(
+            listOf(
+                TranscriptEntry.Text("Only segment text here", startTimeMs = 0, endTimeMs = 1000),
+            ),
+            entries,
+        )
+    }
+
+    @Test
+    fun `parse podcast index json prefers speaker and body over embedded vtt`() {
+        val subtitles = """
+            |{
+            |  "segments": [
+            |    { "body": "Hello there", "speaker": "Alice" }
+            |  ],
+            |  "vtt": "WEBVTT\n\n1\n00:00:00.000 --> 00:00:01.000\nShould be ignored\n"
+            |}
+        """.trimMargin()
+        val source = Buffer().writeUtf8(subtitles)
+
+        val entries = parser.parse(source).getOrThrow()
+
+        assertEquals(
+            listOf(
+                TranscriptEntry.Speaker("Alice"),
+                TranscriptEntry.Text("Hello there"),
             ),
             entries,
         )


### PR DESCRIPTION
Fixes PCDROID-655

## Description

Adds support for the [Flightcast](https://flightcast.fm) JSON transcript format, matching the implementation already shipped on the [web player](https://github.com/Automattic/pocket-casts-webplayer/pull/4718) and [iOS](https://github.com/Automattic/pocket-casts-ios/pull/4706).

Flightcast transcripts are served as `application/json` but differ from the Podcast Index JSON shape we already parse:
- Segments carry `text`/`start`/`end` (rather than `body`/`startTime`/`endTime`) and have no speaker labels.
- The document embeds a full `WEBVTT` string under a top-level `vtt` field.

`JsonParser` now resolves JSON transcripts in the same order as the web/iOS clients:
1. **Podcast Index** — segments with `speaker` + `body`.
2. **Flightcast** — prefer the embedded `WEBVTT` document (parsed via the existing `WebVttParser`).
3. **Fallback** — segments carrying plain `text` (or body-only entries).

## Testing Instructions

1. Play any episode from **"The Diary of a CEO"** (uses the Flightcast transcript format).
2. Open the player and tap the transcript action.
3. Confirm the transcript loads and displays correctly, tapping a line seeks to that point, and auto-scroll follows playback.
4. As a regression check, play any **"The Daily"** episode and confirm its transcript still loads as before.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
