### PR TITLE
Fix widget update crash on devices without app widget support

### DIFF
--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/PlayerWidgetManager.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/PlayerWidgetManager.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.widget
 
+import android.appwidget.AppWidgetManager
 import android.content.Context
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.GlanceAppWidgetManager
@@ -27,7 +28,7 @@ class PlayerWidgetManager @Inject constructor(
     private val widgetManager = GlanceAppWidgetManager(context)
     private val updateMutex = Mutex()
 
-    suspend fun updateQueue(queue: List<BaseEpisode>) = updateMutex.withLock {
+    suspend fun updateQueue(queue: List<BaseEpisode>) = updateWidgets {
         val episodes = queue.map(PlayerWidgetEpisode::fromBaseEpisode)
         updateSmallWidgets { state -> state.copy(episode = episodes.firstOrNull()) }
         updateMediumWidgets { state -> state.copy(episode = episodes.firstOrNull()) }
@@ -35,7 +36,7 @@ class PlayerWidgetManager @Inject constructor(
         updateClassicWidgets { state -> state.copy(episode = episodes.firstOrNull()) }
     }
 
-    suspend fun updateIsPlaying(isPlaying: Boolean) = updateMutex.withLock {
+    suspend fun updateIsPlaying(isPlaying: Boolean) = updateWidgets {
         updateSmallWidgets { state -> state.copy(isPlaying = isPlaying) }
         updateMediumWidgets { state -> state.copy(isPlaying = isPlaying) }
         updateLargeWidgets { state -> state.copy(isPlaying = isPlaying) }
@@ -44,7 +45,7 @@ class PlayerWidgetManager @Inject constructor(
 
     suspend fun updateUseEpisodeArtwork(
         useEpisodeArtwork: Boolean,
-    ) = updateMutex.withLock {
+    ) = updateWidgets {
         updateSmallWidgets { state -> state.copy(useEpisodeArtwork = useEpisodeArtwork) }
         updateMediumWidgets { state -> state.copy(useEpisodeArtwork = useEpisodeArtwork) }
         updateLargeWidgets { state -> state.copy(useEpisodeArtwork = useEpisodeArtwork) }
@@ -53,19 +54,27 @@ class PlayerWidgetManager @Inject constructor(
 
     suspend fun updateUseDynamicColors(
         useDynamicColors: Boolean,
-    ) = updateMutex.withLock {
+    ) = updateWidgets {
         updateSmallWidgets { state -> state.copy(useDynamicColors = useDynamicColors) }
         updateMediumWidgets { state -> state.copy(useDynamicColors = useDynamicColors) }
         updateLargeWidgets { state -> state.copy(useDynamicColors = useDynamicColors) }
         updateClassicWidgets { state -> state.copy(useDynamicColors = useDynamicColors) }
     }
 
-    suspend fun updateSkipBackwardDuration(seconds: Int) = updateMutex.withLock {
+    suspend fun updateSkipBackwardDuration(seconds: Int) = updateWidgets {
         updateClassicWidgets { state -> state.copy(skipBackwardSeconds = seconds) }
     }
 
-    suspend fun updateSkipForwardDuration(seconds: Int) = updateMutex.withLock {
+    suspend fun updateSkipForwardDuration(seconds: Int) = updateWidgets {
         updateClassicWidgets { state -> state.copy(skipForwardSeconds = seconds) }
+    }
+
+    private suspend fun updateWidgets(update: suspend () -> Unit) {
+        // AppWidgetManager is null on devices without app widget support, Glance crashes with an NPE in that case
+        if (AppWidgetManager.getInstance(context) == null) {
+            return
+        }
+        updateMutex.withLock { update() }
     }
 
     private suspend fun updateSmallWidgets(


### PR DESCRIPTION
## Description

Fixes a `NullPointerException` thrown from Glance when the app updates its player widgets on devices that do not support app widgets:

```
java.lang.NullPointerException: Attempt to invoke virtual method 'java.util.List android.appwidget.AppWidgetManager.getInstalledProviders()' on a null object reference
    at androidx.glance.appwidget.GlanceAppWidgetManager.addAllReceiversAndProvidersToPreferences(GlanceAppWidgetManager.kt:272)
```

While running tests locally, I came across this exception. I’ve also seen it reported in Sentry before, so I thought it would be worth fixing while I was here.

## Testing Instructions
1. Run the app on a regular device, add the small, medium, large, and classic player widgets to the home screen.
2. Play an episode, then pause it, and confirm the widgets update as before (artwork, play state, queue).
3. Change the skip forward/backward durations in Settings > General and confirm the classic widget reflects them.
4. To verify the crash guard, run the app on a device or profile without app widget support (or mock `AppWidgetManager.getInstance` to return null) and confirm playback no longer crashes the app.

## Screenshots or Screencast 
Not applicable, no UI changes.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
 