### PR TITLE
[HLS] Show video icon on HLS episode rows

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/BaseEpisodeViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/BaseEpisodeViewHolder.kt
@@ -68,6 +68,8 @@ abstract class BaseEpisodeViewHolder<T : Any>(
 
     private var isObservingRowData = false
 
+    private var hasHlsAlternateEnclosure = false
+
     @Suppress("UNCHECKED_CAST")
     private val swipeLayout = binding.root as SwipeRowLayout<SwipeAction>
 
@@ -162,10 +164,12 @@ abstract class BaseEpisodeViewHolder<T : Any>(
 
     private fun observeRowData() {
         disposable.clear()
+        hasHlsAlternateEnclosure = false
         disposable += rowDataProvider.episodeRowDataObservable(episode.uuid)
             .doOnSubscribe { isObservingRowData = true }
             .doOnDispose { isObservingRowData = false }
             .subscribeBy(onNext = { data ->
+                hasHlsAlternateEnclosure = data.hasHlsAlternateEnclosure
                 isPlaying = data.playbackState.isPlaying && data.playbackState.episodeUuid == episode.uuid
                 bindPlaybackButton()
 
@@ -202,7 +206,7 @@ abstract class BaseEpisodeViewHolder<T : Any>(
 
     private fun bindStatus(downloadProgress: Int) {
         binding.star.isVisible = episode.isStarred
-        binding.video.isVisible = episode.isVideo
+        binding.video.isVisible = episode.showsVideoIcon(hasHlsAlternateEnclosure)
         binding.progressBar.isVisible = false
         binding.progressCircle.isVisible = false
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/AlternateEnclosureDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/AlternateEnclosureDao.kt
@@ -5,11 +5,15 @@ import androidx.room.Insert
 import androidx.room.Query
 import androidx.room.Transaction
 import au.com.shiftyjelly.pocketcasts.models.entity.EpisodeAlternateEnclosure
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 abstract class AlternateEnclosureDao {
     @Query("SELECT * FROM episode_alternate_enclosures WHERE episode_uuid IS :episodeUuid ORDER BY position ASC")
     abstract suspend fun findByEpisodeUuid(episodeUuid: String): List<EpisodeAlternateEnclosure>
+
+    @Query("SELECT EXISTS(SELECT 1 FROM episode_alternate_enclosures WHERE episode_uuid IS :episodeUuid AND type IN (:hlsMimeTypes))")
+    abstract fun hasHlsEnclosure(episodeUuid: String, hlsMimeTypes: Set<String>): Flow<Boolean>
 
     @Insert
     protected abstract suspend fun insertAll(enclosures: List<EpisodeAlternateEnclosure>)

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/AlternateEnclosureDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/AlternateEnclosureDao.kt
@@ -12,7 +12,7 @@ abstract class AlternateEnclosureDao {
     @Query("SELECT * FROM episode_alternate_enclosures WHERE episode_uuid IS :episodeUuid ORDER BY position ASC")
     abstract suspend fun findByEpisodeUuid(episodeUuid: String): List<EpisodeAlternateEnclosure>
 
-    @Query("SELECT EXISTS(SELECT 1 FROM episode_alternate_enclosures WHERE episode_uuid IS :episodeUuid AND type IN (:hlsMimeTypes))")
+    @Query("SELECT EXISTS(SELECT 1 FROM episode_alternate_enclosures WHERE episode_uuid IS :episodeUuid AND LOWER(type) IN (:hlsMimeTypes))")
     abstract fun hasHlsEnclosure(episodeUuid: String, hlsMimeTypes: Set<String>): Flow<Boolean>
 
     @Insert

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/BaseEpisode.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/BaseEpisode.kt
@@ -164,6 +164,8 @@ sealed interface BaseEpisode {
     val isAudio: Boolean
         get() = !isVideo
 
+    fun showsVideoIcon(hasHlsAlternateEnclosure: Boolean): Boolean = isVideo || isHlsOnly || hasHlsAlternateEnclosure
+
     val podcastOrSubstituteUuid: String
         get() = if (this is PodcastEpisode) this.podcastUuid else Podcast.userPodcast.uuid
 

--- a/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/entity/BaseEpisodeHlsDetectionTest.kt
+++ b/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/entity/BaseEpisodeHlsDetectionTest.kt
@@ -114,6 +114,30 @@ class BaseEpisodeHlsDetectionTest {
         assertTrue(episode.isStreamUrlHls)
     }
 
+    @Test
+    fun `video episode shows the video icon`() {
+        val episode = createEpisode(downloadUrl = "https://example.com/episode.mp4", fileType = "video/mp4")
+        assertTrue(episode.showsVideoIcon(hasHlsAlternateEnclosure = false))
+    }
+
+    @Test
+    fun `HLS only episode shows the video icon`() {
+        val episode = createEpisode(downloadUrl = "https://example.com/episode.m3u8")
+        assertTrue(episode.showsVideoIcon(hasHlsAlternateEnclosure = false))
+    }
+
+    @Test
+    fun `episode with an HLS alternate enclosure shows the video icon`() {
+        val episode = createEpisode(downloadUrl = "https://example.com/episode.mp3")
+        assertTrue(episode.showsVideoIcon(hasHlsAlternateEnclosure = true))
+    }
+
+    @Test
+    fun `plain audio episode does not show the video icon`() {
+        val episode = createEpisode(downloadUrl = "https://example.com/episode.mp3", fileType = "audio/mpeg")
+        assertFalse(episode.showsVideoIcon(hasHlsAlternateEnclosure = false))
+    }
+
     private fun createEpisode(
         downloadUrl: String? = null,
         fileType: String? = null,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/AlternateEnclosureManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/AlternateEnclosureManager.kt
@@ -1,7 +1,10 @@
 package au.com.shiftyjelly.pocketcasts.repositories.podcast
 
 import au.com.shiftyjelly.pocketcasts.models.entity.EpisodeAlternateEnclosure
+import kotlinx.coroutines.flow.Flow
 
 interface AlternateEnclosureManager {
     suspend fun findForEpisode(episodeUuid: String): List<EpisodeAlternateEnclosure>
+
+    fun hasHlsAlternateEnclosure(episodeUuid: String): Flow<Boolean>
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/AlternateEnclosureManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/AlternateEnclosureManagerImpl.kt
@@ -1,11 +1,15 @@
 package au.com.shiftyjelly.pocketcasts.repositories.podcast
 
 import au.com.shiftyjelly.pocketcasts.models.db.dao.AlternateEnclosureDao
+import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.EpisodeAlternateEnclosure
 import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
 
 class AlternateEnclosureManagerImpl @Inject constructor(
     private val alternateEnclosureDao: AlternateEnclosureDao,
 ) : AlternateEnclosureManager {
     override suspend fun findForEpisode(episodeUuid: String): List<EpisodeAlternateEnclosure> = alternateEnclosureDao.findByEpisodeUuid(episodeUuid)
+
+    override fun hasHlsAlternateEnclosure(episodeUuid: String): Flow<Boolean> = alternateEnclosureDao.hasHlsEnclosure(episodeUuid, BaseEpisode.HLS_MIME_TYPES)
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeRowData.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeRowData.kt
@@ -28,6 +28,7 @@ data class EpisodeRowData(
     val playbackState: PlaybackState,
     val isInUpNext: Boolean,
     val hasBookmarks: Boolean,
+    val hasHlsAlternateEnclosure: Boolean,
 )
 
 data class UserEpisodeRowData(
@@ -46,6 +47,7 @@ class EpisodeRowDataProvider @Inject constructor(
     private val upNextQueue: UpNextQueue,
     private val bookmarkManager: BookmarkManager,
     private val userEpisodeManager: UserEpisodeManager,
+    private val alternateEnclosureManager: AlternateEnclosureManager,
     private val settings: Settings,
 ) {
 
@@ -71,6 +73,7 @@ class EpisodeRowDataProvider @Inject constructor(
                     playbackStatusObservable(episodeUuid),
                     isInUpNextObservable(episodeUuid),
                     hasBookmarksObservable(episodeUuid),
+                    hasHlsAlternateEnclosureObservable(episodeUuid),
                     ::EpisodeRowData,
                 )
             }
@@ -105,6 +108,13 @@ class EpisodeRowDataProvider @Inject constructor(
                     prev.positionMs == curr.positionMs &&
                     prev.isBuffering == curr.isBuffering
             }
+    }
+
+    private fun hasHlsAlternateEnclosureObservable(episodeUuid: String): Observable<Boolean> {
+        return alternateEnclosureManager.hasHlsAlternateEnclosure(episodeUuid)
+            .asObservable()
+            .startWith(false)
+            .distinctUntilChanged()
     }
 
     private fun isInUpNextObservable(episodeUuid: String): Observable<Boolean> {

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/AlternateEnclosureManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/AlternateEnclosureManagerImplTest.kt
@@ -2,9 +2,13 @@ package au.com.shiftyjelly.pocketcasts.repositories.podcast
 
 import au.com.shiftyjelly.pocketcasts.models.db.dao.AlternateEnclosureDao
 import au.com.shiftyjelly.pocketcasts.models.entity.AlternateEnclosureSource
+import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.EpisodeAlternateEnclosure
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
@@ -26,6 +30,13 @@ class AlternateEnclosureManagerImplTest {
         whenever(alternateEnclosureDao.findByEpisodeUuid("episode-uuid")).thenReturn(emptyList())
 
         assertEquals(emptyList<EpisodeAlternateEnclosure>(), manager.findForEpisode("episode-uuid"))
+    }
+
+    @Test
+    fun `hasHlsAlternateEnclosure queries the dao with the HLS mime types`() = runBlocking {
+        whenever(alternateEnclosureDao.hasHlsEnclosure("episode-uuid", BaseEpisode.HLS_MIME_TYPES)).thenReturn(flowOf(true))
+
+        assertTrue(manager.hasHlsAlternateEnclosure("episode-uuid").first())
     }
 
     private fun enclosure(position: Int) = EpisodeAlternateEnclosure(


### PR DESCRIPTION
## Description
This PR adds the logic to treat HLS episodes as video episodes, displaying the video icon on the episode row.

Fixes PCDROID-670 https://linear.app/a8c/issue/PCDROID-670/show-video-icon-on-hls-episode-rows

## Testing Instructions
1. Open a podcast that has hls episodes (e.g The confidence chronicles)
2. Notice video icon on episode rows

## Screenshots or Screencast 

<img width="1080" height="2424" alt="Screenshot_20260714_104411" src="https://github.com/user-attachments/assets/fcc3ad7d-3502-447d-976e-6f9c2b9d3f72" />

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
