### PR TITLE
Avoid empty-list crash on login failure message

### DIFF
--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginWithEmailScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginWithEmailScreen.kt
@@ -86,7 +86,7 @@ fun LoginWithEmailScreen(
                 val currentState = signInState as? SignInState.Failure
                 val message = currentState?.message
                     ?: stringResource(
-                        currentState?.errors?.last()?.message
+                        currentState?.errors?.lastOrNull()?.message
                             ?: LR.string.error_login_failed,
                     )
                 ErrorScreen(message)


### PR DESCRIPTION
## Description

On Wear OS, a failed email login renders `ErrorScreen` with a message derived from `SignInState.Failure`. When the failure carries no top-level `message`, the screen falls back to the last entry in the `errors` list via `errors.last()`.

`last()` throws `NoSuchElementException` on an empty list, so a `Failure` with a null `message` and an empty `errors` list crashes the watch app at exactly the moment the user is being told their login failed. This swaps it for `lastOrNull()`, which lets the existing elvis fallback to the generic `error_login_failed` string do its job instead.

No behaviour change when `errors` is non-empty; this only affects the previously-crashing empty case.

## Testing Instructions

1. Build and run the `wear` app on a Wear OS emulator or watch.
2. Navigate to the login flow and choose **Sign in with email**.
3. Enter an email and password that will fail authentication (e.g. a valid-format email with a wrong password).
4. Confirm the error screen appears with a message and the app does not crash.
5. To exercise the specific fixed path, temporarily force the failure state to have a null `message` and an empty `errors` list (for example, by emitting `SignInState.Failure(message = null, errors = emptyList())` from `LoginWithEmailViewModel`). Before this change the screen crashes with `NoSuchElementException`; after it, the generic "Login failed" message is shown.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
