### PR TITLE
Guard against null runningAppProcesses in isAppForeground

### DIFF
--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/extensions/Context.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/extensions/Context.kt
@@ -31,7 +31,7 @@ fun Context.isLandscape() = resources.configuration.orientation == Configuration
 fun Context.isAppForeground(): Boolean {
     val activityManager =
         this.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
-    val runningProcesses = activityManager.runningAppProcesses
+    val runningProcesses = activityManager.runningAppProcesses.orEmpty()
     var isInForeground = false
     for (processInfo in runningProcesses) {
         if (processInfo.importance == ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND &&


### PR DESCRIPTION
## Description

`ActivityManager.getRunningAppProcesses()` is annotated as non-null, but it can return `null` in practice (for example when the system is under memory pressure, or on some OEM builds where the caller is not allowed to enumerate processes). Because Kotlin trusts the platform annotation, iterating the result crashed with an NPE inside `Context.isAppForeground()`.

This guards the call with `.orEmpty()`, so a `null` process list is treated the same as "no foreground process found" and `isAppForeground()` returns `false` instead of throwing.

## Testing Instructions

This is a defensive fix for a state that is hard to reproduce on demand, so the goal is to confirm no regression in the normal foreground/background paths:

1. Go to Profile tab -> Settings -> Headphone controls
2. Change the "Next action" to "Add bookmark"
3. With the app in the foreground trigger the headphone next action with `adb shell input keyevent KEYCODE_MEDIA_NEXT`
4. ✅ Verify the change bookmark title page appears
5. With the app in the background trigger the headphone next action 
6. ✅ Verify the bookmark notification is delivered

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
