### PR TITLE
Reduce network traffic from streaming fingerprint decoding

### DIFF
--- a/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/TranscriptViewModel.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/TranscriptViewModel.kt
@@ -144,7 +144,7 @@ class TranscriptViewModel @AssistedInject constructor(
             if (transcriptState is TranscriptState.Loaded && transcriptState.transcript is Transcript.Text) {
                 val currentPlayingUuid = playbackManager.getCurrentEpisode()?.uuid
                 if (currentPlayingUuid == episodeUuid) {
-                    fingerprintTimingManager.prepareForCurrentEpisode()
+                    fingerprintTimingManager.prepareForCurrentEpisode(FingerprintTimingManager.PrepareTrigger.TRANSCRIPT_VIEW)
                     _uiState.update { state -> state.copy(syncedState = fingerprintTimingManager.state) }
                     observeSyncedState()
                 }

--- a/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptPage.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptPage.kt
@@ -75,6 +75,19 @@ fun TranscriptPage(
 ) {
     val theme = rememberTranscriptTheme()
     val listState = rememberLazyListState()
+
+    val syncableEpisodeUuid = uiState.transcriptEpisodeUuid.takeIf { uiState.isTextTranscriptLoaded }
+    DisposableEffect(fingerprintTimingManager, syncableEpisodeUuid) {
+        if (syncableEpisodeUuid != null) {
+            fingerprintTimingManager?.onTranscriptShown(syncableEpisodeUuid)
+        }
+        onDispose {
+            if (syncableEpisodeUuid != null) {
+                fingerprintTimingManager?.onTranscriptDismissed(syncableEpisodeUuid)
+            }
+        }
+    }
+
     var highlightState by remember { mutableStateOf(HighlightState()) }
     var hasInitiallyScrolled by remember { mutableStateOf(false) }
     var isAutoScrollSuppressed by remember { mutableStateOf(false) }

--- a/modules/features/transcripts/src/test/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/TranscriptViewModelTest.kt
+++ b/modules/features/transcripts/src/test/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/TranscriptViewModelTest.kt
@@ -369,7 +369,7 @@ class TranscriptViewModelTest {
     @Test
     fun `track synced transcript seek failed event when failed`() = runTest {
         setUpTapToSeek()
-        syncedStateFlow.value = FingerprintTimingManager.State.Failed(RuntimeException("no match"))
+        syncedStateFlow.value = FingerprintTimingManager.State.Failed(RuntimeException("no match"), episodeUuid = "episode-uuid")
 
         awaitTapToSeekAvailable()
         drainEvents()
@@ -395,7 +395,7 @@ class TranscriptViewModelTest {
     @Test
     fun `track synced transcript seek failed event without message when unavailable`() = runTest {
         setUpTapToSeek()
-        syncedStateFlow.value = FingerprintTimingManager.State.Unavailable
+        syncedStateFlow.value = FingerprintTimingManager.State.Unavailable(episodeUuid = "episode-uuid")
 
         awaitTapToSeekAvailable()
         drainEvents()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/CacheBackedMediaDataSource.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/CacheBackedMediaDataSource.kt
@@ -1,0 +1,70 @@
+package au.com.shiftyjelly.pocketcasts.repositories.fingerprint
+
+import android.media.MediaDataSource
+import android.net.Uri
+import androidx.annotation.OptIn
+import androidx.media3.common.C
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.DataSpec
+
+@OptIn(UnstableApi::class)
+internal class CacheBackedMediaDataSource(
+    private val dataSourceFactory: DataSource.Factory,
+    private val uri: Uri,
+    private val cacheKey: String,
+    private val cachedLengthAt: (position: Long, length: Long) -> Long,
+) : MediaDataSource() {
+    private var dataSource: DataSource? = null
+    private var position = -1L
+    private var totalSize = C.LENGTH_UNSET.toLong()
+
+    override fun getSize(): Long {
+        if (totalSize == C.LENGTH_UNSET.toLong()) {
+            openAt(0)
+        }
+        return totalSize
+    }
+
+    override fun readAt(position: Long, buffer: ByteArray, offset: Int, size: Int): Int {
+        if (size == 0) return 0
+        var waited = 0L
+        while (cachedLengthAt(position, size.toLong()) <= 0L && waited < FOLLOW_TIMEOUT_MS) {
+            Thread.sleep(POLL_MS)
+            waited += POLL_MS
+        }
+        if (position != this.position || dataSource == null) {
+            openAt(position)
+        }
+        val read = dataSource?.read(buffer, offset, size) ?: return -1
+        if (read == C.RESULT_END_OF_INPUT) return -1
+        this.position += read
+        return read
+    }
+
+    override fun close() {
+        closeSource()
+        position = -1L
+    }
+
+    private fun openAt(position: Long) {
+        closeSource()
+        val source = dataSourceFactory.createDataSource()
+        val opened = source.open(DataSpec.Builder().setUri(uri).setKey(cacheKey).setPosition(position).build())
+        if (position == 0L && opened != C.LENGTH_UNSET.toLong()) {
+            totalSize = opened
+        }
+        dataSource = source
+        this.position = position
+    }
+
+    private fun closeSource() {
+        runCatching { dataSource?.close() }
+        dataSource = null
+    }
+
+    private companion object {
+        private const val POLL_MS = 100L
+        private const val FOLLOW_TIMEOUT_MS = 60_000L
+    }
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/CacheBackedMediaDataSource.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/CacheBackedMediaDataSource.kt
@@ -13,6 +13,7 @@ internal class CacheBackedMediaDataSource(
     private val dataSourceFactory: DataSource.Factory,
     private val uri: Uri,
     private val cacheKey: String,
+    private val isActive: () -> Boolean = { true },
     private val cachedLengthAt: (position: Long, length: Long) -> Long,
 ) : MediaDataSource() {
     private var dataSource: DataSource? = null
@@ -29,7 +30,7 @@ internal class CacheBackedMediaDataSource(
     override fun readAt(position: Long, buffer: ByteArray, offset: Int, size: Int): Int {
         if (size == 0) return 0
         var waited = 0L
-        while (cachedLengthAt(position, size.toLong()) <= 0L && waited < FOLLOW_TIMEOUT_MS) {
+        while (cachedLengthAt(position, size.toLong()) <= 0L && waited < FOLLOW_TIMEOUT_MS && isActive()) {
             Thread.sleep(POLL_MS)
             waited += POLL_MS
         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintConstants.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintConstants.kt
@@ -13,6 +13,9 @@ object FingerprintConstants {
     /** Position must be stable for this long before a seek restarts the stream; coalesces rapid multi-tap skips. */
     const val RESTART_DEBOUNCE_MS = 1_500L
 
+    /** How often a running remote decode re-checks that the network still permits streaming. */
+    const val METERED_RECHECK_INTERVAL_MS = 5_000L
+
     /** Minimum match score to accept a fingerprint match result. */
     const val MATCH_SCORE_THRESHOLD = 0.5f
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintReferenceRetriever.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintReferenceRetriever.kt
@@ -1,6 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.repositories.fingerprint
 
+import android.content.Context
 import au.com.shiftyjelly.pocketcasts.servers.di.NoCache
+import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.IOException
@@ -26,6 +28,7 @@ import timber.log.Timber
 @Singleton
 class FingerprintReferenceRetriever @Inject constructor(
     @NoCache private val okHttpClient: OkHttpClient,
+    @ApplicationContext private val context: Context,
 ) {
     private val inFlightRequests = mutableMapOf<String, Deferred<ByteArray?>>()
     private val requestMutex = Mutex()
@@ -122,8 +125,38 @@ class FingerprintReferenceRetriever @Inject constructor(
         if (file.exists()) file.readBytes() else null
     }
 
+    suspend fun loadCachedReference(episodeUuid: String): ByteArray? = withContext(Dispatchers.IO) {
+        runCatching {
+            val file = cachedReferenceFile(episodeUuid)
+            if (!file.exists()) return@runCatching null
+            file.setLastModified(System.currentTimeMillis())
+            file.readBytes()
+        }.getOrNull()
+    }
+
+    suspend fun saveCachedReference(episodeUuid: String, data: ByteArray) = withContext(Dispatchers.IO) {
+        runCatching {
+            val file = cachedReferenceFile(episodeUuid)
+            file.parentFile?.mkdirs()
+            file.writeBytes(data)
+            pruneCachedReferences()
+        }.onFailure { Timber.w(it, "FingerprintReferenceRetriever: failed to cache reference for $episodeUuid") }
+        Unit
+    }
+
+    private fun cachedReferenceFile(episodeUuid: String) = File(File(context.cacheDir, CACHE_DIR_NAME), "$episodeUuid.ref.fp.json")
+
+    private fun pruneCachedReferences() {
+        val files = File(context.cacheDir, CACHE_DIR_NAME).listFiles() ?: return
+        files.sortedByDescending { it.lastModified() }
+            .drop(REFERENCE_CACHE_MAX_FILES)
+            .forEach { it.delete() }
+    }
+
     companion object {
         private const val MAX_RETRIES = 3
+        private const val CACHE_DIR_NAME = "episode_fingerprints"
+        private const val REFERENCE_CACHE_MAX_FILES = 20
 
         fun referencePath(audioFilePath: String): String {
             val dotIndex = audioFilePath.lastIndexOf('.')

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
@@ -7,6 +7,7 @@ import android.media.MediaFormat
 import android.os.SystemClock
 import androidx.annotation.VisibleForTesting
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.BuildConfig
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.ChapterManager
@@ -57,7 +58,15 @@ class FingerprintTimingManager @Inject constructor(
     private val eventHorizon: EventHorizon,
     @ApplicationContext private val context: Context,
     private val chapterManager: Lazy<ChapterManager>,
+    private val settings: Settings,
 ) {
+
+    /** Who asked for preparation; decides whether streaming over a metered network is acceptable. */
+    enum class PrepareTrigger {
+        PLAYBACK,
+        TRANSCRIPT_VIEW,
+        BOOKMARK,
+    }
 
     sealed interface State {
         data object Idle : State
@@ -138,6 +147,8 @@ class FingerprintTimingManager @Inject constructor(
     internal var debugTrackingEnabled = false
 
     // Context for current preparation
+    private var currentTrigger = PrepareTrigger.PLAYBACK
+
     @Volatile
     private var currentEpisodeUuid: String? = null
     private var currentAudioFilePath: String? = null
@@ -170,13 +181,13 @@ class FingerprintTimingManager @Inject constructor(
                 val uuid = state.episodeUuid
                 if (state.isPlaying && !uuid.isNullOrEmpty() && uuid != lastEpisodeUuid) {
                     lastEpisodeUuid = uuid
-                    prepareForCurrentEpisode()
+                    prepareForCurrentEpisode(PrepareTrigger.PLAYBACK)
                 }
             }
         }
     }
 
-    fun prepareForCurrentEpisode() {
+    fun prepareForCurrentEpisode(trigger: PrepareTrigger) {
         val episode = playbackManager.getCurrentEpisode() ?: run {
             // No episode is currently loaded, so there is no episode UUID to attribute this to.
             markUnavailable(reason = "no_episode", episodeUuid = null)
@@ -200,7 +211,7 @@ class FingerprintTimingManager @Inject constructor(
             // Abort if a newer stop()/prepare() has started since we acquired the lock.
             if (gen != generation) return@launch
             startPlaybackProgressObserver(episodeUuid)
-            prepareForEpisode(gen, episodeUuid, podcastUuid, audioSource, episode.isDownloaded, episode.duration)
+            prepareForEpisode(gen, episodeUuid, podcastUuid, audioSource, episode.isDownloaded, episode.duration, trigger)
         }
     }
 
@@ -373,6 +384,7 @@ class FingerprintTimingManager @Inject constructor(
         preparationStartMs = 0
         currentIsStreaming = false
         currentEager = false
+        currentTrigger = PrepareTrigger.PLAYBACK
     }
 
     /**
@@ -395,6 +407,7 @@ class FingerprintTimingManager @Inject constructor(
         audioSource: String?,
         isDownloaded: Boolean,
         durationSec: Double,
+        trigger: PrepareTrigger,
     ) {
         if (!FeatureFlag.isEnabled(Feature.SYNCED_TRANSCRIPTS)) {
             markUnavailable(reason = "feature_disabled", isStreaming = !isDownloaded, episodeUuid = episodeUuid)
@@ -415,9 +428,25 @@ class FingerprintTimingManager @Inject constructor(
             return
         }
 
+        val blocked = shouldBlockRemoteFingerprinting(
+            isDownloaded = isDownloaded,
+            trigger = trigger,
+            warnOnMeteredNetwork = settings.warnOnMeteredNetwork.value,
+            isUnmetered = { Network.isUnmeteredConnection(context) },
+        )
+        if (blocked) {
+            mutex.withLock {
+                if (gen != generation) return
+                markUnavailable(reason = "metered_network", isStreaming = true, episodeUuid = episodeUuid)
+            }
+            Timber.d("FingerprintTimingManager: skipping remote fingerprinting on metered network")
+            return
+        }
+
         val eager = shouldRunEagerPass(episodeUuid, isDownloaded)
         mutex.withLock {
             if (gen != generation) return
+            currentTrigger = trigger
             currentEpisodeUuid = episodeUuid
             activeEpisodeUuid = episodeUuid
             currentAudioFilePath = audioSource
@@ -602,8 +631,20 @@ class FingerprintTimingManager @Inject constructor(
         }
     }
 
+    private fun canStreamOnCurrentNetwork(): Boolean = !currentIsStreaming ||
+        !shouldBlockRemoteFingerprinting(
+            isDownloaded = false,
+            trigger = currentTrigger,
+            warnOnMeteredNetwork = settings.warnOnMeteredNetwork.value,
+            isUnmetered = { Network.isUnmeteredConnection(context) },
+        )
+
     /** Must be called under [mutex]. */
     private fun restartFromPlayhead() {
+        if (!canStreamOnCurrentNetwork()) {
+            Timber.d("FingerprintTimingManager: skipping stream restart on metered network")
+            return
+        }
         val matcher = currentMatcher ?: return
         val audioPath = currentAudioFilePath ?: return
         val uuid = currentEpisodeUuid ?: return
@@ -614,6 +655,10 @@ class FingerprintTimingManager @Inject constructor(
 
     /** Must be called under [mutex]. Continues an existing run, so the drift filter's trusted anchor is kept. */
     private fun restartFromRunEnd(runEndSec: Double) {
+        if (!canStreamOnCurrentNetwork()) {
+            Timber.d("FingerprintTimingManager: skipping stream restart on metered network")
+            return
+        }
         val matcher = currentMatcher ?: return
         val audioPath = currentAudioFilePath ?: return
         val uuid = currentEpisodeUuid ?: return
@@ -1037,6 +1082,18 @@ class FingerprintTimingManager @Inject constructor(
             isDownloaded: Boolean,
             isUnmetered: () -> Boolean,
         ): Boolean = hasGeneratedChapters && (isDownloaded || isUnmetered())
+
+        /** [isUnmetered] is a supplier so the network lookup is skipped for downloaded episodes. */
+        internal fun shouldBlockRemoteFingerprinting(
+            isDownloaded: Boolean,
+            trigger: PrepareTrigger,
+            warnOnMeteredNetwork: Boolean,
+            isUnmetered: () -> Boolean,
+        ): Boolean {
+            if (isDownloaded) return false
+            if (isUnmetered()) return false
+            return trigger != PrepareTrigger.TRANSCRIPT_VIEW || warnOnMeteredNetwork
+        }
 
         /** Decides how a playback-progress tick affects the fingerprint stream. */
         internal fun decideOnProgress(

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
@@ -208,7 +208,12 @@ class FingerprintTimingManager @Inject constructor(
             val gen: Long
             mutex.withLock {
                 // Already prepared for this episode — reuse existing state.
-                if (currentEpisodeUuid == episodeUuid && state !is State.Idle) return@launch
+                if (currentEpisodeUuid == episodeUuid && state !is State.Idle) {
+                    if (trigger == PrepareTrigger.TRANSCRIPT_VIEW) {
+                        currentTrigger = trigger
+                    }
+                    return@launch
+                }
                 resetState()
                 generation++
                 gen = generation
@@ -240,6 +245,21 @@ class FingerprintTimingManager @Inject constructor(
             }
         }
         Timber.d("FingerprintTimingManager: stopped")
+    }
+
+    fun onTranscriptShown(episodeUuid: String) {
+        if (playbackManager.getCurrentEpisode()?.uuid != episodeUuid) return
+        prepareForCurrentEpisode(PrepareTrigger.TRANSCRIPT_VIEW)
+    }
+
+    fun onTranscriptDismissed(episodeUuid: String) {
+        scope.launch {
+            mutex.withLock {
+                if (currentEpisodeUuid == episodeUuid && currentTrigger == PrepareTrigger.TRANSCRIPT_VIEW) {
+                    currentTrigger = PrepareTrigger.PLAYBACK
+                }
+            }
+        }
     }
 
     /** Must be called under [mutex]. */

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
@@ -532,8 +532,12 @@ class FingerprintTimingManager @Inject constructor(
             ),
         )
 
-        // Try loading cached reference from disk (only for downloaded episodes)
-        val cachedData = if (isDownloaded) referenceRetriever.loadReferenceData(audioSource) else null
+        // Try loading cached reference from disk
+        val cachedData = if (isDownloaded) {
+            referenceRetriever.loadReferenceData(audioSource)
+        } else {
+            referenceRetriever.loadCachedReference(episodeUuid)
+        }
         if (cachedData != null) {
             val reference = ReferenceFingerprint.decode(cachedData)
             if (reference != null) {
@@ -565,6 +569,8 @@ class FingerprintTimingManager @Inject constructor(
 
         if (isDownloaded) {
             referenceRetriever.saveReferenceData(referenceData, audioSource)
+        } else {
+            referenceRetriever.saveCachedReference(episodeUuid, referenceData)
         }
         configureForReference(gen, reference, referenceData, audioSource, episodeUuid)
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
@@ -661,10 +661,17 @@ class FingerprintTimingManager @Inject constructor(
             hasPendingRestart = pendingRestartJob?.isActive == true,
             hasStreamStarted = lastStreamStartTimeMs != 0L,
             msSinceStreamStart = SystemClock.elapsedRealtime() - lastStreamStartTimeMs,
+            isStreaming = currentIsStreaming,
         )
         lastProgressPositionMs = positionMs
         when (decision) {
             ProgressDecision.None -> Unit
+
+            ProgressDecision.CancelDecode -> {
+                Timber.d("FingerprintTimingManager: playback within mapped range — cancelling decode")
+                generationJob?.cancel()
+                generationJob = null
+            }
 
             ProgressDecision.ScheduleDebouncedRestart -> {
                 Timber.d("FingerprintTimingManager: playback jumped — scheduling restart")
@@ -1148,6 +1155,7 @@ class FingerprintTimingManager @Inject constructor(
 
     internal sealed interface ProgressDecision {
         data object None : ProgressDecision
+        data object CancelDecode : ProgressDecision
         data object ScheduleDebouncedRestart : ProgressDecision
         data object RestartOutsideRange : ProgressDecision
         data class RestartFromRunEnd(val runEndSec: Double) : ProgressDecision
@@ -1190,11 +1198,15 @@ class FingerprintTimingManager @Inject constructor(
             hasPendingRestart: Boolean,
             hasStreamStarted: Boolean,
             msSinceStreamStart: Long,
+            isStreaming: Boolean,
         ): ProgressDecision {
             if (isEager) return ProgressDecision.None
             val isJump = lastPositionSec != null && abs(positionSec - lastPositionSec) > FingerprintConstants.RESTART_DELTA_SECONDS
             if (isJump) {
-                if (mappedRunEndSec != null) return ProgressDecision.None
+                if (mappedRunEndSec != null) {
+                    val mappedFarAhead = mappedRunEndSec >= positionSec + FingerprintConstants.LOOKAHEAD_SECONDS
+                    return if (isStreaming && isDecodeActive && mappedFarAhead) ProgressDecision.CancelDecode else ProgressDecision.None
+                }
                 if (isCoveredByActiveDecode) return ProgressDecision.None
                 return ProgressDecision.ScheduleDebouncedRestart
             }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
@@ -946,7 +946,8 @@ class FingerprintTimingManager @Inject constructor(
                         // Eager passes decode as fast as possible; throttled passes stay near the playhead.
                         if (!currentEager) {
                             val lastKnownPositionMs = lastProgressPositionMs
-                            if (lastKnownPositionMs >= 0 && decodedSeconds - lastKnownPositionMs / 1000.0 > FingerprintConstants.LOOKAHEAD_SECONDS) {
+                            val playheadSec = if (lastKnownPositionMs >= 0) lastKnownPositionMs / 1000.0 else startOffset
+                            if (decodedSeconds - playheadSec > FingerprintConstants.LOOKAHEAD_SECONDS) {
                                 delay((FingerprintConstants.OUTSIDE_LOOKAHEAD_SLEEP_SECONDS * 1000).toLong())
                             }
                         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
@@ -6,11 +6,13 @@ import android.media.MediaExtractor
 import android.media.MediaFormat
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
+import android.net.Uri
 import android.os.SystemClock
 import androidx.annotation.VisibleForTesting
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.BuildConfig
+import au.com.shiftyjelly.pocketcasts.repositories.playback.ExoPlayerDataSourceFactory
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.ChapterManager
 import au.com.shiftyjelly.pocketcasts.utils.AppPlatform
@@ -61,6 +63,7 @@ class FingerprintTimingManager @Inject constructor(
     @ApplicationContext private val context: Context,
     private val chapterManager: Lazy<ChapterManager>,
     private val settings: Settings,
+    private val dataSourceFactory: Lazy<ExoPlayerDataSourceFactory>,
 ) {
 
     /** Who asked for preparation; decides whether streaming over a metered network is acceptable. */
@@ -157,6 +160,7 @@ class FingerprintTimingManager @Inject constructor(
     @Volatile
     private var currentEpisodeUuid: String? = null
     private var currentAudioFilePath: String? = null
+    private var currentSharedCacheKey: String? = null
     private var currentDurationSec: Double = 0.0
     private var currentReferenceData: ByteArray? = null
     private var currentReferenceFilePath: String? = null
@@ -203,6 +207,10 @@ class FingerprintTimingManager @Inject constructor(
         val podcastUuid = episode.podcastOrSubstituteUuid
         // Fingerprint the progressive enclosure, not the HLS rendition; timings may drift if the renditions differ.
         val audioSource = episode.downloadedFilePath ?: episode.downloadUrl
+        // Reuse the player's on-disk cache (same UUID key) instead of a second download when it applies.
+        val sharedCacheKey = episodeUuid.takeIf {
+            !episode.isDownloaded && !episode.isStreamUrlHls && settings.cacheEntirePlayingEpisode.value
+        }
 
         scope.launch {
             val gen: Long
@@ -221,7 +229,7 @@ class FingerprintTimingManager @Inject constructor(
             // Abort if a newer stop()/prepare() has started since we acquired the lock.
             if (gen != generation) return@launch
             startPlaybackProgressObserver(episodeUuid)
-            prepareForEpisode(gen, episodeUuid, podcastUuid, audioSource, episode.isDownloaded, episode.duration, trigger)
+            prepareForEpisode(gen, episodeUuid, podcastUuid, audioSource, sharedCacheKey, episode.isDownloaded, episode.duration, trigger)
         }
     }
 
@@ -440,6 +448,7 @@ class FingerprintTimingManager @Inject constructor(
         filterCandidatePool.clear()
         currentEpisodeUuid = null
         currentAudioFilePath = null
+        currentSharedCacheKey = null
         currentDurationSec = 0.0
         currentReferenceData = null
         currentReferenceFilePath = null
@@ -473,6 +482,7 @@ class FingerprintTimingManager @Inject constructor(
         episodeUuid: String,
         podcastUuid: String,
         audioSource: String?,
+        sharedCacheKey: String?,
         isDownloaded: Boolean,
         durationSec: Double,
         trigger: PrepareTrigger,
@@ -525,6 +535,7 @@ class FingerprintTimingManager @Inject constructor(
             currentEpisodeUuid = episodeUuid
             activeEpisodeUuid = episodeUuid
             currentAudioFilePath = audioSource
+            currentSharedCacheKey = sharedCacheKey
             currentDurationSec = durationSec
             currentIsStreaming = !isDownloaded
             currentEager = eager
@@ -800,11 +811,25 @@ class FingerprintTimingManager @Inject constructor(
             return
         }
 
+        val cacheKey = currentSharedCacheKey?.takeIf { isRemoteUrl }
         val extractor = MediaExtractor()
+        val cacheSource = if (cacheKey != null) {
+            val factory = dataSourceFactory.get()
+            CacheBackedMediaDataSource(factory.blockingCacheFactory, Uri.parse(audioFilePath), cacheKey) { position, length ->
+                factory.cachedLengthAt(cacheKey, position, length)
+            }
+        } else {
+            null
+        }
         try {
-            extractor.setDataSource(audioFilePath)
+            if (cacheSource != null) {
+                extractor.setDataSource(cacheSource)
+            } else {
+                extractor.setDataSource(audioFilePath)
+            }
         } catch (e: Exception) {
             extractor.release()
+            cacheSource?.close()
             Timber.w(e, "FingerprintTimingManager: failed to open audio file")
             if (gen != generation) return
             markFailed(e, stage = "audio_open")
@@ -817,6 +842,7 @@ class FingerprintTimingManager @Inject constructor(
         }
         if (audioTrackIndex == null) {
             extractor.release()
+            cacheSource?.close()
             Timber.w("FingerprintTimingManager: no audio track found")
             if (gen != generation) return
             markUnavailable(reason = "audio_unavailable", isStreaming = isRemoteUrl, episodeUuid = episodeUuid)
@@ -867,6 +893,7 @@ class FingerprintTimingManager @Inject constructor(
             runCatching { codec.stop() }
             codec.release()
             extractor.release()
+            cacheSource?.close()
         }
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
@@ -831,7 +831,7 @@ class FingerprintTimingManager @Inject constructor(
             )
 
             try {
-                decodeAndFingerprint(gen, extractor, codec, streamer, matcher, episodeUuid, startingAt, sampleRate, channelCount)
+                decodeAndFingerprint(gen, isRemoteUrl, extractor, codec, streamer, matcher, episodeUuid, startingAt, sampleRate, channelCount)
 
                 // Flush remaining windows
                 val tail = streamer.flush()
@@ -853,6 +853,7 @@ class FingerprintTimingManager @Inject constructor(
 
     private suspend fun decodeAndFingerprint(
         gen: Long,
+        isRemoteUrl: Boolean,
         extractor: MediaExtractor,
         codec: MediaCodec,
         streamer: StreamingWindowedFingerprinter,
@@ -865,6 +866,7 @@ class FingerprintTimingManager @Inject constructor(
         val bufferInfo = MediaCodec.BufferInfo()
         var inputDone = false
         val timeoutUs = FingerprintConstants.CODEC_TIMEOUT_US
+        var lastNetworkCheckMs = SystemClock.elapsedRealtime()
         // Default to 16-bit (safest assumption). Updated when the codec
         // reports its actual format via INFO_OUTPUT_FORMAT_CHANGED.
         var isOutputFloat = false
@@ -872,6 +874,16 @@ class FingerprintTimingManager @Inject constructor(
         while (true) {
             currentCoroutineContext().ensureActive()
             if (gen != generation) throw CancellationException("Fingerprint stream superseded")
+
+            val now = SystemClock.elapsedRealtime()
+            if (isRemoteUrl && now - lastNetworkCheckMs >= FingerprintConstants.METERED_RECHECK_INTERVAL_MS) {
+                lastNetworkCheckMs = now
+                val allowed = mutex.withLock { gen != generation || canStreamOnCurrentNetwork() }
+                if (!allowed) {
+                    Timber.d("FingerprintTimingManager: network no longer permits streaming — stopping fingerprint stream")
+                    throw CancellationException("Fingerprint stream stopped on metered network")
+                }
+            }
 
             // Feed input
             if (!inputDone) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import android.media.MediaCodec
 import android.media.MediaExtractor
 import android.media.MediaFormat
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
 import android.os.SystemClock
 import androidx.annotation.VisibleForTesting
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
@@ -137,6 +139,9 @@ class FingerprintTimingManager @Inject constructor(
     private var activeDecodeFrontierSec = 0.0
 
     @Volatile
+    private var unmeteredRetryCallback: ConnectivityManager.NetworkCallback? = null
+
+    @Volatile
     private var generation = 0L
 
     // Drift filter state
@@ -235,6 +240,48 @@ class FingerprintTimingManager @Inject constructor(
             }
         }
         Timber.d("FingerprintTimingManager: stopped")
+    }
+
+    /** Must be called under [mutex]. */
+    private fun registerUnmeteredRetry(episodeUuid: String) {
+        if (unmeteredRetryCallback != null) return
+        val callback = object : ConnectivityManager.NetworkCallback() {
+            override fun onCapabilitiesChanged(network: android.net.Network, networkCapabilities: NetworkCapabilities) {
+                if (!networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED)) return
+                if (!Network.isUnmeteredConnection(context)) return
+                if (playbackManager.getCurrentEpisode()?.uuid != episodeUuid) return
+                val self = this
+                scope.launch {
+                    val shouldRetry = mutex.withLock {
+                        if (unmeteredRetryCallback !== self) return@withLock false
+                        unregisterUnmeteredRetry()
+                        true
+                    }
+                    if (shouldRetry) {
+                        Timber.d("FingerprintTimingManager: unmetered network available — retrying preparation")
+                        prepareForCurrentEpisode(PrepareTrigger.PLAYBACK)
+                    }
+                }
+            }
+        }
+        unmeteredRetryCallback = callback
+        runCatching {
+            val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+            connectivityManager.registerDefaultNetworkCallback(callback)
+        }.onFailure {
+            unmeteredRetryCallback = null
+            Timber.w(it, "FingerprintTimingManager: failed to register network callback")
+        }
+    }
+
+    /** Must be called under [mutex]. */
+    private fun unregisterUnmeteredRetry() {
+        val callback = unmeteredRetryCallback ?: return
+        unmeteredRetryCallback = null
+        runCatching {
+            val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+            connectivityManager.unregisterNetworkCallback(callback)
+        }
     }
 
     private fun elapsedPreparationMs(): Long = if (preparationStartMs == 0L) 0L else SystemClock.elapsedRealtime() - preparationStartMs
@@ -359,6 +406,7 @@ class FingerprintTimingManager @Inject constructor(
         progressObserverJob = null
         pendingRestartJob?.cancel()
         pendingRestartJob = null
+        unregisterUnmeteredRetry()
         mappingPlaybackToReference.clear()
         mappingReferenceToPlayback.clear()
         debugRejections.clear()
@@ -438,6 +486,7 @@ class FingerprintTimingManager @Inject constructor(
             mutex.withLock {
                 if (gen != generation) return
                 markUnavailable(reason = "metered_network", isStreaming = true, episodeUuid = episodeUuid)
+                registerUnmeteredRetry(episodeUuid)
             }
             Timber.d("FingerprintTimingManager: skipping remote fingerprinting on metered network")
             return

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
@@ -483,6 +483,12 @@ class FingerprintTimingManager @Inject constructor(
             return
         }
 
+        if (Util.getAppPlatform(context) != AppPlatform.Phone) {
+            markUnavailable(reason = "unsupported_platform", isStreaming = !isDownloaded, episodeUuid = episodeUuid)
+            Timber.d("FingerprintTimingManager: unsupported platform")
+            return
+        }
+
         if (durationSec <= 0) {
             markUnavailable(reason = "invalid_duration", isStreaming = !isDownloaded, episodeUuid = episodeUuid)
             Timber.d("FingerprintTimingManager: invalid duration for $episodeUuid")

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
@@ -6,9 +6,9 @@ import android.media.MediaExtractor
 import android.media.MediaFormat
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
-import android.net.Uri
 import android.os.SystemClock
 import androidx.annotation.VisibleForTesting
+import androidx.core.net.toUri
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.BuildConfig
@@ -209,7 +209,7 @@ class FingerprintTimingManager @Inject constructor(
         val audioSource = episode.downloadedFilePath ?: episode.downloadUrl
         // Reuse the player's on-disk cache (same UUID key) instead of a second download when it applies.
         val sharedCacheKey = episodeUuid.takeIf {
-            !episode.isDownloaded && !episode.isStreamUrlHls && settings.cacheEntirePlayingEpisode.value
+            !episode.isDownloaded && !episode.isDownloading && !episode.isStreamUrlHls && settings.cacheEntirePlayingEpisode.value
         }
 
         scope.launch {
@@ -811,11 +811,12 @@ class FingerprintTimingManager @Inject constructor(
             return
         }
 
-        val cacheKey = currentSharedCacheKey?.takeIf { isRemoteUrl }
+        val factory = dataSourceFactory.get()
+        // Only follow the player's on-disk cache when it actually exists; otherwise read the URL directly.
+        val cacheKey = currentSharedCacheKey?.takeIf { isRemoteUrl && factory.isCacheAvailable }
         val extractor = MediaExtractor()
         val cacheSource = if (cacheKey != null) {
-            val factory = dataSourceFactory.get()
-            CacheBackedMediaDataSource(factory.blockingCacheFactory, Uri.parse(audioFilePath), cacheKey) { position, length ->
+            CacheBackedMediaDataSource(factory.blockingCacheFactory, audioFilePath.toUri(), cacheKey, isActive = { gen == generation }) { position, length ->
                 factory.cachedLengthAt(cacheKey, position, length)
             }
         } else {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ExoPlayerDataSourceFactory.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ExoPlayerDataSourceFactory.kt
@@ -66,6 +66,8 @@ class ExoPlayerDataSourceFactory @Inject constructor(
         .setFlags(CacheDataSource.FLAG_IGNORE_CACHE_ON_ERROR or CacheDataSource.FLAG_BLOCK_ON_CACHE)
         .let { if (cache != null) it.setCache(cache) else it }
 
+    val isCacheAvailable get() = cache != null
+
     fun cachedLengthAt(cacheKey: String, position: Long, length: Long): Long = cache?.getCachedLength(cacheKey, position, length) ?: -1L
 
     fun createMediaSource(

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ExoPlayerDataSourceFactory.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ExoPlayerDataSourceFactory.kt
@@ -61,6 +61,13 @@ class ExoPlayerDataSourceFactory @Inject constructor(
         .setFlags(CacheDataSource.FLAG_IGNORE_CACHE_ON_ERROR)
         .let { if (cache != null) it.setCache(cache) else it }
 
+    val blockingCacheFactory get() = CacheDataSource.Factory()
+        .setUpstreamDataSourceFactory(defaultFactory)
+        .setFlags(CacheDataSource.FLAG_IGNORE_CACHE_ON_ERROR or CacheDataSource.FLAG_BLOCK_ON_CACHE)
+        .let { if (cache != null) it.setCache(cache) else it }
+
+    fun cachedLengthAt(cacheKey: String, position: Long, length: Long): Long = cache?.getCachedLength(cacheKey, position, length) ?: -1L
+
     fun createMediaSource(
         episodeLocation: EpisodeLocation,
         clipRange: ClosedRange<Long>? = null,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/ChapterManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/ChapterManagerImpl.kt
@@ -11,6 +11,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.FingerprintTiming
 import au.com.shiftyjelly.pocketcasts.utils.AppPlatform
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import dagger.Lazy
 import javax.inject.Inject
 import kotlin.time.Duration
@@ -32,6 +33,8 @@ class ChapterManagerImpl @Inject constructor(
     private val appPlatform: AppPlatform,
     private val settings: Settings,
 ) : ChapterManager {
+    private var unalignedLogEpisodeUuid: String? = null
+
     override suspend fun updateChapters(
         episodeUuid: String,
         chapters: List<DbChapter>,
@@ -83,6 +86,10 @@ class ChapterManagerImpl @Inject constructor(
     private fun alignGeneratedChapters(episodeUuid: String, chapters: Chapters): Chapters {
         val manager = fingerprintTimingManager.get()
         if (manager.activeEpisodeUuid != episodeUuid || manager.mappingSnapshot.isEmpty()) {
+            if (chapters.hasGeneratedChapters && unalignedLogEpisodeUuid != episodeUuid) {
+                unalignedLogEpisodeUuid = episodeUuid
+                LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Generated chapters for $episodeUuid are unaligned: no fingerprint mapping available")
+            }
             return chapters
         }
         return alignGeneratedChapters(chapters) { reference ->

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/TranscriptWindowExtractor.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/TranscriptWindowExtractor.kt
@@ -61,7 +61,7 @@ class TranscriptWindowExtractor @Inject constructor(
         refNow()?.let { return it }
         if (playbackManager.get().getCurrentEpisode()?.uuid != episodeUuid) return timeSecs
 
-        manager.prepareForCurrentEpisode()
+        manager.prepareForCurrentEpisode(FingerprintTimingManager.PrepareTrigger.BOOKMARK)
         val ref = withTimeoutOrNull(COVERAGE_TIMEOUT) {
             merge(
                 manager.mappingVersion.map { refNow() }.filter { it != null },

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/DriftFilterTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/DriftFilterTest.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.repositories.fingerprint
 
 import android.content.Context
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.FingerprintTimingManager.TimeMappingEntry
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
@@ -31,6 +32,7 @@ class DriftFilterTest {
             eventHorizon = mock(EventHorizon::class.java),
             context = mock(Context::class.java),
             chapterManager = Lazy { mock(ChapterManager::class.java) },
+            settings = mock(Settings::class.java),
         )
         manager.debugTrackingEnabled = true
     }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/DriftFilterTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/DriftFilterTest.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.repositories.fingerprint
 import android.content.Context
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.FingerprintTimingManager.TimeMappingEntry
+import au.com.shiftyjelly.pocketcasts.repositories.playback.ExoPlayerDataSourceFactory
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.ChapterManager
@@ -33,6 +34,7 @@ class DriftFilterTest {
             context = mock(Context::class.java),
             chapterManager = Lazy { mock(ChapterManager::class.java) },
             settings = mock(Settings::class.java),
+            dataSourceFactory = Lazy { mock(ExoPlayerDataSourceFactory::class.java) },
         )
         manager.debugTrackingEnabled = true
     }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintReferenceRetrieverTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintReferenceRetrieverTest.kt
@@ -1,0 +1,55 @@
+package au.com.shiftyjelly.pocketcasts.repositories.fingerprint
+
+import android.content.Context
+import java.io.File
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.whenever
+
+class FingerprintReferenceRetrieverTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private lateinit var retriever: FingerprintReferenceRetriever
+
+    @Before
+    fun setUp() {
+        val context = mock(Context::class.java)
+        whenever(context.cacheDir).thenReturn(tempFolder.root)
+        retriever = FingerprintReferenceRetriever(OkHttpClient(), context)
+    }
+
+    @Test
+    fun `saveCachedReference then loadCachedReference round trips`() = runTest {
+        retriever.saveCachedReference("episode-1", byteArrayOf(1, 2, 3))
+
+        assertArrayEquals(byteArrayOf(1, 2, 3), retriever.loadCachedReference("episode-1"))
+    }
+
+    @Test
+    fun `loadCachedReference returns null when missing`() = runTest {
+        assertNull(retriever.loadCachedReference("episode-1"))
+    }
+
+    @Test
+    fun `saveCachedReference prunes oldest entries beyond cap`() = runTest {
+        val cacheDir = File(tempFolder.root, "episode_fingerprints")
+        for (i in 0 until 21) {
+            retriever.saveCachedReference("episode-$i", byteArrayOf(i.toByte()))
+            File(cacheDir, "episode-$i.ref.fp.json").setLastModified(1_000L * (i + 1))
+        }
+
+        retriever.saveCachedReference("episode-new", byteArrayOf(42))
+
+        assertNull(retriever.loadCachedReference("episode-0"))
+        assertArrayEquals(byteArrayOf(42), retriever.loadCachedReference("episode-new"))
+    }
+}

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManagerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManagerTest.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.repositories.fingerprint
 
+import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.FingerprintTimingManager.PrepareTrigger
 import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.FingerprintTimingManager.ProgressDecision
 import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.FingerprintTimingManager.TimeMappingEntry
 import org.junit.Assert.assertEquals
@@ -159,6 +160,87 @@ class FingerprintTimingManagerTest {
             },
         )
         assertFalse(queriedNetwork)
+    }
+
+    @Test
+    fun `shouldBlockRemoteFingerprinting never blocks downloaded episodes`() {
+        val blocked = FingerprintTimingManager.shouldBlockRemoteFingerprinting(
+            isDownloaded = true,
+            trigger = PrepareTrigger.PLAYBACK,
+            warnOnMeteredNetwork = true,
+            isUnmetered = { false },
+        )
+        assertFalse(blocked)
+    }
+
+    @Test
+    fun `shouldBlockRemoteFingerprinting does not query network for downloaded episodes`() {
+        var queriedNetwork = false
+        FingerprintTimingManager.shouldBlockRemoteFingerprinting(
+            isDownloaded = true,
+            trigger = PrepareTrigger.PLAYBACK,
+            warnOnMeteredNetwork = false,
+            isUnmetered = {
+                queriedNetwork = true
+                true
+            },
+        )
+        assertFalse(queriedNetwork)
+    }
+
+    @Test
+    fun `shouldBlockRemoteFingerprinting never blocks on unmetered network`() {
+        val blocked = FingerprintTimingManager.shouldBlockRemoteFingerprinting(
+            isDownloaded = false,
+            trigger = PrepareTrigger.PLAYBACK,
+            warnOnMeteredNetwork = true,
+            isUnmetered = { true },
+        )
+        assertFalse(blocked)
+    }
+
+    @Test
+    fun `shouldBlockRemoteFingerprinting blocks playback trigger on metered network`() {
+        val blocked = FingerprintTimingManager.shouldBlockRemoteFingerprinting(
+            isDownloaded = false,
+            trigger = PrepareTrigger.PLAYBACK,
+            warnOnMeteredNetwork = false,
+            isUnmetered = { false },
+        )
+        assertTrue(blocked)
+    }
+
+    @Test
+    fun `shouldBlockRemoteFingerprinting blocks bookmark trigger on metered network`() {
+        val blocked = FingerprintTimingManager.shouldBlockRemoteFingerprinting(
+            isDownloaded = false,
+            trigger = PrepareTrigger.BOOKMARK,
+            warnOnMeteredNetwork = false,
+            isUnmetered = { false },
+        )
+        assertTrue(blocked)
+    }
+
+    @Test
+    fun `shouldBlockRemoteFingerprinting allows transcript view on metered network`() {
+        val blocked = FingerprintTimingManager.shouldBlockRemoteFingerprinting(
+            isDownloaded = false,
+            trigger = PrepareTrigger.TRANSCRIPT_VIEW,
+            warnOnMeteredNetwork = false,
+            isUnmetered = { false },
+        )
+        assertFalse(blocked)
+    }
+
+    @Test
+    fun `shouldBlockRemoteFingerprinting blocks transcript view when user warns on data use`() {
+        val blocked = FingerprintTimingManager.shouldBlockRemoteFingerprinting(
+            isDownloaded = false,
+            trigger = PrepareTrigger.TRANSCRIPT_VIEW,
+            warnOnMeteredNetwork = true,
+            isUnmetered = { false },
+        )
+        assertTrue(blocked)
     }
 
     @Test

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManagerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManagerTest.kt
@@ -304,6 +304,18 @@ class FingerprintTimingManagerTest {
     }
 
     @Test
+    fun `decideOnProgress jump within run keeps decode when the run end is not far ahead`() {
+        val decision = decideOnProgress(
+            positionSec = 100.0,
+            lastPositionSec = 10.0,
+            mappedRunEndSec = 130.0,
+            isDecodeActive = true,
+            isStreaming = true,
+        )
+        assertEquals(ProgressDecision.None, decision)
+    }
+
+    @Test
     fun `decideOnProgress jump outside mapped range schedules debounced restart`() {
         val decision = decideOnProgress(positionSec = 100.0, lastPositionSec = 10.0)
         assertEquals(ProgressDecision.ScheduleDebouncedRestart, decision)

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManagerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManagerTest.kt
@@ -268,6 +268,42 @@ class FingerprintTimingManagerTest {
     }
 
     @Test
+    fun `decideOnProgress jump within run cancels decode when streaming and mapped far ahead`() {
+        val decision = decideOnProgress(
+            positionSec = 100.0,
+            lastPositionSec = 10.0,
+            mappedRunEndSec = 200.0,
+            isDecodeActive = true,
+            isStreaming = true,
+        )
+        assertEquals(ProgressDecision.CancelDecode, decision)
+    }
+
+    @Test
+    fun `decideOnProgress jump within run keeps decode for local files`() {
+        val decision = decideOnProgress(
+            positionSec = 100.0,
+            lastPositionSec = 10.0,
+            mappedRunEndSec = 200.0,
+            isDecodeActive = true,
+            isStreaming = false,
+        )
+        assertEquals(ProgressDecision.None, decision)
+    }
+
+    @Test
+    fun `decideOnProgress jump within run without active decode does not cancel`() {
+        val decision = decideOnProgress(
+            positionSec = 100.0,
+            lastPositionSec = 10.0,
+            mappedRunEndSec = 200.0,
+            isDecodeActive = false,
+            isStreaming = true,
+        )
+        assertEquals(ProgressDecision.None, decision)
+    }
+
+    @Test
     fun `decideOnProgress jump outside mapped range schedules debounced restart`() {
         val decision = decideOnProgress(positionSec = 100.0, lastPositionSec = 10.0)
         assertEquals(ProgressDecision.ScheduleDebouncedRestart, decision)
@@ -417,6 +453,7 @@ class FingerprintTimingManagerTest {
             mappedRunEndSec = 130.0,
             isDecodeActive = true,
             isRunEndCoveredByActiveDecode = false,
+            isStreaming = true,
         )
         assertEquals(ProgressDecision.RestartFromRunEnd(130.0), decision)
     }
@@ -533,6 +570,7 @@ class FingerprintTimingManagerTest {
         hasPendingRestart: Boolean = false,
         hasStreamStarted: Boolean = hasAnyMapping || isDecodeActive,
         msSinceStreamStart: Long = FingerprintConstants.STREAM_BOOTSTRAP_COOLDOWN_MS,
+        isStreaming: Boolean = false,
     ): ProgressDecision = FingerprintTimingManager.decideOnProgress(
         positionSec = positionSec,
         lastPositionSec = lastPositionSec,
@@ -546,6 +584,7 @@ class FingerprintTimingManagerTest {
         hasPendingRestart = hasPendingRestart,
         hasStreamStarted = hasStreamStarted,
         msSinceStreamStart = msSinceStreamStart,
+        isStreaming = isStreaming,
     )
 
     @Test

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/TranscriptWindowExtractorTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/TranscriptWindowExtractorTest.kt
@@ -102,7 +102,7 @@ class TranscriptWindowExtractorTest {
             referenceSecs = 25.0
             mappingVersion.value++
             null
-        }.whenever(fingerprintTimingManager).prepareForCurrentEpisode()
+        }.whenever(fingerprintTimingManager).prepareForCurrentEpisode(FingerprintTimingManager.PrepareTrigger.BOOKMARK)
 
         val result = extractor(sampleVtt).extractWindow("episode-id", timeSecs = 5, windowSecs = 15)
 
@@ -127,7 +127,7 @@ class TranscriptWindowExtractorTest {
             referenceSecs = 25.0
             mappingVersion.value++
             null
-        }.whenever(fingerprintTimingManager).prepareForCurrentEpisode()
+        }.whenever(fingerprintTimingManager).prepareForCurrentEpisode(FingerprintTimingManager.PrepareTrigger.BOOKMARK)
 
         val result = extractor(sampleVtt).extractWindow("episode-id", timeSecs = 5, windowSecs = 15)
 


### PR DESCRIPTION
## Description
  Fingerprinting a streamed episode decodes the enclosure as a second full download. This PR makes that spend deliberate on metered networks:

  - Preparation now carries a trigger (`PLAYBACK` / `TRANSCRIPT_VIEW` / `BOOKMARK`). On metered data, streamed episodes only fingerprint when the user is looking at the transcript and hasn't enabled "warn about data usage"; otherwise preparation ends `Unavailable(metered_network)` and a `NetworkCallback` retries automatically once an unmetered network appears.
  - That consent expires when the transcript is dismissed and is re-elevated whenever the transcript surface re-enters composition. Without this, a rotation would leave consent downgraded while the user keeps reading.
  - A running remote decode re-checks the network every 5 s and stops itself on a Wi-Fi→cellular handoff; restart paths re-evaluate the policy per attempt, so the handoff also stops future restarts.
  - A seek landing well inside the mapped range cancels a running streaming decode instead of letting it keep pulling enclosure bytes it no longer needs.
  - Before the first playback-progress tick (e.g. preparing while paused) the decode throttles against its own start position, so it can no longer free-run through the whole enclosure.
  - Reference fingerprints for streamed episodes are cached in `cacheDir` (LRU, 20 entries), so re-preparing an episode doesn't re-download them.
  - Fingerprinting is now phone-only, and ChapterManager logs once per episode when generated chapters run unaligned without a mapping their auto-skip boundaries may be offset by dynamically inserted ads.
  

  ## Testing Instructions
  1. Enable `SYNCED_TRANSCRIPTS`, mark the Wi-Fi network as metered (or use cellular), and stream an episode without opening the transcript: no fingerprint enclosure download should start.
  2. Open the transcript,  fingerprinting should start (with "warn about data usage" off) or stay unavailable (with it on).
  3. Close the transcript, seek around, no fingerprint stream restarts on metered data.
  4. Rotate the device while reading the transcript,  sync should survive the rotation.
  5. Start a decode on Wi-Fi, then switch to cellular mid-stream, the decode should stop within ~5 s; switch back to Wi-Fi and it should recover.
  6. Stream the same episode twice,  the second preparation should reuse the cached reference (no reference re-download).


  ## Checklist
  - [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
  - [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
  - [x] I have considered whether it makes sense to add tests for my changes
  - [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
  - [ ] Any jetpack compose components I added or changed are covered by compose previews
  - [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed
  analytics.