### PR TITLE
Migrate colors CDN endpoint off RxJava

### DIFF
--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
@@ -59,7 +59,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.categories.CategoriesManager
 import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory
 import au.com.shiftyjelly.pocketcasts.repositories.images.loadInto
 import au.com.shiftyjelly.pocketcasts.servers.cdn.ArtworkColors
-import au.com.shiftyjelly.pocketcasts.servers.cdn.StaticServiceManagerImpl
+import au.com.shiftyjelly.pocketcasts.servers.cdn.StaticServiceManager
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverEpisode
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverPodcast
@@ -125,7 +125,7 @@ internal data class RemainingPodcastsByCategoryRow(val listId: String?, val cate
 internal data class CategoryAdRow(val categoryId: Int, val categoryName: String, val region: String?, val discoverRow: DiscoverRow)
 internal class DiscoverAdapter(
     val context: Context,
-    val staticServiceManager: StaticServiceManagerImpl,
+    val staticServiceManager: StaticServiceManager,
     val listener: Listener,
     val theme: Theme,
     loadPodcastList: (String, Boolean?) -> Flowable<PodcastList>,

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
@@ -22,7 +22,7 @@ import au.com.shiftyjelly.pocketcasts.podcasts.view.podcast.PodcastFragment
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.categories.CategoriesManager
 import au.com.shiftyjelly.pocketcasts.search.SearchFragment
-import au.com.shiftyjelly.pocketcasts.servers.cdn.StaticServiceManagerImpl
+import au.com.shiftyjelly.pocketcasts.servers.cdn.StaticServiceManager
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverEpisode
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverPodcast
@@ -55,7 +55,7 @@ class DiscoverFragment :
 
     @Inject lateinit var settings: Settings
 
-    @Inject lateinit var staticServiceManager: StaticServiceManagerImpl
+    @Inject lateinit var staticServiceManager: StaticServiceManager
 
     @Inject lateinit var eventHorizon: EventHorizon
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/colors/ColorManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/colors/ColorManager.kt
@@ -3,7 +3,7 @@ package au.com.shiftyjelly.pocketcasts.repositories.colors
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.servers.cdn.ArtworkColors
-import au.com.shiftyjelly.pocketcasts.servers.cdn.StaticServiceManagerImpl
+import au.com.shiftyjelly.pocketcasts.servers.cdn.StaticServiceManager
 import au.com.shiftyjelly.pocketcasts.utils.Optional
 import io.reactivex.Single
 import javax.inject.Inject
@@ -13,25 +13,13 @@ import timber.log.Timber
 
 @Singleton
 class ColorManager @Inject constructor(
-    private val staticServiceManager: StaticServiceManagerImpl,
+    private val staticServiceManager: StaticServiceManager,
     private val podcastManager: PodcastManager,
 ) {
 
     companion object {
-        const val DEFAULT_BACKGROUND_COLOR = 0xFF3D3D3D.toInt()
-
         // the amount of time to leave between color refresh attempts. This is quite low (30 min) because we write out defaults for shows that are missing artwork, so this should always be present
         private const val MIN_TIME_BETWEEN_REFRESH_ATTEMPTS = (30 * 60 * 1000).toLong()
-
-        fun getBackgroundColor(podcast: Podcast?): Int = colorOrDefault(podcast?.backgroundColor, DEFAULT_BACKGROUND_COLOR)
-
-        private fun colorOrDefault(color: Int?, defaultColor: Int): Int {
-            return if (color == null || color == 0) {
-                defaultColor
-            } else {
-                color
-            }
-        }
     }
 
     fun downloadColors(podcastUuid: String): Single<Optional<ArtworkColors>> {

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/cdn/StaticService.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/cdn/StaticService.kt
@@ -1,13 +1,9 @@
 package au.com.shiftyjelly.pocketcasts.servers.cdn
 
-import io.reactivex.Maybe
 import retrofit2.http.GET
 import retrofit2.http.Path
 
 interface StaticService {
-
-    @GET("/discover/images/metadata/{podcastUuid}.json")
-    fun getColorsMaybe(@Path("podcastUuid") podcastUuid: String): Maybe<ColorsResponse>
 
     @GET("/discover/images/metadata/{podcastUuid}.json")
     suspend fun getColors(@Path("podcastUuid") podcastUuid: String): ColorsResponse?

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/cdn/StaticServiceManagerImpl.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/cdn/StaticServiceManagerImpl.kt
@@ -4,13 +4,14 @@ import au.com.shiftyjelly.pocketcasts.models.entity.BlazeAd
 import au.com.shiftyjelly.pocketcasts.utils.Optional
 import io.reactivex.Single
 import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.rx2.rxSingle
 
 class StaticServiceManagerImpl @Inject constructor(
     private val service: StaticService,
 ) : StaticServiceManager {
     override fun getColorsSingle(podcastUuid: String): Single<Optional<ArtworkColors>> {
-        return rxSingle { Optional.of(getColors(podcastUuid)) }
+        return rxSingle(Dispatchers.IO) { Optional.of(getColors(podcastUuid)) }
     }
 
     override suspend fun getColors(podcastUuid: String): ArtworkColors? {

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/cdn/StaticServiceManagerImpl.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/cdn/StaticServiceManagerImpl.kt
@@ -4,18 +4,13 @@ import au.com.shiftyjelly.pocketcasts.models.entity.BlazeAd
 import au.com.shiftyjelly.pocketcasts.utils.Optional
 import io.reactivex.Single
 import javax.inject.Inject
+import kotlinx.coroutines.rx2.rxSingle
 
 class StaticServiceManagerImpl @Inject constructor(
     private val service: StaticService,
 ) : StaticServiceManager {
     override fun getColorsSingle(podcastUuid: String): Single<Optional<ArtworkColors>> {
-        return service.getColorsMaybe(podcastUuid)
-            // convert response to artwork colors
-            .map(ColorsResponse::toArtworkColors)
-            // convert to optional so we can handle if the value is missing
-            .map { Optional.of(it) }
-            .defaultIfEmpty(Optional.empty())
-            .toSingle()
+        return rxSingle { Optional.of(getColors(podcastUuid)) }
     }
 
     override suspend fun getColors(podcastUuid: String): ArtworkColors? {


### PR DESCRIPTION
## Description

Migrates the artwork colors CDN endpoint (`StaticServiceManager`) off RxJava as part of the ongoing effort to remove RxJava from the codebase.

- `StaticServiceManagerImpl.getColorsSingle()` now delegates to the existing `suspend getColors()` via `rxSingle(Dispatchers.IO)` instead of chaining `Maybe`/`Single` operators. This keeps the RxJava-facing API for callers that still need it while the underlying network call is coroutine-based.
- Removes the now-unused `StaticService.getColorsMaybe()` RxJava endpoint; the `suspend getColors()` variant is the single source.
- Updates `ColorManager` and `DiscoverAdapter`/`DiscoverFragment` to depend on the `StaticServiceManager` interface rather than the concrete `StaticServiceManagerImpl`.
- Cleans up dead code in `ColorManager`: removes the unused `DEFAULT_BACKGROUND_COLOR`, `getBackgroundColor()`, and `colorOrDefault()` helpers.

## Testing Instructions

1. Build and run the app (`./gradlew :app:installDebugProd`).
2. Open the Discover tab and browse podcast lists so artwork/colors are fetched from the CDN.
3. Open a podcast that has no cached colors yet and confirm its accent/background colors load correctly.
4. Confirm no regressions in artwork color rendering across the app.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
