### PR TITLE
LOG-01: Make LogBuffer timestamp formatting thread-safe

### DIFF
--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/log/LogBuffer.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/log/LogBuffer.kt
@@ -8,8 +8,8 @@ import java.io.IOException
 import java.io.OutputStream
 import java.io.PrintWriter
 import java.io.StringWriter
-import java.text.SimpleDateFormat
-import java.util.Date
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 import java.util.IllegalFormatException
 import java.util.Locale
 import timber.log.Timber
@@ -28,10 +28,8 @@ object LogBuffer {
     private const val LOG_FILE_NAME = "debug.log"
     private const val LOG_BACKUP_FILE_NAME = "debug.log.1"
 
-    // SimpleDateFormat is not thread-safe and addLog can run on many threads, so give each thread its own instance
-    private val LOG_FILE_DATE_FORMAT = object : ThreadLocal<SimpleDateFormat>() {
-        override fun initialValue() = SimpleDateFormat("dd/M HH:mm:ss.SSS", Locale.US)
-    }
+    private val LOG_FILE_DATE_FORMAT: DateTimeFormatter =
+        DateTimeFormatter.ofPattern("dd/M HH:mm:ss.SSS", Locale.US)
     private const val FILE_MAX_SIZE_BYTES = (200 * 1024).toLong()
 
     private var logPath: String? = null
@@ -161,7 +159,7 @@ object LogBuffer {
             else -> prefix = ""
         }
 
-        prefix += LOG_FILE_DATE_FORMAT.get()?.format(Date()).orEmpty()
+        prefix += LOG_FILE_DATE_FORMAT.format(LocalDateTime.now())
 
         add("$prefix $logMessage")
     }

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/log/LogBuffer.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/log/LogBuffer.kt
@@ -28,7 +28,10 @@ object LogBuffer {
     private const val LOG_FILE_NAME = "debug.log"
     private const val LOG_BACKUP_FILE_NAME = "debug.log.1"
 
-    private val LOG_FILE_DATE_FORMAT = SimpleDateFormat("dd/M HH:mm:ss.SSS", Locale.US)
+    // SimpleDateFormat is not thread-safe and addLog can run on many threads, so give each thread its own instance
+    private val LOG_FILE_DATE_FORMAT = object : ThreadLocal<SimpleDateFormat>() {
+        override fun initialValue() = SimpleDateFormat("dd/M HH:mm:ss.SSS", Locale.US)
+    }
     private const val FILE_MAX_SIZE_BYTES = (200 * 1024).toLong()
 
     private var logPath: String? = null
@@ -158,7 +161,7 @@ object LogBuffer {
             else -> prefix = ""
         }
 
-        prefix += LOG_FILE_DATE_FORMAT.format(Date())
+        prefix += LOG_FILE_DATE_FORMAT.get()?.format(Date()).orEmpty()
 
         add("$prefix $logMessage")
     }


### PR DESCRIPTION
## Description

`LogBuffer.addLog` is called from many threads (playback, sync, downloads, background workers), but it formatted its timestamp prefix through a single shared `SimpleDateFormat` instance. `SimpleDateFormat` is not thread-safe: it keeps mutable formatting state on the instance, so concurrent `format()` calls can interleave and produce corrupted timestamps in `debug.log`, or in the worst case throw from inside the formatter.

The fix replaces it with a single `java.time.DateTimeFormatter`. A `DateTimeFormatter` is immutable and thread-safe by design, so one shared instance can be formatted from any number of threads with no synchronization and no per-thread instance overhead. This module builds with `isCoreLibraryDesugaringEnabled = true` and `minSdk = 24`, so `java.time` is available on every supported device.

The formatted output is unchanged (`dd/M HH:mm:ss.SSS`, `Locale.US`).

An earlier revision of this PR wrapped the `SimpleDateFormat` in a `ThreadLocal`. That also fixed the race, but it allocates a formatter per logging thread and keeps mutable state around; `DateTimeFormatter` was raised in review as the cleaner option and is what this PR now does.

Fixes [PCDROID-665](https://linear.app/a8c/issue/PCDROID-665/log-01-non-thread-safe-simpledateformat-formatted-outside)

## Testing Instructions

This is an internal logging fix with no user-facing behaviour change. To verify the log output is still correct:

1. Build and install a debug build: `./gradlew :app:installDebugProd`
2. Use the app so that it writes debug logs: play an episode, then trigger a refresh/sync from the Podcasts tab.
3. Go to **Profile → Settings → Help & Feedback → Get support** and view/export `debug.log`.
4. Confirm log lines still carry a well-formed timestamp prefix in the `dd/M HH:mm:ss.SSS` format, e.g. `14/7 09:21:33.482`, and that no lines have garbled or interleaved timestamps.
5. Confirm nothing else about the log format changed (log level prefixes and messages are unaffected).

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
