### PR TITLE
Fix leaked connections when refreshing episode details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 *   New Features
     *   Add support for Flightcast transcripts
         ([#5544](https://github.com/Automattic/pocket-casts-android/pull/5544))
+*   Bug Fixes
+    *   Fix leaked network connections when refreshing episode details
+        ([#5546](https://github.com/Automattic/pocket-casts-android/pull/5546))
 
 8.16
 -----

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/UpdateEpisodeDetailsTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/UpdateEpisodeDetailsTask.kt
@@ -26,7 +26,6 @@ import kotlinx.coroutines.withContext
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.OkHttpClient
 import okhttp3.Request
-import timber.log.Timber
 
 @HiltWorker
 class UpdateEpisodeDetailsTask @AssistedInject constructor(
@@ -101,27 +100,22 @@ class UpdateEpisodeDetailsTask @AssistedInject constructor(
 
                 try {
                     val client = withContext(Dispatchers.Default) { httpClient.get() }
-                    val response = client.newCall(request).await()
-
-                    val contentType = response.header("Content-Type")
-                    if (!contentType.isNullOrBlank()) {
-                        if ((episode.fileType.isNullOrBlank() && (contentType.startsWith("audio") || contentType.startsWith("video"))) || contentType.startsWith("video")) {
-                            episodeManager.updateFileTypeBlocking(episode, contentType)
-                            episode.fileType = contentType
+                    client.newCall(request).await().use { response ->
+                        val contentType = response.header("Content-Type")
+                        if (!contentType.isNullOrBlank()) {
+                            if ((episode.fileType.isNullOrBlank() && (contentType.startsWith("audio") || contentType.startsWith("video"))) || contentType.startsWith("video")) {
+                                episodeManager.updateFileTypeBlocking(episode, contentType)
+                                episode.fileType = contentType
+                            }
                         }
-                    }
 
-                    val contentLengthHeader = response.header("Content-Length")
-                    if (!contentLengthHeader.isNullOrBlank()) {
-                        try {
-                            val contentLength = java.lang.Long.parseLong(contentLengthHeader)
+                        val contentLength = response.header("Content-Length")?.toLongOrNull()
+                        if (contentLength != null) {
                             val sizeInBytes = episode.sizeInBytes
                             if ((sizeInBytes == 0L || sizeInBytes != contentLength) && contentLength > 153600) {
                                 episodeManager.updateSizeInBytesBlocking(episode, contentLength)
                                 episode.sizeInBytes = contentLength
                             }
-                        } catch (nfe: NumberFormatException) {
-                            Timber.i(nfe, "Unable to read content length.")
                         }
                     }
                 } catch (ioException: IOException) {


### PR DESCRIPTION
## Description

`UpdateEpisodeDetailsTask` issues a `HEAD` request per episode to refresh its content type and size, but never closed the resulting OkHttp `Response`. Because the response body was left open, the underlying connection could not be returned to the pool or released, leaking connections every time episode details were refreshed.

This wraps the response in a `use { }` block so it is always closed once the headers have been read, releasing the connection back to OkHttp.

While here, the content-length parsing was simplified from a manual `Long.parseLong` + `NumberFormatException` catch to `String.toLongOrNull()`, which removes the now-unused Timber import and a Java-style try/catch.

No behavioural change beyond the connection being released and a `null`/non-numeric `Content-Length` being ignored (the old catch did the same).

## Testing Instructions

1. Subscribe to one or more podcasts so there are episodes without cached file type/size details. (Episode 20 of the Pocket Casts test podcast)
2. Trigger an episode details refresh (e.g. open the podcast/episode list so `UpdateEpisodeDetailsTask` runs).
3. Confirm episode file types and sizes still populate correctly.
4. With a network profiler or OkHttp connection pool logging, confirm connections are released after each `HEAD` request rather than accumulating.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
