### PR TITLE
Add descriptive headers to shared GitHub workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,3 +1,8 @@
+# Automatically posts a Claude code review on every pull request.
+#
+# This workflow is shared between the Android, iOS, and Web Player repos.
+# If you edit it here, please apply the same change to the other two.
+
 name: Claude Code Review
 
 on:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,4 +1,4 @@
-# Runs Claude on demand when with a @claude mention.
+# Runs Claude on demand with a @claude mention.
 #
 # This workflow is shared between the Android, iOS, and Web Player repos.
 # If you edit it here, please apply the same change to the other two.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,3 +1,8 @@
+# Runs Claude on demand when with a @claude mention.
+#
+# This workflow is shared between the Android, iOS, and Web Player repos.
+# If you edit it here, please apply the same change to the other two.
+
 name: Claude Code
 
 on:


### PR DESCRIPTION
## Description
The `claude.yml` and `claude-code-review.yml` workflows are copies of the same files in the Pocket Casts iOS and Web Player repos, but nothing in the files said so. Anyone editing one of them here had no way of knowing the other two repos would drift out of sync.

This adds a short comment header to each workflow saying what it does and that it is shared across the Android, iOS, and Web Player repos, with a note to apply any edit to the other two. Comments only, no behavioural change to either workflow.

## Testing Instructions

No testing required as it's just documentation. 

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
