### PR TITLE
Improvement to the Claude GitHub workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -9,10 +9,18 @@ on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
 
+# Cancel an in-progress review when a newer commit is pushed to the same PR.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   claude-review:
-    # Only run for PRs from the same repository.
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # Skip draft pushes and cross-repo/dependabot PRs. Drafts still review on open/reopen/ready.
+    if: >-
+      !(github.event.pull_request.draft == true && github.event.action == 'synchronize') &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]'
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,7 +34,7 @@ jobs:
       )
     runs-on: ubuntu-latest
     permissions:
-      contents: write # Downgrade to `read` if Claude should not push commits/branches
+      contents: read
       pull-requests: write
       issues: write
       actions: read # Required for Claude to read CI results on PRs


### PR DESCRIPTION
## Description

Hardens the Claude GitHub Actions workflows, applying feedback that surfaced in the iOS review of the equivalent workflow: https://github.com/Automattic/pocket-casts-ios/pull/4747#issuecomment-4970787171

Changes to `.github/workflows/claude-code-review.yml`:
- **Add a `concurrency` group** keyed by PR number with `cancel-in-progress: true`, so rapid pushes cancel stale in-progress reviews instead of stacking multiple concurrent reviews (wasted API spend and duplicate progress comments).
- **Skip auto-review on draft pushes.** Drafts are still reviewed on `opened`/`reopened`/`ready_for_review`, but a `synchronize` push to a draft no longer burns a full review.
- **Skip Dependabot PRs.** Dependabot branches live in the same repo, so the `head.repo` guard passed and the job ran, but Dependabot runs get a read-only token with no `ANTHROPIC_API_KEY`, so every Dependabot PR would fail with a red ❌. Guard on `github.actor != 'dependabot[bot]'`.

Change to `.github/workflows/claude.yml`:
- **Downgrade `contents: write` to `contents: read`.** The mention workflow does not need push-capable Claude, so we drop the elevated permission (point 4 in the iOS review).

## Testing Instructions

These are CI workflow changes, so verification happens through GitHub Actions:

1. Open this PR and confirm the `claude-review` job runs (this PR is from the same repo and is not a draft/dependabot).
2. Mark a test PR as draft and push a new commit; confirm the auto-review job is skipped on the `synchronize` event, then mark it ready for review and confirm the review runs.
3. Push two commits in quick succession to a PR and confirm the earlier `claude-review` run is cancelled by the newer one (concurrency).
4. Confirm a Dependabot PR no longer triggers a failing `claude-review` check.
5. Trigger the mention workflow (`@claude` comment) and confirm it still functions with `contents: read`.

## Screenshots or Screencast

Not applicable, no UI changes.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
