### PR TITLE
Add rewind after interruptions setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 8.17
 -----
 *   New Features
+    *   Add an optional "Rewind after interruptions" setting that jumps back a little when playback resumes after calls, alarms, navigation and other audio
+        ([#5611](https://github.com/Automattic/pocket-casts-android/pull/5611))
     *   Add support for Flightcast transcripts
         ([#5544](https://github.com/Automattic/pocket-casts-android/pull/5544))
     *   Stats Heatmap

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
@@ -338,6 +338,20 @@ class PlaybackSettingsFragment : BaseFragment() {
                             )
                         }
 
+                        SettingsItems.SETTINGS_INTERRUPTION_REWIND -> {
+                            if (FeatureFlag.isEnabled(Feature.INTERRUPTION_REWIND)) {
+                                InterruptionRewind(
+                                    saved = settings.interruptionRewindSeconds.flow.collectAsState().value,
+                                    onSave = { seconds ->
+                                        // TODO: track a SettingsGeneralInterruptionRewindChangedEvent once it is
+                                        // available in the Event Horizon library, it can't be added from this repo
+                                        // updateModifiedAt is false because this setting is device-local, not synced
+                                        settings.interruptionRewindSeconds.set(seconds, updateModifiedAt = false)
+                                    },
+                                )
+                            }
+                        }
+
                         SettingsItems.SETTINGS_PLAY_UP_NEXT_EPISODE -> {
                             PlayUpNextOnTap(
                                 saved = settings.tapOnUpNextShouldPlay.flow.collectAsState().value,
@@ -596,6 +610,30 @@ class PlaybackSettingsFragment : BaseFragment() {
     )
 
     @Composable
+    private fun InterruptionRewind(
+        saved: Int,
+        onSave: (Int) -> Unit,
+    ) = SettingRadioDialogRow(
+        primaryText = stringResource(LR.string.settings_interruption_rewind),
+        secondaryText = if (saved > 0) {
+            stringResource(LR.string.settings_interruption_rewind_summary, saved)
+        } else {
+            stringResource(LR.string.settings_interruption_rewind_summary_off)
+        },
+        options = listOf(0, 5, 10, 15, 30, 60),
+        savedOption = saved,
+        optionToLocalisedString = { seconds ->
+            if (seconds > 0) {
+                getString(LR.string.seconds_plural, seconds)
+            } else {
+                getString(LR.string.off)
+            }
+        },
+        onSave = onSave,
+        indent = false,
+    )
+
+    @Composable
     private fun PlayUpNextOnTap(saved: Boolean, onSave: (Boolean) -> Unit) = SettingRow(
         primaryText = stringResource(LR.string.settings_up_next_tap),
         secondaryText = stringResource(LR.string.settings_up_next_tap_summary),
@@ -704,6 +742,7 @@ private enum class SettingsItems {
     SETTINGS_OPEN_PLAYER_AUTOMATICALLY,
     SETTINGS_GENERATED_CHAPTERS,
     SETTINGS_INTELLIGENT_PLAYBACK,
+    SETTINGS_INTERRUPTION_REWIND,
     SETTINGS_PLAY_UP_NEXT_EPISODE,
     SETTINGS_ADJUST_REMAINING_TIME,
     SETTINGS_GENERAL_AUTOPLAY,

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1601,6 +1601,9 @@
     <string name="settings_other_media_actions">Other media actions</string>
     <string name="settings_playback_resumption">Intelligent playback resumption</string>
     <string name="settings_playback_resumption_summary">If on, Pocket Casts will go back a little in episodes you resume so you can catch up more comfortably.</string>
+    <string name="settings_interruption_rewind">Rewind after interruptions</string>
+    <string name="settings_interruption_rewind_summary">Go back %1$d seconds when playback is interrupted by calls, alarms, navigation and other audio.</string>
+    <string name="settings_interruption_rewind_summary_off">Don\'t go back when playback is interrupted by calls, alarms, navigation and other audio.</string>
     <string name="settings_podcast_artwork">Podcast Artwork</string>
     <string name="settings_podcast_custom">Custom for this podcast</string>
     <string name="settings_podcast_episode_grouping">Podcast episode grouping</string>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -99,6 +99,8 @@ interface Settings {
         const val PREFERENCE_CHAPTERS_EXPANDED = "chaptersExpanded"
         const val PREFERENCE_UPNEXT_EXPANDED = "upnextExpanded"
         const val INTELLIGENT_PLAYBACK_RESUMPTION = "intelligentPlaybackResumption"
+        const val INTERRUPTION_REWIND_SECONDS = "interruptionRewindSeconds"
+        const val DEFAULT_INTERRUPTION_REWIND_SECONDS = 5
         const val UP_NEXT_BADGE_MAX_COUNT = 999
 
         const val STORAGE_ON_CUSTOM_FOLDER = "custom_folder"
@@ -510,7 +512,15 @@ interface Settings {
     fun getLastPausedUUID(): String?
     fun setLastPausedAt(pausedAt: Int)
     fun getLastPausedAt(): Int?
+    fun setLastPauseWasInterruption(wasInterruption: Boolean)
+    fun getLastPauseWasInterruption(): Boolean
     val intelligentPlaybackResumption: UserSetting<Boolean>
+
+    /**
+     * How many seconds to rewind when playback resumes after an audio interruption, 0 means off.
+     * Stored on device only, not synced.
+     */
+    val interruptionRewindSeconds: UserSetting<Int>
     val autoAddUpNextLimit: UserSetting<Int>
     val autoAddUpNextLimitBehaviour: UserSetting<AutoAddUpNextLimitBehaviour>
     fun getMaxUpNextEpisodes(): Int

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -949,9 +949,23 @@ class SettingsImpl @Inject constructor(
         return if (lastPausedAt != 0) lastPausedAt else null
     }
 
+    override fun setLastPauseWasInterruption(wasInterruption: Boolean) {
+        setBoolean("last_pause_was_interruption", wasInterruption)
+    }
+
+    override fun getLastPauseWasInterruption(): Boolean {
+        return getBoolean("last_pause_was_interruption", defaultValue = false)
+    }
+
     override val intelligentPlaybackResumption = UserSetting.BoolPref(
         sharedPrefKey = Settings.INTELLIGENT_PLAYBACK_RESUMPTION,
         defaultValue = true,
+        sharedPrefs = sharedPreferences,
+    )
+
+    override val interruptionRewindSeconds = UserSetting.IntPref(
+        sharedPrefKey = Settings.INTERRUPTION_REWIND_SECONDS,
+        defaultValue = Settings.DEFAULT_INTERRUPTION_REWIND_SECONDS,
         sharedPrefs = sharedPreferences,
     )
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -226,6 +226,7 @@ open class PlaybackManager @Inject constructor(
     private var resettingPlayer = false
     private var episodeLastBufferStatus: EpisodeBufferStatus? = null
     private var focusWasPlaying: Date? = null
+    private var pauseDueToInterruption = false
     private var forcePlayerSwitch = false
     private var updateTimerDisposable: Disposable? = null
     private var bufferUpdateTimerDisposable: Disposable? = null
@@ -892,13 +893,25 @@ open class PlaybackManager @Inject constructor(
         }
     }
 
-    fun pause(transientLoss: Boolean = false, sourceView: SourceView = SourceView.UNKNOWN) {
+    fun pause(
+        transientLoss: Boolean = false,
+        sourceView: SourceView = SourceView.UNKNOWN,
+        dueToInterruption: Boolean = false,
+    ) {
         launch {
-            pauseSuspend(transientLoss, sourceView)
+            pauseSuspend(transientLoss, sourceView, dueToInterruption)
         }
     }
 
-    suspend fun pauseSuspend(transientLoss: Boolean = false, sourceView: SourceView = SourceView.UNKNOWN) {
+    suspend fun pauseSuspend(
+        transientLoss: Boolean = false,
+        sourceView: SourceView = SourceView.UNKNOWN,
+        dueToInterruption: Boolean = false,
+    ) {
+        // remembered until the player reports the pause so onPlayerPaused can tell the
+        // resumption helper whether this pause came from an audio interruption
+        pauseDueToInterruption = dueToInterruption
+
         if (!transientLoss) {
             focusManager.giveUpAudioFocus()
             playbackStateRelay.blockingFirst().let { playbackState ->
@@ -1525,13 +1538,18 @@ open class PlaybackManager @Inject constructor(
 
         val episode = getCurrentEpisode()
 
+        // consume the interruption marker so pauses that reach this callback without going
+        // through pauseSuspend (sleep timer, cast receiver, error paths) can't reuse a stale value
+        val dueToInterruption = pauseDueToInterruption
+        pauseDueToInterruption = false
+
         player?.let {
             val positionMs = it.getCurrentPositionMs()
             if (positionMs > 0) {
                 updateCurrentPositionInDatabase()
 
                 episode?.let { episode ->
-                    resumptionHelper.paused(episode, positionMs)
+                    resumptionHelper.paused(episode, positionMs, dueToInterruption = dueToInterruption)
                 }
             }
         }
@@ -1868,7 +1886,7 @@ open class PlaybackManager @Inject constructor(
             LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Focus lost while playing")
             focusWasPlaying = Date()
 
-            pause(transientLoss = transientLoss, sourceView = SourceView.AUTO_PAUSE)
+            pause(transientLoss = transientLoss, sourceView = SourceView.AUTO_PAUSE, dueToInterruption = true)
         } else {
             LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Focus lost not playing")
             focusWasPlaying = null

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ResumptionHelper.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ResumptionHelper.kt
@@ -2,6 +2,8 @@ package au.com.shiftyjelly.pocketcasts.repositories.playback
 
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.hours
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.utils.minutes
@@ -13,44 +15,71 @@ class ResumptionHelper(val settings: Settings) {
     private var lastPauseTime: Date? = settings.getLastPauseTime()
 
     fun adjustedStartTimeMsFor(episode: BaseEpisode): Int {
-        if (!settings.intelligentPlaybackResumption.value ||
-            settings.getLastPausedUUID() != episode.uuid ||
+        if (settings.getLastPausedUUID() != episode.uuid ||
             (settings.getLastPausedAt() ?: 0) != episode.playedUpToMs
         ) {
             return episode.playedUpToMs
         }
 
-        val lastPauseTime = this.lastPauseTime ?: return episode.playedUpToMs
-
-        val adjustedTime = when {
-            lastPauseTime.timeIntervalSinceNow() > 24.hours() -> {
-                LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "More than 24 hours since this episode was paused, jumping back 30 seconds")
-                episode.playedUpToMs - 30.seconds()
-            }
-
-            lastPauseTime.timeIntervalSinceNow() > 1.hours() -> {
-                LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "More than 1 hour since this episode was paused, jumping back 15 seconds")
-                episode.playedUpToMs - 15.seconds()
-            }
-
-            lastPauseTime.timeIntervalSinceNow() > 5.minutes() -> {
-                LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "More than 5 minutes since this episode was paused, jumping back 10 seconds")
-                episode.playedUpToMs - 10.seconds()
-            }
-
-            else -> {
-                LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Not enough time passed since this episode was last paused, no time adjustment required")
-                episode.playedUpToMs.toLong()
-            }
+        // the pause length rewind and the interruption rewind can both apply to the same resume,
+        // take the larger of the two rather than stacking them
+        val rewindMs = maxOf(pauseLengthRewindMs(), interruptionRewindMs())
+        if (rewindMs <= 0) {
+            return episode.playedUpToMs
         }
 
-        return adjustedTime.toInt().coerceAtLeast(0)
+        return (episode.playedUpToMs - rewindMs).toInt().coerceAtLeast(0)
     }
 
-    fun paused(episode: BaseEpisode, atPlayedUpToMs: Int) {
+    fun paused(episode: BaseEpisode, atPlayedUpToMs: Int, dueToInterruption: Boolean = false) {
         lastPauseTime = Date()
         settings.setLastPauseTime(Date())
         settings.setLastPausedUUID(episode.uuid)
         settings.setLastPausedAt(atPlayedUpToMs)
+        settings.setLastPauseWasInterruption(dueToInterruption)
+    }
+
+    private fun pauseLengthRewindMs(): Long {
+        if (!settings.intelligentPlaybackResumption.value) {
+            return 0
+        }
+
+        val lastPauseTime = this.lastPauseTime ?: return 0
+
+        return when {
+            lastPauseTime.timeIntervalSinceNow() > 24.hours() -> {
+                LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "More than 24 hours since this episode was paused, jumping back 30 seconds")
+                30.seconds()
+            }
+
+            lastPauseTime.timeIntervalSinceNow() > 1.hours() -> {
+                LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "More than 1 hour since this episode was paused, jumping back 15 seconds")
+                15.seconds()
+            }
+
+            lastPauseTime.timeIntervalSinceNow() > 5.minutes() -> {
+                LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "More than 5 minutes since this episode was paused, jumping back 10 seconds")
+                10.seconds()
+            }
+
+            else -> {
+                LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Not enough time passed since this episode was last paused, no time adjustment required")
+                0
+            }
+        }
+    }
+
+    private fun interruptionRewindMs(): Long {
+        if (!FeatureFlag.isEnabled(Feature.INTERRUPTION_REWIND) || !settings.getLastPauseWasInterruption()) {
+            return 0
+        }
+
+        val rewindSeconds = settings.interruptionRewindSeconds.value
+        if (rewindSeconds <= 0) {
+            return 0
+        }
+
+        LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Playback was interrupted, jumping back $rewindSeconds seconds")
+        return rewindSeconds.seconds()
     }
 }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3SessionCallbackTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3SessionCallbackTest.kt
@@ -356,6 +356,7 @@ class Media3SessionCallbackTest {
         verify(playbackManager).pauseSuspend(
             transientLoss = any(),
             sourceView = any(),
+            dueToInterruption = any(),
         )
     }
 

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ResumptionHelperTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ResumptionHelperTest.kt
@@ -1,0 +1,206 @@
+package au.com.shiftyjelly.pocketcasts.repositories.playback
+
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
+import au.com.shiftyjelly.pocketcasts.sharedtest.InMemoryFeatureFlagRule
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
+import au.com.shiftyjelly.pocketcasts.utils.hours
+import au.com.shiftyjelly.pocketcasts.utils.minutes
+import java.util.Date
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+class ResumptionHelperTest {
+
+    @get:Rule
+    val featureFlagRule = InMemoryFeatureFlagRule()
+
+    @Before
+    fun setUp() {
+        FeatureFlag.setEnabled(Feature.INTERRUPTION_REWIND, true)
+    }
+
+    private fun episode(playedUpToMs: Int = PLAYED_UP_TO_MS, uuid: String = EPISODE_UUID) = PodcastEpisode(
+        uuid = uuid,
+        podcastUuid = "podcast-uuid",
+        publishedDate = Date(),
+    ).apply {
+        this.playedUpToMs = playedUpToMs
+    }
+
+    private fun settingsMock(
+        lastPausedUuid: String? = EPISODE_UUID,
+        lastPausedAtMs: Int? = PLAYED_UP_TO_MS,
+        wasInterruption: Boolean = false,
+        lastPauseTime: Date? = Date(),
+        isIntelligentResumptionEnabled: Boolean = true,
+        rewindSeconds: Int = 5,
+    ): Settings {
+        val intelligentResumptionSetting = mock<UserSetting<Boolean>> {
+            on { value } doReturn isIntelligentResumptionEnabled
+        }
+        val interruptionRewindSetting = mock<UserSetting<Int>> {
+            on { value } doReturn rewindSeconds
+        }
+        return mock {
+            on { getLastPausedUUID() } doReturn lastPausedUuid
+            on { getLastPausedAt() } doReturn lastPausedAtMs
+            on { getLastPauseWasInterruption() } doReturn wasInterruption
+            on { getLastPauseTime() } doReturn lastPauseTime
+            on { intelligentPlaybackResumption } doReturn intelligentResumptionSetting
+            on { interruptionRewindSeconds } doReturn interruptionRewindSetting
+        }
+    }
+
+    @Test
+    fun `interruption rewind applies when the last pause was an interruption`() {
+        val settings = settingsMock(wasInterruption = true, rewindSeconds = 30)
+        val helper = ResumptionHelper(settings)
+
+        assertEquals(PLAYED_UP_TO_MS - 30_000, helper.adjustedStartTimeMsFor(episode()))
+    }
+
+    @Test
+    fun `interruption rewind does not apply to a regular pause`() {
+        val settings = settingsMock(wasInterruption = false, rewindSeconds = 30)
+        val helper = ResumptionHelper(settings)
+
+        assertEquals(PLAYED_UP_TO_MS, helper.adjustedStartTimeMsFor(episode()))
+    }
+
+    @Test
+    fun `interruption rewind does not apply when turned off`() {
+        val settings = settingsMock(wasInterruption = true, rewindSeconds = 0)
+        val helper = ResumptionHelper(settings)
+
+        assertEquals(PLAYED_UP_TO_MS, helper.adjustedStartTimeMsFor(episode()))
+    }
+
+    @Test
+    fun `interruption rewind does not apply when the feature flag is disabled`() {
+        FeatureFlag.setEnabled(Feature.INTERRUPTION_REWIND, false)
+        val settings = settingsMock(wasInterruption = true, rewindSeconds = 30)
+        val helper = ResumptionHelper(settings)
+
+        assertEquals(PLAYED_UP_TO_MS, helper.adjustedStartTimeMsFor(episode()))
+    }
+
+    @Test
+    fun `interruption rewind applies when intelligent playback resumption is off`() {
+        val settings = settingsMock(
+            wasInterruption = true,
+            rewindSeconds = 30,
+            isIntelligentResumptionEnabled = false,
+        )
+        val helper = ResumptionHelper(settings)
+
+        assertEquals(PLAYED_UP_TO_MS - 30_000, helper.adjustedStartTimeMsFor(episode()))
+    }
+
+    @Test
+    fun `interruption rewind does not rewind past the episode start`() {
+        val settings = settingsMock(
+            wasInterruption = true,
+            rewindSeconds = 30,
+            lastPausedAtMs = 3_000,
+        )
+        val helper = ResumptionHelper(settings)
+
+        assertEquals(0, helper.adjustedStartTimeMsFor(episode(playedUpToMs = 3_000)))
+    }
+
+    @Test
+    fun `no adjustment for a different episode than the last paused one`() {
+        val settings = settingsMock(wasInterruption = true, rewindSeconds = 30)
+        val helper = ResumptionHelper(settings)
+
+        val other = episode(uuid = "another-episode-uuid")
+
+        assertEquals(PLAYED_UP_TO_MS, helper.adjustedStartTimeMsFor(other))
+    }
+
+    @Test
+    fun `no adjustment when the playback position moved since the last pause`() {
+        val settings = settingsMock(wasInterruption = true, rewindSeconds = 30, lastPausedAtMs = 1_000)
+        val helper = ResumptionHelper(settings)
+
+        assertEquals(PLAYED_UP_TO_MS, helper.adjustedStartTimeMsFor(episode()))
+    }
+
+    @Test
+    fun `longer pause length rewind wins over a shorter interruption rewind`() {
+        val settings = settingsMock(
+            wasInterruption = true,
+            rewindSeconds = 5,
+            lastPauseTime = Date(Date().time - 25.hours()),
+        )
+        val helper = ResumptionHelper(settings)
+
+        // paused for more than 24 hours, the 30 second pause length rewind beats the 5 second interruption rewind
+        assertEquals(PLAYED_UP_TO_MS - 30_000, helper.adjustedStartTimeMsFor(episode()))
+    }
+
+    @Test
+    fun `longer interruption rewind wins over a shorter pause length rewind`() {
+        val settings = settingsMock(
+            wasInterruption = true,
+            rewindSeconds = 60,
+            lastPauseTime = Date(Date().time - 6.minutes()),
+        )
+        val helper = ResumptionHelper(settings)
+
+        // paused for more than 5 minutes, the 60 second interruption rewind beats the 10 second pause length rewind
+        assertEquals(PLAYED_UP_TO_MS - 60_000, helper.adjustedStartTimeMsFor(episode()))
+    }
+
+    @Test
+    fun `pause length rewind still applies to regular pauses`() {
+        val settings = settingsMock(
+            wasInterruption = false,
+            lastPauseTime = Date(Date().time - 6.minutes()),
+        )
+        val helper = ResumptionHelper(settings)
+
+        assertEquals(PLAYED_UP_TO_MS - 10_000, helper.adjustedStartTimeMsFor(episode()))
+    }
+
+    @Test
+    fun `no rewind for a short regular pause`() {
+        val settings = settingsMock(wasInterruption = false)
+        val helper = ResumptionHelper(settings)
+
+        assertEquals(PLAYED_UP_TO_MS, helper.adjustedStartTimeMsFor(episode()))
+    }
+
+    @Test
+    fun `paused persists whether the pause came from an interruption`() {
+        val settings = settingsMock()
+        val helper = ResumptionHelper(settings)
+
+        helper.paused(episode(), atPlayedUpToMs = PLAYED_UP_TO_MS, dueToInterruption = true)
+
+        verify(settings).setLastPauseWasInterruption(true)
+    }
+
+    @Test
+    fun `paused defaults to not being an interruption`() {
+        val settings = settingsMock()
+        val helper = ResumptionHelper(settings)
+
+        helper.paused(episode(), atPlayedUpToMs = PLAYED_UP_TO_MS)
+
+        verify(settings).setLastPauseWasInterruption(false)
+    }
+
+    companion object {
+        private const val EPISODE_UUID = "episode-uuid"
+        private const val PLAYED_UP_TO_MS = 600_000
+    }
+}

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -369,6 +369,15 @@ enum class Feature(
         hasDevToggle = true,
         addedOn = LocalDate.parse("2026-07-02"),
     ),
+    INTERRUPTION_REWIND(
+        key = "interruption_rewind",
+        title = "Rewind after audio interruptions like calls and navigation",
+        defaultValue = isDebugOrPrototypeBuild,
+        tier = FeatureTier.Free,
+        hasFirebaseRemoteFlag = true,
+        hasDevToggle = true,
+        addedOn = LocalDate.parse("2026-07-19"),
+    ),
 }
 
 sealed class FeatureTier {


### PR DESCRIPTION
## Description

This PR adds an optional **"Rewind after interruptions"** setting: when playback resumes after an audio interruption (phone call, alarm, Assistant, Android Auto navigation prompt or another app taking audio focus), Pocket Casts seeks back a configurable number of seconds so listeners don't lose context. This is especially useful in the car, where navigation prompts regularly interrupt playback. A matching PR with identical behavior is open for iOS: Automattic/pocket-casts-ios#4788.

**Behavior**

- New row in Settings > Playback, directly below Intelligent playback resumption: radio dialog with Off, 5, 10, 15, 30, 60 seconds (default: 5 seconds once the feature flag is enabled).
- Rewind applies on both automatic resume (focus regained) and manual resume after an interruption-caused pause.
- When Intelligent playback resumption would also rewind the same resume, the **larger amount wins** - the two never stack.
- Only pauses caused by audio focus loss count as interruptions: ducking, headphone unplug (becoming noisy) and interruptions while already paused never trigger it; the rewind clamps at 0:00. Users who want every navigation prompt to trigger the rewind can set "Play over notifications" to never, making prompts pause playback.
- Android Auto inherits the behavior automatically via the shared playback engine. On Automotive, a permanent focus loss stops playback (deactivating the MediaSession) as before - a stop is session teardown, not a pause, so no interruption rewind applies there by design.
- Behind the new `interruption_rewind` feature flag (default: debug/prototype builds only). The setting is device-local; adding it to named-settings sync would need a server-side key and is left as a possible follow-up for maintainers.

**Implementation notes**

- `PlaybackManager.onFocusLoss` marks its pause as interruption-caused; the marker travels through `pauseSuspend` and is consumed (and cleared) in `onPlayerPaused`, so pauses reaching that callback via other paths (sleep timer, cast receiver, error paths) can never reuse a stale value.
- `ResumptionHelper` computes the existing pause-length ladder and the interruption rewind separately and applies `maxOf()` of the two.

## Testing Instructions

1. Run a debug build (flag `interruption_rewind` is on by default there) and start playing an episode.
2. Go to Settings > Playback > Rewind after interruptions and pick e.g. 30 seconds.
3. With "Play over notifications" set to never, trigger an interruption while playing: set an alarm that fires, or receive a phone call.
4. When the alarm is dismissed / call ends, playback resumes and starts ~30 seconds before the interruption point.
5. For a long interruption (>2 min, no auto-resume): press play manually - the rewind still applies.
6. Set the setting to Off and verify resume happens exactly where playback stopped (for pauses shorter than 5 minutes).
7. Verify no stacking: with interruption rewind 60s, interrupt for >5 minutes, resume - playback rewinds 60s (not 70s). A manual pause of >5 minutes still gets the unchanged Intelligent playback resumption rewind (10s).
8. Verify a sleep-timer pause or headphone unplug followed by resume does not trigger the interruption rewind.

## Screenshots or Screencast

The new settings row reuses the existing `SettingRadioDialogRow` component below Intelligent playback resumption.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics. *Maintainer action needed: the setting change should track a `SettingsGeneralInterruptionRewindChangedEvent` (value property = chosen seconds); the event type comes from the generated Event Horizon library, which I can't extend as an external contributor - there is a TODO at the call site in `PlaybackSettingsFragment`.*

#### I have tested any UI changes...
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack