### PR TITLE
Move leaked network connection fix to the 8.16 changelog section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,15 @@
 *   New Features
     *   Add support for Flightcast transcripts
         ([#5544](https://github.com/Automattic/pocket-casts-android/pull/5544))
-*   Bug Fixes
-    *   Fix leaked network connections when refreshing episode details
-        ([#5546](https://github.com/Automattic/pocket-casts-android/pull/5546))
 
 8.16
 -----
 *   New Features
     *   Up Next sort by duration
         ([#5399](https://github.com/Automattic/pocket-casts-android/pull/5399))
+*   Bug Fixes
+    *   Fix leaked network connections when refreshing episode details
+        ([#5546](https://github.com/Automattic/pocket-casts-android/pull/5546))
 
 8.15
 -----


### PR DESCRIPTION
## Description

The fix for leaked network connections when refreshing episode details ([#5546](https://github.com/Automattic/pocket-casts-android/pull/5546)) was listed under the unreleased 8.17 section of the CHANGELOG, but it was cherry-picked into the 8.16 release branch and shipped in 8.16. This moves the entry into the 8.16 section so the release notes reflect the version users actually received it in.

This is a CHANGELOG-only change: no production code, resources, or behaviour are touched.

## Testing Instructions

No testing required as it's just an update to the changelog

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

