### PR TITLE
Move leaked network connection fix to the 8.16 changelog section (cherry-pick to 8.16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,14 @@
 8.17
 -----
-*   Bug Fixes
-    *   Fix leaked network connections when refreshing episode details
-        ([#5546](https://github.com/Automattic/pocket-casts-android/pull/5546))
-
 
 8.16
------
-
-8.15
 -----
 *   New Features
     *   Up Next sort by duration
         ([#5399](https://github.com/Automattic/pocket-casts-android/pull/5399))
+*   Bug Fixes
+    *   Fix leaked network connections when refreshing episode details
+        ([#5546](https://github.com/Automattic/pocket-casts-android/pull/5546))
 
 8.15
 -----


### PR DESCRIPTION
## Description

Cherry-pick of #5557 into `release/8.16`.

The change moves the leaked connection fix into version 8.16 as I push this to the release branch.  
