### PR TITLE
Fix leaked connections when refreshing episode details (cherry-pick to 8.16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 8.17
 -----
+*   Bug Fixes
+    *   Fix leaked network connections when refreshing episode details
+        ([#5546](https://github.com/Automattic/pocket-casts-android/pull/5546))
 
 
 8.16

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/UpdateEpisodeDetailsTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/UpdateEpisodeDetailsTask.kt
@@ -26,7 +26,6 @@ import kotlinx.coroutines.withContext
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.OkHttpClient
 import okhttp3.Request
-import timber.log.Timber
 
 @HiltWorker
 class UpdateEpisodeDetailsTask @AssistedInject constructor(
@@ -101,27 +100,22 @@ class UpdateEpisodeDetailsTask @AssistedInject constructor(
 
                 try {
                     val client = withContext(Dispatchers.Default) { httpClient.get() }
-                    val response = client.newCall(request).await()
-
-                    val contentType = response.header("Content-Type")
-                    if (!contentType.isNullOrBlank()) {
-                        if ((episode.fileType.isNullOrBlank() && (contentType.startsWith("audio") || contentType.startsWith("video"))) || contentType.startsWith("video")) {
-                            episodeManager.updateFileTypeBlocking(episode, contentType)
-                            episode.fileType = contentType
+                    client.newCall(request).await().use { response ->
+                        val contentType = response.header("Content-Type")
+                        if (!contentType.isNullOrBlank()) {
+                            if ((episode.fileType.isNullOrBlank() && (contentType.startsWith("audio") || contentType.startsWith("video"))) || contentType.startsWith("video")) {
+                                episodeManager.updateFileTypeBlocking(episode, contentType)
+                                episode.fileType = contentType
+                            }
                         }
-                    }
 
-                    val contentLengthHeader = response.header("Content-Length")
-                    if (!contentLengthHeader.isNullOrBlank()) {
-                        try {
-                            val contentLength = java.lang.Long.parseLong(contentLengthHeader)
+                        val contentLength = response.header("Content-Length")?.toLongOrNull()
+                        if (contentLength != null) {
                             val sizeInBytes = episode.sizeInBytes
                             if ((sizeInBytes == 0L || sizeInBytes != contentLength) && contentLength > 153600) {
                                 episodeManager.updateSizeInBytesBlocking(episode, contentLength)
                                 episode.sizeInBytes = contentLength
                             }
-                        } catch (nfe: NumberFormatException) {
-                            Timber.i(nfe, "Unable to read content length.")
                         }
                     }
                 } catch (ioException: IOException) {


### PR DESCRIPTION
## Description

Cherry-pick of #5546 into `release/8.16`.

> **This change was already reviewed and merged on `main`.** This PR exists to land it in the upcoming release. CI and a quick review should still run to confirm the cherry-pick applies cleanly and introduces no issues on the release branch, since `release/8.16` may have diverged from `main`.

- Original PR: https://github.com/Automattic/pocket-casts-android/pull/5546
- Cherry-picked commit: `d5d8cfa0fd`

The cherry-pick conflicted only in `CHANGELOG.md`, because the release branch does not yet have the unrelated Flightcast transcripts entry from #5544. Resolved by keeping just the #5546 bug-fix entry. The code change in `UpdateEpisodeDetailsTask.kt` applied cleanly.

## Testing Instructions

See the original PR (https://github.com/Automattic/pocket-casts-android/pull/5546) for full testing steps. In addition, verify the change behaves as described on top of `release/8.16`.
