### PR TITLE
Guard enum type converters against out-of-range DB values

### DIFF
--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/converter/EpisodePlayingStatusConverter.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/converter/EpisodePlayingStatusConverter.kt
@@ -7,7 +7,7 @@ class EpisodePlayingStatusConverter {
 
     @TypeConverter
     fun toEpisodePlayingStatus(value: Int?): EpisodePlayingStatus? {
-        return if (value == null) null else EpisodePlayingStatus.entries[value]
+        return if (value == null) null else EpisodePlayingStatus.entries.getOrNull(value) ?: EpisodePlayingStatus.NOT_PLAYED
     }
 
     @TypeConverter

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/converter/PodcastLicensingEnumConverter.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/converter/PodcastLicensingEnumConverter.kt
@@ -7,7 +7,7 @@ class PodcastLicensingEnumConverter {
 
     @TypeConverter
     fun toLicensing(value: Int?): Podcast.Licensing? {
-        return if (value == null) null else Podcast.Licensing.values()[value]
+        return if (value == null) null else Podcast.Licensing.entries.getOrNull(value) ?: Podcast.Licensing.KEEP_EPISODES
     }
 
     @TypeConverter

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/converter/SyncStatusConverter.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/converter/SyncStatusConverter.kt
@@ -7,7 +7,7 @@ class SyncStatusConverter {
 
     @TypeConverter
     fun toSyncStatus(value: Int?): SyncStatus? {
-        return if (value == null) null else SyncStatus.values()[value]
+        return if (value == null) null else SyncStatus.entries.getOrNull(value) ?: SyncStatus.NOT_SYNCED
     }
 
     @TypeConverter

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/converter/UserEpisodeServerStatusConverter.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/converter/UserEpisodeServerStatusConverter.kt
@@ -6,7 +6,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.UserEpisodeServerStatus
 class UserEpisodeServerStatusConverter {
     @TypeConverter
     fun toUserEpisodeServerStatus(value: Int?): UserEpisodeServerStatus? {
-        return if (value == null) null else UserEpisodeServerStatus.values()[value]
+        return if (value == null) null else UserEpisodeServerStatus.entries.getOrNull(value) ?: UserEpisodeServerStatus.LOCAL
     }
 
     @TypeConverter


### PR DESCRIPTION
## Description

Room enum `TypeConverter`s read enum constants by index directly from the stored `Int` with no bounds check (`EnumType.values()[value]` / `entries[value]`). Because several of these columns are populated from server data (e.g. `licensing`, `server_status`, `sync_status`), a value outside the enum's declared range, from a newly introduced server-side type, forward-compat data, or corruption, throws `ArrayIndexOutOfBoundsException`. Once such a value lands in a row, every subsequent read of that row crashes.

This guards the four affected converters using the same safe pattern already used by `EpisodesSortTypeConverter` / `TrimModeTypeConverter`: `entries.getOrNull(value)` falling back to a sensible default rather than throwing.

Changed converters and their fallbacks:
- `PodcastLicensingEnumConverter` -> `Podcast.Licensing.KEEP_EPISODES`
- `SyncStatusConverter` -> `SyncStatus.NOT_SYNCED`
- `UserEpisodeServerStatusConverter` -> `UserEpisodeServerStatus.LOCAL`
- `EpisodePlayingStatusConverter` -> `EpisodePlayingStatus.NOT_PLAYED`

Fixes https://linear.app/a8c/issue/PCDROID-664/model-02-enum-type-converters-crash-on-out-of-range-unknown-db-values

## Testing Instructions

This is a defensive data-layer change with no UI surface; verify via the model unit tests and reasoning about the read path.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
