### PR TITLE
Homogenize milestone error handling across the release lanes

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -400,10 +400,10 @@ platform :android do
         api_token: ENV.fetch('GITHUB_TOKEN')
       )
 
-      buildkite_annotate(context: 'translations-pr-url', message: "Translations PR: #{pr_url || 'Error creating PR'}") if is_ci?
+      buildkite_annotate(context: 'translations-pr-url', message: "Translations PR: #{pr_url || 'Error creating PR'}") if is_ci
     else
       UI.important('No translations were downloaded, so no PR was created')
-      buildkite_annotate(context: 'translations-pr-url', message: 'No translations were downloaded, so no PR was created') if is_ci?
+      buildkite_annotate(context: 'translations-pr-url', message: 'No translations were downloaded, so no PR was created') if is_ci
       Fastlane::Helper::GitHelper.checkout_and_pull(base_branch)
       Fastlane::Helper::GitHelper.delete_local_branch_if_exists!(pr_branch)
     end
@@ -508,7 +508,7 @@ platform :android do
         RELEASE_VERSION: release_version_current
       }
     }
-    if is_ci?
+    if is_ci
       buildkite_pipeline_upload(**pipeline_args)
     else
       buildkite_trigger_build(
@@ -990,6 +990,6 @@ platform :android do
     MESSAGE
 
     UI.error(error_message)
-    buildkite_annotate(style: 'warning', context: 'error-with-milestone', message: error_message) if is_ci?
+    buildkite_annotate(style: 'warning', context: 'error-with-milestone', message: error_message) if is_ci
   end
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -449,7 +449,7 @@ platform :android do
       set_milestone_frozen_marker(repository: GITHUB_REPO, milestone: version, freeze: false)
       close_milestone(repository: GITHUB_REPO, milestone: version)
     rescue StandardError => e
-      report_milestone_error(error_title: "Error closing the milestone `#{version}`: #{e.message}")
+      report_milestone_error(error_title: "Error unfreezing or closing the milestone `#{version}`: #{e.message}")
     end
 
     push_to_git_remote(tags: false)
@@ -982,7 +982,7 @@ platform :android do
   # Reports a milestone-related error, both in the logs and — on CI — as a Buildkite annotation,
   # clarifying that the error is expected when the release task is not being run for the first time.
   def report_milestone_error(error_title:)
-    error_message = <<-MESSAGE
+    error_message = <<~MESSAGE
       #{error_title}
 
       - If this is not the first time you are running the release task (e.g. retrying because it failed on first attempt), the milestone might have already been closed and this error is expected.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -449,8 +449,20 @@ platform :android do
     version = release_version_current
 
     # Wrap up
-    set_milestone_frozen_marker(repository: GITHUB_REPO, milestone: version, freeze: false)
-    close_milestone(repository: GITHUB_REPO, milestone: version)
+    begin
+      set_milestone_frozen_marker(repository: GITHUB_REPO, milestone: version, freeze: false)
+      close_milestone(repository: GITHUB_REPO, milestone: version)
+    rescue StandardError => e
+      error_message = <<-MESSAGE
+        Error closing milestone `#{version}`: #{e.message}
+
+        - If this is not the first time you are running the release task (e.g. retrying because it failed on first attempt), the milestone might have already been closed and this error is expected.
+        - Otherwise if this is the first you are running the release task for this version, please investigate the error.
+      MESSAGE
+
+      UI.error(error_message)
+      buildkite_annotate(style: 'warning', context: 'error-with-milestone', message: error_message) if is_ci?
+    end
 
     push_to_git_remote(tags: false)
     trigger_release_build(branch_to_build: "release/#{version}")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -181,11 +181,7 @@ platform :android do
         milestone: new_version
       )
     rescue StandardError => e
-      UI.error <<~MESSAGE
-        Error moving PRs to next milestone or freezing the current `#{new_version}` milestone: #{e.message}.
-        Please manually check that the PRs which were targeting milestone `#{new_version}` have been moved to the next one
-        and that the milestone `#{new_version}` that just entered code-freeze had the "❄️" marker added to its title.
-      MESSAGE
+      report_milestone_error(error_title: "Error moving PRs to the next milestone or freezing the `#{new_version}` milestone: #{e.message}")
     end
   end
 
@@ -330,7 +326,7 @@ platform :android do
     begin
       close_milestone(repository: GITHUB_REPO, milestone: release_version_current)
     rescue StandardError => e
-      UI.important("Could not find a GitHub milestone for hotfix #{release_version_current} to close: #{e}")
+      report_milestone_error(error_title: "Error closing the milestone `#{release_version_current}` for the hotfix: #{e.message}")
     end
   end
 
@@ -453,15 +449,7 @@ platform :android do
       set_milestone_frozen_marker(repository: GITHUB_REPO, milestone: version, freeze: false)
       close_milestone(repository: GITHUB_REPO, milestone: version)
     rescue StandardError => e
-      error_message = <<-MESSAGE
-        Error closing milestone `#{version}`: #{e.message}
-
-        - If this is not the first time you are running the release task (e.g. retrying because it failed on first attempt), the milestone might have already been closed and this error is expected.
-        - Otherwise if this is the first you are running the release task for this version, please investigate the error.
-      MESSAGE
-
-      UI.error(error_message)
-      buildkite_annotate(style: 'warning', context: 'error-with-milestone', message: error_message) if is_ci?
+      report_milestone_error(error_title: "Error closing the milestone `#{version}`: #{e.message}")
     end
 
     push_to_git_remote(tags: false)
@@ -989,5 +977,19 @@ platform :android do
     buildkite_annotate(style: 'error', context: 'error-checking-branch', message: error_message) if is_ci
 
     UI.user_error!(error_message)
+  end
+
+  # Reports a milestone-related error, both in the logs and — on CI — as a Buildkite annotation,
+  # clarifying that the error is expected when the release task is not being run for the first time.
+  def report_milestone_error(error_title:)
+    error_message = <<-MESSAGE
+      #{error_title}
+
+      - If this is not the first time you are running the release task (e.g. retrying because it failed on first attempt), the milestone might have already been closed and this error is expected.
+      - Otherwise if this is the first you are running the release task for this version, please investigate the error.
+    MESSAGE
+
+    UI.error(error_message)
+    buildkite_annotate(style: 'warning', context: 'error-with-milestone', message: error_message) if is_ci?
   end
 end


### PR DESCRIPTION
Closes AINFRA-2707

- 🧵 Thread in Slack: p1784280315812929/1784270734.514819-slack-CC7L49W13
- 🔗 Companion PR in pocket-casts-ios: https://github.com/Automattic/pocket-casts-ios/pull/4778

## Why?

Milestone manipulation across the release lanes was handled inconsistently:
 - `finalize_release` called `set_milestone_frozen_marker` + `close_milestone` with no error handling at all, so re-running the lane (when the milestone is already closed or missing) would crash it
 - `finalize_hotfix_release` only logged via `UI.important`; and `code_freeze` only logged via `UI.error` without a Buildkite annotation.

This PR makes all of them behave the same way.

## How?

It extracts a `report_milestone_error(error_title:)` helper — mirroring the convention already used in the repos for our other apps — which logs a descriptive warning and, on CI, adds a `warning` Buildkite annotation explaining that the error is expected on a re-run.

Every milestone rescue path (`code_freeze`, `finalize_release`, and `finalize_hotfix_release`) now routes through that helper, and the previously-missing `begin/rescue` around `finalize_release` is added.

Note: I also took the occasion to standardize our use of `is_ci?` to `is_ci` (both the one with or without `?` are valid methods in fastlane and alias to one another, so the idea was just to be consistent across our `Fastfile`)

## Testing Instructions

This only affects release automation, so it can't be exercised from a normal build. To sanity-check the behavior, on a release branch run `bundle exec fastlane finalize_release` (or `finalize_hotfix_release`) a second time, or against a version whose milestone is already closed, and confirm the lane now logs the "Error closing the milestone" warning (plus a `warning` Buildkite annotation on CI) and completes instead of aborting.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md (Not user-facing — release automation only.)
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting) (Ruby `Fastfile` change; `ruby -c` passes and the `Fastfile` is excluded from the RuboCop length cops.)
- [x] I have considered whether it makes sense to add tests for my changes (Fastlane lanes; not unit-testable in this repo.)
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml` (N/A)
- [x] Any jetpack compose components I added or changed are covered by compose previews (N/A)
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics. (No analytics changes.)