### PR TITLE
[Synced Transcripts] Fix broken seek failed event tracking

### DIFF
--- a/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/TranscriptViewModel.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/TranscriptViewModel.kt
@@ -178,18 +178,22 @@ class TranscriptViewModel @AssistedInject constructor(
 
     /**
      * Seeks playback to the tapped transcript [entry]. Returns the playback position (ms) sought
-     * to, or `null` if the entry is untimed, syncing is inactive, or no mapping is available. The
-     * caller uses the returned position to drive the highlight directly rather than re-deriving it
-     * from the (lossy) playback position.
+     * to, or `null` if the entry is untimed, tap-to-seek is unavailable, or no mapping is
+     * available (which tracks a seek failure). The caller uses the returned position to drive the
+     * highlight directly rather than re-deriving it from the (lossy) playback position.
      */
     fun seekToTranscriptEntry(entry: TranscriptEntry): Int? {
         val textEntry = entry as? TranscriptEntry.Text ?: return null
         if (textEntry.startTimeMs < 0) return null
         val currentState = _uiState.value
-        if (!currentState.isSyncedActive) return null
+        if (!currentState.isTapToSeekAvailable) return null
 
         val refTimeSec = textEntry.startTimeMs / 1000.0
-        val seekTimeMs = fingerprintTimingManager.playbackTimeMs(forReferenceTime = refTimeSec)
+        val seekTimeMs = if (currentState.isSyncedActive) {
+            fingerprintTimingManager.playbackTimeMs(forReferenceTime = refTimeSec)
+        } else {
+            null
+        }
         if (seekTimeMs == null) {
             track { source, podcastUuid, episodeUuid ->
                 SyncedTranscriptsSeekFailedEvent(
@@ -464,6 +468,13 @@ data class UiState(
     val transcriptEpisodeUuid get() = (transcriptState as? TranscriptState.Loaded)?.transcript?.episodeUuid
 
     val isSyncedActive get() = syncedState is FingerprintTimingManager.State.Active &&
+        transcriptEpisodeUuid != null &&
+        transcriptEpisodeUuid == playingEpisodeUuid
+
+    val isGeneratedTextTranscript get() = ((transcriptState as? TranscriptState.Loaded)?.transcript as? Transcript.Text)?.isGenerated == true
+
+    val isTapToSeekAvailable get() = isGeneratedTextTranscript &&
+        !isPaywallVisible &&
         transcriptEpisodeUuid != null &&
         transcriptEpisodeUuid == playingEpisodeUuid
 

--- a/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptPage.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptPage.kt
@@ -112,7 +112,7 @@ fun TranscriptPage(
                     .fillMaxWidth(),
             ) {
                 val tapToSeekHandler: ((TranscriptEntry, Int) -> Unit)? =
-                    if (uiState.isSyncedActive && viewModel != null) {
+                    if (FeatureFlag.isEnabled(Feature.SYNCED_TRANSCRIPTS) && uiState.isTapToSeekAvailable && viewModel != null) {
                         { entry, index ->
                             val seekTarget = viewModel.seekToTranscriptEntry(entry)
                             if (seekTarget != null) {

--- a/modules/features/transcripts/src/test/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/TranscriptViewModelTest.kt
+++ b/modules/features/transcripts/src/test/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/TranscriptViewModelTest.kt
@@ -6,12 +6,14 @@ import au.com.shiftyjelly.pocketcasts.analytics.testing.TestEventSink
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.Transcript
 import au.com.shiftyjelly.pocketcasts.models.to.TranscriptEntry
+import au.com.shiftyjelly.pocketcasts.models.type.EpisodeDownloadStatus
 import au.com.shiftyjelly.pocketcasts.models.type.SignInState
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.payment.PaymentClient
 import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.FingerprintTimingManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.transcript.TranscriptManager
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import au.com.shiftyjelly.pocketcasts.sharing.SharingRequest
@@ -39,8 +41,11 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import timber.log.Timber
 
@@ -61,6 +66,7 @@ class TranscriptViewModelTest {
     private val playbackManager = mock<PlaybackManager> {
         on { playbackStateFlow } doReturn playbackStateFlow
     }
+    private val episodeManager = mock<EpisodeManager>()
 
     lateinit var viewModel: TranscriptViewModel
 
@@ -68,7 +74,7 @@ class TranscriptViewModelTest {
     fun setUp() {
         viewModel = TranscriptViewModel(
             transcriptManager = transcriptManager,
-            episodeManager = mock(),
+            episodeManager = episodeManager,
             userManager = mock {
                 on { getSignInState() } doReturn signInStateFlow.asFlowable()
             },
@@ -310,14 +316,12 @@ class TranscriptViewModelTest {
 
     @Test
     fun `track synced transcript seek used event`() = runTest {
-        val episode = PodcastEpisode(uuid = "episode-uuid", publishedDate = Date())
+        setUpTapToSeek()
         whenever(fingerprintTimingManager.state).thenReturn(FingerprintTimingManager.State.Active(coverage = 1))
         whenever(fingerprintTimingManager.playbackTimeMs(any())).thenReturn(20_000)
-        whenever(playbackManager.getCurrentEpisode()).thenReturn(episode)
         syncedStateFlow.value = FingerprintTimingManager.State.Active(coverage = 1)
-        playbackStateFlow.value = PlaybackState(episodeUuid = "episode-uuid", positionMs = 10_000)
 
-        awaitSyncedActive()
+        awaitTapToSeekAvailable()
         drainEvents()
 
         val seekTarget = viewModel.seekToTranscriptEntry(TranscriptEntry.Text("Line", startTimeMs = 30_000))
@@ -336,13 +340,122 @@ class TranscriptViewModelTest {
     }
 
     @Test
-    fun `track synced transcript seek failed event`() = runTest {
-        val episode = PodcastEpisode(uuid = "episode-uuid", publishedDate = Date())
-        whenever(fingerprintTimingManager.state).thenReturn(FingerprintTimingManager.State.Active(coverage = 1))
-        whenever(fingerprintTimingManager.playbackTimeMs(any())).thenReturn(null)
-        whenever(playbackManager.getCurrentEpisode()).thenReturn(episode)
+    fun `track synced transcript seek failed event when preparing`() = runTest {
+        setUpTapToSeek()
+        syncedStateFlow.value = FingerprintTimingManager.State.Preparing
+
+        awaitTapToSeekAvailable()
+        drainEvents()
+
+        viewModel.messages.test {
+            val seekTarget = viewModel.seekToTranscriptEntry(TranscriptEntry.Text("Line", startTimeMs = 30_000))
+
+            assertNull(seekTarget)
+            assertEquals(
+                SyncedTranscriptsSeekFailedEvent(
+                    reason = "mapping_unavailable",
+                    syncedState = "preparing",
+                    source = TranscriptSourceType.Player,
+                    episodeUuid = "episode-uuid",
+                    podcastUuid = AnalyticsTracker.INVALID_OR_NULL_VALUE,
+                ),
+                eventSink.pollEvent(),
+            )
+            assertEquals(TranscriptMessage.TapToSeekStreamingUnavailable, awaitItem())
+            verify(playbackManager, never()).seekToTimeMs(any(), anyOrNull())
+        }
+    }
+
+    @Test
+    fun `track synced transcript seek failed event when failed`() = runTest {
+        setUpTapToSeek()
+        syncedStateFlow.value = FingerprintTimingManager.State.Failed(RuntimeException("no match"))
+
+        awaitTapToSeekAvailable()
+        drainEvents()
+
+        viewModel.messages.test {
+            val seekTarget = viewModel.seekToTranscriptEntry(TranscriptEntry.Text("Line", startTimeMs = 30_000))
+
+            assertNull(seekTarget)
+            assertEquals(
+                SyncedTranscriptsSeekFailedEvent(
+                    reason = "mapping_unavailable",
+                    syncedState = "failed",
+                    source = TranscriptSourceType.Player,
+                    episodeUuid = "episode-uuid",
+                    podcastUuid = AnalyticsTracker.INVALID_OR_NULL_VALUE,
+                ),
+                eventSink.pollEvent(),
+            )
+            assertEquals(TranscriptMessage.TapToSeekStreamingUnavailable, awaitItem())
+        }
+    }
+
+    @Test
+    fun `track synced transcript seek failed event without message when unavailable`() = runTest {
+        setUpTapToSeek()
+        syncedStateFlow.value = FingerprintTimingManager.State.Unavailable
+
+        awaitTapToSeekAvailable()
+        drainEvents()
+
+        viewModel.messages.test {
+            val seekTarget = viewModel.seekToTranscriptEntry(TranscriptEntry.Text("Line", startTimeMs = 30_000))
+
+            assertNull(seekTarget)
+            assertEquals(
+                SyncedTranscriptsSeekFailedEvent(
+                    reason = "mapping_unavailable",
+                    syncedState = "unavailable",
+                    source = TranscriptSourceType.Player,
+                    episodeUuid = "episode-uuid",
+                    podcastUuid = AnalyticsTracker.INVALID_OR_NULL_VALUE,
+                ),
+                eventSink.pollEvent(),
+            )
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `track synced transcript seek failed event without message when episode is downloaded`() = runTest {
+        setUpTapToSeek()
+        val episode = PodcastEpisode(
+            uuid = "episode-uuid",
+            publishedDate = Date(),
+            podcastUuid = "podcast-uuid",
+            downloadStatus = EpisodeDownloadStatus.Downloaded,
+        )
+        whenever(episodeManager.findByUuid("episode-uuid")).thenReturn(episode)
+        syncedStateFlow.value = FingerprintTimingManager.State.Preparing
+
+        awaitTapToSeekAvailable()
+        drainEvents()
+
+        viewModel.messages.test {
+            val seekTarget = viewModel.seekToTranscriptEntry(TranscriptEntry.Text("Line", startTimeMs = 30_000))
+
+            assertNull(seekTarget)
+            assertEquals(
+                SyncedTranscriptsSeekFailedEvent(
+                    reason = "mapping_unavailable",
+                    syncedState = "preparing",
+                    source = TranscriptSourceType.Player,
+                    episodeUuid = "episode-uuid",
+                    podcastUuid = "podcast-uuid",
+                ),
+                eventSink.pollEvent(),
+            )
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `do not track seek events for non generated transcript`() = runTest {
+        setUpTapToSeek()
+        transcriptManager.avaiableTranscript = Transcript.TextPreview
         syncedStateFlow.value = FingerprintTimingManager.State.Active(coverage = 1)
-        playbackStateFlow.value = PlaybackState(episodeUuid = "episode-uuid", positionMs = 10_000)
 
         awaitSyncedActive()
         drainEvents()
@@ -350,16 +463,51 @@ class TranscriptViewModelTest {
         val seekTarget = viewModel.seekToTranscriptEntry(TranscriptEntry.Text("Line", startTimeMs = 30_000))
 
         assertNull(seekTarget)
-        assertEquals(
-            SyncedTranscriptsSeekFailedEvent(
-                reason = "mapping_unavailable",
-                syncedState = "active",
-                source = TranscriptSourceType.Player,
-                episodeUuid = "episode-uuid",
-                podcastUuid = AnalyticsTracker.INVALID_OR_NULL_VALUE,
-            ),
-            eventSink.pollEvent(),
-        )
+        assertTrue(eventSink.isEmpty())
+        verify(playbackManager, never()).seekToTimeMs(any(), anyOrNull())
+    }
+
+    @Test
+    fun `do not track seek events when transcript episode is not playing`() = runTest {
+        setUpTapToSeek()
+        playbackStateFlow.value = PlaybackState(episodeUuid = "other-uuid", positionMs = 10_000)
+        syncedStateFlow.value = FingerprintTimingManager.State.Active(coverage = 1)
+
+        awaitUiState { it.transcriptState is TranscriptState.Loaded && it.playingEpisodeUuid == "other-uuid" }
+        drainEvents()
+
+        val seekTarget = viewModel.seekToTranscriptEntry(TranscriptEntry.Text("Line", startTimeMs = 30_000))
+
+        assertNull(seekTarget)
+        assertTrue(eventSink.isEmpty())
+    }
+
+    @Test
+    fun `do not track seek events when paywall is visible`() = runTest {
+        setUpTapToSeek()
+        signInStateFlow.value = SignInState.SignedOut
+        syncedStateFlow.value = FingerprintTimingManager.State.Active(coverage = 1)
+
+        awaitSyncedActive()
+        drainEvents()
+
+        val seekTarget = viewModel.seekToTranscriptEntry(TranscriptEntry.Text("Line", startTimeMs = 30_000))
+
+        assertNull(seekTarget)
+        assertTrue(eventSink.isEmpty())
+    }
+
+    @Test
+    fun `do not track seek events for untimed entries`() = runTest {
+        setUpTapToSeek()
+        syncedStateFlow.value = FingerprintTimingManager.State.Preparing
+
+        awaitTapToSeekAvailable()
+        drainEvents()
+
+        assertNull(viewModel.seekToTranscriptEntry(TranscriptEntry.Speaker("Speaker")))
+        assertNull(viewModel.seekToTranscriptEntry(TranscriptEntry.Text("Line", startTimeMs = -1)))
+        assertTrue(eventSink.isEmpty())
     }
 
     @Test
@@ -379,11 +527,22 @@ class TranscriptViewModelTest {
         )
     }
 
-    private suspend fun awaitSyncedActive() {
+    private fun setUpTapToSeek() {
+        transcriptManager.avaiableTranscript = Transcript.TextPreview.copy(isGenerated = true)
+        signInStateFlow.value = SignInState.SignedIn("email", Subscription.PlusPreview)
+        playbackStateFlow.value = PlaybackState(episodeUuid = "episode-uuid", positionMs = 10_000)
+        whenever(playbackManager.getCurrentEpisode()).thenReturn(PodcastEpisode(uuid = "episode-uuid", publishedDate = Date()))
+    }
+
+    private suspend fun awaitSyncedActive() = awaitUiState { it.isSyncedActive }
+
+    private suspend fun awaitTapToSeekAvailable() = awaitUiState { it.isTapToSeekAvailable && it.syncedState == syncedStateFlow.value }
+
+    private suspend fun awaitUiState(predicate: (UiState) -> Boolean) {
         viewModel.uiState.test {
             viewModel.loadTranscript("episode-uuid")
             var state = awaitItem()
-            while (!state.isSyncedActive) {
+            while (!predicate(state)) {
                 state = awaitItem()
             }
             cancelAndIgnoreRemainingEvents()


### PR DESCRIPTION
## Description
It's been reported that the `synced_transcripts_seek_failed` event was never reported due to a bug in the code.
After further investifagation, it turned out that both the UI (`TranscriptPage`) and `seekToTranscriptEntry` gated on `isSyncedActive` -- a state that already requires fingerprint syncing to be working, so the failure path was unreachable. The fix introduced a looser `isTapToSeekAvailable` gate (generated text transcript, no paywall, matching playing episode) for enabling the tap handler, and only attempts the fingerprint time mapping when sync is actually active,so when sync isn't active or the mapping returns null, the seek-failed event now fires.
Also added tests for proper coverage

## Testing Instructions
 1. Build and install the debug app
  2. Confirm the SYNCED_TRANSCRIPTS feature flag is on
  3. Start streaming (not downloaded) an episode that has a Pocket Casts-generated transcript, using a Plus account.
  4. Open the full-screen player and tap the Transcript tab.
  5. Immediately (within the first seconds, while fingerprint sync is still preparing) tap any transcript line.
  6. Verify a "streaming unavailable" toast appears and no seek happens.
  7. In logcat, filter for synced_transcripts_seek_failed and verify the event fired with synced_state=preparing (or idle).


## Screenshots or Screencast 

<img width="1570" height="255" alt="SCR-20260715-kkae" src="https://github.com/user-attachments/assets/58931e9d-9072-40f8-a4eb-d992557f20e2" />

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
