### PR TITLE
Remove dead and vestigial RxJava usages

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/CreateAccountViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/CreateAccountViewModel.kt
@@ -14,7 +14,6 @@ import com.automattic.eventhorizon.EventHorizon
 import com.automattic.eventhorizon.NewsletterOptInChangedEvent
 import com.automattic.eventhorizon.NewsletterSourceType
 import dagger.hilt.android.lifecycle.HiltViewModel
-import io.reactivex.disposables.CompositeDisposable
 import javax.inject.Inject
 import kotlinx.coroutines.launch
 
@@ -33,7 +32,6 @@ class CreateAccountViewModel
     val newsletter = MutableLiveData<Boolean>().apply { postValue(false) }
 
     val createAccountState = MutableLiveData<CreateAccountState>().apply { value = CreateAccountState.CurrentlyValid }
-    private val disposables = CompositeDisposable()
     var defaultSubscriptionType = SubscriptionType.FREE
 
     companion object {
@@ -153,11 +151,6 @@ class CreateAccountViewModel
 
     fun onCloseDoneForm() {
         eventHorizon.track(AccountUpdatedDismissedEvent)
-    }
-
-    override fun onCleared() {
-        super.onCleared()
-        disposables.clear()
     }
 }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/EpisodeListAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/EpisodeListAdapter.kt
@@ -24,7 +24,6 @@ import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectEpisodesHelpe
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectEpisodesHelper.Companion.MULTI_SELECT_TOGGLE_PAYLOAD
 import au.com.shiftyjelly.pocketcasts.views.swipe.SwipeAction
 import au.com.shiftyjelly.pocketcasts.views.swipe.SwipeRowActions
-import io.reactivex.disposables.CompositeDisposable
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
 val PLAYBACK_DIFF: DiffUtil.ItemCallback<BaseEpisode> = object : DiffUtil.ItemCallback<BaseEpisode>() {
@@ -53,7 +52,6 @@ class EpisodeListAdapter(
     private val multiSelectHelper: MultiSelectEpisodesHelper,
     private val fragmentManager: FragmentManager,
 ) : ListAdapter<BaseEpisode, RecyclerView.ViewHolder>(PLAYBACK_DIFF) {
-    val disposables = CompositeDisposable()
 
     init {
         setHasStableIds(true)
@@ -177,11 +175,6 @@ class EpisodeListAdapter(
             streamByDefault = settings.streamingMode.value,
             animateMultiSelection = animateMultiSelection,
         )
-    }
-
-    override fun onDetachedFromRecyclerView(recyclerView: RecyclerView) {
-        super.onDetachedFromRecyclerView(recyclerView)
-        disposables.clear()
     }
 
     override fun onViewRecycled(holder: RecyclerView.ViewHolder) {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -67,7 +67,6 @@ import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectEpisodesHelpe
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectEpisodesHelper.Companion.MULTI_SELECT_TOGGLE_PAYLOAD
 import au.com.shiftyjelly.pocketcasts.views.swipe.SwipeAction
 import au.com.shiftyjelly.pocketcasts.views.swipe.SwipeRowActions
-import io.reactivex.disposables.CompositeDisposable
 import java.util.Date
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -231,7 +230,6 @@ class PodcastAdapter(
         val VIEW_TYPE_DIVIDER_TITLE = R.layout.adapter_divider_row
     }
 
-    private val disposables = CompositeDisposable()
     private var podcast: Podcast = Podcast()
     private var podcastDescription = AnnotatedString("")
 
@@ -376,11 +374,6 @@ class PodcastAdapter(
             is EpisodeViewHolder -> bindEpisodeViewHolder(holder, position, animateMultiSelection = MULTI_SELECT_TOGGLE_PAYLOAD in payloads)
             else -> super.onBindViewHolder(holder, position, payloads)
         }
-    }
-
-    override fun onDetachedFromRecyclerView(recyclerView: RecyclerView) {
-        super.onDetachedFromRecyclerView(recyclerView)
-        disposables.clear()
     }
 
     private fun bindingEpisodeHeaderViewHolder(holder: EpisodeHeaderViewHolder, position: Int) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/StatsManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/StatsManager.kt
@@ -2,7 +2,6 @@ package au.com.shiftyjelly.pocketcasts.repositories.user
 
 import au.com.shiftyjelly.pocketcasts.models.to.StatsBundle
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import io.reactivex.Single
 
 interface StatsManager {
     val timeSavedVariableSpeed: Long
@@ -37,7 +36,6 @@ interface StatsManager {
     fun reset()
     fun isSynced(settings: Settings): Boolean
     fun setSyncStatus(isSynced: Boolean)
-    fun getServerStatsRx(): Single<StatsBundle>
     suspend fun getServerStats(): StatsBundle
     fun mergeStats(statsOne: Map<String, Long>?, statsTwo: Map<String, Long>?): Map<String, Long>
     suspend fun cacheMergedStats()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/StatsManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/StatsManagerImpl.kt
@@ -3,10 +3,7 @@ package au.com.shiftyjelly.pocketcasts.repositories.user
 import au.com.shiftyjelly.pocketcasts.models.to.StatsBundle
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
-import io.reactivex.Single
 import javax.inject.Inject
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.rx2.rxSingle
 import timber.log.Timber
 
 class StatsManagerImpl @Inject constructor(
@@ -208,10 +205,6 @@ class StatsManagerImpl @Inject constructor(
 
     override fun setSyncStatus(isSynced: Boolean) {
         settings.setBooleanForKey(SYNC_STATUS, isSynced)
-    }
-
-    override fun getServerStatsRx(): Single<StatsBundle> {
-        return rxSingle(Dispatchers.IO) { getServerStats() }
     }
 
     override suspend fun getServerStats(): StatsBundle {


### PR DESCRIPTION
## Description

First step toward removing RxJava from the codebase. This PR contains **pure deletions with no behaviour change**, dead and vestigial RxJava usages that already have coroutine equivalents or were never actually wired up:

- **`StatsManager` / `StatsManagerImpl`** — deleted the unused `getServerStatsRx(): Single<StatsBundle>`. It had zero callers and the `suspend fun getServerStats()` twin already covers it. Also removed the now-unused `Single` / `rxSingle` / `Dispatchers` imports.
- **`CreateAccountViewModel`** — removed a vestigial `CompositeDisposable` (it was declared and cleared in `onCleared()` but nothing was ever subscribed to it) and the resulting empty `onCleared()` override.
- **`EpisodeListAdapter` / `PodcastAdapter`** — removed vestigial `CompositeDisposable` fields (no subscribers, no external users) and their now-redundant `onDetachedFromRecyclerView` overrides.

The `io.reactivex` import is now gone entirely from both adapters and the account view model.

This is intentionally a small, zero-risk starting point for a larger RxJava → Coroutines/Flow migration; the higher-ripple manager/interface conversions will follow in separate PRs.

## Testing Instructions

No behaviour change, so nothing to exercise manually. 

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md <!-- n/a: not user-facing -->
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes <!-- pure removal of unused code; no new tests warranted -->
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml` <!-- n/a: no strings -->
- [x] Any jetpack compose components I added or changed are covered by compose previews <!-- n/a: no compose changes -->
- [x] I have updated (or requested that someone edit) the Event Horizon schema to reflect any new or changed analytics. <!-- n/a: no analytics changes -->

