### PR TITLE
Fix podcast episode row button not switching to play when connected to Chromecast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
         ([#5550](https://github.com/Automattic/pocket-casts-android/pull/5550))
     *   Fix Automotive crash when using Google Assistant voice commands to control playback
         ([#5551](https://github.com/Automattic/pocket-casts-android/pull/5551))
+    *   Fix podcast episode row button not switching to play when connected to Chromecast
+        ([#5604](https://github.com/Automattic/pocket-casts-android/pull/5604))
 
 8.16
 -----

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -417,7 +417,7 @@ class PodcastAdapter(
             isMultiSelectEnabled = multiSelectEpisodesHelper.isMultiSelecting,
             isSelected = multiSelectEpisodesHelper.isSelected(episode),
             useEpisodeArtwork = settings.artworkConfiguration.value.useEpisodeArtwork(Element.Podcasts),
-            streamByDefault = settings.streamingMode.value,
+            streamByDefault = settings.streamingMode.value || castConnected,
             tint = tintColor,
             animateMultiSelection = animateMultiSelection,
         )

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
@@ -6,6 +6,7 @@ import androidx.annotation.StringRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.asLiveData
 import androidx.lifecycle.toLiveData
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
@@ -132,9 +133,7 @@ class PodcastViewModel @Inject constructor(
 
     val tintColor = MutableLiveData<Int>()
 
-    val castConnected = castManager.isConnectedObservable
-        .toFlowable(BackpressureStrategy.LATEST)
-        .toLiveData()
+    val castConnected = castManager.isConnectedFlow.asLiveData()
 
     override val coroutineContext: CoroutineContext
         get() = Dispatchers.Default

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/chromecast/CastManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/chromecast/CastManager.kt
@@ -1,10 +1,10 @@
 package au.com.shiftyjelly.pocketcasts.repositories.chromecast
 
-import io.reactivex.Observable
+import kotlinx.coroutines.flow.StateFlow
 
 interface CastManager {
 
-    val isConnectedObservable: Observable<Boolean>
+    val isConnectedFlow: StateFlow<Boolean>
 
     suspend fun isAvailable(): Boolean
     suspend fun isConnected(): Boolean

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/chromecast/CastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/chromecast/CastManagerImpl.kt
@@ -12,10 +12,12 @@ import com.google.android.gms.cast.framework.SessionManager
 import com.google.android.gms.cast.framework.SessionManagerListener
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
-import com.jakewharton.rxrelay2.BehaviorRelay
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 
@@ -27,7 +29,8 @@ class CastManagerImpl @Inject constructor(
     private val sessionManagerListener = CastSessionManagerListener()
     private var sessionListener: CastManager.SessionListener? = null
 
-    override val isConnectedObservable = BehaviorRelay.create<Boolean>().apply { accept(false) }
+    private val _isConnectedFlow = MutableStateFlow(false)
+    override val isConnectedFlow: StateFlow<Boolean> = _isConnectedFlow.asStateFlow()
 
     init {
         try {
@@ -116,7 +119,7 @@ class CastManagerImpl @Inject constructor(
             Timber.i("Cast Session onSessionStarted")
             eventHorizon.track(ChromecastStartedCastingEvent)
             sessionListener?.sessionStarted()
-            isConnectedObservable.accept(true)
+            _isConnectedFlow.value = true
         }
 
         override fun onSessionStartFailed(session: Session, i: Int) {
@@ -132,7 +135,7 @@ class CastManagerImpl @Inject constructor(
             Timber.i("Cast Session onSessionEnded")
             eventHorizon.track(ChromecastStoppedCastingEvent)
             sessionListener?.sessionEnded()
-            isConnectedObservable.accept(false)
+            _isConnectedFlow.value = false
         }
 
         override fun onSessionResuming(session: Session, s: String) {
@@ -142,7 +145,7 @@ class CastManagerImpl @Inject constructor(
         override fun onSessionResumed(session: Session, b: Boolean) {
             Timber.i("Cast Session onSessionResumed $sessionListener")
             sessionListener?.sessionReconnected()
-            isConnectedObservable.accept(true)
+            _isConnectedFlow.value = true
         }
 
         override fun onSessionResumeFailed(session: Session, i: Int) {
@@ -152,7 +155,7 @@ class CastManagerImpl @Inject constructor(
 
         override fun onSessionSuspended(session: Session, i: Int) {
             Timber.i("Cast Session onSessionSuspended")
-            isConnectedObservable.accept(false)
+            _isConnectedFlow.value = false
         }
     }
 }


### PR DESCRIPTION
## Description

When the user has Settings -> Row action set to Download, the button on podcast episode rows shows a download action. While connected to Chromecast, downloading is not the sensible default (playback happens on the cast device), so the button is supposed to switch to a play (stream) button for the duration of the cast session.

This stopped working: it is a regression from #4500, which consolidated the podcast episode UI. That refactor removed the read of `PodcastAdapter.castConnected` when computing `streamByDefault` for episode rows, leaving the whole cast-connected chain (ViewModel LiveData -> Fragment observer -> adapter property) writing a value nothing consumed. This PR restores `streamByDefault = settings.streamingMode.value || castConnected` at the bind site.

It also migrates `CastManager`'s connection state from an RxJava `BehaviorRelay`/`Observable` to a Kotlin `StateFlow`, in line with the codebase's move away from RxJava.

## Testing Instructions

1. In Pocket Casts, go to Profile -> Settings -> General and set Row action to Download.
2. Open a podcast page and confirm episode rows show a download button.
3. Connect to a Chromecast device.
4. Confirm the episode row buttons switch to a play button while the cast session is active.
5. Disconnect from Chromecast and confirm the buttons revert to download.

## Screencast 

https://github.com/user-attachments/assets/1446f7fe-5390-4631-b8dd-48d76afc6765

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
 