### PR TITLE
Resolve generated chapter seeks through on-demand audio fingerprinting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
         ([#5536](https://github.com/Automattic/pocket-casts-android/pull/5536))
     *   HLS support
         ([#5602](https://github.com/Automattic/pocket-casts-android/pull/5602))
+    *   Resolve generated chapter seeks through on-demand audio fingerprinting
+        ([#5577](https://github.com/Automattic/pocket-casts-android/pull/5577))
 *   Bug Fixes
     *   Fix episodes being cached over mobile data when Warn before using data is enabled
         ([#5567](https://github.com/Automattic/pocket-casts-android/pull/5567))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
     *   HLS support
         ([#5602](https://github.com/Automattic/pocket-casts-android/pull/5602))
     *   Resolve generated chapter seeks through on-demand audio fingerprinting
-        ([#5577](https://github.com/Automattic/pocket-casts-android/pull/5577))
+        ([#5613](https://github.com/Automattic/pocket-casts-android/pull/5613))
 *   Bug Fixes
     *   Fix episodes being cached over mobile data when Warn before using data is enabled
         ([#5567](https://github.com/Automattic/pocket-casts-android/pull/5567))

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChapterRow.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChapterRow.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Checkbox
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.runtime.Composable
@@ -56,6 +57,7 @@ fun ChapterRow(
     onClick: () -> Unit,
     onUrlClick: () -> Unit,
     modifier: Modifier = Modifier,
+    isResolving: Boolean = false,
 ) {
     val chapter = state.chapter
     var selectedState by remember(chapter.index) { mutableStateOf(state.chapter.selected) }
@@ -100,12 +102,22 @@ fun ChapterRow(
                 )
                 Spacer(Modifier.width(8.dp))
             }
-            TextH50(
-                text = (chapter.uiIndex).toString(),
-                color = textColor,
-                modifier = Modifier
-                    .padding(horizontal = 12.dp),
-            )
+            if (isResolving) {
+                CircularProgressIndicator(
+                    color = textColor,
+                    strokeWidth = 2.dp,
+                    modifier = Modifier
+                        .padding(horizontal = 12.dp)
+                        .size(16.dp),
+                )
+            } else {
+                TextH50(
+                    text = (chapter.uiIndex).toString(),
+                    color = textColor,
+                    modifier = Modifier
+                        .padding(horizontal = 12.dp),
+                )
+            }
             Spacer(Modifier.width(8.dp))
             TextH50(
                 text = chapter.title,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersFragment.kt
@@ -56,6 +56,7 @@ class ChaptersFragment : BaseFragment() {
         savedInstanceState: Bundle?,
     ) = contentWithoutConsumedInsets {
         val state by viewModel.uiState.collectAsState()
+        val resolvingChapterIndex by viewModel.resolvingChapterIndex.collectAsState()
 
         AppThemeWithBackground(mode.themeType) {
             ChaptersTheme(state.podcast) {
@@ -73,6 +74,7 @@ class ChaptersFragment : BaseFragment() {
                     onSkipChaptersClick = viewModel::enableTogglingOrUpsell,
                     onSelectionChange = viewModel::selectChapter,
                     onUrlClick = ::openChapterUrl,
+                    resolvingChapterIndex = resolvingChapterIndex,
                     modifier = Modifier.nestedScroll(rememberNestedScrollInteropConnection()),
                 )
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersPage.kt
@@ -37,6 +37,7 @@ fun ChaptersPage(
     isTogglingChapters: Boolean,
     showSubscriptionIcon: Boolean,
     modifier: Modifier = Modifier,
+    resolvingChapterIndex: Int? = null,
 ) {
     LazyColumn(
         state = lazyListState,
@@ -81,6 +82,7 @@ fun ChaptersPage(
                 onSelectionChange = onSelectionChange,
                 onClick = { onChapterClick(state.chapter) },
                 onUrlClick = { onUrlClick(state.chapter) },
+                isResolving = state.chapter.index == resolvingChapterIndex,
                 modifier = Modifier.animateItem(),
             )
             if (index < chapters.lastIndex) {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersViewModel.kt
@@ -61,12 +61,9 @@ class ChaptersViewModel @AssistedInject constructor(
 
     val uiState = mode.uiStateFlow().stateIn(viewModelScope, SharingStarted.Lazily, UiState())
 
-    val resolvingChapterIndex = combine(
-        generatedChapterSeeker.resolvingChapter,
-        playbackManager.playbackStateFlow.map { it.episodeUuid }.distinctUntilChanged(),
-    ) { resolving, episodeUuid ->
-        resolving?.takeIf { it.episodeUuid == episodeUuid }?.chapterIndex
-    }.stateIn(viewModelScope, SharingStarted.Lazily, null)
+    val resolvingChapterIndex = generatedChapterSeeker
+        .resolvingChapterIndex(playbackManager.playbackStateFlow.map { it.episodeUuid })
+        .stateIn(viewModelScope, SharingStarted.Lazily, null)
 
     @OptIn(ExperimentalCoroutinesApi::class)
     private fun Mode.uiStateFlow() = when (this) {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersViewModel.kt
@@ -11,6 +11,7 @@ import au.com.shiftyjelly.pocketcasts.models.to.toChapterOriginType
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.di.IoDispatcher
+import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.GeneratedChapterSeeker
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.ChapterManager
@@ -53,11 +54,19 @@ class ChaptersViewModel @AssistedInject constructor(
     private val episodeManager: EpisodeManager,
     private val settings: Settings,
     private val eventHorizon: EventHorizon,
+    private val generatedChapterSeeker: GeneratedChapterSeeker,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
     private val isTogglingChapters = MutableStateFlow(false)
 
     val uiState = mode.uiStateFlow().stateIn(viewModelScope, SharingStarted.Lazily, UiState())
+
+    val resolvingChapterIndex = combine(
+        generatedChapterSeeker.resolvingChapter,
+        playbackManager.playbackStateFlow.map { it.episodeUuid }.distinctUntilChanged(),
+    ) { resolving, episodeUuid ->
+        resolving?.takeIf { it.episodeUuid == episodeUuid }?.chapterIndex
+    }.stateIn(viewModelScope, SharingStarted.Lazily, null)
 
     @OptIn(ExperimentalCoroutinesApi::class)
     private fun Mode.uiStateFlow() = when (this) {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/nowplaying/EpisodeTitles.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/nowplaying/EpisodeTitles.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
@@ -21,6 +22,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.RippleConfiguration
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.remember
@@ -83,9 +85,12 @@ fun EpisodeTitles(
         }
     }.observeAsState(PlayerHeadingSectionState())
 
+    val resolvingChapterIndex by playerViewModel.resolvingChapterIndex.collectAsState()
+
     Content(
         state = state,
         playerColors = playerColors,
+        resolvingChapterIndex = resolvingChapterIndex,
         onPreviousChapterClick = { playerViewModel.onPreviousChapterClick() },
         onNextChapterClick = { playerViewModel.onNextChapterClick() },
         onChapterTitleClick = { playerViewModel.onChapterTitleClick(it) },
@@ -104,9 +109,14 @@ private fun Content(
     onChapterTitleClick: (Chapter) -> Unit,
     onPodcastTitleClick: () -> Unit,
     modifier: Modifier = Modifier,
+    resolvingChapterIndex: Int? = null,
     textAlign: TextAlign = TextAlign.Center,
     playerColors: PlayerColors = MaterialTheme.theme.rememberPlayerColorsOrDefault(),
 ) {
+    val currentChapterIndex = state.chapter?.index
+    val isResolvingPrevious = resolvingChapterIndex != null && currentChapterIndex != null && resolvingChapterIndex < currentChapterIndex
+    val isResolvingNext = resolvingChapterIndex != null && currentChapterIndex != null && resolvingChapterIndex > currentChapterIndex
+
     CompositionLocalProvider(
         LocalRippleConfiguration provides RippleConfiguration(color = playerColors.contrast01),
     ) {
@@ -115,8 +125,9 @@ private fun Content(
         ) {
             if (state.isChaptersPresent) {
                 ChapterPreviousButton(
-                    enabled = !state.isFirstChapter,
+                    enabled = !state.isFirstChapter && !isResolvingPrevious,
                     alpha = if (state.isFirstChapter) 0.5f else 1f,
+                    isResolving = isResolvingPrevious,
                     iconTint = playerColors.contrast01,
                     onClick = onPreviousChapterClick,
                 )
@@ -194,9 +205,10 @@ private fun Content(
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
                     ChapterNextButtonWithChapterProgressCircle(
-                        enabled = !state.isLastChapter,
+                        enabled = !state.isLastChapter && !isResolvingNext,
                         alpha = if (state.isLastChapter) 0.5f else 1f,
                         progress = state.chapterProgress,
+                        isResolving = isResolvingNext,
                         iconTint = playerColors.contrast01,
                         progressTint = playerColors.contrast04,
                         onClick = onNextChapterClick,
@@ -221,6 +233,7 @@ private fun Content(
 private fun ChapterPreviousButton(
     enabled: Boolean,
     alpha: Float,
+    isResolving: Boolean,
     iconTint: Color,
     onClick: () -> Unit,
 ) {
@@ -233,11 +246,19 @@ private fun ChapterPreviousButton(
             contentAlignment = Alignment.Center,
             modifier = Modifier.clip(CircleShape),
         ) {
-            Icon(
-                painter = painterResource(R.drawable.ic_chapter_skipbackwards),
-                tint = iconTint,
-                contentDescription = stringResource(LR.string.player_action_previous_chapter),
-            )
+            if (isResolving) {
+                CircularProgressIndicator(
+                    color = iconTint,
+                    strokeWidth = 2.dp,
+                    modifier = Modifier.size(16.dp),
+                )
+            } else {
+                Icon(
+                    painter = painterResource(R.drawable.ic_chapter_skipbackwards),
+                    tint = iconTint,
+                    contentDescription = stringResource(LR.string.player_action_previous_chapter),
+                )
+            }
         }
     }
 }
@@ -247,6 +268,7 @@ private fun ChapterNextButtonWithChapterProgressCircle(
     enabled: Boolean,
     progress: Float,
     alpha: Float,
+    isResolving: Boolean,
     iconTint: Color,
     progressTint: Color,
     onClick: () -> Unit,
@@ -259,11 +281,19 @@ private fun ChapterNextButtonWithChapterProgressCircle(
             .alpha(alpha)
             .semantics { this.contentDescription = contentDescription },
     ) {
-        Icon(
-            painter = painterResource(R.drawable.ic_chapter_skipforward),
-            tint = iconTint,
-            contentDescription = null,
-        )
+        if (isResolving) {
+            CircularProgressIndicator(
+                color = iconTint,
+                strokeWidth = 2.dp,
+                modifier = Modifier.size(16.dp),
+            )
+        } else {
+            Icon(
+                painter = painterResource(R.drawable.ic_chapter_skipforward),
+                tint = iconTint,
+                contentDescription = null,
+            )
+        }
 
         ChapterProgressCircle(
             progress = progress,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/nowplaying/EpisodeTitles.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/nowplaying/EpisodeTitles.kt
@@ -58,6 +58,7 @@ import au.com.shiftyjelly.pocketcasts.player.R
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.PlayerViewModel
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
@@ -407,6 +408,18 @@ private fun PlayerHeadingSectionPreview(
                         title = "Episode title / ".repeat(10),
                         isChaptersPresent = true,
                     ),
+                    onPreviousChapterClick = {},
+                    onNextChapterClick = {},
+                    onChapterTitleClick = {},
+                    onPodcastTitleClick = {},
+                )
+
+                Content(
+                    state = state.copy(
+                        isChaptersPresent = true,
+                        chapter = Chapter("Chapter", 0.milliseconds, 100.milliseconds, index = 1, uiIndex = 2),
+                    ),
+                    resolvingChapterIndex = 2,
                     onPreviousChapterClick = {},
                     onNextChapterClick = {},
                     onChapterTitleClick = {},

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/nowplaying/EpisodeTitles.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/nowplaying/EpisodeTitles.kt
@@ -238,10 +238,13 @@ private fun ChapterPreviousButton(
     iconTint: Color,
     onClick: () -> Unit,
 ) {
+    val contentDescription = stringResource(LR.string.player_action_previous_chapter)
     IconButton(
         enabled = enabled,
         onClick = onClick,
-        modifier = Modifier.alpha(alpha),
+        modifier = Modifier
+            .alpha(alpha)
+            .semantics { this.contentDescription = contentDescription },
     ) {
         Box(
             contentAlignment = Alignment.Center,
@@ -257,7 +260,7 @@ private fun ChapterPreviousButton(
                 Icon(
                     painter = painterResource(R.drawable.ic_chapter_skipbackwards),
                     tint = iconTint,
-                    contentDescription = stringResource(LR.string.player_action_previous_chapter),
+                    contentDescription = null,
                 )
             }
         }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -31,6 +31,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
 import au.com.shiftyjelly.pocketcasts.repositories.di.IoDispatcher
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadQueue
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadType
+import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.GeneratedChapterSeeker
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackNoticeManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
@@ -81,6 +82,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.rx2.asObservable
@@ -97,6 +99,7 @@ class PlayerViewModel @Inject constructor(
     private val podcastManager: PodcastManager,
     private val bookmarkManager: BookmarkManager,
     private val downloadQueue: DownloadQueue,
+    private val generatedChapterSeeker: GeneratedChapterSeeker,
     private val sleepTimer: SleepTimer,
     private val settings: Settings,
     private val theme: Theme,
@@ -335,6 +338,10 @@ class PlayerViewModel @Inject constructor(
         }
     val playbackNotice = playbackNoticeManager.playbackNotice
         .stateIn(viewModelScope, started = SharingStarted.WhileSubscribed(5_000), initialValue = null)
+
+    val resolvingChapterIndex = generatedChapterSeeker
+        .resolvingChapterIndex(playbackManager.playbackStateFlow.map { it.episodeUuid })
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
 
     val playerFlow = playbackManager.playerFlow
 

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ChaptersViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ChaptersViewModelTest.kt
@@ -42,6 +42,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -62,7 +63,7 @@ class ChaptersViewModelTest {
     private val episodeManager = mock<EpisodeManager>()
     private val settings = mock<Settings>()
     private val generatedChapterSeeker = mock<GeneratedChapterSeeker> {
-        on { resolvingChapter } doReturn MutableStateFlow(null)
+        on { resolvingChapterIndex(any()) } doReturn MutableStateFlow<Int?>(null)
     }
 
     private val episode = PodcastEpisode(uuid = "id", publishedDate = Date())

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ChaptersViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ChaptersViewModelTest.kt
@@ -16,6 +16,7 @@ import au.com.shiftyjelly.pocketcasts.player.view.chapters.ChaptersViewModel
 import au.com.shiftyjelly.pocketcasts.player.view.chapters.ChaptersViewModel.Mode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
+import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.GeneratedChapterSeeker
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.ChapterManager
@@ -41,6 +42,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
@@ -59,6 +61,9 @@ class ChaptersViewModelTest {
     private val playbackManager = mock<PlaybackManager>()
     private val episodeManager = mock<EpisodeManager>()
     private val settings = mock<Settings>()
+    private val generatedChapterSeeker = mock<GeneratedChapterSeeker> {
+        on { resolvingChapter } doReturn MutableStateFlow(null)
+    }
 
     private val episode = PodcastEpisode(uuid = "id", publishedDate = Date())
     private val chapters = Chapters(
@@ -102,6 +107,7 @@ class ChaptersViewModelTest {
             episodeManager = episodeManager,
             settings = settings,
             eventHorizon = EventHorizon(eventSink),
+            generatedChapterSeeker = generatedChapterSeeker,
             ioDispatcher = testDispatcher,
         )
     }
@@ -254,6 +260,7 @@ class ChaptersViewModelTest {
             episodeManager = episodeManager,
             settings = settings,
             eventHorizon = EventHorizon(TestEventSink()),
+            generatedChapterSeeker = generatedChapterSeeker,
             ioDispatcher = testDispatcher,
         )
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -911,6 +911,7 @@ class EpisodeFragment : BaseFragment() {
                                     onSkipChaptersClick = chaptersViewModel::enableTogglingOrUpsell,
                                     isTogglingChapters = chaptersState.isTogglingChapters,
                                     showSubscriptionIcon = chaptersState.showSubscriptionIcon,
+                                    resolvingChapterIndex = chaptersViewModel.resolvingChapterIndex.collectAsState().value,
                                     modifier = Modifier
                                         .fillMaxWidth()
                                         .heightIn(max = screenHeight),

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/Chapter.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/Chapter.kt
@@ -14,6 +14,8 @@ data class Chapter(
     val imagePath: String? = null,
     val selected: Boolean = true,
     val origin: ChapterOrigin = ChapterOrigin.Unknown,
+    // Original reference-timeline start for generated chapters, kept when startTime is aligned to the stream.
+    val referenceStartTime: Duration? = null,
 ) {
 
     val isGenerated: Boolean

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/ChapterSeekResult.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/ChapterSeekResult.kt
@@ -1,0 +1,16 @@
+package au.com.shiftyjelly.pocketcasts.repositories.fingerprint
+
+import kotlin.time.Duration
+
+sealed interface ChapterSeekResult {
+    data class Resolved(val playbackTime: Duration, val usedPrior: Boolean) : ChapterSeekResult
+    data class Unresolved(val reason: String) : ChapterSeekResult
+
+    companion object {
+        const val REASON_TIMEOUT = "timeout"
+        const val REASON_NO_AUDIO_SOURCE = "no_audio_source"
+        const val REASON_NO_REFERENCE = "no_reference"
+        const val REASON_AUDIO_UNAVAILABLE = "audio_unavailable"
+        const val REASON_NO_MATCH = "no_match"
+    }
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/ChapterSeekResult.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/ChapterSeekResult.kt
@@ -12,5 +12,6 @@ sealed interface ChapterSeekResult {
         const val REASON_NO_REFERENCE = "no_reference"
         const val REASON_AUDIO_UNAVAILABLE = "audio_unavailable"
         const val REASON_NO_MATCH = "no_match"
+        const val REASON_METERED_NETWORK = "metered_network"
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintConstants.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintConstants.kt
@@ -60,4 +60,19 @@ object FingerprintConstants {
 
     /** Maximum stored debug rejections (FIFO eviction). */
     const val DEBUG_REJECTION_CAP = 500
+
+    /** Forward audio decoded from the raw reference time when no mapping estimate exists. */
+    const val ON_DEMAND_COLD_BUDGET_SECONDS = 240.0
+
+    /** Audio decoded past the mapping estimate to absorb intervening ads. */
+    const val ON_DEMAND_FORWARD_BUDGET_SECONDS = 120.0
+
+    /** Cap on searching below the mapping estimate when the accumulated offset is large. */
+    const val ON_DEMAND_BACKWARD_MAX_SECONDS = 180.0
+
+    /** Minimum committed anchors for an on-demand resolve to be trusted. */
+    const val ON_DEMAND_MIN_ANCHORS = 2
+
+    /** Hard timeout for an on-demand chapter resolve. */
+    const val ON_DEMAND_TIMEOUT_MS = 5_000L
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
@@ -277,6 +277,31 @@ class FingerprintTimingManager @Inject constructor(
     }
 
     /**
+     * Playback time for [referenceTime] when the active mapping is dense around it, so a full
+     * on-demand resolve is unnecessary. Null when the mapping is missing, sparse, or another episode's.
+     */
+    fun densePlaybackTime(episodeUuid: String, referenceTime: Duration): Duration? {
+        if (activeEpisodeUuid != episodeUuid) return null
+        val entries = snapshotReferenceToPlayback
+        val referenceTimeSec = referenceTime.toDouble(DurationUnit.SECONDS)
+        var lo = 0
+        var hi = entries.size
+        while (lo < hi) {
+            val mid = (lo + hi) / 2
+            if (entries[mid].referenceTime <= referenceTimeSec) lo = mid + 1 else hi = mid
+        }
+        if (hi - 1 < 0 || hi >= entries.size) return null
+        if (entries[hi].referenceTime - entries[hi - 1].referenceTime > FingerprintConstants.HIGHLIGHT_MAX_GAP_SECONDS) return null
+        val playback = interpolate(
+            time = referenceTimeSec,
+            entries = entries,
+            keySelector = { it.referenceTime },
+            valueSelector = { it.playbackTime },
+        ) ?: return null
+        return playback.seconds
+    }
+
+    /**
      * One-shot bounded resolve of a generated chapter's reference time to the playback timeline.
      * Decodes only a small search window around the expected location, matches into a scratch
      * accumulator, and never touches the continuous mapping or the public state.

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
@@ -330,6 +330,15 @@ class FingerprintTimingManager @Inject constructor(
         isDownloaded: Boolean,
         referenceTimeSec: Double,
     ): ChapterSeekResult {
+        val blocked = shouldBlockOnDemandResolve(
+            isDownloaded = isDownloaded,
+            warnOnMeteredNetwork = settings.warnOnMeteredNetwork.value,
+            isUnmetered = { Network.isUnmeteredConnection(context) },
+        )
+        if (blocked) {
+            Timber.d("FingerprintTimingManager: skipping on-demand resolve on metered network")
+            return ChapterSeekResult.Unresolved(ChapterSeekResult.REASON_METERED_NETWORK)
+        }
         var estimatedPlayback: Double? = null
         var warmReferenceData: ByteArray? = null
         mutex.withLock {
@@ -398,11 +407,15 @@ class FingerprintTimingManager @Inject constructor(
     ): ByteArray? {
         if (isDownloaded) {
             referenceRetriever.loadReferenceData(audioSource)?.let { return it }
+        } else {
+            referenceRetriever.loadCachedReference(episodeUuid)?.let { return it }
         }
         val baseUrl = "${BuildConfig.SERVER_SHOW_NOTES_URLS}/generated_transcripts/"
         val data = referenceRetriever.fetchReferenceData(baseUrl, podcastUuid, episodeUuid) ?: return null
         if (isDownloaded) {
             referenceRetriever.saveReferenceData(data, audioSource)
+        } else {
+            referenceRetriever.saveCachedReference(episodeUuid, data)
         }
         return data
     }
@@ -1380,14 +1393,18 @@ class FingerprintTimingManager @Inject constructor(
     }
 
     companion object {
-        /**
-         * Core eager-pass gate (assumes the platform check already passed). [isUnmetered] is a supplier so the
-         * network lookup is skipped for downloaded episodes.
-         */
+        /** Core eager-pass gate (assumes the platform check already passed). */
         internal fun computeEager(
             hasGeneratedChapters: Boolean,
             isDownloaded: Boolean,
         ): Boolean = hasGeneratedChapters && isDownloaded
+
+        /** A chapter tap is user-initiated, so metered data is allowed unless the user asked to be warned. */
+        internal fun shouldBlockOnDemandResolve(
+            isDownloaded: Boolean,
+            warnOnMeteredNetwork: Boolean,
+            isUnmetered: () -> Boolean,
+        ): Boolean = !isDownloaded && warnOnMeteredNetwork && !isUnmetered()
 
         /** [isUnmetered] is a supplier so the network lookup is skipped for downloaded episodes. */
         internal fun shouldBlockRemoteFingerprinting(

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
@@ -10,6 +10,7 @@ import android.os.SystemClock
 import androidx.annotation.VisibleForTesting
 import androidx.core.net.toUri
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.BuildConfig
 import au.com.shiftyjelly.pocketcasts.repositories.playback.ExoPlayerDataSourceFactory
@@ -35,6 +36,9 @@ import javax.inject.Singleton
 import kotlin.math.abs
 import kotlin.math.floor
 import kotlin.math.max
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.DurationUnit
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -50,6 +54,8 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import timber.log.Timber
 import uniffi.fingerprint_uniffi.CheckpointMatcher
 import uniffi.fingerprint_uniffi.StreamingWindowedFingerprinter
@@ -90,6 +96,11 @@ class FingerprintTimingManager @Inject constructor(
     data class DebugRejection(
         val playbackTime: Double,
         val score: Float?,
+    )
+
+    internal data class SearchWindow(
+        val startSec: Double,
+        val endSec: Double,
     )
 
     private val _stateFlow = MutableStateFlow<State>(State.Idle)
@@ -261,6 +272,168 @@ class FingerprintTimingManager @Inject constructor(
                 if (currentEpisodeUuid == episodeUuid && currentTrigger == PrepareTrigger.TRANSCRIPT_VIEW) {
                     currentTrigger = PrepareTrigger.PLAYBACK
                 }
+            }
+        }
+    }
+
+    /**
+     * One-shot bounded resolve of a generated chapter's reference time to the playback timeline.
+     * Decodes only a small search window around the expected location, matches into a scratch
+     * accumulator, and never touches the continuous mapping or the public state.
+     */
+    suspend fun resolveChapterPlaybackTime(episode: BaseEpisode, referenceTime: Duration): ChapterSeekResult {
+        val audioSource = episode.downloadedFilePath
+            ?: episode.downloadUrl
+            ?: return ChapterSeekResult.Unresolved(ChapterSeekResult.REASON_NO_AUDIO_SOURCE)
+        return withContext(Dispatchers.Default) {
+            withTimeoutOrNull(FingerprintConstants.ON_DEMAND_TIMEOUT_MS) {
+                performResolve(
+                    episodeUuid = episode.uuid,
+                    podcastUuid = episode.podcastOrSubstituteUuid,
+                    audioSource = audioSource,
+                    isDownloaded = episode.isDownloaded,
+                    referenceTimeSec = referenceTime.toDouble(DurationUnit.SECONDS),
+                )
+            } ?: ChapterSeekResult.Unresolved(ChapterSeekResult.REASON_TIMEOUT)
+        }
+    }
+
+    private suspend fun performResolve(
+        episodeUuid: String,
+        podcastUuid: String,
+        audioSource: String,
+        isDownloaded: Boolean,
+        referenceTimeSec: Double,
+    ): ChapterSeekResult {
+        var estimatedPlayback: Double? = null
+        var warmReferenceData: ByteArray? = null
+        mutex.withLock {
+            if (currentEpisodeUuid == episodeUuid) {
+                warmReferenceData = currentReferenceData
+                estimatedPlayback = interpolate(
+                    time = referenceTimeSec,
+                    entries = snapshotReferenceToPlayback,
+                    keySelector = { it.referenceTime },
+                    valueSelector = { it.playbackTime },
+                )
+            }
+        }
+        val usedPrior = estimatedPlayback != null
+
+        val referenceData = warmReferenceData
+            ?: loadOrFetchReferenceData(podcastUuid, episodeUuid, audioSource, isDownloaded)
+            ?: return ChapterSeekResult.Unresolved(ChapterSeekResult.REASON_NO_REFERENCE)
+
+        val reference = ReferenceFingerprint.decode(referenceData)
+            ?: return ChapterSeekResult.Unresolved(ChapterSeekResult.REASON_NO_REFERENCE)
+        val matcher = buildMatcher(reference)
+            ?: return ChapterSeekResult.Unresolved(ChapterSeekResult.REASON_NO_REFERENCE)
+
+        val window = searchWindow(referenceTimeSec, estimatedPlayback)
+        val acc = MappingAccumulator()
+        try {
+            matcher.use {
+                streamFingerprintBounded(
+                    audioFilePath = audioSource,
+                    matcher = it,
+                    startingAt = alignToWindowGrid(window.startSec),
+                    endingAt = window.endSec,
+                    acc = acc,
+                )
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.w(e, "FingerprintTimingManager: on-demand resolve failed for $episodeUuid")
+            return ChapterSeekResult.Unresolved(ChapterSeekResult.REASON_AUDIO_UNAVAILABLE)
+        }
+
+        if (acc.playbackToReference.size < FingerprintConstants.ON_DEMAND_MIN_ANCHORS) {
+            return ChapterSeekResult.Unresolved(ChapterSeekResult.REASON_NO_MATCH)
+        }
+        val playback = interpolate(
+            time = referenceTimeSec,
+            entries = acc.referenceToPlayback,
+            keySelector = { it.referenceTime },
+            valueSelector = { it.playbackTime },
+        ) ?: return ChapterSeekResult.Unresolved(ChapterSeekResult.REASON_NO_MATCH)
+
+        // The ad offset is non-negative, so the true position is never before the reference time.
+        return ChapterSeekResult.Resolved(
+            playbackTime = max(referenceTimeSec, playback).seconds,
+            usedPrior = usedPrior,
+        )
+    }
+
+    private suspend fun loadOrFetchReferenceData(
+        podcastUuid: String,
+        episodeUuid: String,
+        audioSource: String,
+        isDownloaded: Boolean,
+    ): ByteArray? {
+        if (isDownloaded) {
+            referenceRetriever.loadReferenceData(audioSource)?.let { return it }
+        }
+        val baseUrl = "${BuildConfig.SERVER_SHOW_NOTES_URLS}/generated_transcripts/"
+        val data = referenceRetriever.fetchReferenceData(baseUrl, podcastUuid, episodeUuid) ?: return null
+        if (isDownloaded) {
+            referenceRetriever.saveReferenceData(data, audioSource)
+        }
+        return data
+    }
+
+    private fun buildMatcher(reference: ReferenceFingerprint): CheckpointMatcher? {
+        val checkpoints = reference.libraryCheckpoints()
+        if (checkpoints.isEmpty()) return null
+        val matcher = CheckpointMatcher()
+        for (checkpoint in checkpoints) {
+            matcher.add(
+                checkpoint.timestampSeconds,
+                checkpoint.hashes.map { it.toUInt() },
+                reference.checkpointDurationSeconds,
+            )
+        }
+        return matcher
+    }
+
+    private suspend fun streamFingerprintBounded(
+        audioFilePath: String,
+        matcher: CheckpointMatcher,
+        startingAt: Double,
+        endingAt: Double,
+        acc: MappingAccumulator,
+    ) {
+        // Capture the current generation so the decode aborts if the episode changes mid-resolve.
+        val gen = generation
+        val isRemoteUrl = audioFilePath.startsWith("http://") || audioFilePath.startsWith("https://")
+        openAudioStream(gen, audioFilePath, startingAt).use { stream ->
+            stream.start()
+
+            val streamer = StreamingWindowedFingerprinter(
+                stream.sampleRate.toUInt(),
+                stream.channelCount.toUShort(),
+                FingerprintConstants.WINDOW_DURATION_MS.toUInt(),
+                FingerprintConstants.WINDOW_INTERVAL_MS.toUInt(),
+            )
+            try {
+                decodeAndFingerprint(
+                    stream = stream,
+                    gen = gen,
+                    isRemoteUrl = isRemoteUrl,
+                    streamer = streamer,
+                    startOffset = startingAt,
+                    endingAt = endingAt,
+                    throttleToPlayhead = false,
+                    trackFrontier = false,
+                ) { windows ->
+                    matchWindows(windows, matcher, startingAt, acc)
+                }
+                val tail = streamer.flush()
+                if (tail.isNotEmpty()) {
+                    matchWindows(tail, matcher, startingAt, acc)
+                }
+            } finally {
+                streamer.close()
             }
         }
     }
@@ -591,8 +764,8 @@ class FingerprintTimingManager @Inject constructor(
         audioFilePath: String,
         episodeUuid: String,
     ) {
-        val libraryCheckpoints = reference.libraryCheckpoints()
-        if (libraryCheckpoints.isEmpty()) {
+        val matcher = buildMatcher(reference)
+        if (matcher == null) {
             markUnavailable(reason = "no_checkpoints", isStreaming = currentIsStreaming, episodeUuid = episodeUuid)
             Timber.d("FingerprintTimingManager: no usable checkpoints for $episodeUuid")
             return
@@ -601,18 +774,8 @@ class FingerprintTimingManager @Inject constructor(
         Timber.d(
             "FingerprintTimingManager: reference for $episodeUuid — " +
                 "totalDuration=${reference.totalDuration}s, " +
-                "${libraryCheckpoints.size} checkpoints",
+                "${matcher.count()} checkpoints",
         )
-
-        // Create matcher and populate with reference checkpoints
-        val matcher = CheckpointMatcher()
-        for (checkpoint in libraryCheckpoints) {
-            matcher.add(
-                checkpoint.timestampSeconds,
-                checkpoint.hashes.map { it.toUInt() },
-                reference.checkpointDurationSeconds,
-            )
-        }
 
         // Try loading mapping cache (only for local files)
         val refPath = FingerprintReferenceRetriever.referencePath(audioFilePath)
@@ -786,19 +949,37 @@ class FingerprintTimingManager @Inject constructor(
         }
     }
 
-    private suspend fun streamFingerprint(
-        gen: Long,
-        audioFilePath: String,
-        matcher: CheckpointMatcher,
-        episodeUuid: String,
-        startingAt: Double,
-    ) {
+    private class AudioOpenException(cause: Exception) : Exception(cause)
+    private class AudioUnavailableException(message: String) : Exception(message)
+
+    private class AudioStream(
+        val extractor: MediaExtractor,
+        val codec: MediaCodec,
+        val format: MediaFormat,
+        val sampleRate: Int,
+        val channelCount: Int,
+        private val cacheSource: AutoCloseable? = null,
+    ) : AutoCloseable {
+        fun start() {
+            // Request float PCM output. If the codec doesn't support it,
+            // it falls back to 16-bit; we detect the actual format below.
+            format.setInteger(MediaFormat.KEY_PCM_ENCODING, android.media.AudioFormat.ENCODING_PCM_FLOAT)
+            codec.configure(format, null, null, 0)
+            codec.start()
+        }
+
+        override fun close() {
+            runCatching { codec.stop() }
+            codec.release()
+            extractor.release()
+            cacheSource?.close()
+        }
+    }
+
+    private fun openAudioStream(gen: Long, audioFilePath: String, startingAt: Double): AudioStream {
         val isRemoteUrl = audioFilePath.startsWith("http://") || audioFilePath.startsWith("https://")
         if (!isRemoteUrl && !File(audioFilePath).exists()) {
-            Timber.w("FingerprintTimingManager: audio file not found at $audioFilePath")
-            if (gen != generation) return
-            markUnavailable(reason = "audio_unavailable", isStreaming = isRemoteUrl, episodeUuid = episodeUuid)
-            return
+            throw AudioUnavailableException("audio file not found at $audioFilePath")
         }
 
         val factory = dataSourceFactory.get()
@@ -821,23 +1002,16 @@ class FingerprintTimingManager @Inject constructor(
         } catch (e: Exception) {
             extractor.release()
             cacheSource?.close()
-            Timber.w(e, "FingerprintTimingManager: failed to open audio file")
-            if (gen != generation) return
-            markFailed(e, stage = "audio_open")
-            return
+            throw AudioOpenException(e)
         }
 
-        // Find audio track
         val audioTrackIndex = (0 until extractor.trackCount).firstOrNull { i ->
             extractor.getTrackFormat(i).getString(MediaFormat.KEY_MIME)?.startsWith("audio/") == true
         }
         if (audioTrackIndex == null) {
             extractor.release()
             cacheSource?.close()
-            Timber.w("FingerprintTimingManager: no audio track found")
-            if (gen != generation) return
-            markUnavailable(reason = "audio_unavailable", isStreaming = isRemoteUrl, episodeUuid = episodeUuid)
-            return
+            throw AudioUnavailableException("no audio track found")
         }
 
         extractor.selectTrack(audioTrackIndex)
@@ -846,28 +1020,66 @@ class FingerprintTimingManager @Inject constructor(
         val channelCount = format.getInteger(MediaFormat.KEY_CHANNEL_COUNT)
         val mime = format.getString(MediaFormat.KEY_MIME) ?: "audio/mpeg"
 
-        // Seek to start position
         if (startingAt > 0) {
             extractor.seekTo((startingAt * 1_000_000).toLong(), MediaExtractor.SEEK_TO_CLOSEST_SYNC)
         }
 
-        val codec = MediaCodec.createDecoderByType(mime)
-        try {
-            // Request float PCM output. If the codec doesn't support it,
-            // it falls back to 16-bit; we detect the actual format below.
-            format.setInteger(MediaFormat.KEY_PCM_ENCODING, android.media.AudioFormat.ENCODING_PCM_FLOAT)
-            codec.configure(format, null, null, 0)
-            codec.start()
+        val codec = try {
+            MediaCodec.createDecoderByType(mime)
+        } catch (e: Exception) {
+            extractor.release()
+            cacheSource?.close()
+            throw AudioOpenException(e)
+        }
+        return AudioStream(extractor, codec, format, sampleRate, channelCount, cacheSource)
+    }
+
+    private suspend fun streamFingerprint(
+        gen: Long,
+        audioFilePath: String,
+        matcher: CheckpointMatcher,
+        episodeUuid: String,
+        startingAt: Double,
+    ) {
+        val isRemoteUrl = audioFilePath.startsWith("http://") || audioFilePath.startsWith("https://")
+        val stream = try {
+            openAudioStream(gen, audioFilePath, startingAt)
+        } catch (e: AudioUnavailableException) {
+            Timber.w("FingerprintTimingManager: ${e.message}")
+            markUnavailable(reason = "audio_unavailable", isStreaming = isRemoteUrl, episodeUuid = episodeUuid)
+            return
+        } catch (e: AudioOpenException) {
+            Timber.w(e, "FingerprintTimingManager: failed to open audio file")
+            markFailed(e.cause ?: e, stage = "audio_open")
+            return
+        }
+
+        stream.use {
+            stream.start()
 
             val streamer = StreamingWindowedFingerprinter(
-                sampleRate.toUInt(),
-                channelCount.toUShort(),
+                stream.sampleRate.toUInt(),
+                stream.channelCount.toUShort(),
                 FingerprintConstants.WINDOW_DURATION_MS.toUInt(),
                 FingerprintConstants.WINDOW_INTERVAL_MS.toUInt(),
             )
 
             try {
-                decodeAndFingerprint(gen, isRemoteUrl, extractor, codec, streamer, matcher, episodeUuid, startingAt, sampleRate, channelCount)
+                decodeAndFingerprint(
+                    stream = stream,
+                    gen = gen,
+                    isRemoteUrl = isRemoteUrl,
+                    streamer = streamer,
+                    startOffset = startingAt,
+                    endingAt = null,
+                    throttleToPlayhead = !currentEager,
+                    trackFrontier = true,
+                ) { windows ->
+                    mutex.withLock {
+                        if (gen != generation) throw CancellationException("Fingerprint stream superseded")
+                        processMatches(windows, matcher, startingAt)
+                    }
+                }
 
                 // Flush remaining windows
                 val tail = streamer.flush()
@@ -880,26 +1092,22 @@ class FingerprintTimingManager @Inject constructor(
             } finally {
                 streamer.close()
             }
-        } finally {
-            runCatching { codec.stop() }
-            codec.release()
-            extractor.release()
-            cacheSource?.close()
         }
     }
 
     private suspend fun decodeAndFingerprint(
+        stream: AudioStream,
         gen: Long,
         isRemoteUrl: Boolean,
-        extractor: MediaExtractor,
-        codec: MediaCodec,
         streamer: StreamingWindowedFingerprinter,
-        matcher: CheckpointMatcher,
-        episodeUuid: String,
         startOffset: Double,
-        sampleRate: Int,
-        channelCount: Int,
+        endingAt: Double?,
+        throttleToPlayhead: Boolean,
+        trackFrontier: Boolean,
+        onWindows: suspend (List<WindowedFingerprint>) -> Unit,
     ) {
+        val extractor = stream.extractor
+        val codec = stream.codec
         val bufferInfo = MediaCodec.BufferInfo()
         var inputDone = false
         val timeoutUs = FingerprintConstants.CODEC_TIMEOUT_US
@@ -959,22 +1167,19 @@ class FingerprintTimingManager @Inject constructor(
                     if (outputBuffer != null && bufferInfo.size > 0) {
                         val samples = extractFloatSamples(outputBuffer, bufferInfo, isOutputFloat)
                         if (samples.isNotEmpty()) {
-                            val windows = streamer.pushSamplesF32(samples, channelCount.toUShort())
+                            val windows = streamer.pushSamplesF32(samples, stream.channelCount.toUShort())
                             if (windows.isNotEmpty()) {
-                                mutex.withLock {
-                                    if (gen != generation) throw CancellationException("Fingerprint stream superseded")
-                                    processMatches(windows, matcher, startOffset)
-                                }
+                                onWindows(windows)
                             }
                         }
 
                         val decodedSeconds = startOffset + streamer.durationMs().toDouble() / 1000.0
-                        if (gen == generation) {
+                        if (trackFrontier && gen == generation) {
                             activeDecodeFrontierSec = decodedSeconds
                         }
 
                         // Eager passes decode as fast as possible; throttled passes stay near the playhead.
-                        if (!currentEager) {
+                        if (throttleToPlayhead) {
                             val lastKnownPositionMs = lastProgressPositionMs
                             val playheadSec = if (lastKnownPositionMs >= 0) lastKnownPositionMs / 1000.0 else startOffset
                             if (decodedSeconds - playheadSec > FingerprintConstants.LOOKAHEAD_SECONDS) {
@@ -984,6 +1189,7 @@ class FingerprintTimingManager @Inject constructor(
                     }
                     codec.releaseOutputBuffer(outputIndex, false)
                     if (isEos) break
+                    if (endingAt != null && startOffset + streamer.durationMs().toDouble() / 1000.0 >= endingAt) break
                 }
             }
         }
@@ -1031,6 +1237,27 @@ class FingerprintTimingManager @Inject constructor(
     ) {
         val isDebug = debugTrackingEnabled || FeatureFlag.isEnabled(Feature.SYNCED_TRANSCRIPT_DEBUG)
 
+        matchWindows(windows, matcher, startOffset, mapping) { rejected ->
+            if (isDebug) recordDebugRejection(rejected.playbackTime, rejected.score)
+        }
+
+        publishSnapshot()
+        val coverage = mapping.playbackToReference.size
+        if (coverage >= FingerprintConstants.MINIMUM_COVERAGE_FOR_ACTIVE) {
+            markActive(coverage)
+        }
+        if (isDebug) {
+            debugRejectionsSnapshot = debugRejections.toList()
+        }
+    }
+
+    private fun matchWindows(
+        windows: List<WindowedFingerprint>,
+        matcher: CheckpointMatcher,
+        startOffset: Double,
+        acc: MappingAccumulator,
+        onRejected: (TimeMappingEntry) -> Unit = {},
+    ) {
         for (window in windows) {
             val absolutePlaybackTime = startOffset + window.timestampMs.toDouble() / 1000.0
             val matches = matcher.findTopMatches(window.hashes, 2u)
@@ -1043,30 +1270,21 @@ class FingerprintTimingManager @Inject constructor(
 
             val runnerUpScore = matches.getOrNull(1)?.score ?: 0f
             val dominance = best.score - runnerUpScore
-
-            // Passes floor but fails anchor threshold or dominance → rejection (red)
-            if (best.score < FingerprintConstants.DRIFT_ANCHOR_SCORE_THRESHOLD ||
-                dominance < FingerprintConstants.DRIFT_SCORE_DOMINANCE_GAP
-            ) {
-                if (isDebug) recordDebugRejection(absolutePlaybackTime, best.score)
-                continue
-            }
-
             val candidate = TimeMappingEntry(
                 playbackTime = absolutePlaybackTime,
                 referenceTime = best.timestamp.toDouble(),
                 score = best.score,
             )
-            consider(candidate, isDebug)
-        }
 
-        publishSnapshot()
-        val coverage = mapping.playbackToReference.size
-        if (coverage >= FingerprintConstants.MINIMUM_COVERAGE_FOR_ACTIVE) {
-            markActive(coverage)
-        }
-        if (isDebug) {
-            debugRejectionsSnapshot = debugRejections.toList()
+            // Passes floor but fails anchor threshold or dominance → rejection (red)
+            if (best.score < FingerprintConstants.DRIFT_ANCHOR_SCORE_THRESHOLD ||
+                dominance < FingerprintConstants.DRIFT_SCORE_DOMINANCE_GAP
+            ) {
+                onRejected(candidate)
+                continue
+            }
+
+            acc.consider(candidate, onRejected)
         }
     }
 
@@ -1271,6 +1489,23 @@ class FingerprintTimingManager @Inject constructor(
 
             val fraction = if (t1 > t0) (time - t0) / (t1 - t0) else 0.0
             return v0 + fraction * (v1 - v0)
+        }
+
+        /**
+         * Audio region to decode for an on-demand resolve. Ad offsets are non-negative and
+         * non-decreasing, so the true position is at or after the reference time; cold resolves
+         * only search forward, warm ones bracket the mapping-derived estimate.
+         */
+        internal fun searchWindow(referenceTimeSec: Double, estimatedPlaybackSec: Double?): SearchWindow {
+            if (estimatedPlaybackSec == null) {
+                return SearchWindow(
+                    startSec = referenceTimeSec,
+                    endSec = referenceTimeSec + FingerprintConstants.ON_DEMAND_COLD_BUDGET_SECONDS,
+                )
+            }
+            val startSec = max(referenceTimeSec, estimatedPlaybackSec - FingerprintConstants.ON_DEMAND_BACKWARD_MAX_SECONDS)
+            val endSec = max(estimatedPlaybackSec, startSec) + FingerprintConstants.ON_DEMAND_FORWARD_BUDGET_SECONDS
+            return SearchWindow(startSec, endSec)
         }
 
         /** True when [playbackTime] is bracketed by two anchors ≤ [FingerprintConstants.HIGHLIGHT_MAX_GAP_SECONDS] apart. */

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
@@ -110,10 +110,9 @@ class FingerprintTimingManager @Inject constructor(
     private val decodeDispatcher = Dispatchers.IO.limitedParallelism(1)
     private val mutex = Mutex()
 
-    // Mapping state: writers build new lists under mutex, then atomically publish via @Volatile.
+    // Mapping state: writers mutate the accumulator under mutex, then atomically publish via @Volatile.
     // Readers access the snapshot without locking, safe for use from the UI thread.
-    private var mappingPlaybackToReference = mutableListOf<TimeMappingEntry>()
-    private var mappingReferenceToPlayback = mutableListOf<TimeMappingEntry>()
+    private val mapping = MappingAccumulator()
 
     @Volatile
     private var snapshotPlaybackToReference: List<TimeMappingEntry> = emptyList()
@@ -146,10 +145,6 @@ class FingerprintTimingManager @Inject constructor(
 
     @Volatile
     private var generation = 0L
-
-    // Drift filter state
-    private var filterLastTrusted: TimeMappingEntry? = null
-    private var filterCandidatePool = mutableListOf<TimeMappingEntry>()
 
     @VisibleForTesting
     internal var debugTrackingEnabled = false
@@ -435,8 +430,7 @@ class FingerprintTimingManager @Inject constructor(
         pendingRestartJob?.cancel()
         pendingRestartJob = null
         unregisterUnmeteredRetry()
-        mappingPlaybackToReference.clear()
-        mappingReferenceToPlayback.clear()
+        mapping.reset()
         debugRejections.clear()
         debugRejectionsSnapshot = emptyList()
         publishSnapshot()
@@ -444,8 +438,6 @@ class FingerprintTimingManager @Inject constructor(
         lastStreamStartTimeMs = 0L
         activeDecodeStartSec = 0.0
         activeDecodeFrontierSec = 0.0
-        filterLastTrusted = null
-        filterCandidatePool.clear()
         currentEpisodeUuid = null
         currentAudioFilePath = null
         currentSharedCacheKey = null
@@ -638,10 +630,9 @@ class FingerprintTimingManager @Inject constructor(
             currentMatcher = matcher
             _stateFlow.value = State.Preparing
             if (cached != null) {
-                mappingPlaybackToReference = cached.entries.toMutableList()
-                mappingReferenceToPlayback = cached.entries.sortedBy { it.referenceTime }.toMutableList()
+                mapping.replaceAll(cached.entries)
                 publishSnapshot()
-                filterLastTrusted = cached.entries.lastOrNull()
+                mapping.lastTrusted = cached.entries.lastOrNull()
                 markActive(cached.entries.size)
                 Timber.d("FingerprintTimingManager: loaded mapping from cache for $episodeUuid (${cached.entries.size} entries)")
                 return
@@ -669,13 +660,13 @@ class FingerprintTimingManager @Inject constructor(
 
     private fun processProgress(positionMs: Int) {
         val positionSec = positionMs / 1000.0
-        val mappedRunEndSec = mappedRunEnd(positionSec, mappingPlaybackToReference)
+        val mappedRunEndSec = mappedRunEnd(positionSec, mapping.playbackToReference)
         val decision = decideOnProgress(
             positionSec = positionSec,
             lastPositionSec = if (lastProgressPositionMs >= 0) lastProgressPositionMs / 1000.0 else null,
             isEager = currentEager,
             mappedRunEndSec = mappedRunEndSec,
-            hasAnyMapping = mappingPlaybackToReference.isNotEmpty(),
+            hasAnyMapping = mapping.playbackToReference.isNotEmpty(),
             isDecodeActive = generationJob?.isActive == true,
             isCoveredByActiveDecode = isCoveredByActiveDecode(positionSec),
             isRunEndCoveredByActiveDecode = mappedRunEndSec != null && isCoveredByActiveDecode(mappedRunEndSec),
@@ -723,7 +714,7 @@ class FingerprintTimingManager @Inject constructor(
             mutex.withLock {
                 if (gen != generation) return@withLock
                 val settledSec = lastProgressPositionMs / 1000.0
-                if (mappedRunEnd(settledSec, mappingPlaybackToReference) != null || isCoveredByActiveDecode(settledSec)) return@withLock
+                if (mappedRunEnd(settledSec, mapping.playbackToReference) != null || isCoveredByActiveDecode(settledSec)) return@withLock
                 Timber.d("FingerprintTimingManager: playback jumped — restarting")
                 restartFromPlayhead()
             }
@@ -747,8 +738,7 @@ class FingerprintTimingManager @Inject constructor(
         val matcher = currentMatcher ?: return
         val audioPath = currentAudioFilePath ?: return
         val uuid = currentEpisodeUuid ?: return
-        filterLastTrusted = null
-        filterCandidatePool.clear()
+        mapping.resetFilter()
         startStream(audioPath, matcher, uuid, startPosition = lastProgressPositionMs / 1000.0)
     }
 
@@ -1071,7 +1061,7 @@ class FingerprintTimingManager @Inject constructor(
         }
 
         publishSnapshot()
-        val coverage = mappingPlaybackToReference.size
+        val coverage = mapping.playbackToReference.size
         if (coverage >= FingerprintConstants.MINIMUM_COVERAGE_FOR_ACTIVE) {
             markActive(coverage)
         }
@@ -1095,64 +1085,12 @@ class FingerprintTimingManager @Inject constructor(
         candidate: TimeMappingEntry,
         isDebug: Boolean = debugTrackingEnabled || FeatureFlag.isEnabled(Feature.SYNCED_TRANSCRIPT_DEBUG),
     ): Int {
-        val trusted = filterLastTrusted
-        if (trusted != null && isInTrend(candidate, trusted)) {
-            flushPoolAsRejected(isDebug)
-            insertMapping(candidate)
-            filterLastTrusted = candidate
-            if (isDebug) debugRejectionsSnapshot = debugRejections.toList()
-            return 1
+        val inserted = mapping.consider(candidate) { rejected ->
+            if (isDebug) recordDebugRejection(rejected.playbackTime, rejected.score)
+            Timber.d("FingerprintTimingManager: drift filter rejected candidate at playback ${rejected.playbackTime}s")
         }
-
-        filterCandidatePool.add(candidate)
-        val n = FingerprintConstants.DRIFT_BOOTSTRAP_COUNT
-
-        if (filterCandidatePool.size < n) return 0
-
-        val recent = filterCandidatePool.takeLast(n)
-        if (formsConsistentSequence(recent)) {
-            val keepStart = filterCandidatePool.size - n
-            for (i in 0 until keepStart) {
-                if (isDebug) recordDebugRejection(filterCandidatePool[i].playbackTime, filterCandidatePool[i].score)
-                Timber.d("FingerprintTimingManager: drift filter evicted candidate at playback ${filterCandidatePool[i].playbackTime}s")
-            }
-            for (entry in recent) {
-                insertMapping(entry)
-            }
-            filterLastTrusted = recent.last()
-            filterCandidatePool.clear()
-            if (isDebug) debugRejectionsSnapshot = debugRejections.toList()
-            return n
-        }
-
-        val evicted = filterCandidatePool.removeAt(0)
-        if (isDebug) recordDebugRejection(evicted.playbackTime, evicted.score)
-        Timber.d("FingerprintTimingManager: drift filter evicted candidate at playback ${evicted.playbackTime}s")
         if (isDebug) debugRejectionsSnapshot = debugRejections.toList()
-        return 0
-    }
-
-    private fun flushPoolAsRejected(isDebug: Boolean) {
-        if (isDebug) {
-            for (candidate in filterCandidatePool) {
-                recordDebugRejection(candidate.playbackTime, candidate.score)
-            }
-        }
-        filterCandidatePool.clear()
-    }
-
-    private fun isInTrend(candidate: TimeMappingEntry, anchor: TimeMappingEntry): Boolean {
-        val deltaPlayback = candidate.playbackTime - anchor.playbackTime
-        val deltaReference = candidate.referenceTime - anchor.referenceTime
-        return abs(deltaReference - deltaPlayback) <= FingerprintConstants.DRIFT_TOLERANCE_SECONDS
-    }
-
-    private fun formsConsistentSequence(entries: List<TimeMappingEntry>): Boolean {
-        if (entries.size < 2) return true
-        for (i in 1 until entries.size) {
-            if (!isInTrend(entries[i], entries[i - 1])) return false
-        }
-        return true
+        return inserted
     }
 
     private fun recordDebugRejection(playbackTime: Double, score: Float?) {
@@ -1163,17 +1101,13 @@ class FingerprintTimingManager @Inject constructor(
     }
 
     internal fun insertMapping(entry: TimeMappingEntry) {
-        val pbIdx = mappingPlaybackToReference.sortedInsertionIndex { it.playbackTime < entry.playbackTime }
-        mappingPlaybackToReference.add(pbIdx, entry)
-
-        val refIdx = mappingReferenceToPlayback.sortedInsertionIndex { it.referenceTime < entry.referenceTime }
-        mappingReferenceToPlayback.add(refIdx, entry)
+        mapping.insert(entry)
     }
 
     /** Publish an immutable snapshot of the mapping lists for lock-free reads. */
     private fun publishSnapshot() {
-        snapshotPlaybackToReference = mappingPlaybackToReference.toList()
-        snapshotReferenceToPlayback = mappingReferenceToPlayback.toList()
+        snapshotPlaybackToReference = mapping.playbackToReference.toList()
+        snapshotReferenceToPlayback = mapping.referenceToPlayback.toList()
         _mappingVersion.value++
     }
 
@@ -1361,18 +1295,4 @@ class FingerprintTimingManager @Inject constructor(
             return max(0.0, floor(time / stride) * stride)
         }
     }
-}
-
-private inline fun <T> MutableList<T>.sortedInsertionIndex(crossinline predicate: (T) -> Boolean): Int {
-    var lo = 0
-    var hi = size
-    while (lo < hi) {
-        val mid = (lo + hi) / 2
-        if (predicate(this[mid])) {
-            lo = mid + 1
-        } else {
-            hi = mid
-        }
-    }
-    return lo
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
@@ -656,14 +656,14 @@ class FingerprintTimingManager @Inject constructor(
 
     /**
      * Eager full-stream mapping only makes sense on mobile, for episodes with generated chapters,
-     * and when pulling the whole audio is cheap: a local download, or streaming on an unmetered network.
+     * and only for local downloads. Streaming episodes fall back to the throttled follow-the-playhead
+     * pass plus the bounded on-demand resolver, so we never pull a whole file over the network to map it.
      */
     private suspend fun shouldRunEagerPass(episodeUuid: String, isDownloaded: Boolean): Boolean {
         if (Util.getAppPlatform(context) != AppPlatform.Phone) return false
         return computeEager(
             hasGeneratedChapters = chapterManager.get().hasGeneratedChapters(episodeUuid),
             isDownloaded = isDownloaded,
-            isUnmetered = { Network.isUnmeteredConnection(context) },
         )
     }
 
@@ -1387,8 +1387,7 @@ class FingerprintTimingManager @Inject constructor(
         internal fun computeEager(
             hasGeneratedChapters: Boolean,
             isDownloaded: Boolean,
-            isUnmetered: () -> Boolean,
-        ): Boolean = hasGeneratedChapters && (isDownloaded || isUnmetered())
+        ): Boolean = hasGeneratedChapters && isDownloaded
 
         /** [isUnmetered] is a supplier so the network lookup is skipped for downloaded episodes. */
         internal fun shouldBlockRemoteFingerprinting(

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/GeneratedChapterSeeker.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/GeneratedChapterSeeker.kt
@@ -1,0 +1,96 @@
+package au.com.shiftyjelly.pocketcasts.repositories.fingerprint
+
+import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
+import au.com.shiftyjelly.pocketcasts.models.to.Chapter
+import au.com.shiftyjelly.pocketcasts.utils.AppPlatform
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
+import dagger.Lazy
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.math.ceil
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.DurationUnit
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.job
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import timber.log.Timber
+
+/**
+ * Resolves generated chapter seeks to the real stream position via the fingerprint map.
+ * Returns null whenever the caller should fall back to the chapter's own start time.
+ */
+@Singleton
+class GeneratedChapterSeeker @Inject constructor(
+    private val fingerprintTimingManager: Lazy<FingerprintTimingManager>,
+    private val appPlatform: AppPlatform,
+) {
+    data class ResolvingChapter(val episodeUuid: String, val chapterIndex: Int)
+
+    private val mutex = Mutex()
+    private var activeCaller: Job? = null
+
+    // Session cache of resolved chapter starts for the most recent episode.
+    private var cacheEpisodeUuid: String? = null
+    private val resolvedCache = mutableMapOf<Int, Duration>()
+
+    private val _resolvingChapter = MutableStateFlow<ResolvingChapter?>(null)
+    val resolvingChapter: StateFlow<ResolvingChapter?> = _resolvingChapter.asStateFlow()
+
+    suspend fun resolveSeekTime(episode: BaseEpisode, chapter: Chapter): Duration? {
+        if (!isEnabled(chapter)) return null
+        val referenceTime = chapter.referenceStartTime ?: return null
+
+        mutex.withLock {
+            if (cacheEpisodeUuid != episode.uuid) {
+                cacheEpisodeUuid = episode.uuid
+                resolvedCache.clear()
+            }
+            resolvedCache[chapter.index]
+        }?.let { return it }
+
+        val manager = fingerprintTimingManager.get()
+        manager.densePlaybackTime(episode.uuid, referenceTime)?.let { return it }
+
+        // Last tap wins: a new resolve cancels the previous caller, so a superseded tap never seeks.
+        val myJob = currentCoroutineContext().job
+        mutex.withLock {
+            activeCaller?.takeIf { it !== myJob }?.cancel()
+            activeCaller = myJob
+        }
+
+        val resolving = ResolvingChapter(episode.uuid, chapter.index)
+        _resolvingChapter.value = resolving
+        try {
+            return when (val result = manager.resolveChapterPlaybackTime(episode, referenceTime)) {
+                is ChapterSeekResult.Resolved -> {
+                    val playbackTime = ceil(result.playbackTime.toDouble(DurationUnit.SECONDS)).seconds
+                    mutex.withLock {
+                        if (cacheEpisodeUuid == episode.uuid) resolvedCache[chapter.index] = playbackTime
+                    }
+                    Timber.d("GeneratedChapterSeeker: resolved chapter ${chapter.index} to $playbackTime (usedPrior=${result.usedPrior})")
+                    playbackTime
+                }
+
+                is ChapterSeekResult.Unresolved -> {
+                    Timber.d("GeneratedChapterSeeker: unresolved chapter ${chapter.index} (${result.reason})")
+                    null
+                }
+            }
+        } finally {
+            _resolvingChapter.compareAndSet(resolving, null)
+            mutex.withLock { if (activeCaller === myJob) activeCaller = null }
+        }
+    }
+
+    private fun isEnabled(chapter: Chapter): Boolean = chapter.isGenerated &&
+        appPlatform == AppPlatform.Phone &&
+        FeatureFlag.isEnabled(Feature.SYNCED_TRANSCRIPTS) &&
+        FeatureFlag.isEnabled(Feature.GENERATED_CHAPTERS)
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/GeneratedChapterSeeker.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/GeneratedChapterSeeker.kt
@@ -14,9 +14,12 @@ import kotlin.time.Duration.Companion.seconds
 import kotlin.time.DurationUnit
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.job
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -42,6 +45,13 @@ class GeneratedChapterSeeker @Inject constructor(
 
     private val _resolvingChapter = MutableStateFlow<ResolvingChapter?>(null)
     val resolvingChapter: StateFlow<ResolvingChapter?> = _resolvingChapter.asStateFlow()
+
+    fun resolvingChapterIndex(episodeUuid: Flow<String?>): Flow<Int?> = combine(
+        resolvingChapter,
+        episodeUuid.distinctUntilChanged(),
+    ) { resolving, uuid ->
+        resolving?.takeIf { it.episodeUuid == uuid }?.chapterIndex
+    }
 
     suspend fun resolveSeekTime(episode: BaseEpisode, chapter: Chapter): Duration? {
         if (!isEnabled(chapter)) return null

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/GeneratedChapterSeeker.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/GeneratedChapterSeeker.kt
@@ -13,6 +13,7 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.DurationUnit
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -23,6 +24,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.job
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import timber.log.Timber
 
 /**
@@ -70,13 +72,12 @@ class GeneratedChapterSeeker @Inject constructor(
 
         // Last tap wins: a new resolve cancels the previous caller, so a superseded tap never seeks.
         val myJob = currentCoroutineContext().job
+        val resolving = ResolvingChapter(episode.uuid, chapter.index)
         mutex.withLock {
             activeCaller?.takeIf { it !== myJob }?.cancel()
             activeCaller = myJob
+            _resolvingChapter.value = resolving
         }
-
-        val resolving = ResolvingChapter(episode.uuid, chapter.index)
-        _resolvingChapter.value = resolving
         try {
             return when (val result = manager.resolveChapterPlaybackTime(episode, referenceTime)) {
                 is ChapterSeekResult.Resolved -> {
@@ -94,8 +95,15 @@ class GeneratedChapterSeeker @Inject constructor(
                 }
             }
         } finally {
-            _resolvingChapter.compareAndSet(resolving, null)
-            mutex.withLock { if (activeCaller === myJob) activeCaller = null }
+            // The resolving state is only cleared by its owner, so a superseded tap can't wipe the new tap's spinner.
+            withContext(NonCancellable) {
+                mutex.withLock {
+                    if (activeCaller === myJob) {
+                        activeCaller = null
+                        _resolvingChapter.value = null
+                    }
+                }
+            }
         }
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/GeneratedChapterSeeker.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/GeneratedChapterSeeker.kt
@@ -41,9 +41,12 @@ class GeneratedChapterSeeker @Inject constructor(
     private val mutex = Mutex()
     private var activeCaller: Job? = null
 
-    // Session cache of resolved chapter starts for the most recent episode.
+    // Session cache of resolved chapter starts for the most recent episode. Deterministic failures
+    // are remembered too: a missing reference blocks the episode, a no-match blocks its chapter.
     private var cacheEpisodeUuid: String? = null
     private val resolvedCache = mutableMapOf<Int, Duration>()
+    private val failedChapters = mutableSetOf<Int>()
+    private var referenceUnavailable = false
 
     private val _resolvingChapter = MutableStateFlow<ResolvingChapter?>(null)
     val resolvingChapter: StateFlow<ResolvingChapter?> = _resolvingChapter.asStateFlow()
@@ -63,12 +66,17 @@ class GeneratedChapterSeeker @Inject constructor(
             if (cacheEpisodeUuid != episode.uuid) {
                 cacheEpisodeUuid = episode.uuid
                 resolvedCache.clear()
+                failedChapters.clear()
+                referenceUnavailable = false
             }
             resolvedCache[chapter.index]
         }?.let { return it }
 
         val manager = fingerprintTimingManager.get()
         manager.densePlaybackTime(episode.uuid, referenceTime)?.let { return it }
+
+        // A remembered failure repeats deterministically, so fall back without re-resolving.
+        if (mutex.withLock { referenceUnavailable || chapter.index in failedChapters }) return null
 
         // Last tap wins: a new resolve cancels the previous caller, so a superseded tap never seeks.
         val myJob = currentCoroutineContext().job
@@ -90,6 +98,14 @@ class GeneratedChapterSeeker @Inject constructor(
                 }
 
                 is ChapterSeekResult.Unresolved -> {
+                    mutex.withLock {
+                        if (cacheEpisodeUuid == episode.uuid) {
+                            when (result.reason) {
+                                ChapterSeekResult.REASON_NO_REFERENCE -> referenceUnavailable = true
+                                ChapterSeekResult.REASON_NO_MATCH -> failedChapters += chapter.index
+                            }
+                        }
+                    }
                     Timber.d("GeneratedChapterSeeker: unresolved chapter ${chapter.index} (${result.reason})")
                     null
                 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/MappingAccumulator.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/MappingAccumulator.kt
@@ -1,0 +1,99 @@
+package au.com.shiftyjelly.pocketcasts.repositories.fingerprint
+
+import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.FingerprintTimingManager.TimeMappingEntry
+import kotlin.math.abs
+
+/**
+ * Sorted playback<->reference anchor lists plus the drift-filter state that feeds them.
+ * The continuous transcript flow and one-shot chapter resolves each use their own instance,
+ * so a resolve can never disturb the live mapping.
+ */
+internal class MappingAccumulator {
+    val playbackToReference = mutableListOf<TimeMappingEntry>()
+    val referenceToPlayback = mutableListOf<TimeMappingEntry>()
+    var lastTrusted: TimeMappingEntry? = null
+    val candidatePool = mutableListOf<TimeMappingEntry>()
+
+    fun insert(entry: TimeMappingEntry) {
+        val pbIdx = playbackToReference.sortedInsertionIndex { it.playbackTime < entry.playbackTime }
+        playbackToReference.add(pbIdx, entry)
+
+        val refIdx = referenceToPlayback.sortedInsertionIndex { it.referenceTime < entry.referenceTime }
+        referenceToPlayback.add(refIdx, entry)
+    }
+
+    fun replaceAll(entries: List<TimeMappingEntry>) {
+        playbackToReference.clear()
+        playbackToReference += entries.sortedBy { it.playbackTime }
+        referenceToPlayback.clear()
+        referenceToPlayback += entries.sortedBy { it.referenceTime }
+    }
+
+    fun consider(candidate: TimeMappingEntry, onRejected: (TimeMappingEntry) -> Unit): Int {
+        val trusted = lastTrusted
+        if (trusted != null && isInTrend(candidate, trusted)) {
+            candidatePool.forEach(onRejected)
+            candidatePool.clear()
+            insert(candidate)
+            lastTrusted = candidate
+            return 1
+        }
+
+        candidatePool.add(candidate)
+        val n = FingerprintConstants.DRIFT_BOOTSTRAP_COUNT
+        if (candidatePool.size < n) return 0
+
+        val recent = candidatePool.takeLast(n)
+        if (formsConsistentSequence(recent)) {
+            for (i in 0 until candidatePool.size - n) {
+                onRejected(candidatePool[i])
+            }
+            recent.forEach(::insert)
+            lastTrusted = recent.last()
+            candidatePool.clear()
+            return n
+        }
+
+        onRejected(candidatePool.removeAt(0))
+        return 0
+    }
+
+    fun resetFilter() {
+        lastTrusted = null
+        candidatePool.clear()
+    }
+
+    fun reset() {
+        playbackToReference.clear()
+        referenceToPlayback.clear()
+        resetFilter()
+    }
+
+    private fun isInTrend(candidate: TimeMappingEntry, anchor: TimeMappingEntry): Boolean {
+        val deltaPlayback = candidate.playbackTime - anchor.playbackTime
+        val deltaReference = candidate.referenceTime - anchor.referenceTime
+        return abs(deltaReference - deltaPlayback) <= FingerprintConstants.DRIFT_TOLERANCE_SECONDS
+    }
+
+    private fun formsConsistentSequence(entries: List<TimeMappingEntry>): Boolean {
+        if (entries.size < 2) return true
+        for (i in 1 until entries.size) {
+            if (!isInTrend(entries[i], entries[i - 1])) return false
+        }
+        return true
+    }
+}
+
+internal inline fun <T> MutableList<T>.sortedInsertionIndex(crossinline predicate: (T) -> Boolean): Int {
+    var lo = 0
+    var hi = size
+    while (lo < hi) {
+        val mid = (lo + hi) / 2
+        if (predicate(this[mid])) {
+            lo = mid + 1
+        } else {
+            hi = mid
+        }
+    }
+    return lo
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -45,6 +45,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
 import au.com.shiftyjelly.pocketcasts.repositories.chromecast.CastManager
 import au.com.shiftyjelly.pocketcasts.repositories.di.NotificationPermissionChecker
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadQueue
+import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.GeneratedChapterSeeker
 import au.com.shiftyjelly.pocketcasts.repositories.history.upnext.UpNextHistoryManager
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationHelper
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationManager
@@ -96,6 +97,7 @@ import com.automattic.eventhorizon.PlayerEpisodeCompletedEvent
 import com.automattic.eventhorizon.Trackable
 import com.jakewharton.rxrelay2.BehaviorRelay
 import com.jakewharton.rxrelay2.Relay
+import dagger.Lazy
 import dagger.hilt.android.qualifiers.ApplicationContext
 import io.reactivex.BackpressureStrategy
 import io.reactivex.Completable
@@ -170,6 +172,7 @@ open class PlaybackManager @Inject constructor(
     private val autoPlaySelector: AutoPlaySelector,
     private val browseTreeProvider: BrowseTreeProvider,
     private val alternateEnclosureManager: AlternateEnclosureManager,
+    private val generatedChapterSeeker: Lazy<GeneratedChapterSeeker>,
 ) : FocusManager.FocusChangeListener,
     AudioNoisyManager.AudioBecomingNoisyListener,
     CoroutineScope {
@@ -1129,7 +1132,7 @@ open class PlaybackManager @Inject constructor(
             val episode = getCurrentEpisode() ?: return@launch
             val currentTimeMs = getCurrentTimeMs(episode = episode)
             playbackStateRelay.blockingFirst().chapters.getNextSelectedChapter(currentTimeMs.milliseconds)?.let { chapter ->
-                seekToTimeMsInternal(chapter.startTime)
+                seekToChapterStart(episode, chapter)
                 trackPlaybackEvent(SourceView.PLAYER) { source, contentType ->
                     PlaybackChapterSkippedEvent(
                         source = source.analyticsValue,
@@ -1146,7 +1149,7 @@ open class PlaybackManager @Inject constructor(
             val episode = getCurrentEpisode() ?: return@launch
             val currentTimeMs = getCurrentTimeMs(episode)
             playbackStateRelay.blockingFirst().chapters.getPreviousSelectedChapter(currentTimeMs.milliseconds)?.let { chapter ->
-                seekToTimeMsInternal(chapter.startTime)
+                seekToChapterStart(episode, chapter)
                 trackPlaybackEvent(SourceView.PLAYER) { source, contentType ->
                     PlaybackChapterSkippedEvent(
                         source = source.analyticsValue,
@@ -1176,7 +1179,7 @@ open class PlaybackManager @Inject constructor(
     fun skipToChapter(chapter: Chapter) {
         launch {
             if (chapter.selected) {
-                seekToTimeMsInternal(chapter.startTime)
+                seekToChapterStart(getCurrentEpisode(), chapter)
             } else {
                 skipToNextSelectedOrLastChapter()
             }
@@ -1187,11 +1190,22 @@ open class PlaybackManager @Inject constructor(
         launch {
             val chapter = playbackStateRelay.blockingFirst().chapters.firstOrNull { it.index == index } ?: return@launch
             if (chapter.selected) {
-                seekToTimeMsInternal(chapter.startTime)
+                seekToChapterStart(getCurrentEpisode(), chapter)
             } else {
                 skipToNextSelectedOrLastChapter()
             }
         }
+    }
+
+    /**
+     * Generated chapter timestamps live on the reference timeline; resolve the real stream position
+     * through the fingerprint map before seeking. Falls back to the chapter's own start time.
+     */
+    private suspend fun seekToChapterStart(episode: BaseEpisode?, chapter: Chapter) {
+        val resolved = episode?.let { generatedChapterSeeker.get().resolveSeekTime(it, chapter) }
+        // Resolving can take seconds; drop the seek if the episode changed meanwhile.
+        if (episode != null && getCurrentEpisode()?.uuid != episode.uuid) return
+        seekToTimeMsInternal(resolved ?: chapter.startTime)
     }
 
     fun clearUpNextAsync() {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/ChapterManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/ChapterManagerImpl.kt
@@ -118,6 +118,7 @@ class ChapterManagerImpl @Inject constructor(
                 uiIndex = -1, // We set any value here as it is updated later in the processing chain
                 selected = firstChapter.index !in episode.deselectedChapters,
                 origin = firstChapter.origin,
+                referenceStartTime = newStartTime.takeIf { firstChapter.origin == ChapterOrigin.Generated },
             )
         }
         .filter { it.duration > Duration.ZERO }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManagerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManagerTest.kt
@@ -616,4 +616,32 @@ class FingerprintTimingManagerTest {
         val aligned = FingerprintTimingManager.alignToWindowGrid(0.0)
         assertEquals(0.0, aligned, 0.001)
     }
+
+    @Test
+    fun `searchWindow cold searches forward from reference time`() {
+        val window = FingerprintTimingManager.searchWindow(referenceTimeSec = 600.0, estimatedPlaybackSec = null)
+        assertEquals(600.0, window.startSec, 0.001)
+        assertEquals(600.0 + FingerprintConstants.ON_DEMAND_COLD_BUDGET_SECONDS, window.endSec, 0.001)
+    }
+
+    @Test
+    fun `searchWindow warm brackets the estimate within budgets`() {
+        val window = FingerprintTimingManager.searchWindow(referenceTimeSec = 600.0, estimatedPlaybackSec = 900.0)
+        assertEquals(900.0 - FingerprintConstants.ON_DEMAND_BACKWARD_MAX_SECONDS, window.startSec, 0.001)
+        assertEquals(900.0 + FingerprintConstants.ON_DEMAND_FORWARD_BUDGET_SECONDS, window.endSec, 0.001)
+    }
+
+    @Test
+    fun `searchWindow warm never starts below reference time`() {
+        val window = FingerprintTimingManager.searchWindow(referenceTimeSec = 600.0, estimatedPlaybackSec = 650.0)
+        assertEquals(600.0, window.startSec, 0.001)
+        assertEquals(650.0 + FingerprintConstants.ON_DEMAND_FORWARD_BUDGET_SECONDS, window.endSec, 0.001)
+    }
+
+    @Test
+    fun `searchWindow warm keeps forward budget when estimate is below reference time`() {
+        val window = FingerprintTimingManager.searchWindow(referenceTimeSec = 600.0, estimatedPlaybackSec = 300.0)
+        assertEquals(600.0, window.startSec, 0.001)
+        assertEquals(600.0 + FingerprintConstants.ON_DEMAND_FORWARD_BUDGET_SECONDS, window.endSec, 0.001)
+    }
 }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManagerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManagerTest.kt
@@ -113,27 +113,17 @@ class FingerprintTimingManagerTest {
         val eager = FingerprintTimingManager.computeEager(
             hasGeneratedChapters = true,
             isDownloaded = true,
-            isUnmetered = { false },
         )
         assertTrue(eager)
     }
 
     @Test
-    fun `computeEager runs for streaming episode on unmetered network`() {
+    fun `computeEager skips streaming episode`() {
+        // Streaming episodes never eager-decode the whole file; they use the throttled pass plus
+        // the bounded on-demand resolver, regardless of network, to avoid pulling the whole file.
         val eager = FingerprintTimingManager.computeEager(
             hasGeneratedChapters = true,
             isDownloaded = false,
-            isUnmetered = { true },
-        )
-        assertTrue(eager)
-    }
-
-    @Test
-    fun `computeEager skips streaming episode on metered network`() {
-        val eager = FingerprintTimingManager.computeEager(
-            hasGeneratedChapters = true,
-            isDownloaded = false,
-            isUnmetered = { false },
         )
         assertFalse(eager)
     }
@@ -143,23 +133,8 @@ class FingerprintTimingManagerTest {
         val eager = FingerprintTimingManager.computeEager(
             hasGeneratedChapters = false,
             isDownloaded = true,
-            isUnmetered = { true },
         )
         assertFalse(eager)
-    }
-
-    @Test
-    fun `computeEager does not query network for downloaded episode`() {
-        var queriedNetwork = false
-        FingerprintTimingManager.computeEager(
-            hasGeneratedChapters = true,
-            isDownloaded = true,
-            isUnmetered = {
-                queriedNetwork = true
-                true
-            },
-        )
-        assertFalse(queriedNetwork)
     }
 
     @Test

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManagerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManagerTest.kt
@@ -219,6 +219,46 @@ class FingerprintTimingManagerTest {
     }
 
     @Test
+    fun `shouldBlockOnDemandResolve never blocks downloaded episodes`() {
+        val blocked = FingerprintTimingManager.shouldBlockOnDemandResolve(
+            isDownloaded = true,
+            warnOnMeteredNetwork = true,
+            isUnmetered = { error("network should not be queried") },
+        )
+        assertFalse(blocked)
+    }
+
+    @Test
+    fun `shouldBlockOnDemandResolve allows streaming on metered network by default`() {
+        val blocked = FingerprintTimingManager.shouldBlockOnDemandResolve(
+            isDownloaded = false,
+            warnOnMeteredNetwork = false,
+            isUnmetered = { false },
+        )
+        assertFalse(blocked)
+    }
+
+    @Test
+    fun `shouldBlockOnDemandResolve blocks streaming on metered network when user warns on data use`() {
+        val blocked = FingerprintTimingManager.shouldBlockOnDemandResolve(
+            isDownloaded = false,
+            warnOnMeteredNetwork = true,
+            isUnmetered = { false },
+        )
+        assertTrue(blocked)
+    }
+
+    @Test
+    fun `shouldBlockOnDemandResolve never blocks on unmetered network`() {
+        val blocked = FingerprintTimingManager.shouldBlockOnDemandResolve(
+            isDownloaded = false,
+            warnOnMeteredNetwork = true,
+            isUnmetered = { true },
+        )
+        assertFalse(blocked)
+    }
+
+    @Test
     fun `decideOnProgress ignores ticks in eager mode`() {
         val decision = decideOnProgress(positionSec = 100.0, lastPositionSec = 10.0, isEager = true)
         assertEquals(ProgressDecision.None, decision)

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/GeneratedChapterSeekerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/GeneratedChapterSeekerTest.kt
@@ -161,6 +161,25 @@ class GeneratedChapterSeekerTest {
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
+    fun `superseded tap does not clear the new tap's resolving state`() = runTest {
+        timingManager = mock {
+            on { resolveChapterPlaybackTime(any(), any()) } doSuspendableAnswer { awaitCancellation() }
+        }
+        val seeker = seeker()
+        launch { seeker.resolveSeekTime(episode, generatedChapter) }
+        runCurrent()
+        val secondTap = launch { seeker.resolveSeekTime(episode, generatedChapter) }
+        runCurrent()
+
+        assertEquals(GeneratedChapterSeeker.ResolvingChapter("episode-uuid", 2), seeker.resolvingChapter.value)
+
+        secondTap.cancelAndJoin()
+
+        assertNull(seeker.resolvingChapter.value)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
     fun `resolving chapter index follows the current episode`() = runTest {
         timingManager = mock {
             on { resolveChapterPlaybackTime(any(), any()) } doSuspendableAnswer { awaitCancellation() }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/GeneratedChapterSeekerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/GeneratedChapterSeekerTest.kt
@@ -10,6 +10,13 @@ import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import dagger.Lazy
 import java.util.Date
 import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -18,6 +25,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -149,5 +157,23 @@ class GeneratedChapterSeekerTest {
 
         assertNull(seeker.resolvingChapter.value)
         verify(timingManager).densePlaybackTime("episode-uuid", 100.seconds)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `resolving chapter index follows the current episode`() = runTest {
+        timingManager = mock {
+            on { resolveChapterPlaybackTime(any(), any()) } doSuspendableAnswer { awaitCancellation() }
+        }
+        val seeker = seeker()
+        val job = launch { seeker.resolveSeekTime(episode, generatedChapter) }
+        runCurrent()
+
+        assertEquals(2, seeker.resolvingChapterIndex(flowOf("episode-uuid")).first())
+        assertNull(seeker.resolvingChapterIndex(flowOf("other-uuid")).first())
+
+        job.cancelAndJoin()
+
+        assertNull(seeker.resolvingChapterIndex(flowOf("episode-uuid")).first())
     }
 }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/GeneratedChapterSeekerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/GeneratedChapterSeekerTest.kt
@@ -1,0 +1,153 @@
+package au.com.shiftyjelly.pocketcasts.repositories.fingerprint
+
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.to.Chapter
+import au.com.shiftyjelly.pocketcasts.models.to.ChapterOrigin
+import au.com.shiftyjelly.pocketcasts.sharedtest.InMemoryFeatureFlagRule
+import au.com.shiftyjelly.pocketcasts.utils.AppPlatform
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
+import dagger.Lazy
+import java.util.Date
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyBlocking
+
+class GeneratedChapterSeekerTest {
+    @get:Rule
+    val featureFlagRule = InMemoryFeatureFlagRule()
+
+    private val episode = PodcastEpisode(uuid = "episode-uuid", publishedDate = Date())
+
+    private val generatedChapter = Chapter(
+        title = "Generated",
+        startTime = 130.seconds,
+        endTime = 200.seconds,
+        index = 2,
+        uiIndex = 3,
+        origin = ChapterOrigin.Generated,
+        referenceStartTime = 100.seconds,
+    )
+
+    private lateinit var timingManager: FingerprintTimingManager
+
+    @Before
+    fun setUp() {
+        FeatureFlag.setEnabled(Feature.SYNCED_TRANSCRIPTS, true)
+        FeatureFlag.setEnabled(Feature.GENERATED_CHAPTERS, true)
+        timingManager = mock()
+    }
+
+    private fun seeker(appPlatform: AppPlatform = AppPlatform.Phone) = GeneratedChapterSeeker(
+        fingerprintTimingManager = Lazy { timingManager },
+        appPlatform = appPlatform,
+    )
+
+    @Test
+    fun `returns null for non-generated chapters`() = runTest {
+        val chapter = generatedChapter.copy(origin = ChapterOrigin.ShowNotes)
+
+        assertNull(seeker().resolveSeekTime(episode, chapter))
+        verifyBlocking(timingManager, never()) { resolveChapterPlaybackTime(any(), any()) }
+    }
+
+    @Test
+    fun `returns null when synced transcripts flag is off`() = runTest {
+        FeatureFlag.setEnabled(Feature.SYNCED_TRANSCRIPTS, false)
+
+        assertNull(seeker().resolveSeekTime(episode, generatedChapter))
+        verifyBlocking(timingManager, never()) { resolveChapterPlaybackTime(any(), any()) }
+    }
+
+    @Test
+    fun `returns null on non-phone platforms`() = runTest {
+        assertNull(seeker(AppPlatform.Automotive).resolveSeekTime(episode, generatedChapter))
+        verifyBlocking(timingManager, never()) { resolveChapterPlaybackTime(any(), any()) }
+    }
+
+    @Test
+    fun `returns null without a reference start time`() = runTest {
+        val chapter = generatedChapter.copy(referenceStartTime = null)
+
+        assertNull(seeker().resolveSeekTime(episode, chapter))
+        verifyBlocking(timingManager, never()) { resolveChapterPlaybackTime(any(), any()) }
+    }
+
+    @Test
+    fun `uses the dense mapping fast path without resolving`() = runTest {
+        timingManager = mock {
+            on { densePlaybackTime(eq("episode-uuid"), eq(100.seconds)) } doReturn 131.5.seconds
+        }
+
+        assertEquals(131.5.seconds, seeker().resolveSeekTime(episode, generatedChapter))
+        verifyBlocking(timingManager, never()) { resolveChapterPlaybackTime(any(), any()) }
+    }
+
+    @Test
+    fun `resolves and caches the rounded-up playback time`() = runTest {
+        timingManager = mock {
+            on { resolveChapterPlaybackTime(any(), eq(100.seconds)) } doReturn
+                ChapterSeekResult.Resolved(playbackTime = 130.2.seconds, usedPrior = false)
+        }
+        val seeker = seeker()
+
+        assertEquals(131.seconds, seeker.resolveSeekTime(episode, generatedChapter))
+        assertEquals(131.seconds, seeker.resolveSeekTime(episode, generatedChapter))
+        verifyBlocking(timingManager, times(1)) { resolveChapterPlaybackTime(any(), any()) }
+    }
+
+    @Test
+    fun `returns null and does not cache when unresolved`() = runTest {
+        timingManager = mock {
+            on { resolveChapterPlaybackTime(any(), any()) } doReturn
+                ChapterSeekResult.Unresolved(ChapterSeekResult.REASON_NO_MATCH)
+        }
+        val seeker = seeker()
+
+        assertNull(seeker.resolveSeekTime(episode, generatedChapter))
+        assertNull(seeker.resolveSeekTime(episode, generatedChapter))
+        verifyBlocking(timingManager, times(2)) { resolveChapterPlaybackTime(any(), any()) }
+    }
+
+    @Test
+    fun `cache is dropped when the episode changes`() = runTest {
+        timingManager = mock {
+            on { resolveChapterPlaybackTime(any(), any()) } doReturn
+                ChapterSeekResult.Resolved(playbackTime = 130.0.seconds, usedPrior = true)
+        }
+        val seeker = seeker()
+        val otherEpisode = PodcastEpisode(uuid = "other-uuid", publishedDate = Date())
+
+        seeker.resolveSeekTime(episode, generatedChapter)
+        seeker.resolveSeekTime(otherEpisode, generatedChapter)
+        seeker.resolveSeekTime(episode, generatedChapter)
+
+        verifyBlocking(timingManager, times(3)) { resolveChapterPlaybackTime(any(), any()) }
+    }
+
+    @Test
+    fun `clears resolving state after a resolve`() = runTest {
+        timingManager = mock {
+            on { resolveChapterPlaybackTime(any(), any()) } doReturn
+                ChapterSeekResult.Resolved(playbackTime = 130.0.seconds, usedPrior = false)
+        }
+        val seeker = seeker()
+
+        seeker.resolveSeekTime(episode, generatedChapter)
+
+        assertNull(seeker.resolvingChapter.value)
+        verify(timingManager).densePlaybackTime("episode-uuid", 100.seconds)
+    }
+}

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/GeneratedChapterSeekerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/GeneratedChapterSeekerTest.kt
@@ -25,6 +25,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doReturnConsecutively
 import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -117,7 +118,20 @@ class GeneratedChapterSeekerTest {
     }
 
     @Test
-    fun `returns null and does not cache when unresolved`() = runTest {
+    fun `retries when unresolved for a transient reason`() = runTest {
+        timingManager = mock {
+            on { resolveChapterPlaybackTime(any(), any()) } doReturn
+                ChapterSeekResult.Unresolved(ChapterSeekResult.REASON_TIMEOUT)
+        }
+        val seeker = seeker()
+
+        assertNull(seeker.resolveSeekTime(episode, generatedChapter))
+        assertNull(seeker.resolveSeekTime(episode, generatedChapter))
+        verifyBlocking(timingManager, times(2)) { resolveChapterPlaybackTime(any(), any()) }
+    }
+
+    @Test
+    fun `does not retry a chapter that failed with no match`() = runTest {
         timingManager = mock {
             on { resolveChapterPlaybackTime(any(), any()) } doReturn
                 ChapterSeekResult.Unresolved(ChapterSeekResult.REASON_NO_MATCH)
@@ -126,6 +140,62 @@ class GeneratedChapterSeekerTest {
 
         assertNull(seeker.resolveSeekTime(episode, generatedChapter))
         assertNull(seeker.resolveSeekTime(episode, generatedChapter))
+        verifyBlocking(timingManager, times(1)) { resolveChapterPlaybackTime(any(), any()) }
+    }
+
+    @Test
+    fun `no match failure does not block other chapters`() = runTest {
+        timingManager = mock {
+            on { resolveChapterPlaybackTime(any(), any()) } doReturn
+                ChapterSeekResult.Unresolved(ChapterSeekResult.REASON_NO_MATCH)
+        }
+        val seeker = seeker()
+        val otherChapter = generatedChapter.copy(index = 3, referenceStartTime = 300.seconds)
+
+        assertNull(seeker.resolveSeekTime(episode, generatedChapter))
+        assertNull(seeker.resolveSeekTime(episode, otherChapter))
+        verifyBlocking(timingManager, times(2)) { resolveChapterPlaybackTime(any(), any()) }
+    }
+
+    @Test
+    fun `missing reference blocks further resolves for the episode`() = runTest {
+        timingManager = mock {
+            on { resolveChapterPlaybackTime(any(), any()) } doReturn
+                ChapterSeekResult.Unresolved(ChapterSeekResult.REASON_NO_REFERENCE)
+        }
+        val seeker = seeker()
+        val otherChapter = generatedChapter.copy(index = 3, referenceStartTime = 300.seconds)
+
+        assertNull(seeker.resolveSeekTime(episode, generatedChapter))
+        assertNull(seeker.resolveSeekTime(episode, otherChapter))
+        verifyBlocking(timingManager, times(1)) { resolveChapterPlaybackTime(any(), any()) }
+    }
+
+    @Test
+    fun `dense mapping still serves a chapter that previously failed`() = runTest {
+        timingManager = mock {
+            on { densePlaybackTime(any(), any()) } doReturnConsecutively listOf(null, 131.5.seconds)
+            on { resolveChapterPlaybackTime(any(), any()) } doReturn
+                ChapterSeekResult.Unresolved(ChapterSeekResult.REASON_NO_MATCH)
+        }
+        val seeker = seeker()
+
+        assertNull(seeker.resolveSeekTime(episode, generatedChapter))
+        assertEquals(131.5.seconds, seeker.resolveSeekTime(episode, generatedChapter))
+        verifyBlocking(timingManager, times(1)) { resolveChapterPlaybackTime(any(), any()) }
+    }
+
+    @Test
+    fun `negative results are dropped when the episode changes`() = runTest {
+        timingManager = mock {
+            on { resolveChapterPlaybackTime(any(), any()) } doReturn
+                ChapterSeekResult.Unresolved(ChapterSeekResult.REASON_NO_REFERENCE)
+        }
+        val seeker = seeker()
+        val otherEpisode = PodcastEpisode(uuid = "other-uuid", publishedDate = Date())
+
+        assertNull(seeker.resolveSeekTime(episode, generatedChapter))
+        assertNull(seeker.resolveSeekTime(otherEpisode, generatedChapter))
         verifyBlocking(timingManager, times(2)) { resolveChapterPlaybackTime(any(), any()) }
     }
 

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/MappingAccumulatorTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/MappingAccumulatorTest.kt
@@ -1,0 +1,58 @@
+package au.com.shiftyjelly.pocketcasts.repositories.fingerprint
+
+import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.FingerprintTimingManager.TimeMappingEntry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MappingAccumulatorTest {
+
+    @Test
+    fun `replaceAll keeps both lookup directions sorted`() {
+        val acc = MappingAccumulator()
+        acc.replaceAll(
+            listOf(
+                TimeMappingEntry(playbackTime = 15.0, referenceTime = 5.0),
+                TimeMappingEntry(playbackTime = 5.0, referenceTime = 15.0),
+                TimeMappingEntry(playbackTime = 10.0, referenceTime = 10.0),
+            ),
+        )
+
+        assertEquals(listOf(5.0, 10.0, 15.0), acc.playbackToReference.map { it.playbackTime })
+        assertEquals(listOf(5.0, 10.0, 15.0), acc.referenceToPlayback.map { it.referenceTime })
+    }
+
+    @Test
+    fun `scratch accumulator does not disturb another instance`() {
+        val main = MappingAccumulator()
+        val bootstrap = listOf(
+            TimeMappingEntry(playbackTime = 10.0, referenceTime = 10.0),
+            TimeMappingEntry(playbackTime = 12.0, referenceTime = 12.0),
+            TimeMappingEntry(playbackTime = 14.0, referenceTime = 14.0),
+        )
+        bootstrap.forEach { main.consider(it) {} }
+
+        val scratch = MappingAccumulator()
+        scratch.consider(TimeMappingEntry(playbackTime = 500.0, referenceTime = 900.0)) {}
+        scratch.reset()
+
+        assertEquals(3, main.playbackToReference.size)
+        assertEquals(bootstrap, main.playbackToReference)
+        assertEquals(bootstrap.last(), main.lastTrusted)
+    }
+
+    @Test
+    fun `reset clears mapping and filter state`() {
+        val acc = MappingAccumulator()
+        acc.consider(TimeMappingEntry(playbackTime = 10.0, referenceTime = 10.0)) {}
+        acc.replaceAll(listOf(TimeMappingEntry(playbackTime = 1.0, referenceTime = 1.0)))
+        acc.lastTrusted = TimeMappingEntry(playbackTime = 1.0, referenceTime = 1.0)
+
+        acc.reset()
+
+        assertTrue(acc.playbackToReference.isEmpty())
+        assertTrue(acc.referenceToPlayback.isEmpty())
+        assertTrue(acc.candidatePool.isEmpty())
+        assertEquals(null, acc.lastTrusted)
+    }
+}

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/ChapterManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/ChapterManagerImplTest.kt
@@ -787,6 +787,20 @@ class ChapterManagerImplTest {
     }
 
     @Test
+    fun `align keeps the reference start time on translated generated chapters`() {
+        val chapters = Chapters(
+            listOf(
+                Chapter(title = "A", startTime = 10.seconds, endTime = 20.seconds, index = 0, uiIndex = 1, origin = ChapterOrigin.Generated, referenceStartTime = 10.seconds),
+            ),
+        )
+
+        val aligned = ChapterManagerImpl.alignGeneratedChapters(chapters) { it + 30.seconds }
+
+        assertEquals(40.seconds, aligned[0].startTime)
+        assertEquals(10.seconds, aligned[0].referenceStartTime)
+    }
+
+    @Test
     fun `align returns chapters unchanged when none are generated`() {
         val chapters = Chapters(
             listOf(


### PR DESCRIPTION
## Description

Generated chapter timestamps live on the reference (ad-free) timeline, so seeking to `chapter.startTime` lands early whenever dynamically inserted ads shift the stream. This PR routes generated-chapter seeks through a bounded on-demand fingerprint resolve, adapting the approach that landed on iOS (pocket-casts-ios#4728) while keeping Android's existing strengths.

How a seek resolves, in order:
1. **Session cache** — a chapter already resolved this session seeks instantly.
2. **Dense mapping fast path** — if the continuous fingerprint map already brackets the chapter start with anchors ≤8s apart, interpolate directly (no decode).
3. **Bounded on-demand resolve** — decode and fingerprint only a small search window: cold `[t, t+240s]`, or warm `[max(t, est−180s), est+120s]` when the continuous map provides an estimate. Requires ≥2 anchors, hard 5s timeout, last-tap-wins supersession, and the scratch mapping never touches the continuous map.
4. **Raw-seek fallback** — anything unresolved falls back to the chapter's own start time (current behavior).

While a resolve is in flight, the chapter row shows a small spinner and the player's next/previous chapter button shows the same indicator.

As a quick recap, these are the areas where the android implementation is stronger than the iOS:
| Strength | What it buys |
  |---|---|
  | Eager whole-file pass for **downloaded** episodes | Accurate chapter-list timestamps + instant, correct seeks anywhere — even past the 240s cold-window limit. Costs only CPU on downloads |
  | Reactive whole-list chapter realignment | The chapter list shows true playback times as the map grows; iOS shows raw reference times until a chapter is tapped |
  | `densePlaybackTime` fast path | Skips the bounded decode entirely when the continuous map already brackets the chapter — instant seek, no spinner |
  | Proactive prep on playback start (+ bookmarks) | Mapping is often warm before the user ever opens a transcript or taps a chapter; iOS only starts when the transcript opens |
  | Metered-network gating + unmetered retry | Data-saving safeguard iOS has none of |
  | Cache-following decode source | Resolves can succeed in regions the player hasn't buffered; iOS falls back to a raw seek there |
  | Richer restart heuristics | Debounced restarts, bootstrap cooldown, run-end continuation — fewer wasted decode restarts on scrubbing |

Fixes PCDROID-671 https://linear.app/a8c/issue/PCDROID-671/check-on-the-latest-ios-implementation-changes

## Testing Instructions

1. Debug build with `SYNCED_TRANSCRIPTS` and `GENERATED_CHAPTERS` enabled.
2. Stream (don't download) an episode with generated chapters and dynamic ads.
3. Open the chapters list and tap a chapter well ahead of the playhead — the row shows a spinner, then playback lands on the chapter content (not early into an ad); if resolution fails, the seek falls back to the raw chapter time within 5s.
4. Use the next/previous chapter buttons in the full player — the tapped button shows the spinner during the resolve.
5. Download the same episode and reopen it — the chapter list re-aligns via the eager pass and taps seek instantly (unchanged behavior).
6. Verify transcript highlight and tap-to-seek still behave as before.

## Screenshots or Screencast

https://github.com/user-attachments/assets/085c2f3c-3107-42a4-849f-8c174e53dca1


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

#### I have tested any UI changes...
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack