### PR TITLE
Cancel notifications by tag and id, not id alone

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationHelperImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationHelperImpl.kt
@@ -230,6 +230,8 @@ class NotificationHelperImpl @Inject constructor(@ApplicationContext private val
         val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
         val notificationTag = intentExtras?.getString(INTENT_EXTRA_NOTIFICATION_TAG, null)
         if (!notificationTag.isNullOrBlank()) {
+            manager.cancel(notificationTag, notificationId)
+        } else {
             manager.cancel(notificationId)
         }
     }


### PR DESCRIPTION
## Description

`NotificationHelperImpl.removeNotification()` cancelled notifications by ID alone. When a notification is posted with a tag, `NotificationManager.cancel(id)` does not dismiss it, because Android keys active notifications by the `(tag, id)` pair. As a result, tagged notifications (e.g. playback error notifications) could linger after the user acted on them.

This method is currently only used by the bookmarks feature. I’m not entirely sure the fix is necessary, as tapping the “Change title” action in the notification appears to dismiss it already. That said, I’m not certain whether this behavior is consistent across older Android versions.

This issue was identified during our AI bug hunt, and the fix is straightforward. It also makes sense to address it now in case this method is used elsewhere in the app in the future.

## Testing Instructions
1. Trigger a notification that is posted with a tag (for example, a playback error notification).
2. Perform the action that invokes `removeNotification` (e.g. tap the action that dismisses/handles the notification).
3. Confirm the notification is removed from the notification shade.
4. Repeat with a notification posted without a tag and confirm it is still dismissed correctly (no regression).

## Screenshots or Screencast
Not applicable, no UI changes.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.