### PR TITLE
Avoid crash when an allow-listed media browser caller's signature does not match

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/auto/PackageValidator.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/auto/PackageValidator.kt
@@ -112,9 +112,9 @@ class PackageValidator(context: Context, @XmlRes xmlResId: Int) {
         }
 
         val callerSignature = callerPackageInfo.signature
-        val isPackageInAllowList = certificateAllowList[callingPackage]?.signatures?.first {
+        val isPackageInAllowList = certificateAllowList[callingPackage]?.signatures?.any {
             it.signature == callerSignature
-        } != null
+        } == true
 
         val isCallerKnown = when {
             // If it's our own app making the call, allow it.


### PR DESCRIPTION
## Description

`PackageValidator.isKnownCaller()` decides whether a media browser client (Android Auto, Automotive, Wear, Assistant, etc.) is allowed to connect. Part of that check looks up the calling package in `allowed_media_browser_callers.xml` and compares the caller's certificate signature against the signatures listed for that package.

That comparison used `signatures.first { it.signature == callerSignature }`, which throws `NoSuchElementException` when no element matches. So if an allow-listed package connected while reporting a certificate signature that matched none of the keys we list for it (for example a differently signed build of the caller, a re-signed OEM variant, or a stale entry in the allow list), the validator threw instead of returning a verdict, and the exception propagated out of `onConnect`/`onGetRoot` and crashed playback service startup.

The fix replaces `first { } != null` with `any { } == true`. Behaviour is unchanged for callers that do match a listed signature; a mismatch is now cleanly rejected as an unknown caller (falling through to the remaining checks: own app, system UID, platform signature, `MEDIA_CONTENT_CONTROL`) instead of throwing.

Note that `first { } != null` was never a meaningful null check: `first` returns a non-null element or throws, so the `!= null` was dead and the mismatch path was always the throwing path.

Fixes https://linear.app/a8c/issue/PCDROID-668/playback-06-packagevalidatorisknowncaller-throws

## Testing Instructions

This is hard to test. I think the best option would be to test that the existing successful path works. To do this, install it on an automotive emulator, check you can browse for an episode to play, and control the episode playback.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
