### PR TITLE
Enforce using foreground service during playback

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationDrawer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationDrawer.kt
@@ -9,4 +9,8 @@ interface NotificationDrawer {
         sessionToken: MediaSessionCompat.Token,
         useEpisodeArtwork: Boolean,
     ): Notification
+
+    fun buildPreparingNotification(
+        sessionToken: MediaSessionCompat.Token,
+    ): Notification
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationDrawerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationDrawerImpl.kt
@@ -90,6 +90,25 @@ class NotificationDrawerImpl @Inject constructor(
             .build()
     }
 
+    override fun buildPreparingNotification(
+        sessionToken: MediaSessionCompat.Token,
+    ): Notification {
+        val mediaStyle = MediaStyle()
+            .setMediaSession(sessionToken)
+            .setShowCancelButton(true)
+            .setCancelButtonIntent(stopPendingIntent)
+
+        return notificationHelper.playbackChannelBuilder()
+            .setContentTitle(context.getString(LR.string.loading))
+            .setDeleteIntent(stopPendingIntent)
+            .setOnlyAlertOnce(true)
+            .setShowWhen(false)
+            .setSmallIcon(IR.drawable.notification)
+            .setStyle(mediaStyle)
+            .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+            .build()
+    }
+
     private fun loadArtwork(episode: BaseEpisode, useEpisodeArtwork: Boolean): Bitmap? {
         val request = imageRequestFactory.create(episode, useEpisodeArtwork)
         return when (val result = context.imageLoader.executeBlocking(request)) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/LegacyPlaybackService.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/LegacyPlaybackService.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.repositories.playback
 import android.app.ForegroundServiceStartNotAllowedException
 import android.app.Notification
 import android.content.Intent
+import android.content.pm.ServiceInfo
 import android.os.Build
 import android.os.Bundle
 import android.support.v4.media.MediaBrowserCompat
@@ -11,6 +12,7 @@ import android.support.v4.media.MediaMetadataCompat.METADATA_KEY_MEDIA_ID
 import android.support.v4.media.session.MediaControllerCompat
 import android.support.v4.media.session.MediaSessionCompat
 import android.support.v4.media.session.PlaybackStateCompat
+import androidx.core.app.ServiceCompat
 import androidx.media.MediaBrowserServiceCompat
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -109,6 +111,35 @@ open class LegacyPlaybackService :
         sleepTimerHandler = SleepTimerHandler(sleepTimer, playbackManager, { applicationContext }, this).also { it.observe() }
     }
 
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        // Action-only: once started via startForegroundService the FGS contract must be honoured even if the flag flips off.
+        if (intent?.action == MediaSessionManager.ACTION_START_PLAYBACK_FOREGROUND) {
+            startForegroundEarly()
+        }
+        return super.onStartCommand(intent, flags, startId)
+    }
+
+    private fun startForegroundEarly() {
+        if (isForeground || Util.isAutomotive(this)) return
+        val mediaSession = playbackManager.mediaSessionManager.mediaSession ?: return
+        try {
+            val notification = notificationDrawer.buildPreparingNotification(mediaSession.sessionToken)
+            ServiceCompat.startForeground(this, Settings.NotificationId.PLAYING.value, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK)
+            isForeground = true
+            notificationManager.enteredForeground(notification)
+            playbackManager.mediaSessionManager.setServiceForeground(true)
+            LogBuffer.i(LogBuffer.TAG_PLAYBACK, "startForeground early (preparing)")
+        } catch (e: Exception) {
+            LogBuffer.e(LogBuffer.TAG_PLAYBACK, "startForeground early failed: $e")
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && e is ForegroundServiceStartNotAllowedException) {
+                val currentValue = settings.getTimesToShowBatteryWarning()
+                settings.setTimesToShowBatteryWarning(2 + currentValue)
+                eventHorizon.track(com.automattic.eventhorizon.PlaybackForegroundServiceErrorEvent)
+            }
+            stopSelf()
+        }
+    }
+
     override fun onTaskRemoved(rootIntent: Intent?) {
         if (Util.isAutomotive(this)) return
         @Suppress("SENSELESS_COMPARISON") // mediaSession becomes nullable in the Media3 integration PR
@@ -124,6 +155,7 @@ open class LegacyPlaybackService :
     override fun onDestroy() {
         super.onDestroy()
         isForeground = false
+        playbackManager.mediaSessionManager.setServiceForeground(false)
 
         disposables.clear()
         sleepTimerHandler?.dispose()
@@ -262,6 +294,7 @@ open class LegacyPlaybackService :
                             startForeground(Settings.NotificationId.PLAYING.value, notification)
                             isForeground = true
                             notificationManager.enteredForeground(notification)
+                            playbackManager.mediaSessionManager.setServiceForeground(true)
                             LogBuffer.i(LogBuffer.TAG_PLAYBACK, "startForeground state: $state")
                         } catch (e: Exception) {
                             LogBuffer.e(LogBuffer.TAG_PLAYBACK, "attempted startForeground for state: $state, but that threw an exception we caught: $e")
@@ -283,7 +316,7 @@ open class LegacyPlaybackService :
                     val removeNotification = state != PlaybackStateCompat.STATE_PAUSED || settings.hideNotificationOnPause.value
                     if (removeNotification || isForegroundService) {
                         val isTransientLoss = playbackManager.playbackStateRelay.blockingFirst().transientLoss
-                        if (isTransientLoss) {
+                        if (isTransientLoss || playbackManager.mediaSessionManager.isSwitchingPlayer) {
                             return
                         }
 
@@ -296,6 +329,7 @@ open class LegacyPlaybackService :
 
                         stopForeground(if (removeNotification) STOP_FOREGROUND_REMOVE else STOP_FOREGROUND_DETACH)
                         isForeground = false
+                        playbackManager.mediaSessionManager.setServiceForeground(false)
                         if (removeNotification) {
                             notificationManager.cancel(Settings.NotificationId.PLAYING.value)
                         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -17,6 +17,7 @@ import android.view.KeyEvent
 import androidx.annotation.DrawableRes
 import androidx.annotation.MainThread
 import androidx.annotation.OptIn
+import androidx.core.content.ContextCompat
 import androidx.core.content.IntentCompat
 import androidx.core.net.toUri
 import androidx.media.utils.MediaConstants.PLAYBACK_STATE_EXTRAS_KEY_MEDIA_ID
@@ -66,9 +67,13 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -76,6 +81,7 @@ import kotlinx.coroutines.rx2.asObservable
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import timber.log.Timber
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -95,6 +101,7 @@ class MediaSessionManager(
     companion object {
         const val EXTRA_TRANSIENT = "pocketcasts_transient_loss"
         const val ACTION_NOT_SUPPORTED = "action_not_supported"
+        const val ACTION_START_PLAYBACK_FOREGROUND = "au.com.shiftyjelly.pocketcasts.action.START_PLAYBACK_FOREGROUND"
 
         // These manufacturers have issues when the skip to next/previous track are missing from the media session.
         private val MANUFACTURERS_TO_HIDE_CUSTOM_SKIP_BUTTONS = listOf("mercedes-benz")
@@ -206,6 +213,16 @@ class MediaSessionManager(
 
     @Volatile
     private var forwardingPlayer: PocketCastsForwardingPlayer? = null
+
+    private val _isServiceForeground = MutableStateFlow(false)
+    val isServiceForeground: StateFlow<Boolean> = _isServiceForeground.asStateFlow()
+
+    fun setServiceForeground(foreground: Boolean) {
+        _isServiceForeground.value = foreground
+    }
+
+    @Volatile
+    var isSwitchingPlayer: Boolean = false
 
     @Volatile
     internal var media3Callback: Media3SessionCallback? = null
@@ -581,19 +598,49 @@ class MediaSessionManager(
     }
 
     fun startServiceIfNeeded(context: Context) {
-        if (needsMedia3Session) {
-            if (media3Session != null) return
-        }
         val component = resolveMediaBrowserServiceComponent(context)
         if (component == null) {
             Timber.e("No enabled media browser service found in manifest")
             return
         }
+        if (FeatureFlag.isEnabled(Feature.FOREGROUND_BEFORE_PLAYBACK)) {
+            startServiceForeground(context, component)
+            return
+        }
+        if (needsMedia3Session && media3Session != null) return
         try {
             context.startService(Intent().setComponent(component))
         } catch (e: Exception) {
             Timber.e(e, "Failed to start ${component.className}")
         }
+    }
+
+    private fun startServiceForeground(context: Context, component: ComponentName): Boolean {
+        if (_isServiceForeground.value) return true
+        val intent = Intent(ACTION_START_PLAYBACK_FOREGROUND).setComponent(component)
+        return try {
+            ContextCompat.startForegroundService(context, intent)
+            true
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to start foreground service ${component.className}")
+            setServiceForeground(false)
+            false
+        }
+    }
+
+    suspend fun ensureForegroundServiceStarted(context: Context, timeoutMs: Long = 2000L): Boolean {
+        if (_isServiceForeground.value) return true
+        val component = resolveMediaBrowserServiceComponent(context)
+        if (component == null) {
+            Timber.e("No enabled media browser service found for foreground start")
+            return false
+        }
+        if (!startServiceForeground(context, component)) return false
+        if (_isServiceForeground.value) return true
+        return withTimeoutOrNull(timeoutMs) {
+            isServiceForeground.first { it }
+            true
+        } ?: false
     }
 
     @OptIn(UnstableApi::class)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -83,6 +83,7 @@ import com.automattic.eventhorizon.PlaybackContentType
 import com.automattic.eventhorizon.PlaybackEpisodeAutoplayedEvent
 import com.automattic.eventhorizon.PlaybackEpisodeDurationChangedEvent
 import com.automattic.eventhorizon.PlaybackFailedEvent
+import com.automattic.eventhorizon.PlaybackForegroundServiceErrorEvent
 import com.automattic.eventhorizon.PlaybackPauseEvent
 import com.automattic.eventhorizon.PlaybackPlayEvent
 import com.automattic.eventhorizon.PlaybackSeekEvent
@@ -912,6 +913,8 @@ open class PlaybackManager @Inject constructor(
     suspend fun stop() {
         LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Stopping playback")
 
+        mediaSessionManager.isSwitchingPlayer = false
+
         cancelPrefetchNextEpisode()
         cancelUpdateTimer()
         cancelBufferUpdateTimer()
@@ -1290,6 +1293,7 @@ open class PlaybackManager @Inject constructor(
 
     @OptIn(UnstableApi::class)
     suspend fun onPlayerError(event: PlayerEvent.PlayerError) {
+        mediaSessionManager.isSwitchingPlayer = false
         settings.recordErrorSession()
         val episode = getCurrentEpisode()
 
@@ -1457,6 +1461,7 @@ open class PlaybackManager @Inject constructor(
 
     fun onPlayerPlaying() {
         Timber.i("PlaybackService onPlayerPlaying")
+        mediaSessionManager.isSwitchingPlayer = false
         val episode = getCurrentEpisode() ?: return
 
         playbackStateRelay.blockingFirst().let { playbackState ->
@@ -1476,6 +1481,7 @@ open class PlaybackManager @Inject constructor(
     }
 
     suspend fun onPlayerPaused() {
+        mediaSessionManager.isSwitchingPlayer = false
         withContext(Dispatchers.Main) {
             playbackStateRelay.blockingFirst().let { playbackState ->
                 playbackStateRelay.accept(playbackState.copy(state = PlaybackState.State.PAUSED, lastChangeFrom = LastChangeFrom.OnPlayerPaused.value))
@@ -2252,6 +2258,15 @@ open class PlaybackManager @Inject constructor(
             return
         }
 
+        // Android 17: reach the foreground service before requesting audio focus, otherwise focus is denied.
+        if (FeatureFlag.isEnabled(Feature.FOREGROUND_BEFORE_PLAYBACK) && !Util.isAutomotive(application) && player?.isRemote != true) {
+            val foreground = mediaSessionManager.ensureForegroundServiceStarted(application)
+            if (!foreground) {
+                LogBuffer.e(LogBuffer.TAG_PLAYBACK, "Foreground service not ready before playback, proceeding with fallback")
+                eventHorizon.track(PlaybackForegroundServiceErrorEvent)
+            }
+        }
+
         val hasAudioFocus = focusManager.tryToGetAudioFocus()
         if (!hasAudioFocus) {
             return
@@ -2337,6 +2352,9 @@ open class PlaybackManager @Inject constructor(
     private suspend fun resetPlayer() {
         if (resettingPlayer) return
         resettingPlayer = true
+        if (FeatureFlag.isEnabled(Feature.FOREGROUND_BEFORE_PLAYBACK)) {
+            mediaSessionManager.isSwitchingPlayer = true
+        }
 
         withContext(Dispatchers.Main) {
             player?.stop()
@@ -2348,7 +2366,10 @@ open class PlaybackManager @Inject constructor(
                 player = playerManager.createSimplePlayer(this@PlaybackManager::onPlayerEvent)
                 // Start the service early so it's ready when we install the player later.
                 // The ExoPlayer doesn't exist yet — SimplePlayer creates it lazily in prepare().
-                mediaSessionManager.startServiceIfNeeded(application)
+                // When the flag is on, play() starts the foreground service via the gate instead.
+                if (!FeatureFlag.isEnabled(Feature.FOREGROUND_BEFORE_PLAYBACK)) {
+                    mediaSessionManager.startServiceIfNeeded(application)
+                }
                 Timber.i("Creating media player of type SimplePlayer.")
             }
         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
@@ -2,14 +2,18 @@ package au.com.shiftyjelly.pocketcasts.repositories.playback
 
 import android.app.ForegroundServiceStartNotAllowedException
 import android.content.Intent
+import android.content.pm.ServiceInfo
 import android.os.Binder
 import android.os.Build
 import android.os.IBinder
 import androidx.annotation.OptIn
+import androidx.core.app.NotificationCompat
+import androidx.core.app.ServiceCompat
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.session.DefaultMediaNotificationProvider
 import androidx.media3.session.MediaLibraryService
 import androidx.media3.session.MediaSession
+import androidx.media3.session.MediaStyleNotificationHelper
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.utils.Util
@@ -23,6 +27,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import au.com.shiftyjelly.pocketcasts.images.R as IR
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 const val MEDIA_ID_ROOT = "__ROOT__"
 const val PODCASTS_ROOT = "__PODCASTS__"
@@ -101,12 +106,16 @@ open class PlaybackService :
         // AAOS handles media UI entirely — skip app-managed notification removal
         // to avoid killing the foreground service.
         val isTransientLoss = (session.player as? PocketCastsForwardingPlayer)?.isTransientLoss == true
-        if (!Util.isAutomotive(this) && !startInForegroundRequired && settings.hideNotificationOnPause.value && !isTransientLoss) {
+        // Media3 demotes the service itself when foreground isn't required, so pass requireForeground through super.
+        val requireForeground = startInForegroundRequired || playbackManager.mediaSessionManager.isSwitchingPlayer
+        if (!Util.isAutomotive(this) && !requireForeground && settings.hideNotificationOnPause.value && !isTransientLoss) {
             stopForeground(STOP_FOREGROUND_REMOVE)
+            playbackManager.mediaSessionManager.setServiceForeground(false)
             return
         }
         try {
-            super.onUpdateNotification(session, startInForegroundRequired)
+            super.onUpdateNotification(session, requireForeground)
+            playbackManager.mediaSessionManager.setServiceForeground(requireForeground)
         } catch (e: Exception) {
             LogBuffer.e(LogBuffer.TAG_PLAYBACK, "onUpdateNotification failed: $e")
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && e is ForegroundServiceStartNotAllowedException) {
@@ -119,6 +128,10 @@ open class PlaybackService :
 
     @OptIn(UnstableApi::class)
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        // Action-only: once started via startForegroundService the FGS contract must be honoured even if the flag flips off.
+        if (intent?.action == MediaSessionManager.ACTION_START_PLAYBACK_FOREGROUND) {
+            startForegroundEarly()
+        }
         // MediaLibraryService doesn't automatically route ACTION_MEDIA_BUTTON intents
         // sent via PendingIntent.getService (e.g., from PiP controls) to the session callback.
         // Forward them so onMediaButtonEvent is invoked.
@@ -144,6 +157,37 @@ open class PlaybackService :
     }
 
     @OptIn(UnstableApi::class)
+    private fun startForegroundEarly() {
+        if (Util.isAutomotive(this)) return
+        val session = playbackManager.mediaSessionManager.getMedia3Session()
+        try {
+            val title = playbackManager.getCurrentEpisode()?.title ?: getString(LR.string.loading)
+            val builder = NotificationCompat.Builder(this, Settings.NotificationChannel.NOTIFICATION_CHANNEL_ID_PLAYBACK.id)
+                .setContentTitle(title)
+                .setSmallIcon(IR.drawable.notification)
+                .setOnlyAlertOnce(true)
+                .setShowWhen(false)
+                .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+            if (session != null) {
+                builder.setStyle(MediaStyleNotificationHelper.MediaStyle(session))
+            }
+            ServiceCompat.startForeground(this, Settings.NotificationId.PLAYING.value, builder.build(), ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK)
+            playbackManager.mediaSessionManager.setServiceForeground(true)
+            LogBuffer.i(LogBuffer.TAG_PLAYBACK, "startForeground early (preparing, media3)")
+        } catch (e: Exception) {
+            LogBuffer.e(LogBuffer.TAG_PLAYBACK, "startForeground early failed (media3): $e")
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && e is ForegroundServiceStartNotAllowedException) {
+                val currentValue = settings.getTimesToShowBatteryWarning()
+                settings.setTimesToShowBatteryWarning(2 + currentValue)
+                eventHorizon.track(PlaybackForegroundServiceErrorEvent)
+            }
+            if (session?.connectedControllers.isNullOrEmpty()) {
+                stopSelf()
+            }
+        }
+    }
+
+    @OptIn(UnstableApi::class)
     override fun onTaskRemoved(rootIntent: Intent?) {
         if (Util.isAutomotive(this)) return
         val player = playbackManager.mediaSessionManager.getMedia3Session()?.player
@@ -157,6 +201,7 @@ open class PlaybackService :
 
     override fun onDestroy() {
         super.onDestroy()
+        playbackManager.mediaSessionManager.setServiceForeground(false)
         playbackManager.mediaSessionManager.release()
 
         sleepTimerHandler?.dispose()

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManagerForegroundTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManagerForegroundTest.kt
@@ -1,0 +1,99 @@
+package au.com.shiftyjelly.pocketcasts.repositories.playback
+
+import android.content.ComponentName
+import android.content.IntentFilter
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import au.com.shiftyjelly.pocketcasts.sharedtest.InMemoryFeatureFlagRule
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
+import com.automattic.eventhorizon.EventHorizon
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class MediaSessionManagerForegroundTest {
+
+    @get:Rule
+    val featureFlagRule = InMemoryFeatureFlagRule()
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val context = RuntimeEnvironment.getApplication()
+
+    private lateinit var manager: MediaSessionManager
+
+    @Before
+    fun setUp() {
+        // Register a media browser service so the gate can resolve a component and dispatch a start.
+        val component = ComponentName(context, PlaybackService::class.java)
+        val shadowPackageManager = shadowOf(context.packageManager)
+        shadowPackageManager.addServiceIfNotPresent(component)
+        shadowPackageManager.addIntentFilterForService(component, IntentFilter("android.media.browse.MediaBrowserService"))
+
+        manager = MediaSessionManager(
+            playbackManager = mock(),
+            podcastManager = mock<PodcastManager>(),
+            episodeManager = mock<EpisodeManager>(),
+            playlistManager = mock<PlaylistManager>(),
+            settings = mock<Settings>(),
+            context = context,
+            eventHorizon = mock<EventHorizon>(),
+            bookmarkManager = mock<BookmarkManager>(),
+            browseTreeProvider = mock(),
+            applicationScope = CoroutineScope(testDispatcher),
+        )
+    }
+
+    @Test
+    fun `setServiceForeground updates the foreground state`() {
+        assertFalse(manager.isServiceForeground.value)
+
+        manager.setServiceForeground(true)
+        assertTrue(manager.isServiceForeground.value)
+
+        manager.setServiceForeground(false)
+        assertFalse(manager.isServiceForeground.value)
+    }
+
+    @Test
+    fun `ensureForegroundServiceStarted returns immediately when already foreground`() = runTest(testDispatcher) {
+        FeatureFlag.setEnabled(Feature.FOREGROUND_BEFORE_PLAYBACK, true)
+        manager.setServiceForeground(true)
+
+        assertTrue(manager.ensureForegroundServiceStarted(context, timeoutMs = 50))
+    }
+
+    @Test
+    fun `ensureForegroundServiceStarted resolves once the service reaches foreground`() = runTest(testDispatcher) {
+        FeatureFlag.setEnabled(Feature.FOREGROUND_BEFORE_PLAYBACK, true)
+
+        val result = async { manager.ensureForegroundServiceStarted(context, timeoutMs = 5000) }
+        manager.setServiceForeground(true)
+
+        assertTrue(result.await())
+    }
+
+    @Test
+    fun `ensureForegroundServiceStarted returns false when the service never reaches foreground`() = runTest(testDispatcher) {
+        FeatureFlag.setEnabled(Feature.FOREGROUND_BEFORE_PLAYBACK, true)
+
+        assertFalse(manager.ensureForegroundServiceStarted(context, timeoutMs = 50))
+    }
+}

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -198,6 +198,15 @@ enum class Feature(
         hasDevToggle = true,
         addedOn = LocalDate.parse("2026-03-04"),
     ),
+    FOREGROUND_BEFORE_PLAYBACK(
+        key = "foreground_before_playback",
+        title = "Foreground service before playback (Android 17 audio hardening)",
+        defaultValue = isDebugOrPrototypeBuild,
+        tier = FeatureTier.Free,
+        hasFirebaseRemoteFlag = true,
+        hasDevToggle = true,
+        addedOn = LocalDate.parse("2026-07-13"),
+    ),
     NEXT_EPISODE_PREFETCH(
         key = "next_episode_prefetch",
         title = "Next Episode Prefetch",


### PR DESCRIPTION
## Description
It's been reported that our app is not compatible with upcomfing Android 17-related audio playback restrictions as there were some scenarios when we didn't ensure that our playback service runs in the foreground. A couple of such scenarios:
- resume a paused episode from the background via home screen widgets
- cold background play (app process was killed before, starting playback from the media notification or via bluetooth commands)
- auto play hits next episode of queue while phone screen is off
- google assistant voice commands

This PR attempts to fix those scenarios. I have added the feature flag `FOREGROUND_BEFORE_PLAYBACK` and put my changes behind it. Previously we requested focus first and only promoted the service reactively, so background plays (Bluetooth, widgets, notifications, auto-play, Auto/Wear) got their focus request denied and were silently stopped. The core change is a suspend gate (`ensureForegroundServiceStarted`) called at the top of `PlaybackManager.play()` that starts the service via startForegroundService and waits on a shared `isServiceForeground` signal both services update, so the FGS is guaranteed live before focus regardless of feature-flag path (legacy or Media3) or entry point. It also keeps the service foreground across auto-play episode switches so a background advance never needs a fresh start exemption, and fails open — if the service genuinely can't start it falls back to the old behavior rather than blocking playback.

See: p1783932483344609-slack-C028JAG44VD

## Testing Instructions
You'll need to spin up an emulator with Android 17.

1. Install the debug build and open the app, play something once so there's an episode in Up Next.
2. In dev settings, turn on the FOREGROUND_BEFORE_PLAYBACK flag (leave MEDIA3_SESSION on for now).
3. Turn on enforcement: `adb shell cmd audio set-enable-hardening enable`.
4. Check your logcat, filter for "AudioHardening\|Playback" 

Background play scenarios (the ones that used to break)
  5. Lock the screen, then hit play on a Bluetooth headset → audio should actually start.
  6. Background the app, tap play on a home-screen widget → audio starts, notification shows.
  7. Trigger a new-episode notification, background the app, tap "Play" on it → audio starts.
  8. Play something, screen off, let the episode finish → next episode auto-plays without dropping.
  9. From Android Auto (or adb shell am a play-from-search), say/pick something to play → it plays.
  10. After each: check adb dumpsys audio and logcat show no AudioHardening suppression for our package.

  Same thing on the legacy path
  11. Turn `MEDIA3_SESSION` off, force-stop the app, then repeat steps 5–10 → same results.

  Regression / normal behavior
  12. Normal foreground play/pause/skip still works, no weird "Loading" notification lingering.
  13. Pause, swipe the notification away (if hide-on-pause off), then resume from the widget → still plays.
  14. Get a transient interruption (nav prompt or a phone call) → playback ducks/pauses then resumes fine.
  15. Cast to a Chromecast, play, then disconnect → local playback resumes normally.
  16. Flip the flag off, repeat a couple of plays → behaves exactly like before (sanity that it's inert).

  Teardown
  17. Reset enforcement: `adb shell cmd audio set-enable-hardening disable`.

## Screenshots or Screencast 
<!-- if applicable -->

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack