### PR TITLE
Only pass valid durations to the Engage SDK

### DIFF
--- a/modules/features/engage/src/main/kotlin/au/com/shiftyjelly/pocketcasts/engage/ClusterService.kt
+++ b/modules/features/engage/src/main/kotlin/au/com/shiftyjelly/pocketcasts/engage/ClusterService.kt
@@ -1,7 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.engage
 
 import android.content.Context
-import android.net.Uri
+import androidx.core.net.toUri
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.deeplink.ShareListDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ShowEpisodeDeepLink
@@ -48,7 +48,7 @@ internal class ClusterService(
                     .setName(podcast.title)
                     .addPosterImage(
                         Image.Builder()
-                            .setImageUri(Uri.parse(podcast.coverUrl))
+                            .setImageUri(podcast.coverUrl.toUri())
                             .setImageWidthInPixel(podcast.coverSize)
                             .setImageHeightInPixel(podcast.coverSize)
                             .build(),
@@ -71,14 +71,14 @@ internal class ClusterService(
                     .setName(episode.title)
                     .addPosterImage(
                         Image.Builder()
-                            .setImageUri(Uri.parse(episode.coverUrl))
+                            .setImageUri(episode.coverUrl.toUri())
                             .setImageWidthInPixel(episode.coverSize)
                             .setImageHeightInPixel(episode.coverSize)
                             .build(),
                     )
                     .setPlayBackUri(episode.uri(autoPlay = true, SourceView.ENGAGE_SDK_RECOMMENDATIONS))
                     .setPodcastSeriesTitle(episode.podcastTitle)
-                    .setDurationMillis(episode.durationMs)
+                    .addDurationMillis(episode.durationMs)
                     .setPublishDateEpochMillis(episode.releaseTimestampMs)
                     .setInfoPageUri(episode.uri(autoPlay = false, SourceView.ENGAGE_SDK_RECOMMENDATIONS))
                     .addEpisodeIndex(episode.episodeNumber)
@@ -100,7 +100,7 @@ internal class ClusterService(
                     .setName(podcast.title)
                     .addPosterImage(
                         Image.Builder()
-                            .setImageUri(Uri.parse(podcast.coverUrl))
+                            .setImageUri(podcast.coverUrl.toUri())
                             .setImageWidthInPixel(podcast.coverSize)
                             .setImageHeightInPixel(podcast.coverSize)
                             .build(),
@@ -122,7 +122,7 @@ internal class ClusterService(
                         .setName(podcast.title)
                         .addPosterImage(
                             Image.Builder()
-                                .setImageUri(Uri.parse(podcast.coverUrl))
+                                .setImageUri(podcast.coverUrl.toUri())
                                 .setImageWidthInPixel(podcast.coverSize)
                                 .setImageHeightInPixel(podcast.coverSize)
                                 .build(),
@@ -174,14 +174,14 @@ internal class ClusterService(
                 .setName(episode.title)
                 .addPosterImage(
                     Image.Builder()
-                        .setImageUri(Uri.parse(episode.coverUrl))
+                        .setImageUri(episode.coverUrl.toUri())
                         .setImageWidthInPixel(episode.coverSize)
                         .setImageHeightInPixel(episode.coverSize)
                         .build(),
                 )
                 .setPlayBackUri(episode.uri(autoPlay = true, SourceView.ENGAGE_SDK_CONTINUATION))
                 .setPodcastSeriesTitle(episode.podcastTitle)
-                .setDurationMillis(episode.durationMs)
+                .addDurationMillis(episode.durationMs)
                 .setPublishDateEpochMillis(episode.releaseTimestampMs)
                 .setInfoPageUri(episode.uri(autoPlay = false, SourceView.ENGAGE_SDK_CONTINUATION))
                 .addEpisodeIndex(episode.episodeNumber)
@@ -222,7 +222,7 @@ internal class ClusterService(
                 .setName(podcast.title)
                 .addPosterImage(
                     Image.Builder()
-                        .setImageUri(Uri.parse(podcast.landscapeCoverUrl))
+                        .setImageUri(podcast.landscapeCoverUrl.toUri())
                         .setImageWidthInPixel(podcast.landscapeCoverWidth)
                         .setImageHeightInPixel(podcast.landscapeCoverHeight)
                         .build(),
@@ -263,7 +263,7 @@ internal class ClusterService(
                 val entity = SignInCardEntity.Builder()
                     .addPosterImage(
                         Image.Builder()
-                            .setImageUri(Uri.parse("https://static.pocketcasts.com/assets/engage-sdk-banner.png"))
+                            .setImageUri("https://static.pocketcasts.com/assets/engage-sdk-banner.png".toUri())
                             .setImageWidthInPixel(1264)
                             .setImageHeightInPixel(712)
                             .build(),
@@ -322,6 +322,15 @@ internal class ClusterService(
     private fun PodcastSeriesEntity.Builder.addLastEngagementTimeMillis(time: Long?): PodcastSeriesEntity.Builder {
         return if (time != null) {
             setLastEngagementTimeMillis(time)
+        } else {
+            this
+        }
+    }
+
+    // The feed doesn't always provide a duration, and the Engage SDK says to omit the duration if it's invalid.
+    private fun PodcastEpisodeEntity.Builder.addDurationMillis(durationMs: Long): PodcastEpisodeEntity.Builder {
+        return if (durationMs > 0) {
+            setDurationMillis(durationMs)
         } else {
             this
         }


### PR DESCRIPTION
## Description

Podcast episode entities published to the Engage SDK were sometimes reporting invalid duration metadata. Episode durations come from the podcast author's feed XML, which we don't control, so the value can be missing or non-positive (for example `0`). We were passing that value straight through to `setDurationMillis`, which the Engage SDK rejects as invalid.

This change adds a small `addDurationMillis` helper that only calls `setDurationMillis` when the duration is greater than zero, and omits the field otherwise. Duration is an optional field on `PodcastEpisodeEntity`, so omitting it is the recommended behaviour when a valid value isn't available.

While in the file, the deprecated `Uri.parse(...)` calls were also swapped for the `String.toUri()` KTX extension for consistency.

Fixes [PCDROID-546](https://linear.app/a8c/issue/PCDROID-546/04766288-issue-with-engage-sdk-integration-in-your-app)

## Testing Instructions

1. Download the [verification app](https://developer.android.com/guide/playcore/engage/workflow#verify-app)
2. Remove from modules/features/engage/src/main/AndroidManifest.xml the following: `<meta-data android:name="com.google.android.engage.service.ENV" android:value="PRODUCTION" />`
3. Run the debugProd variant
4. Minimise the app
5. Open the “Play Engage Verify App” 
6. Episodes should be listed with durations

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
