### PR TITLE
Fix status bar icon contrast in bookmark dialogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
     *   HLS support
         ([#5602](https://github.com/Automattic/pocket-casts-android/pull/5602))
 *   Bug Fixes
+    *   Fix status bar icon contrast in light-themed bookmark dialogs
+        ([#2127](https://github.com/Automattic/pocket-casts-android/issues/2127))
     *   Fix episodes being cached over mobile data when Warn before using data is enabled
         ([#5567](https://github.com/Automattic/pocket-casts-android/pull/5567))
     *   Reduce the chance of episode playback progress reverting during listening history sync

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksContainerFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksContainerFragment.kt
@@ -51,7 +51,7 @@ class BookmarksContainerFragment : BaseDialogFragment() {
         get() = if (sourceView == SourceView.PROFILE) {
             StatusBarIconColor.Theme
         } else {
-            StatusBarIconColor.Light
+            StatusBarIconColor.ThemeNoToolbar
         }
 
     var binding: FragmentBookmarksContainerBinding? = null


### PR DESCRIPTION
## Description

Fixes the status bar icon contrast when opening Bookmarks from a user file. Light-background themes now use dark status bar icons, while dark-background themes continue using light icons.

Fixes #2127

## Testing Instructions

1. Use a paid account with an uploaded file.
2. Select a light-background theme.
3. Open Profile > Files, select a file, and tap Bookmarks.
4. Verify that the status bar icons are dark and readable.
5. Repeat with a dark-background theme and verify that the icons remain light.
6. Dismiss the dialog and verify that the previous status bar appearance is restored.

## Screenshots or Screencast

Not included because the affected Cloud File flow requires a paid account with uploaded content.

## Checklist

- [x] Added an entry to `CHANGELOG.md`.
- [x] Ran `./gradlew spotlessCheck`.
- [x] Considered automated coverage; the existing unit-test setup does not expose Android system-bar rendering.
- [x] No strings, Compose UI, analytics schema, or migrations changed.

## Validation

- `git diff --check`
- `./gradlew spotlessCheck`
- `:modules:features:player:testDebugUnitTest` — 77 tests, 0 failures, 0 skipped
