### PR TITLE
Fix Claude review workflow: persist checkout credentials

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -41,7 +41,9 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 1
-          persist-credentials: false
+          # Credentials must persist so claude-code-action can `git fetch` the
+          # PR branch; the job's token is read-only for contents anyway.
+          persist-credentials: true
 
       - name: Run Claude Code Review
         if: steps.workflow-changes.outputs.skip != 'true'


### PR DESCRIPTION
## Description
Fixes the "Claude Code Review" workflow, which fails on any PR it actually reviews:

```
fatal: could not read Username for 'https://github.com': No such device or address
Error: Command failed: git fetch origin --depth=20 <pr-branch>
```

The checkout step sets `persist-credentials: false`, so no auth token is written into the workspace's git config. `claude-code-action` then runs its own `git fetch origin <pr-branch>` to check out the PR head and has no way to authenticate. This PR sets `persist-credentials: true` explicitly (with a comment explaining why, so a future security lint doesn't flip it back). It's safe: the job's token only has `contents: read`, so the persisted credential can fetch but not push. The mention-triggered `claude.yml` already persists credentials (checkout default).

Same fix as the one first diagnosed on the Web Player repo (Automattic/pocket-casts-webplayer#4725) — this workflow file is shared between the Android, iOS, and Web Player repos, and its header asks for changes to be applied to all three.

## Testing Instructions
- This PR itself skips the Claude review (the workflow-changes guard step), so it can't self-verify.
- After merge, push to any open PR (or re-run a failed "Claude Code Review" run)
- Verify the review job checks out the PR branch and posts a review instead of failing at `git fetch`

## Screenshots or Screencast 
n/a — CI workflow change, no UI.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md — n/a, not user-facing
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting) — n/a, YAML workflow only, no Kotlin/Java touched
- [x] I have considered whether it makes sense to add tests for my changes — n/a, GitHub Actions config
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml` — n/a
- [ ] Any jetpack compose components I added or changed are covered by compose previews — n/a
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics. — n/a
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
