### PR TITLE
Call `shouldUseBypass` less often

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ShiftyAudioRendererV2.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ShiftyAudioRendererV2.kt
@@ -40,7 +40,7 @@ class ShiftyAudioRendererV2(
 
     @Throws(ExoPlaybackException::class)
     override fun processOutputBuffer(positionUs: Long, elapsedRealtimeUs: Long, codec: MediaCodecAdapter?, buffer: ByteBuffer?, bufferIndex: Int, bufferFlags: Int, sampleCount: Int, bufferPresentationTimeUs: Long, isDecodeOnlyBuffer: Boolean, isLastBuffer: Boolean, format: Format): Boolean {
-        if ((isDecodeOnlyBuffer || shouldUseBypass(format)) && bufferFlags and MediaCodec.BUFFER_FLAG_CODEC_CONFIG != 0) {
+        if (bufferFlags and MediaCodec.BUFFER_FLAG_CODEC_CONFIG != 0 && (isDecodeOnlyBuffer || shouldUseBypass(format))) {
             return super.processOutputBuffer(positionUs, elapsedRealtimeUs, codec, buffer, bufferIndex, bufferFlags, sampleCount, bufferPresentationTimeUs, isDecodeOnlyBuffer, isLastBuffer, format)
         }
 


### PR DESCRIPTION
## Description

Each time an audio output buffer was processed the audio renderer  checked whether bypass was enabled. This could indirectly result in very frequent calls down to framework 'direct playback' support.

Swap the order of the condition to short circuit when not handling a  codec configuration buffer, to reduce Binder IPC spam from the framework method call. This may reduce CPU cycles by 5-10%.

## Testing Instructions
Minor/safe change that should be covered by any audio playback.

## Screenshots or Screencast 
n/a

## Checklist
I checked these but I think they aren't applicable:
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
n/a