### PR TITLE
Improve the synced transcripts seek experience

### DIFF
--- a/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/TranscriptViewModel.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/TranscriptViewModel.kt
@@ -418,7 +418,7 @@ class TranscriptViewModel @AssistedInject constructor(
         FingerprintTimingManager.State.Preparing -> "preparing"
         is FingerprintTimingManager.State.Active -> "active"
         is FingerprintTimingManager.State.Failed -> "failed"
-        FingerprintTimingManager.State.Unavailable -> "unavailable"
+        is FingerprintTimingManager.State.Unavailable -> "unavailable"
     }
 
     private suspend fun updateEpisodeMetadata(episodeUuid: String) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintConstants.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintConstants.kt
@@ -22,18 +22,6 @@ object FingerprintConstants {
     /** Interval between windowed fingerprints during live matching, in milliseconds. */
     const val WINDOW_INTERVAL_MS = 1000
 
-    /** Seconds of decoded PCM read per chunk during fingerprint generation. */
-    const val STREAM_CHUNK_SECONDS = 5.0
-
-    /** Seconds between polls when waiting for the streaming buffer to grow. */
-    const val BUFFER_GROW_POLL_CADENCE_SECONDS = 1.0
-
-    /** Give up the streaming grow-loop after this many consecutive seconds without new bytes. */
-    const val BUFFER_GROW_MAX_STALL_SECONDS = 60.0
-
-    /** Trailing audio the grow-loop refuses to read to avoid partial frame noise. */
-    const val BUFFER_GROW_TRAILING_MARGIN_SECONDS = 1.0
-
     /** Minimum number of mapping entries before transitioning to Active. */
     const val MINIMUM_COVERAGE_FOR_ACTIVE = 2
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintConstants.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintConstants.kt
@@ -7,6 +7,9 @@ object FingerprintConstants {
     /** Slack window around the already-mapped range before playback is considered "outside". */
     const val PLAYBACK_RANGE_MARGIN_SECONDS = 30.0
 
+    /** Minimum time between stream restarts while playback sits outside the mapped range. */
+    const val STREAM_BOOTSTRAP_COOLDOWN_MS = 5_000L
+
     /** Minimum match score to accept a fingerprint match result. */
     const val MATCH_SCORE_THRESHOLD = 0.5f
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintConstants.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintConstants.kt
@@ -10,6 +10,9 @@ object FingerprintConstants {
     /** Minimum time between stream restarts while playback sits outside the mapped range. */
     const val STREAM_BOOTSTRAP_COOLDOWN_MS = 5_000L
 
+    /** Position must be stable for this long before a seek restarts the stream; coalesces rapid multi-tap skips. */
+    const val RESTART_DEBOUNCE_MS = 1_500L
+
     /** Minimum match score to accept a fingerprint match result. */
     const val MATCH_SCORE_THRESHOLD = 0.5f
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintReferenceRetriever.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintReferenceRetriever.kt
@@ -106,7 +106,7 @@ class FingerprintReferenceRetriever @Inject constructor(
         null
     }
 
-    fun saveReferenceData(data: ByteArray, audioFilePath: String) {
+    suspend fun saveReferenceData(data: ByteArray, audioFilePath: String) = withContext(Dispatchers.IO) {
         val path = referencePath(audioFilePath)
         try {
             File(path).writeBytes(data)
@@ -116,10 +116,10 @@ class FingerprintReferenceRetriever @Inject constructor(
         }
     }
 
-    fun loadReferenceData(audioFilePath: String): ByteArray? {
+    suspend fun loadReferenceData(audioFilePath: String): ByteArray? = withContext(Dispatchers.IO) {
         val path = referencePath(audioFilePath)
         val file = File(path)
-        return if (file.exists()) file.readBytes() else null
+        if (file.exists()) file.readBytes() else null
     }
 
     companion object {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
@@ -93,6 +93,7 @@ class FingerprintTimingManager @Inject constructor(
         private set
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val decodeDispatcher = Dispatchers.IO.limitedParallelism(1)
     private val mutex = Mutex()
 
     // Mapping state: writers build new lists under mutex, then atomically publish via @Volatile.
@@ -566,7 +567,7 @@ class FingerprintTimingManager @Inject constructor(
         generationJob?.cancel()
         lastStreamStartTimeMs = System.currentTimeMillis()
         val aligned = alignToWindowGrid(startPosition)
-        generationJob = scope.launch {
+        generationJob = scope.launch(decodeDispatcher) {
             try {
                 streamFingerprint(audioFilePath, matcher, episodeUuid, startingAt = aligned)
                 persistMappingCacheIfFull()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
@@ -141,6 +141,7 @@ class FingerprintTimingManager @Inject constructor(
     @Volatile
     private var currentEpisodeUuid: String? = null
     private var currentAudioFilePath: String? = null
+    private var currentDurationSec: Double = 0.0
     private var currentReferenceData: ByteArray? = null
     private var currentReferenceFilePath: String? = null
     private var currentReferenceDuration: Double = 0.0
@@ -360,6 +361,7 @@ class FingerprintTimingManager @Inject constructor(
         filterCandidatePool.clear()
         currentEpisodeUuid = null
         currentAudioFilePath = null
+        currentDurationSec = 0.0
         currentReferenceData = null
         currentReferenceFilePath = null
         currentReferenceDuration = 0.0
@@ -419,6 +421,7 @@ class FingerprintTimingManager @Inject constructor(
             currentEpisodeUuid = episodeUuid
             activeEpisodeUuid = episodeUuid
             currentAudioFilePath = audioSource
+            currentDurationSec = durationSec
             currentIsStreaming = !isDownloaded
             currentEager = eager
             preparationStartMs = SystemClock.elapsedRealtime()
@@ -554,6 +557,9 @@ class FingerprintTimingManager @Inject constructor(
             hasAnyMapping = mappingPlaybackToReference.isNotEmpty(),
             isDecodeActive = generationJob?.isActive == true,
             isCoveredByActiveDecode = isCoveredByActiveDecode(positionSec),
+            isRunEndCoveredByActiveDecode = mappedRunEndSec != null && isCoveredByActiveDecode(mappedRunEndSec),
+            isRunEndNearEpisodeEnd = mappedRunEndSec != null &&
+                mappedRunEndSec >= currentDurationSec - FingerprintConstants.PLAYBACK_RANGE_MARGIN_SECONDS,
             hasPendingRestart = pendingRestartJob?.isActive == true,
             hasStreamStarted = lastStreamStartTimeMs != 0L,
             msSinceStreamStart = SystemClock.elapsedRealtime() - lastStreamStartTimeMs,
@@ -570,6 +576,11 @@ class FingerprintTimingManager @Inject constructor(
             ProgressDecision.RestartOutsideRange -> {
                 Timber.d("FingerprintTimingManager: playback outside mapped range — restarting")
                 restartFromPlayhead()
+            }
+
+            is ProgressDecision.RestartFromRunEnd -> {
+                Timber.d("FingerprintTimingManager: mapping about to run out — resuming decode from run end")
+                restartFromRunEnd(decision.runEndSec)
             }
         }
     }
@@ -599,6 +610,14 @@ class FingerprintTimingManager @Inject constructor(
         filterLastTrusted = null
         filterCandidatePool.clear()
         startStream(audioPath, matcher, uuid, startPosition = lastProgressPositionMs / 1000.0)
+    }
+
+    /** Must be called under [mutex]. Continues an existing run, so the drift filter's trusted anchor is kept. */
+    private fun restartFromRunEnd(runEndSec: Double) {
+        val matcher = currentMatcher ?: return
+        val audioPath = currentAudioFilePath ?: return
+        val uuid = currentEpisodeUuid ?: return
+        startStream(audioPath, matcher, uuid, startPosition = runEndSec)
     }
 
     private fun isCoveredByActiveDecode(positionSec: Double): Boolean {
@@ -1005,6 +1024,7 @@ class FingerprintTimingManager @Inject constructor(
         data object None : ProgressDecision
         data object ScheduleDebouncedRestart : ProgressDecision
         data object RestartOutsideRange : ProgressDecision
+        data class RestartFromRunEnd(val runEndSec: Double) : ProgressDecision
     }
 
     companion object {
@@ -1027,6 +1047,8 @@ class FingerprintTimingManager @Inject constructor(
             hasAnyMapping: Boolean,
             isDecodeActive: Boolean,
             isCoveredByActiveDecode: Boolean,
+            isRunEndCoveredByActiveDecode: Boolean,
+            isRunEndNearEpisodeEnd: Boolean,
             hasPendingRestart: Boolean,
             hasStreamStarted: Boolean,
             msSinceStreamStart: Long,
@@ -1039,7 +1061,15 @@ class FingerprintTimingManager @Inject constructor(
                 return ProgressDecision.ScheduleDebouncedRestart
             }
             if (hasPendingRestart) return ProgressDecision.None
-            if (mappedRunEndSec != null) return ProgressDecision.None
+            if (mappedRunEndSec != null) {
+                val approachingRunEnd = mappedRunEndSec - positionSec < FingerprintConstants.LOOKAHEAD_SECONDS
+                if (approachingRunEnd && !isRunEndCoveredByActiveDecode && !isRunEndNearEpisodeEnd &&
+                    msSinceStreamStart >= FingerprintConstants.STREAM_BOOTSTRAP_COOLDOWN_MS
+                ) {
+                    return ProgressDecision.RestartFromRunEnd(mappedRunEndSec)
+                }
+                return ProgressDecision.None
+            }
             val canRecoverWithoutMapping = !isDecodeActive && hasStreamStarted
             if (!isCoveredByActiveDecode && (hasAnyMapping || canRecoverWithoutMapping) &&
                 msSinceStreamStart >= FingerprintConstants.STREAM_BOOTSTRAP_COOLDOWN_MS

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
@@ -118,6 +118,7 @@ class FingerprintTimingManager @Inject constructor(
     private var lastProgressPositionMs = -1
     private var generationJob: Job? = null
     private var progressObserverJob: Job? = null
+    private var pendingRestartJob: Job? = null
     private var lastStreamStartTimeMs = 0L
 
     @Volatile
@@ -344,6 +345,8 @@ class FingerprintTimingManager @Inject constructor(
         generationJob = null
         progressObserverJob?.cancel()
         progressObserverJob = null
+        pendingRestartJob?.cancel()
+        pendingRestartJob = null
         mappingPlaybackToReference.clear()
         mappingReferenceToPlayback.clear()
         debugRejections.clear()
@@ -551,6 +554,7 @@ class FingerprintTimingManager @Inject constructor(
             hasAnyMapping = mappingPlaybackToReference.isNotEmpty(),
             isDecodeActive = generationJob?.isActive == true,
             isCoveredByActiveDecode = isCoveredByActiveDecode(positionSec),
+            hasPendingRestart = pendingRestartJob?.isActive == true,
             hasStreamStarted = lastStreamStartTimeMs != 0L,
             msSinceStreamStart = SystemClock.elapsedRealtime() - lastStreamStartTimeMs,
         )
@@ -558,8 +562,30 @@ class FingerprintTimingManager @Inject constructor(
         when (decision) {
             ProgressDecision.None -> Unit
 
+            ProgressDecision.ScheduleDebouncedRestart -> {
+                Timber.d("FingerprintTimingManager: playback jumped — scheduling restart")
+                schedulePendingRestart()
+            }
+
             ProgressDecision.RestartOutsideRange -> {
                 Timber.d("FingerprintTimingManager: playback outside mapped range — restarting")
+                restartFromPlayhead()
+            }
+        }
+    }
+
+    /** Must be called under [mutex]. */
+    private fun schedulePendingRestart() {
+        pendingRestartJob?.cancel()
+        val gen = generation
+        pendingRestartJob = scope.launch {
+            delay(FingerprintConstants.RESTART_DEBOUNCE_MS)
+            playbackManager.playbackStateFlow.first { it.isPlaying }
+            mutex.withLock {
+                if (gen != generation) return@withLock
+                val settledSec = lastProgressPositionMs / 1000.0
+                if (mappedRunEnd(settledSec, mappingPlaybackToReference) != null || isCoveredByActiveDecode(settledSec)) return@withLock
+                Timber.d("FingerprintTimingManager: playback jumped — restarting")
                 restartFromPlayhead()
             }
         }
@@ -977,6 +1003,7 @@ class FingerprintTimingManager @Inject constructor(
 
     internal sealed interface ProgressDecision {
         data object None : ProgressDecision
+        data object ScheduleDebouncedRestart : ProgressDecision
         data object RestartOutsideRange : ProgressDecision
     }
 
@@ -1000,6 +1027,7 @@ class FingerprintTimingManager @Inject constructor(
             hasAnyMapping: Boolean,
             isDecodeActive: Boolean,
             isCoveredByActiveDecode: Boolean,
+            hasPendingRestart: Boolean,
             hasStreamStarted: Boolean,
             msSinceStreamStart: Long,
         ): ProgressDecision {
@@ -1008,8 +1036,9 @@ class FingerprintTimingManager @Inject constructor(
             if (isJump) {
                 if (mappedRunEndSec != null) return ProgressDecision.None
                 if (isCoveredByActiveDecode) return ProgressDecision.None
-                return ProgressDecision.RestartOutsideRange
+                return ProgressDecision.ScheduleDebouncedRestart
             }
+            if (hasPendingRestart) return ProgressDecision.None
             if (mappedRunEndSec != null) return ProgressDecision.None
             val canRecoverWithoutMapping = !isDecodeActive && hasStreamStarted
             if (!isCoveredByActiveDecode && (hasAnyMapping || canRecoverWithoutMapping) &&

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
@@ -114,6 +114,7 @@ class FingerprintTimingManager @Inject constructor(
     var debugRejectionsSnapshot: List<DebugRejection> = emptyList()
         private set
 
+    @Volatile
     private var lastProgressPositionMs = -1
     private var generationJob: Job? = null
     private var progressObserverJob: Job? = null
@@ -130,6 +131,7 @@ class FingerprintTimingManager @Inject constructor(
     internal var debugTrackingEnabled = false
 
     // Context for current preparation
+    @Volatile
     private var currentEpisodeUuid: String? = null
     private var currentAudioFilePath: String? = null
     private var currentReferenceData: ByteArray? = null
@@ -137,6 +139,7 @@ class FingerprintTimingManager @Inject constructor(
     private var currentReferenceDuration: Double = 0.0
     private var currentMatcher: CheckpointMatcher? = null
     private var hasReachedActive = false
+    private var hasTrackedFailure = false
 
     // Analytics context for the current preparation.
     private var preparationStartMs: Long = 0
@@ -144,6 +147,7 @@ class FingerprintTimingManager @Inject constructor(
 
     // When true, decode the whole stream from the start ignoring the playhead lookahead throttle,
     // so the full reference<->playback map is available for chapter alignment.
+    @Volatile
     private var currentEager: Boolean = false
 
     init {
@@ -188,7 +192,7 @@ class FingerprintTimingManager @Inject constructor(
             // Abort if a newer stop()/prepare() has started since we acquired the lock.
             if (gen != generation) return@launch
             startPlaybackProgressObserver(episodeUuid)
-            prepareForEpisode(episodeUuid, podcastUuid, audioSource, episode.isDownloaded, episode.duration)
+            prepareForEpisode(gen, episodeUuid, podcastUuid, audioSource, episode.isDownloaded, episode.duration)
         }
     }
 
@@ -233,6 +237,8 @@ class FingerprintTimingManager @Inject constructor(
 
     private fun markFailed(error: Throwable, stage: String) {
         _stateFlow.value = State.Failed(error)
+        if (hasTrackedFailure) return
+        hasTrackedFailure = true
         eventHorizon.track(
             SyncedTranscriptsPreparationFailedEvent(
                 errorCode = 0,
@@ -349,6 +355,7 @@ class FingerprintTimingManager @Inject constructor(
         currentMatcher = null
         activeEpisodeUuid = null
         hasReachedActive = false
+        hasTrackedFailure = false
         preparationStartMs = 0
         currentIsStreaming = false
         currentEager = false
@@ -368,6 +375,7 @@ class FingerprintTimingManager @Inject constructor(
     }
 
     private suspend fun prepareForEpisode(
+        gen: Long,
         episodeUuid: String,
         podcastUuid: String,
         audioSource: String?,
@@ -393,29 +401,31 @@ class FingerprintTimingManager @Inject constructor(
             return
         }
 
-        currentEpisodeUuid = episodeUuid
-        activeEpisodeUuid = episodeUuid
-        currentAudioFilePath = audioSource
-        currentIsStreaming = !isDownloaded
-        currentEager = shouldRunEagerPass(episodeUuid, isDownloaded)
-        preparationStartMs = SystemClock.elapsedRealtime()
+        val eager = shouldRunEagerPass(episodeUuid, isDownloaded)
+        mutex.withLock {
+            if (gen != generation) return
+            currentEpisodeUuid = episodeUuid
+            activeEpisodeUuid = episodeUuid
+            currentAudioFilePath = audioSource
+            currentIsStreaming = !isDownloaded
+            currentEager = eager
+            preparationStartMs = SystemClock.elapsedRealtime()
+        }
         eventHorizon.track(
             SyncedTranscriptsPreparationStartedEvent(
                 episodeDurationSeconds = durationSec.toLong(),
-                isStreaming = currentIsStreaming,
+                isStreaming = !isDownloaded,
                 episodeUuid = episodeUuid,
             ),
         )
 
         // Try loading cached reference from disk (only for downloaded episodes)
-        if (isDownloaded) {
-            val referenceData = referenceRetriever.loadReferenceData(audioSource)
-            if (referenceData != null) {
-                val reference = ReferenceFingerprint.decode(referenceData)
-                if (reference != null) {
-                    configureForReference(reference, referenceData, audioSource, episodeUuid)
-                    return
-                }
+        val cachedData = if (isDownloaded) referenceRetriever.loadReferenceData(audioSource) else null
+        if (cachedData != null) {
+            val reference = ReferenceFingerprint.decode(cachedData)
+            if (reference != null) {
+                configureForReference(gen, reference, cachedData, audioSource, episodeUuid)
+                return
             }
         }
 
@@ -425,16 +435,17 @@ class FingerprintTimingManager @Inject constructor(
 
         val baseUrl = "${BuildConfig.SERVER_SHOW_NOTES_URLS}/generated_transcripts/"
         val referenceData = referenceRetriever.fetchReferenceData(baseUrl, podcastUuid, episodeUuid)
+        if (gen != generation) return
 
         if (referenceData == null) {
-            markUnavailable(reason = "no_reference", isStreaming = currentIsStreaming, episodeUuid = episodeUuid)
+            markUnavailable(reason = "no_reference", isStreaming = !isDownloaded, episodeUuid = episodeUuid)
             Timber.d("FingerprintTimingManager: no reference available for $episodeUuid")
             return
         }
 
         val reference = ReferenceFingerprint.decode(referenceData)
         if (reference == null) {
-            markUnavailable(reason = "reference_decode_failed", isStreaming = currentIsStreaming, episodeUuid = episodeUuid)
+            markUnavailable(reason = "reference_decode_failed", isStreaming = !isDownloaded, episodeUuid = episodeUuid)
             Timber.d("FingerprintTimingManager: failed to decode reference for $episodeUuid")
             return
         }
@@ -442,10 +453,11 @@ class FingerprintTimingManager @Inject constructor(
         if (isDownloaded) {
             referenceRetriever.saveReferenceData(referenceData, audioSource)
         }
-        configureForReference(reference, referenceData, audioSource, episodeUuid)
+        configureForReference(gen, reference, referenceData, audioSource, episodeUuid)
     }
 
     private suspend fun configureForReference(
+        gen: Long,
         reference: ReferenceFingerprint,
         referenceData: ByteArray,
         audioFilePath: String,
@@ -457,13 +469,6 @@ class FingerprintTimingManager @Inject constructor(
             Timber.d("FingerprintTimingManager: no usable checkpoints for $episodeUuid")
             return
         }
-
-        val refPath = FingerprintReferenceRetriever.referencePath(audioFilePath)
-        currentReferenceData = referenceData
-        currentReferenceFilePath = refPath
-        currentReferenceDuration = reference.totalDuration
-
-        _stateFlow.value = State.Preparing
 
         Timber.d(
             "FingerprintTimingManager: reference for $episodeUuid — " +
@@ -480,28 +485,40 @@ class FingerprintTimingManager @Inject constructor(
                 reference.checkpointDurationSeconds,
             )
         }
-        currentMatcher = matcher
 
         // Try loading mapping cache (only for local files)
+        val refPath = FingerprintReferenceRetriever.referencePath(audioFilePath)
         val isLocalFile = !audioFilePath.startsWith("http://") && !audioFilePath.startsWith("https://")
         val cached = if (isLocalFile) FingerprintMappingCache.load(audioFilePath, refPath, referenceData) else null
-        if (cached != null) {
-            mutex.withLock {
+
+        mutex.withLock {
+            if (gen != generation) {
+                matcher.close()
+                return
+            }
+            currentReferenceData = referenceData
+            currentReferenceFilePath = refPath
+            currentReferenceDuration = reference.totalDuration
+            currentMatcher = matcher
+            _stateFlow.value = State.Preparing
+            if (cached != null) {
                 mappingPlaybackToReference = cached.entries.toMutableList()
                 mappingReferenceToPlayback = cached.entries.sortedBy { it.referenceTime }.toMutableList()
                 publishSnapshot()
                 filterLastTrusted = cached.entries.lastOrNull()
+                markActive(cached.entries.size)
+                Timber.d("FingerprintTimingManager: loaded mapping from cache for $episodeUuid (${cached.entries.size} entries)")
+                return
             }
-            val coverage = cached.entries.size
-            markActive(coverage)
-            Timber.d("FingerprintTimingManager: loaded mapping from cache for $episodeUuid ($coverage entries)")
-            return
         }
 
         // Start streaming fingerprint generation. An eager pass maps the whole timeline from the start;
         // otherwise we follow the playhead.
         val startPosition = if (currentEager) 0.0 else playbackManager.playbackStateFlow.first().positionMs / 1000.0
-        startStream(audioFilePath, matcher, episodeUuid, startPosition = startPosition)
+        mutex.withLock {
+            if (gen != generation) return
+            startStream(audioFilePath, matcher, episodeUuid, startPosition = startPosition)
+        }
     }
 
     private fun onPlaybackProgress(positionMs: Int, episodeUuid: String?) {
@@ -563,19 +580,24 @@ class FingerprintTimingManager @Inject constructor(
             playbackTimeSec <= last.playbackTime + margin
     }
 
+    /** Must be called under [mutex]. */
     private fun startStream(audioFilePath: String, matcher: CheckpointMatcher, episodeUuid: String, startPosition: Double) {
         generationJob?.cancel()
         lastStreamStartTimeMs = System.currentTimeMillis()
         val aligned = alignToWindowGrid(startPosition)
+        // Superseded decode jobs re-check this token before touching shared state.
+        val gen = generation
         generationJob = scope.launch(decodeDispatcher) {
             try {
-                streamFingerprint(audioFilePath, matcher, episodeUuid, startingAt = aligned)
-                persistMappingCacheIfFull()
+                streamFingerprint(gen, audioFilePath, matcher, episodeUuid, startingAt = aligned)
+                if (gen == generation) {
+                    persistMappingCacheIfFull()
+                }
             } catch (_: CancellationException) {
                 Timber.d("FingerprintTimingManager: streaming fingerprint cancelled")
             } catch (e: Exception) {
                 Timber.w(e, "FingerprintTimingManager: streaming fingerprint failed")
-                if (state !is State.Active) {
+                if (gen == generation && state !is State.Active) {
                     markFailed(e, stage = "fingerprint_stream")
                 }
             }
@@ -583,6 +605,7 @@ class FingerprintTimingManager @Inject constructor(
     }
 
     private suspend fun streamFingerprint(
+        gen: Long,
         audioFilePath: String,
         matcher: CheckpointMatcher,
         episodeUuid: String,
@@ -591,6 +614,7 @@ class FingerprintTimingManager @Inject constructor(
         val isRemoteUrl = audioFilePath.startsWith("http://") || audioFilePath.startsWith("https://")
         if (!isRemoteUrl && !File(audioFilePath).exists()) {
             Timber.w("FingerprintTimingManager: audio file not found at $audioFilePath")
+            if (gen != generation) return
             markUnavailable(reason = "audio_unavailable", isStreaming = isRemoteUrl, episodeUuid = episodeUuid)
             return
         }
@@ -601,6 +625,7 @@ class FingerprintTimingManager @Inject constructor(
         } catch (e: Exception) {
             extractor.release()
             Timber.w(e, "FingerprintTimingManager: failed to open audio file")
+            if (gen != generation) return
             markFailed(e, stage = "audio_open")
             return
         }
@@ -611,8 +636,9 @@ class FingerprintTimingManager @Inject constructor(
         }
         if (audioTrackIndex == null) {
             extractor.release()
-            markUnavailable(reason = "audio_unavailable", isStreaming = isRemoteUrl, episodeUuid = episodeUuid)
             Timber.w("FingerprintTimingManager: no audio track found")
+            if (gen != generation) return
+            markUnavailable(reason = "audio_unavailable", isStreaming = isRemoteUrl, episodeUuid = episodeUuid)
             return
         }
 
@@ -643,12 +669,13 @@ class FingerprintTimingManager @Inject constructor(
             )
 
             try {
-                decodeAndFingerprint(extractor, codec, streamer, matcher, episodeUuid, startingAt, sampleRate, channelCount)
+                decodeAndFingerprint(gen, extractor, codec, streamer, matcher, episodeUuid, startingAt, sampleRate, channelCount)
 
                 // Flush remaining windows
                 val tail = streamer.flush()
                 if (tail.isNotEmpty()) {
                     mutex.withLock {
+                        if (gen != generation) throw CancellationException("Fingerprint stream superseded")
                         processMatches(tail, matcher, startingAt)
                     }
                 }
@@ -663,6 +690,7 @@ class FingerprintTimingManager @Inject constructor(
     }
 
     private suspend fun decodeAndFingerprint(
+        gen: Long,
         extractor: MediaExtractor,
         codec: MediaCodec,
         streamer: StreamingWindowedFingerprinter,
@@ -681,6 +709,7 @@ class FingerprintTimingManager @Inject constructor(
 
         while (true) {
             currentCoroutineContext().ensureActive()
+            if (gen != generation) throw CancellationException("Fingerprint stream superseded")
 
             // Feed input
             if (!inputDone) {
@@ -722,6 +751,7 @@ class FingerprintTimingManager @Inject constructor(
                             val windows = streamer.pushSamplesF32(samples, channelCount.toUShort())
                             if (windows.isNotEmpty()) {
                                 mutex.withLock {
+                                    if (gen != generation) throw CancellationException("Fingerprint stream superseded")
                                     processMatches(windows, matcher, startOffset)
                                 }
                             }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
@@ -63,8 +63,8 @@ class FingerprintTimingManager @Inject constructor(
         data object Idle : State
         data object Preparing : State
         data class Active(val coverage: Int) : State
-        data class Failed(val error: Throwable) : State
-        data object Unavailable : State
+        data class Failed(val error: Throwable, val episodeUuid: String?) : State
+        data class Unavailable(val episodeUuid: String?) : State
     }
 
     data class TimeMappingEntry(
@@ -225,7 +225,7 @@ class FingerprintTimingManager @Inject constructor(
         isStreaming: Boolean? = null,
         episodeUuid: String? = currentEpisodeUuid,
     ) {
-        _stateFlow.value = State.Unavailable
+        _stateFlow.value = State.Unavailable(episodeUuid)
         eventHorizon.track(
             SyncedTranscriptsUnavailableEvent(
                 reason = reason,
@@ -236,7 +236,7 @@ class FingerprintTimingManager @Inject constructor(
     }
 
     private fun markFailed(error: Throwable, stage: String) {
-        _stateFlow.value = State.Failed(error)
+        _stateFlow.value = State.Failed(error, currentEpisodeUuid)
         if (hasTrackedFailure) return
         hasTrackedFailure = true
         eventHorizon.track(

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
@@ -121,6 +121,12 @@ class FingerprintTimingManager @Inject constructor(
     private var lastStreamStartTimeMs = 0L
 
     @Volatile
+    private var activeDecodeStartSec = 0.0
+
+    @Volatile
+    private var activeDecodeFrontierSec = 0.0
+
+    @Volatile
     private var generation = 0L
 
     // Drift filter state
@@ -344,6 +350,9 @@ class FingerprintTimingManager @Inject constructor(
         debugRejectionsSnapshot = emptyList()
         publishSnapshot()
         lastProgressPositionMs = -1
+        lastStreamStartTimeMs = 0L
+        activeDecodeStartSec = 0.0
+        activeDecodeFrontierSec = 0.0
         filterLastTrusted = null
         filterCandidatePool.clear()
         currentEpisodeUuid = null
@@ -532,59 +541,53 @@ class FingerprintTimingManager @Inject constructor(
     }
 
     private fun processProgress(positionMs: Int) {
-        // The eager pass already decodes the whole stream, so playhead-driven restarts are unnecessary.
-        if (currentEager) {
-            lastProgressPositionMs = positionMs
-            return
-        }
-        if (lastProgressPositionMs >= 0) {
-            val deltaMs = abs(positionMs - lastProgressPositionMs)
-            if (deltaMs > FingerprintConstants.RESTART_DELTA_SECONDS * 1000) {
-                Timber.d("FingerprintTimingManager: playback jumped ${deltaMs}ms — restarting")
-                val matcher = currentMatcher
-                val audioPath = currentAudioFilePath
-                val uuid = currentEpisodeUuid
-                if (matcher != null && audioPath != null && uuid != null) {
-                    filterLastTrusted = null
-                    filterCandidatePool.clear()
-                    startStream(audioPath, matcher, uuid, startPosition = positionMs / 1000.0)
-                }
-                lastProgressPositionMs = positionMs
-                return
-            }
-        }
+        val positionSec = positionMs / 1000.0
+        val mappedRunEndSec = mappedRunEnd(positionSec, mappingPlaybackToReference)
+        val decision = decideOnProgress(
+            positionSec = positionSec,
+            lastPositionSec = if (lastProgressPositionMs >= 0) lastProgressPositionMs / 1000.0 else null,
+            isEager = currentEager,
+            mappedRunEndSec = mappedRunEndSec,
+            hasAnyMapping = mappingPlaybackToReference.isNotEmpty(),
+            isDecodeActive = generationJob?.isActive == true,
+            isCoveredByActiveDecode = isCoveredByActiveDecode(positionSec),
+            hasStreamStarted = lastStreamStartTimeMs != 0L,
+            msSinceStreamStart = SystemClock.elapsedRealtime() - lastStreamStartTimeMs,
+        )
         lastProgressPositionMs = positionMs
+        when (decision) {
+            ProgressDecision.None -> Unit
 
-        if (!isWithinMappedRange(positionMs / 1000.0) && mappingPlaybackToReference.isNotEmpty()) {
-            // Give the stream time to bootstrap before restarting again.
-            if (System.currentTimeMillis() - lastStreamStartTimeMs < STREAM_BOOTSTRAP_COOLDOWN_MS) return
-
-            Timber.d("FingerprintTimingManager: playback outside mapped range — restarting")
-            val matcher = currentMatcher
-            val audioPath = currentAudioFilePath
-            val uuid = currentEpisodeUuid
-            if (matcher != null && audioPath != null && uuid != null) {
-                filterLastTrusted = null
-                filterCandidatePool.clear()
-                startStream(audioPath, matcher, uuid, startPosition = positionMs / 1000.0)
+            ProgressDecision.RestartOutsideRange -> {
+                Timber.d("FingerprintTimingManager: playback outside mapped range — restarting")
+                restartFromPlayhead()
             }
         }
     }
 
-    private fun isWithinMappedRange(playbackTimeSec: Double): Boolean {
-        val entries = mappingPlaybackToReference
-        val first = entries.firstOrNull() ?: return false
-        val last = entries.lastOrNull() ?: return false
-        val margin = FingerprintConstants.PLAYBACK_RANGE_MARGIN_SECONDS
-        return playbackTimeSec >= first.playbackTime - margin &&
-            playbackTimeSec <= last.playbackTime + margin
+    /** Must be called under [mutex]. */
+    private fun restartFromPlayhead() {
+        val matcher = currentMatcher ?: return
+        val audioPath = currentAudioFilePath ?: return
+        val uuid = currentEpisodeUuid ?: return
+        filterLastTrusted = null
+        filterCandidatePool.clear()
+        startStream(audioPath, matcher, uuid, startPosition = lastProgressPositionMs / 1000.0)
+    }
+
+    private fun isCoveredByActiveDecode(positionSec: Double): Boolean {
+        if (generationJob?.isActive != true) return false
+        return positionSec >= activeDecodeStartSec &&
+            positionSec <= activeDecodeFrontierSec + FingerprintConstants.PLAYBACK_RANGE_MARGIN_SECONDS
     }
 
     /** Must be called under [mutex]. */
     private fun startStream(audioFilePath: String, matcher: CheckpointMatcher, episodeUuid: String, startPosition: Double) {
         generationJob?.cancel()
-        lastStreamStartTimeMs = System.currentTimeMillis()
+        lastStreamStartTimeMs = SystemClock.elapsedRealtime()
         val aligned = alignToWindowGrid(startPosition)
+        activeDecodeStartSec = aligned
+        activeDecodeFrontierSec = aligned
         // Superseded decode jobs re-check this token before touching shared state.
         val gen = generation
         generationJob = scope.launch(decodeDispatcher) {
@@ -757,9 +760,13 @@ class FingerprintTimingManager @Inject constructor(
                             }
                         }
 
+                        val decodedSeconds = startOffset + streamer.durationMs().toDouble() / 1000.0
+                        if (gen == generation) {
+                            activeDecodeFrontierSec = decodedSeconds
+                        }
+
                         // Eager passes decode as fast as possible; throttled passes stay near the playhead.
                         if (!currentEager) {
-                            val decodedSeconds = startOffset + streamer.durationMs().toDouble() / 1000.0
                             val lastKnownPositionMs = lastProgressPositionMs
                             if (lastKnownPositionMs >= 0 && decodedSeconds - lastKnownPositionMs / 1000.0 > FingerprintConstants.LOOKAHEAD_SECONDS) {
                                 delay((FingerprintConstants.OUTSIDE_LOOKAHEAD_SLEEP_SECONDS * 1000).toLong())
@@ -968,9 +975,12 @@ class FingerprintTimingManager @Inject constructor(
         debugRejectionsSnapshot = debugRejections.toList()
     }
 
-    companion object {
-        private const val STREAM_BOOTSTRAP_COOLDOWN_MS = 5_000L
+    internal sealed interface ProgressDecision {
+        data object None : ProgressDecision
+        data object RestartOutsideRange : ProgressDecision
+    }
 
+    companion object {
         /**
          * Core eager-pass gate (assumes the platform check already passed). [isUnmetered] is a supplier so the
          * network lookup is skipped for downloaded episodes.
@@ -980,6 +990,64 @@ class FingerprintTimingManager @Inject constructor(
             isDownloaded: Boolean,
             isUnmetered: () -> Boolean,
         ): Boolean = hasGeneratedChapters && (isDownloaded || isUnmetered())
+
+        /** Decides how a playback-progress tick affects the fingerprint stream. */
+        internal fun decideOnProgress(
+            positionSec: Double,
+            lastPositionSec: Double?,
+            isEager: Boolean,
+            mappedRunEndSec: Double?,
+            hasAnyMapping: Boolean,
+            isDecodeActive: Boolean,
+            isCoveredByActiveDecode: Boolean,
+            hasStreamStarted: Boolean,
+            msSinceStreamStart: Long,
+        ): ProgressDecision {
+            if (isEager) return ProgressDecision.None
+            val isJump = lastPositionSec != null && abs(positionSec - lastPositionSec) > FingerprintConstants.RESTART_DELTA_SECONDS
+            if (isJump) {
+                if (mappedRunEndSec != null) return ProgressDecision.None
+                if (isCoveredByActiveDecode) return ProgressDecision.None
+                return ProgressDecision.RestartOutsideRange
+            }
+            if (mappedRunEndSec != null) return ProgressDecision.None
+            val canRecoverWithoutMapping = !isDecodeActive && hasStreamStarted
+            if (!isCoveredByActiveDecode && (hasAnyMapping || canRecoverWithoutMapping) &&
+                msSinceStreamStart >= FingerprintConstants.STREAM_BOOTSTRAP_COOLDOWN_MS
+            ) {
+                return ProgressDecision.RestartOutsideRange
+            }
+            return ProgressDecision.None
+        }
+
+        /**
+         * End of the contiguous mapped run containing [positionSec], or null when outside a run.
+         * Asymmetric: no slack past a mid-list run end, the margin's grace past the final anchor.
+         */
+        internal fun mappedRunEnd(positionSec: Double, entries: List<TimeMappingEntry>): Double? {
+            if (entries.isEmpty()) return null
+            val margin = FingerprintConstants.PLAYBACK_RANGE_MARGIN_SECONDS
+            var lo = 0
+            var hi = entries.size
+            while (lo < hi) {
+                val mid = (lo + hi) / 2
+                if (entries[mid].playbackTime <= positionSec) lo = mid + 1 else hi = mid
+            }
+            val prev = entries.getOrNull(lo - 1)
+            val next = entries.getOrNull(lo)
+            val inRun = when {
+                prev != null && next != null -> next.playbackTime - prev.playbackTime <= margin
+                prev != null -> positionSec - prev.playbackTime <= margin
+                else -> next != null && next.playbackTime - positionSec <= margin
+            }
+            if (!inRun) return null
+            if (next == null) return prev!!.playbackTime
+            var i = lo
+            while (i + 1 < entries.size && entries[i + 1].playbackTime - entries[i].playbackTime <= margin) {
+                i++
+            }
+            return entries[i].playbackTime
+        }
 
         fun interpolate(
             time: Double,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/TranscriptWindowExtractor.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/TranscriptWindowExtractor.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.withTimeoutOrNull
 import okhttp3.CacheControl
 import okio.Buffer
@@ -62,7 +63,16 @@ class TranscriptWindowExtractor @Inject constructor(
 
         manager.prepareForCurrentEpisode()
         val ref = withTimeoutOrNull(COVERAGE_TIMEOUT) {
-            manager.mappingVersion.map { refNow() }.filter { it != null }.first()
+            merge(
+                manager.mappingVersion.map { refNow() }.filter { it != null },
+                // Bail only on this episode's terminal states; the conflated flow can hold a stale one.
+                manager.stateFlow
+                    .filter {
+                        (it is FingerprintTimingManager.State.Unavailable && it.episodeUuid == episodeUuid) ||
+                            (it is FingerprintTimingManager.State.Failed && it.episodeUuid == episodeUuid)
+                    }
+                    .map { null },
+            ).first()
         }
         return ref ?: timeSecs
     }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManagerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManagerTest.kt
@@ -186,20 +186,20 @@ class FingerprintTimingManagerTest {
     }
 
     @Test
-    fun `decideOnProgress jump outside mapped range restarts`() {
+    fun `decideOnProgress jump outside mapped range schedules debounced restart`() {
         val decision = decideOnProgress(positionSec = 100.0, lastPositionSec = 10.0)
-        assertEquals(ProgressDecision.RestartOutsideRange, decision)
+        assertEquals(ProgressDecision.ScheduleDebouncedRestart, decision)
     }
 
     @Test
-    fun `decideOnProgress jump into mapping gap restarts`() {
+    fun `decideOnProgress jump into mapping gap schedules debounced restart`() {
         val decision = decideOnProgress(
             positionSec = 300.0,
             lastPositionSec = 50.0,
             mappedRunEndSec = null,
             hasAnyMapping = true,
         )
-        assertEquals(ProgressDecision.RestartOutsideRange, decision)
+        assertEquals(ProgressDecision.ScheduleDebouncedRestart, decision)
     }
 
     @Test
@@ -210,6 +210,17 @@ class FingerprintTimingManagerTest {
             hasAnyMapping = true,
             isDecodeActive = true,
             isCoveredByActiveDecode = true,
+        )
+        assertEquals(ProgressDecision.None, decision)
+    }
+
+    @Test
+    fun `decideOnProgress pending restart suppresses outside range restart`() {
+        val decision = decideOnProgress(
+            positionSec = 100.0,
+            lastPositionSec = 99.0,
+            hasAnyMapping = true,
+            hasPendingRestart = true,
         )
         assertEquals(ProgressDecision.None, decision)
     }
@@ -369,6 +380,7 @@ class FingerprintTimingManagerTest {
         hasAnyMapping: Boolean = mappedRunEndSec != null,
         isDecodeActive: Boolean = false,
         isCoveredByActiveDecode: Boolean = false,
+        hasPendingRestart: Boolean = false,
         hasStreamStarted: Boolean = hasAnyMapping || isDecodeActive,
         msSinceStreamStart: Long = FingerprintConstants.STREAM_BOOTSTRAP_COOLDOWN_MS,
     ): ProgressDecision = FingerprintTimingManager.decideOnProgress(
@@ -379,6 +391,7 @@ class FingerprintTimingManagerTest {
         hasAnyMapping = hasAnyMapping,
         isDecodeActive = isDecodeActive,
         isCoveredByActiveDecode = isCoveredByActiveDecode,
+        hasPendingRestart = hasPendingRestart,
         hasStreamStarted = hasStreamStarted,
         msSinceStreamStart = msSinceStreamStart,
     )

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManagerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManagerTest.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.repositories.fingerprint
 
+import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.FingerprintTimingManager.ProgressDecision
 import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.FingerprintTimingManager.TimeMappingEntry
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -159,6 +160,228 @@ class FingerprintTimingManagerTest {
         )
         assertFalse(queriedNetwork)
     }
+
+    @Test
+    fun `decideOnProgress ignores ticks in eager mode`() {
+        val decision = decideOnProgress(positionSec = 100.0, lastPositionSec = 10.0, isEager = true)
+        assertEquals(ProgressDecision.None, decision)
+    }
+
+    @Test
+    fun `decideOnProgress small delta does nothing`() {
+        val decision = decideOnProgress(positionSec = 15.0, lastPositionSec = 10.0)
+        assertEquals(ProgressDecision.None, decision)
+    }
+
+    @Test
+    fun `decideOnProgress first tick is never a jump`() {
+        val decision = decideOnProgress(positionSec = 500.0, lastPositionSec = null)
+        assertEquals(ProgressDecision.None, decision)
+    }
+
+    @Test
+    fun `decideOnProgress jump within mapped run does not restart`() {
+        val decision = decideOnProgress(positionSec = 100.0, lastPositionSec = 10.0, mappedRunEndSec = 120.0)
+        assertEquals(ProgressDecision.None, decision)
+    }
+
+    @Test
+    fun `decideOnProgress jump outside mapped range restarts`() {
+        val decision = decideOnProgress(positionSec = 100.0, lastPositionSec = 10.0)
+        assertEquals(ProgressDecision.RestartOutsideRange, decision)
+    }
+
+    @Test
+    fun `decideOnProgress jump into mapping gap restarts`() {
+        val decision = decideOnProgress(
+            positionSec = 300.0,
+            lastPositionSec = 50.0,
+            mappedRunEndSec = null,
+            hasAnyMapping = true,
+        )
+        assertEquals(ProgressDecision.RestartOutsideRange, decision)
+    }
+
+    @Test
+    fun `decideOnProgress jump covered by active decode does not restart`() {
+        val decision = decideOnProgress(
+            positionSec = 300.0,
+            lastPositionSec = 50.0,
+            hasAnyMapping = true,
+            isDecodeActive = true,
+            isCoveredByActiveDecode = true,
+        )
+        assertEquals(ProgressDecision.None, decision)
+    }
+
+    @Test
+    fun `decideOnProgress outside mapped range respects bootstrap cooldown`() {
+        val decision = decideOnProgress(
+            positionSec = 100.0,
+            lastPositionSec = 99.0,
+            hasAnyMapping = true,
+            msSinceStreamStart = FingerprintConstants.STREAM_BOOTSTRAP_COOLDOWN_MS - 1,
+        )
+        assertEquals(ProgressDecision.None, decision)
+    }
+
+    @Test
+    fun `decideOnProgress outside mapped range restarts after cooldown`() {
+        val decision = decideOnProgress(
+            positionSec = 100.0,
+            lastPositionSec = 99.0,
+            hasAnyMapping = true,
+            msSinceStreamStart = FingerprintConstants.STREAM_BOOTSTRAP_COOLDOWN_MS,
+        )
+        assertEquals(ProgressDecision.RestartOutsideRange, decision)
+    }
+
+    @Test
+    fun `decideOnProgress outside range covered by active decode does not restart`() {
+        val decision = decideOnProgress(
+            positionSec = 100.0,
+            lastPositionSec = 99.0,
+            hasAnyMapping = true,
+            isDecodeActive = true,
+            isCoveredByActiveDecode = true,
+            msSinceStreamStart = FingerprintConstants.STREAM_BOOTSTRAP_COOLDOWN_MS,
+        )
+        assertEquals(ProgressDecision.None, decision)
+    }
+
+    @Test
+    fun `decideOnProgress outside range with decode elsewhere still restarts`() {
+        val decision = decideOnProgress(
+            positionSec = 100.0,
+            lastPositionSec = 99.0,
+            hasAnyMapping = true,
+            isDecodeActive = true,
+            isCoveredByActiveDecode = false,
+            msSinceStreamStart = FingerprintConstants.STREAM_BOOTSTRAP_COOLDOWN_MS,
+        )
+        assertEquals(ProgressDecision.RestartOutsideRange, decision)
+    }
+
+    @Test
+    fun `decideOnProgress empty mapping does not restart before the stream ever ran`() {
+        val decision = decideOnProgress(
+            positionSec = 100.0,
+            lastPositionSec = 99.0,
+        )
+        assertEquals(ProgressDecision.None, decision)
+    }
+
+    @Test
+    fun `decideOnProgress empty mapping does not restart while the decode is running`() {
+        val decision = decideOnProgress(
+            positionSec = 100.0,
+            lastPositionSec = 99.0,
+            isDecodeActive = true,
+            isCoveredByActiveDecode = true,
+        )
+        assertEquals(ProgressDecision.None, decision)
+    }
+
+    @Test
+    fun `decideOnProgress empty mapping restarts after the stream died without producing one`() {
+        val decision = decideOnProgress(
+            positionSec = 100.0,
+            lastPositionSec = 99.0,
+            hasStreamStarted = true,
+        )
+        assertEquals(ProgressDecision.RestartOutsideRange, decision)
+    }
+
+    @Test
+    fun `mappedRunEnd empty mapping returns null`() {
+        assertNull(FingerprintTimingManager.mappedRunEnd(50.0, emptyList()))
+    }
+
+    @Test
+    fun `mappedRunEnd inside contiguous run returns run end`() {
+        assertEquals(100.0, FingerprintTimingManager.mappedRunEnd(35.0, entriesAt(0.0, 100.0, step = 10.0))!!, 0.0)
+    }
+
+    @Test
+    fun `mappedRunEnd on exact anchor returns run end`() {
+        assertEquals(100.0, FingerprintTimingManager.mappedRunEnd(40.0, entriesAt(0.0, 100.0, step = 10.0))!!, 0.0)
+    }
+
+    @Test
+    fun `mappedRunEnd in gap between islands returns null`() {
+        val entries = entriesAt(0.0, 100.0, step = 10.0) + entriesAt(500.0, 600.0, step = 10.0)
+        assertNull(FingerprintTimingManager.mappedRunEnd(300.0, entries))
+    }
+
+    @Test
+    fun `mappedRunEnd exactly on a mid-list island end gets no slack`() {
+        val entries = entriesAt(0.0, 100.0, step = 10.0) + entriesAt(500.0, 600.0, step = 10.0)
+        assertNull(FingerprintTimingManager.mappedRunEnd(100.0, entries))
+    }
+
+    @Test
+    fun `mappedRunEnd just past island end with far next island returns null`() {
+        val entries = entriesAt(0.0, 100.0, step = 10.0) + entriesAt(500.0, 600.0, step = 10.0)
+        assertNull(FingerprintTimingManager.mappedRunEnd(110.0, entries))
+    }
+
+    @Test
+    fun `mappedRunEnd inside first island stops at gap`() {
+        val entries = entriesAt(0.0, 100.0, step = 10.0) + entriesAt(500.0, 600.0, step = 10.0)
+        assertEquals(100.0, FingerprintTimingManager.mappedRunEnd(50.0, entries)!!, 0.0)
+    }
+
+    @Test
+    fun `mappedRunEnd within margin after last entry returns last entry`() {
+        assertEquals(100.0, FingerprintTimingManager.mappedRunEnd(120.0, entriesAt(0.0, 100.0, step = 10.0))!!, 0.0)
+    }
+
+    @Test
+    fun `mappedRunEnd beyond margin after last entry returns null`() {
+        assertNull(FingerprintTimingManager.mappedRunEnd(131.0, entriesAt(0.0, 100.0, step = 10.0)))
+    }
+
+    @Test
+    fun `mappedRunEnd within margin before first entry returns run end`() {
+        assertEquals(200.0, FingerprintTimingManager.mappedRunEnd(80.0, entriesAt(100.0, 200.0, step = 10.0))!!, 0.0)
+    }
+
+    @Test
+    fun `mappedRunEnd beyond margin before first entry returns null`() {
+        assertNull(FingerprintTimingManager.mappedRunEnd(60.0, entriesAt(100.0, 200.0, step = 10.0)))
+    }
+
+    private fun entriesAt(from: Double, to: Double, step: Double): List<TimeMappingEntry> {
+        val entries = mutableListOf<TimeMappingEntry>()
+        var time = from
+        while (time <= to) {
+            entries.add(TimeMappingEntry(playbackTime = time, referenceTime = time))
+            time += step
+        }
+        return entries
+    }
+
+    private fun decideOnProgress(
+        positionSec: Double,
+        lastPositionSec: Double?,
+        isEager: Boolean = false,
+        mappedRunEndSec: Double? = null,
+        hasAnyMapping: Boolean = mappedRunEndSec != null,
+        isDecodeActive: Boolean = false,
+        isCoveredByActiveDecode: Boolean = false,
+        hasStreamStarted: Boolean = hasAnyMapping || isDecodeActive,
+        msSinceStreamStart: Long = FingerprintConstants.STREAM_BOOTSTRAP_COOLDOWN_MS,
+    ): ProgressDecision = FingerprintTimingManager.decideOnProgress(
+        positionSec = positionSec,
+        lastPositionSec = lastPositionSec,
+        isEager = isEager,
+        mappedRunEndSec = mappedRunEndSec,
+        hasAnyMapping = hasAnyMapping,
+        isDecodeActive = isDecodeActive,
+        isCoveredByActiveDecode = isCoveredByActiveDecode,
+        hasStreamStarted = hasStreamStarted,
+        msSinceStreamStart = msSinceStreamStart,
+    )
 
     @Test
     fun `alignToWindowGrid aligns to stride boundary`() {

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManagerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManagerTest.kt
@@ -274,6 +274,72 @@ class FingerprintTimingManagerTest {
     }
 
     @Test
+    fun `decideOnProgress resumes from run end when the mapping is about to run out`() {
+        val decision = decideOnProgress(
+            positionSec = 100.0,
+            lastPositionSec = 99.0,
+            mappedRunEndSec = 130.0,
+        )
+        assertEquals(ProgressDecision.RestartFromRunEnd(130.0), decision)
+    }
+
+    @Test
+    fun `decideOnProgress does not resume while the run end is far ahead`() {
+        val decision = decideOnProgress(
+            positionSec = 100.0,
+            lastPositionSec = 99.0,
+            mappedRunEndSec = 100.0 + FingerprintConstants.LOOKAHEAD_SECONDS,
+        )
+        assertEquals(ProgressDecision.None, decision)
+    }
+
+    @Test
+    fun `decideOnProgress does not resume when a decode already covers the run end`() {
+        val decision = decideOnProgress(
+            positionSec = 100.0,
+            lastPositionSec = 99.0,
+            mappedRunEndSec = 130.0,
+            isDecodeActive = true,
+            isRunEndCoveredByActiveDecode = true,
+        )
+        assertEquals(ProgressDecision.None, decision)
+    }
+
+    @Test
+    fun `decideOnProgress does not resume when the run end is near the episode end`() {
+        val decision = decideOnProgress(
+            positionSec = 100.0,
+            lastPositionSec = 99.0,
+            mappedRunEndSec = 130.0,
+            isRunEndNearEpisodeEnd = true,
+        )
+        assertEquals(ProgressDecision.None, decision)
+    }
+
+    @Test
+    fun `decideOnProgress run end resume respects bootstrap cooldown`() {
+        val decision = decideOnProgress(
+            positionSec = 100.0,
+            lastPositionSec = 99.0,
+            mappedRunEndSec = 130.0,
+            msSinceStreamStart = FingerprintConstants.STREAM_BOOTSTRAP_COOLDOWN_MS - 1,
+        )
+        assertEquals(ProgressDecision.None, decision)
+    }
+
+    @Test
+    fun `decideOnProgress relocates a decode replaying mapped audio to the run end`() {
+        val decision = decideOnProgress(
+            positionSec = 100.0,
+            lastPositionSec = 99.0,
+            mappedRunEndSec = 130.0,
+            isDecodeActive = true,
+            isRunEndCoveredByActiveDecode = false,
+        )
+        assertEquals(ProgressDecision.RestartFromRunEnd(130.0), decision)
+    }
+
+    @Test
     fun `decideOnProgress empty mapping does not restart before the stream ever ran`() {
         val decision = decideOnProgress(
             positionSec = 100.0,
@@ -380,6 +446,8 @@ class FingerprintTimingManagerTest {
         hasAnyMapping: Boolean = mappedRunEndSec != null,
         isDecodeActive: Boolean = false,
         isCoveredByActiveDecode: Boolean = false,
+        isRunEndCoveredByActiveDecode: Boolean = false,
+        isRunEndNearEpisodeEnd: Boolean = false,
         hasPendingRestart: Boolean = false,
         hasStreamStarted: Boolean = hasAnyMapping || isDecodeActive,
         msSinceStreamStart: Long = FingerprintConstants.STREAM_BOOTSTRAP_COOLDOWN_MS,
@@ -391,6 +459,8 @@ class FingerprintTimingManagerTest {
         hasAnyMapping = hasAnyMapping,
         isDecodeActive = isDecodeActive,
         isCoveredByActiveDecode = isCoveredByActiveDecode,
+        isRunEndCoveredByActiveDecode = isRunEndCoveredByActiveDecode,
+        isRunEndNearEpisodeEnd = isRunEndNearEpisodeEnd,
         hasPendingRestart = hasPendingRestart,
         hasStreamStarted = hasStreamStarted,
         msSinceStreamStart = msSinceStreamStart,

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/TranscriptWindowExtractorTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/TranscriptWindowExtractorTest.kt
@@ -6,8 +6,10 @@ import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.FingerprintTiming
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.servers.podcast.TranscriptService
 import java.util.Date
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.currentTime
 import kotlinx.coroutines.test.runTest
 import okhttp3.CacheControl
 import okhttp3.ResponseBody.Companion.toResponseBody
@@ -27,7 +29,9 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 class TranscriptWindowExtractorTest {
 
-    private val fingerprintTimingManager = mock<FingerprintTimingManager>()
+    private val fingerprintTimingManager = mock<FingerprintTimingManager> {
+        on { stateFlow } doReturn MutableStateFlow(FingerprintTimingManager.State.Idle)
+    }
     private val playbackManager = mock<PlaybackManager>()
     private val currentEpisode = PodcastEpisode(uuid = "episode-id", podcastUuid = "podcast-id", publishedDate = Date())
 
@@ -111,6 +115,31 @@ class TranscriptWindowExtractorTest {
     }
 
     @Test
+    fun `wait for the mapping despite a stale unavailable state from another episode`() = runTest {
+        val mappingVersion = MutableStateFlow(0L)
+        var referenceSecs: Double? = null
+        whenever(fingerprintTimingManager.activeEpisodeUuid).thenReturn("episode-id")
+        whenever(fingerprintTimingManager.mappingVersion).thenReturn(mappingVersion)
+        whenever(fingerprintTimingManager.referenceTime(5000)).thenAnswer { referenceSecs }
+        whenever(fingerprintTimingManager.stateFlow).thenReturn(MutableStateFlow(FingerprintTimingManager.State.Unavailable("other-episode")))
+        whenever(playbackManager.getCurrentEpisode()).thenReturn(currentEpisode)
+        doAnswer {
+            referenceSecs = 25.0
+            mappingVersion.value++
+            null
+        }.whenever(fingerprintTimingManager).prepareForCurrentEpisode()
+
+        val result = extractor(sampleVtt).extractWindow("episode-id", timeSecs = 5, windowSecs = 15)
+
+        assertEquals(
+            "Let me start by defining what AI actually means in practice. " +
+                "AI is a broad field that includes machine learning, deep learning, and more. " +
+                "The recent advances have been truly remarkable for the industry.",
+            result,
+        )
+    }
+
+    @Test
     fun `use playback time when the mapping never covers the bookmark`() = runTest {
         whenever(fingerprintTimingManager.activeEpisodeUuid).thenReturn("episode-id")
         whenever(fingerprintTimingManager.referenceTime(5000)).thenReturn(null)
@@ -119,6 +148,25 @@ class TranscriptWindowExtractorTest {
 
         val result = extractor(sampleVtt).extractWindow("episode-id", timeSecs = 5, windowSecs = 15)
 
+        assertEquals(
+            "Welcome to the show everyone. Today we are going to discuss artificial intelligence. " +
+                "Let me start by defining what AI actually means in practice.",
+            result,
+        )
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `use playback time without waiting when fingerprinting is unavailable`() = runTest {
+        whenever(fingerprintTimingManager.activeEpisodeUuid).thenReturn("episode-id")
+        whenever(fingerprintTimingManager.referenceTime(5000)).thenReturn(null)
+        whenever(fingerprintTimingManager.mappingVersion).thenReturn(MutableStateFlow(0L))
+        whenever(fingerprintTimingManager.stateFlow).thenReturn(MutableStateFlow(FingerprintTimingManager.State.Unavailable("episode-id")))
+        whenever(playbackManager.getCurrentEpisode()).thenReturn(currentEpisode)
+
+        val result = extractor(sampleVtt).extractWindow("episode-id", timeSecs = 5, windowSecs = 15)
+
+        assertEquals(0, currentTime)
         assertEquals(
             "Welcome to the show everyone. Today we are going to discuss artificial intelligence. " +
                 "Let me start by defining what AI actually means in practice.",


### PR DESCRIPTION
## Description
 Any playback jump over the restart threshold used to kill and restart the fingerprint decode stream, which made seeking through a synced transcript jarring: the mapping reset, the highlight dropped out, and already-decoded audio was decoded again.
Seek handling is now a pure decision function (`decideOnProgress` + `mappedRunEnd`) instead of inline restart logic:
- Seeks landing inside an already-mapped contiguous run don't restart the stream at all.
- Out-of-run seeks are debounced (1.5 s), so rapid multi-tap skips coalesce into one restart from the final position. The debounce waits out a pause rather than dropping the restart.
- The decode proactively resumes from a mapped run's end just before playback outruns the mapping — unlike a playhead restart, this continues the existing run, so the drift filter's trusted anchor is kept.
- Restarts are suppressed when the running decode already covers the position (start/frontier tracking), and a stream that died without producing a mapping recovers on the next tick.
- `mappedRunEnd` is deliberately asymmetric: no slack past a mid-list run end (the hole should resync immediately), but the margin's grace past the final anchor, where the live decode frontier naturally trails.

Groundwork included: the decode moved off `Dispatchers.Default` onto a single-lane IO dispatcher; a generation token guards every side effect of the decode job (a cancelled job can outlive its generation inside blocking native calls); reference disk I/O is now suspend on `Dispatchers.IO`; `Unavailable`/`Failed` states carry the episode UUID so bookmark transcript alignment bails on this episode's terminal state instead of sitting out the 5 s timeout on a stale one; failure analytics are reported once per preparation instead of once per automatic restart.

  ## Testing Instructions
  1. Enable the `SYNCED_TRANSCRIPTS` feature flag and play an episode with a generated transcript.
  2. Open the transcript and let the highlight sync.
  3. Tap skip-forward repeatedly (4–5 taps) — expect a single decode restart after the taps settle, then resync.
  4. Seek back into an already-listened (mapped) region — expect the highlight to continue instantly with no resync.
  5. Pause immediately after a big seek, wait a few seconds, resume — the restart should still happen.
  6. Play continuously past the edge of the mapped region — sync should continue without a visible gap.
  7. Create a bookmark on an episode where fingerprinting fails (e.g. no reference) — bookmark creation should not stall for 5 s.

  ## Checklist
  - [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
  - [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
  - [x] I have considered whether it makes sense to add tests for my changes
  - [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
  - [ ] Any jetpack compose components I added or changed are covered by compose previews
  - [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed
  analytics.
