### PR TITLE
Guard against Discover carousel crash

### DIFF
--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
@@ -379,6 +379,7 @@ internal class DiscoverAdapter(
             super.onRestoreInstanceState(state)
             recyclerView?.post {
                 val position = scrollingLayoutManager.findFirstVisibleItemPosition()
+                if (position == RecyclerView.NO_POSITION) return@post
                 binding.pageIndicatorView.position = position
                 recyclerView.scrollToPosition(position)
                 trackSponsoredListImpression(position)
@@ -386,6 +387,7 @@ internal class DiscoverAdapter(
         }
 
         private fun trackPageChanged(position: Int) {
+            if (position == RecyclerView.NO_POSITION) return
             eventHorizon.track(
                 DiscoverFeaturedPageChangedEvent(
                     currentPage = position.toLong(),
@@ -395,7 +397,8 @@ internal class DiscoverAdapter(
         }
 
         private fun trackSponsoredListImpression(position: Int) {
-            val discoverPodcast = adapter.currentList[position] as? DiscoverPodcast
+            if (position == RecyclerView.NO_POSITION) return
+            val discoverPodcast = adapter.currentList.getOrNull(position) as? DiscoverPodcast
             discoverPodcast?.listId?.let { listId ->
                 if (listIdImpressionTracked.contains(listId)) return
                 eventHorizon.track(

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
@@ -397,7 +397,6 @@ internal class DiscoverAdapter(
         }
 
         private fun trackSponsoredListImpression(position: Int) {
-            if (position == RecyclerView.NO_POSITION) return
             val discoverPodcast = adapter.currentList.getOrNull(position) as? DiscoverPodcast
             discoverPodcast?.listId?.let { listId ->
                 if (listIdImpressionTracked.contains(listId)) return


### PR DESCRIPTION
## Description

Fixes a crash in the Discover tab's featured carousel impression tracking.

`trackSponsoredListImpression()` indexed into `adapter.currentList[position]` with no bounds check. Two paths can supply an invalid `position`:
- `HorizontalPeekSnapHelper.findTargetSnapPosition` forwards `PagerSnapHelper`'s result, which is `NO_POSITION` (-1) when it can't resolve a snap target (e.g. after a fling).
- `onRestoreInstanceState` passes `findFirstVisibleItemPosition()`, which is -1 for an empty or still-loading carousel.

Either case produces `currentList[-1]`, throwing `IndexOutOfBoundsException` and crashing the Discover tab.

**Fix:** early-return on `position == RecyclerView.NO_POSITION` in `trackSponsoredListImpression`, `trackPageChanged`, and the `onRestoreInstanceState` block, and switch the list access to `currentList.getOrNull(position)` so an out-of-bounds index degrades to a no-op instead of a crash.

Fixes PCDROID-666

Linear: https://linear.app/a8c/issue/PCDROID-666/discover-01-carousel-impression-tracking-crashes-on-no-position-out-of

## Testing Instructions

1. Open the Discover tab and confirm the featured carousel loads and displays podcasts.
2. Fling the featured carousel back and forth rapidly and confirm the app does not crash (previously the snap helper could return `NO_POSITION` mid-fling).
3. Rotate the device / trigger a config change while the Discover tab is open and the carousel is loading, and confirm no crash on state restore.
4. Confirm impression and page-changed analytics still fire for valid positions (e.g. via Event Horizon / logcat), so the guards only suppress invalid indices.

## Screenshots or Screencast

Not applicable, no visible UI changes (crash fix only).

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack