### PR TITLE
Upgrade to Android Gradle Plugin 9.3.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@
 [versions]
 # ignore AboutLibraries versions such as -b02 and stick to the stable versions
 aboutlibraries = "15.0.3"
-android-gradle-plugin = "9.2.1"
+android-gradle-plugin = "9.3.0"
 billing = "9.1.0"
 coil = "3.5.0"
 compose = "2026.05.01" # https://developer.android.com/jetpack/compose/bom/bom-mapping


### PR DESCRIPTION
## Description

Bumps the Android Gradle Plugin from 9.2.1 to 9.3.0 in `gradle/libs.versions.toml`. This keeps the build tooling current with the latest stable AGP release, picking up upstream bug fixes and improvements. No product or configuration code changes are required for this bump.

The alert to upgrade happened when I upgraded to the latest stable version of Android Studio Android Studio Quail 2, 2026.1.2.

## Testing Instructions

Check the CI is green should be enough for this. 

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
