### PR TITLE
Move hide generated chapters changelog entry into 8.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@
         ([#5544](https://github.com/Automattic/pocket-casts-android/pull/5544))
     *   Stats Heatmap
         ([#5536](https://github.com/Automattic/pocket-casts-android/pull/5536))
-    *   Add settings to hide generated chapters
-        ([#5564](https://github.com/Automattic/pocket-casts-android/pull/5564))
 *   Bug Fixes
     *   Reduce the chance of episode playback progress reverting during listening history sync
         ([#5552](https://github.com/Automattic/pocket-casts-android/pull/5552))
@@ -18,6 +16,8 @@
 *   New Features
     *   Up Next sort by duration
         ([#5399](https://github.com/Automattic/pocket-casts-android/pull/5399))
+    *   Add settings to hide generated chapters
+        ([#5564](https://github.com/Automattic/pocket-casts-android/pull/5564))
 *   Bug Fixes
     *   Fix leaked network connections when refreshing episode details
         ([#5546](https://github.com/Automattic/pocket-casts-android/pull/5546))


### PR DESCRIPTION
## Description
Moves the CHANGELOG.md entry for "Add settings to hide generated chapters" ([#5564](https://github.com/Automattic/pocket-casts-android/pull/5564)) from the 8.17 section into the 8.16 section, since that change ships in the 8.16 release. This keeps the changelog accurate about which release includes the feature.

Fixes # N/A (changelog correction only)

## Testing Instructions
1. Open `CHANGELOG.md`.
2. Confirm the "Add settings to hide generated chapters" entry is listed under 8.16, not 8.17.
3. Confirm no other entries were changed.

## Screenshots or Screencast
Not applicable, changelog-only change.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack

🤖 Generated with [Claude Code](https://claude.com/claude-code)