### PR TITLE
Migrate SleepFragment and FolderDao off RxJava

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/SleepFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/SleepFragment.kt
@@ -9,6 +9,7 @@ import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Observer
+import androidx.lifecycle.lifecycleScope
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.components.NumberStepper
 import au.com.shiftyjelly.pocketcasts.compose.extensions.setContentWithViewCompositionStrategy
@@ -33,16 +34,14 @@ import com.automattic.eventhorizon.PlayerSleepTimerSettingsTappedEvent
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import dagger.hilt.android.AndroidEntryPoint
-import io.reactivex.Observable
-import io.reactivex.android.schedulers.AndroidSchedulers
-import io.reactivex.disposables.Disposable
-import io.reactivex.rxkotlin.subscribeBy
-import io.reactivex.schedulers.Schedulers
-import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
-import timber.log.Timber
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.views.R as VR
 
@@ -56,7 +55,7 @@ class SleepFragment : BaseDialogFragment() {
 
     private val viewModel: PlayerViewModel by activityViewModels()
     private var binding: FragmentSleepBinding? = null
-    private var disposable: Disposable? = null
+    private var timerJob: Job? = null
 
     private val args get() = requireArguments().requireParcelable<Args>(NEW_INSTANCE_ARG)
 
@@ -64,19 +63,18 @@ class SleepFragment : BaseDialogFragment() {
         super.onResume()
 
         // refresh the sleep time every second
-        disposable = Observable.interval(0, 1, TimeUnit.SECONDS)
-            .subscribeOn(Schedulers.io())
-            .observeOn(AndroidSchedulers.mainThread())
-            .subscribeBy(
-                onError = { Timber.e(it) },
-                onNext = { viewModel.updateSleepTimer() },
-            )
+        timerJob = viewLifecycleOwner.lifecycleScope.launch {
+            while (isActive) {
+                viewModel.updateSleepTimer()
+                delay(1.seconds)
+            }
+        }
     }
 
     override fun onPause() {
         super.onPause()
 
-        disposable?.dispose()
+        timerJob?.cancel()
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/FolderDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/FolderDao.kt
@@ -10,7 +10,6 @@ import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
 import au.com.shiftyjelly.pocketcasts.models.entity.Folder
 import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
 import au.com.shiftyjelly.pocketcasts.utils.extensions.unidecode
-import io.reactivex.Flowable
 import io.reactivex.Single
 import kotlinx.coroutines.flow.Flow
 
@@ -31,9 +30,6 @@ abstract class FolderDao {
 
     @Query("SELECT * FROM folders WHERE uuid = :uuid")
     abstract suspend fun findByUuid(uuid: String): Folder?
-
-    @Query("SELECT * FROM folders WHERE uuid = :uuid")
-    abstract fun findByUuidRxFlowable(uuid: String): Flowable<List<Folder>>
 
     @Query("SELECT * FROM folders WHERE uuid = :uuid")
     abstract fun findByUuidFlow(uuid: String): Flow<List<Folder>>


### PR DESCRIPTION
## Description

Continues the incremental removal of RxJava in favour of Coroutines/Flow.

- **SleepFragment countdown ticker**: replaces the `Observable.interval(0, 1, TimeUnit.SECONDS)` one-second ticker with a `viewLifecycleOwner.lifecycleScope` coroutine that calls `viewModel.updateSleepTimer()` and `delay(1.seconds)` in a loop. The job is cancelled in `onPause`, matching the previous `disposable.dispose()` lifecycle point. `SleepFragment` no longer references RxJava.
- **FolderDao**: removes the dead `findByUuidRxFlowable` query. It had no remaining callers; `findByUuidFlow` (the Coroutines/Flow equivalent) is already used instead.

No behaviour change: the sleep timer still refreshes once per second while the dialog is resumed.

## Testing Instructions

1. Start playing an episode.
2. Open the player and tap the sleep timer.
3. Set a sleep timer (e.g. 5 minutes) so the countdown is running.
4. Re-open the sleep timer sheet and confirm the remaining time counts down once per second.
5. Dismiss and re-open the sheet a few times and confirm the countdown continues to update correctly and does not leak or double-tick.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
