### PR TITLE
[TV] Show dynamic content on the Home tab

### DIFF
--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -251,6 +251,7 @@
     <string name="tv_row_trending_videos">Trending Videos</string>
     <string name="tv_row_recommendations">Recommendations</string>
     <string name="tv_row_because_you_liked">Because you liked Podcast</string>
+    <string name="tv_home_keep_listening">Keep Listening</string>
     <string name="tv_sign_in_or_enter_code">or enter the following code</string>
     <string name="tv_sign_in_go_to_url">going to %1$s</string>
     <string name="unavailable">Unavailable</string>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/RepositoryProviderModule.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/RepositoryProviderModule.kt
@@ -69,7 +69,11 @@ class RepositoryProviderModule {
     @Provides
     @Singleton
     internal fun provideDiscoverRepository(listWebService: ListWebService, syncManager: SyncManager, @ApplicationContext context: Context): ListRepository {
-        val platform = if (Util.isAutomotive(context)) "automotive" else "android"
+        val platform = when {
+            Util.isAutomotive(context) -> ListRepository.PLATFORM_AUTOMOTIVE
+            Util.isTv(context) -> ListRepository.PLATFORM_TV
+            else -> ListRepository.PLATFORM_ANDROID
+        }
         return ListRepository(
             listWebService,
             syncManager,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/lists/ListRepository.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/lists/ListRepository.kt
@@ -17,7 +17,7 @@ class ListRepository(
 ) {
 
     suspend fun getDiscoverFeed(): Discover {
-        val version = if (FeatureFlag.isEnabled(Feature.RECOMMENDATIONS)) 3 else 2
+        val version = if (platform == PLATFORM_TV || FeatureFlag.isEnabled(Feature.RECOMMENDATIONS)) 3 else 2
         return listWebService.getDiscoverFeed(platform = platform, version = version)
     }
 
@@ -45,5 +45,11 @@ class ListRepository(
 
     suspend fun getPodcastRecommendations(podcastUuid: String, countryCode: String?): ListFeed? {
         return getListFeed(url = "${Settings.SERVER_API_URL}/recommendations/podcast/$podcastUuid?country=${countryCode ?: "global"}")
+    }
+
+    companion object {
+        const val PLATFORM_ANDROID = "android"
+        const val PLATFORM_AUTOMOTIVE = "automotive"
+        const val PLATFORM_TV = "tv"
     }
 }

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/Util.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/Util.kt
@@ -29,6 +29,8 @@ object Util {
 
     fun isAutomotive(context: Context): Boolean = appInfoHasBoolean("pocketcasts_automotive", context)
 
+    fun isTv(context: Context): Boolean = appInfoHasBoolean("pocketcasts_tv", context)
+
     fun isWearOs(context: Context): Boolean = appInfoHasBoolean("pocketcasts_wear_os", context)
 
     // Caching this value since it will always be the same for a given app

--- a/tv/src/main/AndroidManifest.xml
+++ b/tv/src/main/AndroidManifest.xml
@@ -32,6 +32,10 @@
         android:theme="@style/Theme.AppCompat.NoActionBar"
         android:appCategory="audio">
 
+        <meta-data
+            android:name="pocketcasts_tv"
+            android:value="true" />
+
         <activity
             android:name=".TvActivity"
             android:exported="true">

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvRow.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvRow.kt
@@ -13,14 +13,16 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.PlatformTextStyle
@@ -74,21 +76,32 @@ fun <T> TvRow(
                 .padding(bottom = 17.dp),
         )
 
-        val firstItemFocusRequester = remember { FocusRequester() }
+        var lastFocusedIndex by rememberSaveable(items) { mutableIntStateOf(0) }
+        val focusRequesters = remember(items) { List(items.size) { FocusRequester() } }
 
         LazyRow(
             contentPadding = contentPadding,
             horizontalArrangement = Arrangement.spacedBy(itemSpacing),
             modifier = Modifier
                 .focusGroup()
-                .focusRestorer(firstItemFocusRequester),
+                .focusProperties {
+                    onEnter = {
+                        focusRequesters.getOrNull(lastFocusedIndex)?.requestFocus()
+                    }
+                },
         ) {
             itemsIndexed(
                 items = items,
                 key = key?.let { k -> { _, item: T -> k(item) } },
             ) { index, item ->
                 Box(
-                    modifier = if (index == 0) Modifier.focusRequester(firstItemFocusRequester) else Modifier,
+                    modifier = Modifier
+                        .focusRequester(focusRequesters[index])
+                        .onFocusChanged { focusState ->
+                            if (focusState.hasFocus) {
+                                lastFocusedIndex = index
+                            }
+                        },
                 ) {
                     content(item)
                 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeScreen.kt
@@ -1,0 +1,218 @@
+package au.com.shiftyjelly.pocketcasts.home
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.OutlinedButton
+import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.component.TvFeaturedTile
+import au.com.shiftyjelly.pocketcasts.component.TvPodcastTile
+import au.com.shiftyjelly.pocketcasts.component.TvRow
+import au.com.shiftyjelly.pocketcasts.component.TvVideoTile
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.compose.loading.LoadingView
+import au.com.shiftyjelly.pocketcasts.theme.TvColors
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+fun TvHomeScreen(
+    modifier: Modifier = Modifier,
+    viewModel: TvHomeViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    TvHomeContent(
+        uiState = uiState,
+        onRetry = viewModel::load,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun TvHomeContent(
+    uiState: TvHomeUiState,
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    when (uiState) {
+        is TvHomeUiState.Loading -> LoadingView(color = Color.White, modifier = modifier)
+
+        is TvHomeUiState.Error -> TvHomeError(onRetry = onRetry, modifier = modifier)
+
+        is TvHomeUiState.Ready -> if (uiState.rows.isEmpty()) {
+            TvHomeError(onRetry = onRetry, modifier = modifier)
+        } else {
+            TvHomeRows(rows = uiState.rows, modifier = modifier)
+        }
+    }
+}
+
+@Composable
+private fun TvHomeError(
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = modifier.fillMaxSize(),
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text = stringResource(LR.string.error_generic_message),
+                color = Color.White,
+                style = MaterialTheme.typography.bodyLarge,
+            )
+            Spacer(modifier = Modifier.height(24.dp))
+            OutlinedButton(onClick = onRetry) {
+                Text(stringResource(LR.string.retry))
+            }
+        }
+    }
+}
+
+@Composable
+private fun TvHomeRows(
+    rows: List<TvHomeRow>,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(24.dp),
+    ) {
+        item { Spacer(modifier = Modifier.height(8.dp)) }
+
+        rows.forEach { row ->
+            when (row) {
+                is TvHomeRow.FeaturedPodcasts -> item(key = row.id) {
+                    TvRow(
+                        title = row.title,
+                        items = row.podcasts,
+                        itemSpacing = 32.dp,
+                        key = TvHomePodcast::uuid,
+                    ) { podcast ->
+                        TvFeaturedTile(
+                            artworkUrl = podcast.artworkUrl,
+                            isSponsored = podcast.isSponsored,
+                            title = podcast.title,
+                            description = podcast.description,
+                            onGoToPodcast = {},
+                            onPlayLastEpisode = {},
+                        )
+                    }
+                }
+
+                is TvHomeRow.Episodes -> item(key = row.id) {
+                    TvRow(
+                        title = row.title,
+                        items = row.episodes,
+                        itemSpacing = 32.dp,
+                        key = TvHomeEpisode::episodeUuid,
+                    ) { episode ->
+                        TvVideoTile(
+                            thumbnailUrl = episode.thumbnailUrl,
+                            podcastArtworkUrl = episode.podcastArtworkUrl,
+                            podcastTitle = episode.podcastTitle,
+                            episodeTitle = episode.episodeTitle,
+                            onPlayEpisode = {},
+                            onGoToPodcast = {},
+                        )
+                    }
+                }
+
+                is TvHomeRow.Podcasts -> item(key = row.id) {
+                    TvRow(
+                        title = row.title,
+                        items = row.podcasts,
+                        key = TvHomePodcast::uuid,
+                    ) { podcast ->
+                        TvPodcastTile(
+                            artworkUrl = podcast.artworkUrl,
+                            podcastTitle = podcast.title,
+                            onClick = {},
+                        )
+                    }
+                }
+            }
+        }
+
+        item { Spacer(modifier = Modifier.height(8.dp)) }
+    }
+}
+
+@Preview(device = Devices.TV_1080p)
+@Composable
+private fun TvHomeContentPreview() {
+    AppTheme(themeType = Theme.ThemeType.EXTRA_DARK) {
+        MaterialTheme {
+            Box(modifier = Modifier.background(TvColors.Dark)) {
+                TvHomeContent(
+                    uiState = TvHomeUiState.Ready(
+                        rows = listOf(
+                            TvHomeRow.FeaturedPodcasts(
+                                id = "featured",
+                                title = "Featured",
+                                podcasts = (1..3).map { previewPodcast(it) },
+                            ),
+                            TvHomeRow.Episodes(
+                                id = "tv_featured_videos",
+                                title = "Made for TV",
+                                episodes = (1..6).map {
+                                    TvHomeEpisode(
+                                        episodeUuid = "episode-$it",
+                                        episodeTitle = "Episode $it",
+                                        podcastUuid = "podcast-$it",
+                                        podcastTitle = "Podcast $it",
+                                    )
+                                },
+                            ),
+                            TvHomeRow.Podcasts(
+                                id = "trending",
+                                title = "Trending",
+                                podcasts = (1..8).map { previewPodcast(it) },
+                            ),
+                        ),
+                    ),
+                    onRetry = {},
+                )
+            }
+        }
+    }
+}
+
+@Preview(device = Devices.TV_1080p)
+@Composable
+private fun TvHomeErrorPreview() {
+    AppTheme(themeType = Theme.ThemeType.EXTRA_DARK) {
+        MaterialTheme {
+            Box(modifier = Modifier.background(TvColors.Dark)) {
+                TvHomeContent(
+                    uiState = TvHomeUiState.Error,
+                    onRetry = {},
+                )
+            }
+        }
+    }
+}
+
+private fun previewPodcast(index: Int) = TvHomePodcast(
+    uuid = "podcast-$index",
+    title = "Podcast $index",
+    description = "Description of podcast $index",
+)

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModel.kt
@@ -1,0 +1,273 @@
+package au.com.shiftyjelly.pocketcasts.home
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.models.db.dao.PodcastDao
+import au.com.shiftyjelly.pocketcasts.models.db.dao.UpNextDao
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImage
+import au.com.shiftyjelly.pocketcasts.repositories.lists.ListRepository
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.SmartPlaylistDraft
+import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
+import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverEpisode
+import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverPodcast
+import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverRow
+import au.com.shiftyjelly.pocketcasts.servers.model.DisplayStyle
+import au.com.shiftyjelly.pocketcasts.servers.model.ListType
+import au.com.shiftyjelly.pocketcasts.servers.model.transformWithRegion
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@HiltViewModel
+class TvHomeViewModel @Inject constructor(
+    private val listRepository: ListRepository,
+    private val playlistManager: PlaylistManager,
+    private val podcastDao: PodcastDao,
+    private val upNextDao: UpNextDao,
+    private val settings: Settings,
+    private val syncManager: SyncManager,
+    @ApplicationContext private val context: Context,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<TvHomeUiState>(TvHomeUiState.Loading)
+    val uiState: StateFlow<TvHomeUiState> = _uiState.asStateFlow()
+
+    private var loadJob: Job? = null
+
+    init {
+        load()
+    }
+
+    fun load() {
+        loadJob?.cancel()
+        loadJob = viewModelScope.launch {
+            _uiState.value = TvHomeUiState.Loading
+            _uiState.value = try {
+                TvHomeUiState.Ready(loadRows())
+            } catch (exception: CancellationException) {
+                throw exception
+            } catch (exception: Exception) {
+                Timber.e(exception, "Failed to load TV home feed")
+                TvHomeUiState.Error
+            }
+        }
+    }
+
+    private suspend fun loadRows(): List<TvHomeRow> = coroutineScope {
+        val isLoggedIn = syncManager.isLoggedIn()
+        val localRows = async { loadLocalRows(isLoggedIn) }
+        val discoverRows = async { loadDiscoverRows(isLoggedIn) }
+        (localRows.await() + discoverRows.await()).distinctBy(TvHomeRow::id)
+    }
+
+    private suspend fun loadDiscoverRows(isLoggedIn: Boolean): List<TvHomeRow> = coroutineScope {
+        val discover = listRepository.getDiscoverFeed()
+        val region = discover.regions[settings.discoverCountryCode.value]
+            ?: discover.regions[discover.defaultRegionCode]
+            ?: error("Could not resolve discover region")
+        val replacements = mapOf(
+            discover.regionCodeToken to region.code,
+            discover.regionNameToken to region.name,
+        )
+
+        discover.layout
+            .transformWithRegion(region, replacements, context.resources)
+            .filter { isLoggedIn || it.authenticated != true }
+            .map { row -> async { loadRow(row) } }
+            .awaitAll()
+            .filterNotNull()
+    }
+
+    private suspend fun loadLocalRows(isLoggedIn: Boolean): List<TvHomeRow> = coroutineScope {
+        val upNextEpisodesDeferred = async {
+            upNextDao.getUpNextBaseEpisodes(limit = UP_NEXT_LIMIT + 1).filterIsInstance<PodcastEpisode>()
+        }
+        val newReleasesDeferred = async {
+            if (isLoggedIn) {
+                playlistManager.smartEpisodesFlow(NEW_RELEASES_RULES)
+                    .first()
+                    .take(NEW_RELEASES_LIMIT)
+                    .map { it.episode }
+            } else {
+                emptyList()
+            }
+        }
+        val upNextEpisodes = upNextEpisodesDeferred.await()
+        val newReleases = newReleasesDeferred.await()
+        val podcastTitles = findPodcastTitles(upNextEpisodes + newReleases)
+
+        buildList {
+            upNextEpisodes.firstOrNull()?.let { current ->
+                add(
+                    TvHomeRow.Episodes(
+                        id = KEEP_LISTENING_ROW_ID,
+                        title = context.getString(LR.string.tv_home_keep_listening),
+                        episodes = listOf(current.toTvHomeEpisode(podcastTitles)),
+                    ),
+                )
+            }
+            if (isLoggedIn) {
+                val queue = upNextEpisodes.drop(1)
+                if (queue.isNotEmpty()) {
+                    add(
+                        TvHomeRow.Episodes(
+                            id = UP_NEXT_ROW_ID,
+                            title = context.getString(LR.string.up_next),
+                            episodes = queue.map { it.toTvHomeEpisode(podcastTitles) },
+                        ),
+                    )
+                }
+                if (newReleases.isNotEmpty()) {
+                    add(
+                        TvHomeRow.Episodes(
+                            id = NEW_RELEASES_ROW_ID,
+                            title = context.getString(LR.string.filters_title_new_releases),
+                            episodes = newReleases.map { it.toTvHomeEpisode(podcastTitles) },
+                        ),
+                    )
+                }
+            }
+        }
+    }
+
+    private suspend fun findPodcastTitles(episodes: List<PodcastEpisode>): Map<String, String> {
+        val uuids = episodes.map(PodcastEpisode::podcastUuid).distinct()
+        if (uuids.isEmpty()) return emptyMap()
+        return podcastDao.findAllIn(uuids).associate { it.uuid to it.title }
+    }
+
+    private fun PodcastEpisode.toTvHomeEpisode(podcastTitles: Map<String, String>) = TvHomeEpisode(
+        episodeUuid = uuid,
+        episodeTitle = title,
+        podcastUuid = podcastUuid,
+        podcastTitle = podcastTitles[podcastUuid].orEmpty(),
+    )
+
+    private suspend fun loadRow(row: DiscoverRow): TvHomeRow? {
+        return when (row.type) {
+            is ListType.PodcastList -> loadPodcastsRow(row)
+            is ListType.EpisodeList -> loadEpisodesRow(row)
+            is ListType.Categories, is ListType.Unknown -> null
+        }
+    }
+
+    private suspend fun loadPodcastsRow(row: DiscoverRow): TvHomeRow? {
+        val feed = listRepository.getListFeed(row.source, row.authenticated) ?: return null
+        val podcasts = feed.podcasts.orEmpty()
+            .distinctBy(DiscoverPodcast::uuid)
+            .map { it.toTvHomePodcast(isSponsored = row.sponsored) }
+        if (podcasts.isEmpty()) return null
+        val title = feed.title?.takeIf { it.isNotBlank() } ?: row.title
+        return when (row.displayStyle) {
+            is DisplayStyle.Carousel, is DisplayStyle.SinglePodcast -> {
+                TvHomeRow.FeaturedPodcasts(id = row.rowId(), title = title, podcasts = podcasts)
+            }
+
+            else -> TvHomeRow.Podcasts(id = row.rowId(), title = title, podcasts = podcasts)
+        }
+    }
+
+    private suspend fun loadEpisodesRow(row: DiscoverRow): TvHomeRow? {
+        val feed = listRepository.getListFeed(row.source, row.authenticated) ?: return null
+        val episodes = feed.episodes.orEmpty()
+            .distinctBy(DiscoverEpisode::uuid)
+            .map { episode ->
+                TvHomeEpisode(
+                    episodeUuid = episode.uuid,
+                    episodeTitle = episode.title.orEmpty(),
+                    podcastUuid = episode.podcast_uuid,
+                    podcastTitle = episode.podcast_title.orEmpty(),
+                )
+            }
+        if (episodes.isEmpty()) return null
+        val title = feed.title?.takeIf { it.isNotBlank() } ?: row.title
+        return TvHomeRow.Episodes(id = row.rowId(), title = title, episodes = episodes)
+    }
+
+    private fun DiscoverRow.rowId() = listUuid ?: id ?: title
+
+    private fun DiscoverPodcast.toTvHomePodcast(isSponsored: Boolean) = TvHomePodcast(
+        uuid = uuid,
+        title = title.orEmpty(),
+        description = description.orEmpty(),
+        isSponsored = isSponsored,
+    )
+
+    companion object {
+        const val KEEP_LISTENING_ROW_ID = "keep_listening"
+        const val UP_NEXT_ROW_ID = "up_next"
+        const val NEW_RELEASES_ROW_ID = "new_releases"
+
+        private const val UP_NEXT_LIMIT = 12
+        private const val NEW_RELEASES_LIMIT = 12
+
+        private val NEW_RELEASES_RULES = SmartPlaylistDraft.NewReleases.rules.copy(
+            episodeStatus = SmartRules.EpisodeStatusRule(unplayed = true, inProgress = false, completed = false),
+        )
+    }
+}
+
+sealed interface TvHomeUiState {
+    data object Loading : TvHomeUiState
+    data object Error : TvHomeUiState
+    data class Ready(val rows: List<TvHomeRow>) : TvHomeUiState
+}
+
+sealed interface TvHomeRow {
+    val id: String
+    val title: String
+
+    data class FeaturedPodcasts(
+        override val id: String,
+        override val title: String,
+        val podcasts: List<TvHomePodcast>,
+    ) : TvHomeRow
+
+    data class Podcasts(
+        override val id: String,
+        override val title: String,
+        val podcasts: List<TvHomePodcast>,
+    ) : TvHomeRow
+
+    data class Episodes(
+        override val id: String,
+        override val title: String,
+        val episodes: List<TvHomeEpisode>,
+    ) : TvHomeRow
+}
+
+data class TvHomePodcast(
+    val uuid: String,
+    val title: String,
+    val description: String,
+    val isSponsored: Boolean = false,
+) {
+    val artworkUrl: String = PodcastImage.getMediumArtworkUrl(uuid)
+}
+
+data class TvHomeEpisode(
+    val episodeUuid: String,
+    val episodeTitle: String,
+    val podcastUuid: String,
+    val podcastTitle: String,
+) {
+    val thumbnailUrl: String = PodcastImage.getArtworkUrl(size = 960, uuid = podcastUuid, isWearOS = false)
+    val podcastArtworkUrl: String = PodcastImage.getArtworkUrl(size = 200, uuid = podcastUuid, isWearOS = false)
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModel.kt
@@ -72,9 +72,24 @@ class TvHomeViewModel @Inject constructor(
 
     private suspend fun loadRows(): List<TvHomeRow> = coroutineScope {
         val isLoggedIn = syncManager.isLoggedIn()
-        val localRows = async { loadLocalRows(isLoggedIn) }
-        val discoverRows = async { loadDiscoverRows(isLoggedIn) }
-        (localRows.await() + discoverRows.await()).distinctBy(TvHomeRow::id)
+        val localRowsDeferred = async { loadLocalRows(isLoggedIn) }
+        val discoverRowsDeferred = async {
+            try {
+                Result.success(loadDiscoverRows(isLoggedIn))
+            } catch (exception: CancellationException) {
+                throw exception
+            } catch (exception: Exception) {
+                Result.failure(exception)
+            }
+        }
+        val localRows = localRowsDeferred.await()
+        val discoverRows = discoverRowsDeferred.await().getOrElse { exception ->
+            // Keep the local rows on screen, surface the error only when there is nothing to show.
+            if (localRows.isEmpty()) throw exception
+            Timber.e(exception, "Failed to load TV discover rows")
+            emptyList()
+        }
+        (localRows + discoverRows).distinctBy(TvHomeRow::id)
     }
 
     private suspend fun loadDiscoverRows(isLoggedIn: Boolean): List<TvHomeRow> = coroutineScope {
@@ -89,6 +104,7 @@ class TvHomeViewModel @Inject constructor(
 
         discover.layout
             .transformWithRegion(region, replacements, context.resources)
+            .filter { it.categoryId == null } // Rows with a category ID are sponsored ads for the category pages.
             .filter { isLoggedIn || it.authenticated != true }
             .map { row -> async { loadRow(row) } }
             .awaitAll()

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
@@ -31,7 +31,12 @@ fun TvScaffold(
         selectedTabIndex = uiState.selectedTabIndex,
         onTabSelect = viewModel::selectTab,
         modifier = modifier,
-    )
+    ) { tab ->
+        when (tab) {
+            is TvTab.Home -> TvHomeScreen()
+            else -> TvTabPlaceholder(tab = tab)
+        }
+    }
 }
 
 @Composable
@@ -40,6 +45,7 @@ private fun TvScaffoldContent(
     selectedTabIndex: Int,
     onTabSelect: (Int) -> Unit,
     modifier: Modifier = Modifier,
+    tabContent: @Composable (TvTab) -> Unit,
 ) {
     Column(
         modifier = modifier
@@ -61,7 +67,7 @@ private fun TvScaffoldContent(
         )
         Box(modifier = Modifier.weight(1f)) {
             val currentTab = tabs.getOrElse(selectedTabIndex) { tabs.first() }
-            TvTabPlaceholder(tab = currentTab)
+            tabContent(currentTab)
         }
     }
 }
@@ -76,7 +82,9 @@ private fun TvScaffoldPreview() {
                 tabs = TvTab.entries,
                 selectedTabIndex = selectedIndex,
                 onTabSelect = { selectedIndex = it },
-            )
+            ) { tab ->
+                TvTabPlaceholder(tab = tab)
+            }
         }
     }
 }

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModelTest.kt
@@ -1,0 +1,558 @@
+package au.com.shiftyjelly.pocketcasts.home
+
+import android.content.Context
+import android.content.res.Resources
+import app.cash.turbine.test
+import au.com.shiftyjelly.pocketcasts.models.db.dao.PodcastDao
+import au.com.shiftyjelly.pocketcasts.models.db.dao.UpNextDao
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
+import au.com.shiftyjelly.pocketcasts.models.to.PlaylistEpisode
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
+import au.com.shiftyjelly.pocketcasts.repositories.lists.ListRepository
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
+import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
+import au.com.shiftyjelly.pocketcasts.servers.model.Discover
+import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverEpisode
+import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverPodcast
+import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverRegion
+import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverRow
+import au.com.shiftyjelly.pocketcasts.servers.model.DisplayStyle
+import au.com.shiftyjelly.pocketcasts.servers.model.ExpandedStyle
+import au.com.shiftyjelly.pocketcasts.servers.model.ListFeed
+import au.com.shiftyjelly.pocketcasts.servers.model.ListType
+import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import java.util.Date
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TvHomeViewModelTest {
+
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
+
+    private val listRepository = mock<ListRepository>()
+    private val syncManager = mock<SyncManager>()
+    private val podcastDao = mock<PodcastDao> {
+        on { findAllIn(any()) }.thenReturn(emptyList())
+    }
+    private val upNextDao = mock<UpNextDao> {
+        on { getUpNextBaseEpisodes(any()) }.thenReturn(emptyList())
+    }
+    private val playlistManager = mock<PlaylistManager> {
+        whenever(it.smartEpisodesFlow(any(), any(), anyOrNull())).thenReturn(flowOf(emptyList()))
+    }
+    private val resources = mock<Resources>()
+    private val context = mock<Context> {
+        whenever(it.resources).thenReturn(resources)
+        whenever(it.getString(LR.string.tv_home_keep_listening)).thenReturn("Keep Listening")
+        whenever(it.getString(LR.string.up_next)).thenReturn("Up Next")
+        whenever(it.getString(LR.string.filters_title_new_releases)).thenReturn("New Releases")
+    }
+    private val discoverCountryCode = mock<UserSetting<String>> {
+        whenever(it.value).thenReturn("us")
+    }
+    private val settings = mock<Settings> {
+        whenever(it.discoverCountryCode).thenReturn(discoverCountryCode)
+    }
+
+    @Test
+    fun `all rows load in feed order`() = runTest {
+        whenever(syncManager.isLoggedIn()).thenReturn(false)
+        whenever(listRepository.getDiscoverFeed()).thenReturn(
+            discover(
+                row(
+                    id = "featured",
+                    title = "Row Featured",
+                    source = "https://lists/featured.json",
+                    displayStyle = DisplayStyle.Carousel(),
+                ),
+                row(
+                    id = "sponsored-id",
+                    title = "Row Sponsored",
+                    source = "https://lists/sponsored.json",
+                    displayStyle = DisplayStyle.SinglePodcast(),
+                ),
+                row(
+                    id = "videos-id",
+                    title = "Row Videos",
+                    source = "https://lists/videos.json",
+                    type = ListType.EpisodeList,
+                ),
+                row(
+                    id = "trending",
+                    title = "Row Trending",
+                    source = "https://lists/trending.json",
+                    displayStyle = DisplayStyle.SmallList(),
+                ),
+                row(
+                    id = "curated-id",
+                    title = "Row Curated",
+                    source = "https://lists/curated.json",
+                    displayStyle = DisplayStyle.LargeList(),
+                ),
+            ),
+        )
+        whenever(listRepository.getListFeed(eq("https://lists/featured.json"), any()))
+            .thenReturn(podcastFeed("podcast-featured"))
+        whenever(listRepository.getListFeed(eq("https://lists/sponsored.json"), any()))
+            .thenReturn(podcastFeed("podcast-sponsored"))
+        whenever(listRepository.getListFeed(eq("https://lists/videos.json"), any()))
+            .thenReturn(episodeFeed("episode-1"))
+        whenever(listRepository.getListFeed(eq("https://lists/trending.json"), any()))
+            .thenReturn(podcastFeed("podcast-trending"))
+        whenever(listRepository.getListFeed(eq("https://lists/curated.json"), any()))
+            .thenReturn(podcastFeed("podcast-curated"))
+
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val state = awaitItem() as TvHomeUiState.Ready
+            assertEquals(
+                listOf("featured", "sponsored-id", "videos-id", "trending", "curated-id"),
+                state.rows.map { it.id },
+            )
+            assertTrue(state.rows[0] is TvHomeRow.FeaturedPodcasts)
+            assertTrue(state.rows[1] is TvHomeRow.FeaturedPodcasts)
+            assertTrue(state.rows[2] is TvHomeRow.Episodes)
+            assertTrue(state.rows[3] is TvHomeRow.Podcasts)
+            assertTrue(state.rows[4] is TvHomeRow.Podcasts)
+        }
+    }
+
+    @Test
+    fun `authenticated rows are excluded when signed out`() = runTest {
+        whenever(syncManager.isLoggedIn()).thenReturn(false)
+        whenever(listRepository.getDiscoverFeed()).thenReturn(
+            discover(
+                row(
+                    id = "recommendations_user",
+                    title = "Row For You",
+                    source = "https://lists/user.json",
+                    authenticated = true,
+                ),
+                row(id = "trending", title = "Row Trending", source = "https://lists/trending.json"),
+            ),
+        )
+        whenever(listRepository.getListFeed(eq("https://lists/trending.json"), any()))
+            .thenReturn(podcastFeed("podcast-trending"))
+
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val state = awaitItem() as TvHomeUiState.Ready
+            assertEquals(listOf("trending"), state.rows.map { it.id })
+        }
+        verify(listRepository, never()).getListFeed(eq("https://lists/user.json"), any())
+    }
+
+    @Test
+    fun `authenticated rows load when signed in`() = runTest {
+        whenever(syncManager.isLoggedIn()).thenReturn(true)
+        whenever(listRepository.getDiscoverFeed()).thenReturn(
+            discover(
+                row(
+                    id = "recommendations_user",
+                    title = "Row For You",
+                    source = "https://lists/user.json",
+                    authenticated = true,
+                ),
+                row(id = "trending", title = "Row Trending", source = "https://lists/trending.json"),
+            ),
+        )
+        whenever(listRepository.getListFeed(eq("https://lists/user.json"), eq(true)))
+            .thenReturn(podcastFeed("podcast-user"))
+        whenever(listRepository.getListFeed(eq("https://lists/trending.json"), any()))
+            .thenReturn(podcastFeed("podcast-trending"))
+
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val state = awaitItem() as TvHomeUiState.Ready
+            assertEquals(listOf("recommendations_user", "trending"), state.rows.map { it.id })
+        }
+    }
+
+    @Test
+    fun `sponsored row marks its podcasts as sponsored`() = runTest {
+        whenever(syncManager.isLoggedIn()).thenReturn(false)
+        whenever(listRepository.getDiscoverFeed()).thenReturn(
+            discover(
+                row(
+                    id = "sponsored-id",
+                    title = "Row Sponsored",
+                    source = "https://lists/sponsored.json",
+                    displayStyle = DisplayStyle.SinglePodcast(),
+                    sponsored = true,
+                ),
+            ),
+        )
+        whenever(listRepository.getListFeed(eq("https://lists/sponsored.json"), any()))
+            .thenReturn(podcastFeed("podcast-sponsored"))
+
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val state = awaitItem() as TvHomeUiState.Ready
+            val row = state.rows.single() as TvHomeRow.FeaturedPodcasts
+            assertTrue(row.podcasts.single().isSponsored)
+        }
+    }
+
+    @Test
+    fun `rows that fail to load are dropped`() = runTest {
+        whenever(syncManager.isLoggedIn()).thenReturn(false)
+        whenever(listRepository.getDiscoverFeed()).thenReturn(
+            discover(
+                row(id = "featured", title = "Row Featured", source = "https://lists/featured.json"),
+                row(id = "empty-id", title = "Row Empty", source = "https://lists/empty.json"),
+                row(id = "trending", title = "Row Trending", source = "https://lists/trending.json"),
+            ),
+        )
+        whenever(listRepository.getListFeed(eq("https://lists/featured.json"), any())).thenReturn(null)
+        whenever(listRepository.getListFeed(eq("https://lists/empty.json"), any())).thenReturn(podcastFeed())
+        whenever(listRepository.getListFeed(eq("https://lists/trending.json"), any()))
+            .thenReturn(podcastFeed("podcast-trending"))
+
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val state = awaitItem() as TvHomeUiState.Ready
+            assertEquals(listOf("trending"), state.rows.map { it.id })
+        }
+    }
+
+    @Test
+    fun `rows with duplicate ids are deduplicated`() = runTest {
+        whenever(syncManager.isLoggedIn()).thenReturn(false)
+        whenever(listRepository.getDiscoverFeed()).thenReturn(
+            discover(
+                row(id = "trending", title = "Row Trending", source = "https://lists/trending.json"),
+                row(id = "trending", title = "Row Trending Again", source = "https://lists/trending-2.json"),
+            ),
+        )
+        whenever(listRepository.getListFeed(eq("https://lists/trending.json"), any()))
+            .thenReturn(podcastFeed("podcast-1"))
+        whenever(listRepository.getListFeed(eq("https://lists/trending-2.json"), any()))
+            .thenReturn(podcastFeed("podcast-2"))
+
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val state = awaitItem() as TvHomeUiState.Ready
+            assertEquals(listOf("trending"), state.rows.map { it.id })
+        }
+    }
+
+    @Test
+    fun `rows not available in the current region are excluded`() = runTest {
+        whenever(syncManager.isLoggedIn()).thenReturn(false)
+        whenever(listRepository.getDiscoverFeed()).thenReturn(
+            discover(
+                row(id = "featured", title = "Row Featured", source = "https://lists/featured.json"),
+                row(
+                    id = "trending",
+                    title = "Row Trending",
+                    source = "https://lists/trending.json",
+                    regions = listOf("au"),
+                ),
+            ),
+        )
+        whenever(listRepository.getListFeed(eq("https://lists/featured.json"), any()))
+            .thenReturn(podcastFeed("podcast-featured"))
+
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val state = awaitItem() as TvHomeUiState.Ready
+            assertEquals(listOf("featured"), state.rows.map { it.id })
+        }
+        verify(listRepository, never()).getListFeed(eq("https://lists/trending.json"), any())
+    }
+
+    @Test
+    fun `list feed title is preferred over row title`() = runTest {
+        whenever(syncManager.isLoggedIn()).thenReturn(false)
+        whenever(listRepository.getDiscoverFeed()).thenReturn(
+            discover(
+                row(id = "featured", title = "Row Featured", source = "https://lists/featured.json"),
+                row(id = "trending", title = "Row Trending", source = "https://lists/trending.json"),
+            ),
+        )
+        whenever(listRepository.getListFeed(eq("https://lists/featured.json"), any()))
+            .thenReturn(podcastFeed("podcast-featured", title = "Feed Featured"))
+        whenever(listRepository.getListFeed(eq("https://lists/trending.json"), any()))
+            .thenReturn(podcastFeed("podcast-trending", title = null))
+
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val state = awaitItem() as TvHomeUiState.Ready
+            assertEquals(listOf("Feed Featured", "Row Trending"), state.rows.map { it.title })
+        }
+    }
+
+    @Test
+    fun `feed failure shows error state and retry reloads`() = runTest {
+        whenever(syncManager.isLoggedIn()).thenReturn(false)
+        whenever(listRepository.getDiscoverFeed())
+            .thenThrow(RuntimeException("Network error"))
+            .thenReturn(discover(row(id = "trending", title = "Row Trending", source = "https://lists/trending.json")))
+        whenever(listRepository.getListFeed(eq("https://lists/trending.json"), any()))
+            .thenReturn(podcastFeed("podcast-trending"))
+
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            assertEquals(TvHomeUiState.Error, awaitItem())
+
+            viewModel.load()
+
+            assertEquals(TvHomeUiState.Loading, awaitItem())
+            val state = awaitItem() as TvHomeUiState.Ready
+            assertEquals(listOf("trending"), state.rows.map { it.id })
+        }
+    }
+
+    @Test
+    fun `keep listening row shows first up next episode even when signed out`() = runTest {
+        whenever(syncManager.isLoggedIn()).thenReturn(false)
+        whenever(listRepository.getDiscoverFeed()).thenReturn(discover())
+        whenever(upNextDao.getUpNextBaseEpisodes(any())).thenReturn(
+            listOf(
+                episode(uuid = "episode-1", podcastUuid = "podcast-1"),
+                episode(uuid = "episode-2", podcastUuid = "podcast-1"),
+            ),
+        )
+        whenever(podcastDao.findAllIn(any()))
+            .thenReturn(listOf(Podcast(uuid = "podcast-1", title = "Podcast One")))
+
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val state = awaitItem() as TvHomeUiState.Ready
+            assertEquals(listOf(TvHomeViewModel.KEEP_LISTENING_ROW_ID), state.rows.map { it.id })
+            val row = state.rows.single() as TvHomeRow.Episodes
+            assertEquals("Keep Listening", row.title)
+            val rowEpisode = row.episodes.single()
+            assertEquals("episode-1", rowEpisode.episodeUuid)
+            assertEquals("Podcast One", rowEpisode.podcastTitle)
+        }
+    }
+
+    @Test
+    fun `user episodes in up next are skipped`() = runTest {
+        whenever(syncManager.isLoggedIn()).thenReturn(false)
+        whenever(listRepository.getDiscoverFeed()).thenReturn(discover())
+        whenever(upNextDao.getUpNextBaseEpisodes(any())).thenReturn(
+            listOf(
+                UserEpisode(uuid = "user-file", publishedDate = Date()),
+                episode(uuid = "episode-1", podcastUuid = "podcast-1"),
+            ),
+        )
+        whenever(podcastDao.findAllIn(any()))
+            .thenReturn(listOf(Podcast(uuid = "podcast-1", title = "Podcast One")))
+
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val state = awaitItem() as TvHomeUiState.Ready
+            val row = state.rows.single() as TvHomeRow.Episodes
+            assertEquals(listOf("episode-1"), row.episodes.map { it.episodeUuid })
+        }
+    }
+
+    @Test
+    fun `signed in user sees keep listening, up next and new releases rows before discover rows`() = runTest {
+        whenever(syncManager.isLoggedIn()).thenReturn(true)
+        whenever(listRepository.getDiscoverFeed()).thenReturn(
+            discover(row(id = "trending", title = "Row Trending", source = "https://lists/trending.json")),
+        )
+        whenever(listRepository.getListFeed(eq("https://lists/trending.json"), any()))
+            .thenReturn(podcastFeed("podcast-trending"))
+        whenever(upNextDao.getUpNextBaseEpisodes(any())).thenReturn(
+            listOf(
+                episode(uuid = "episode-1", podcastUuid = "podcast-1"),
+                episode(uuid = "episode-2", podcastUuid = "podcast-1"),
+                episode(uuid = "episode-3", podcastUuid = "podcast-2"),
+            ),
+        )
+        whenever(playlistManager.smartEpisodesFlow(any(), any(), anyOrNull())).thenReturn(
+            flowOf(listOf(PlaylistEpisode.Available(episode(uuid = "episode-new", podcastUuid = "podcast-2")))),
+        )
+        whenever(podcastDao.findAllIn(any())).thenReturn(
+            listOf(
+                Podcast(uuid = "podcast-1", title = "Podcast One"),
+                Podcast(uuid = "podcast-2", title = "Podcast Two"),
+            ),
+        )
+
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val state = awaitItem() as TvHomeUiState.Ready
+            assertEquals(
+                listOf(
+                    TvHomeViewModel.KEEP_LISTENING_ROW_ID,
+                    TvHomeViewModel.UP_NEXT_ROW_ID,
+                    TvHomeViewModel.NEW_RELEASES_ROW_ID,
+                    "trending",
+                ),
+                state.rows.map { it.id },
+            )
+            val upNextRow = state.rows[1] as TvHomeRow.Episodes
+            assertEquals(listOf("episode-2", "episode-3"), upNextRow.episodes.map { it.episodeUuid })
+            val newReleasesRow = state.rows[2] as TvHomeRow.Episodes
+            assertEquals(listOf("episode-new"), newReleasesRow.episodes.map { it.episodeUuid })
+            assertEquals("Podcast Two", newReleasesRow.episodes.single().podcastTitle)
+        }
+    }
+
+    @Test
+    fun `up next and new releases rows are hidden when signed out`() = runTest {
+        whenever(syncManager.isLoggedIn()).thenReturn(false)
+        whenever(listRepository.getDiscoverFeed()).thenReturn(discover())
+        whenever(upNextDao.getUpNextBaseEpisodes(any())).thenReturn(
+            listOf(
+                episode(uuid = "episode-1", podcastUuid = "podcast-1"),
+                episode(uuid = "episode-2", podcastUuid = "podcast-1"),
+            ),
+        )
+
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val state = awaitItem() as TvHomeUiState.Ready
+            assertEquals(listOf(TvHomeViewModel.KEEP_LISTENING_ROW_ID), state.rows.map { it.id })
+        }
+    }
+
+    private fun createViewModel() = TvHomeViewModel(
+        listRepository = listRepository,
+        playlistManager = playlistManager,
+        podcastDao = podcastDao,
+        upNextDao = upNextDao,
+        settings = settings,
+        syncManager = syncManager,
+        context = context,
+    )
+
+    private fun episode(uuid: String, podcastUuid: String) = PodcastEpisode(
+        uuid = uuid,
+        podcastUuid = podcastUuid,
+        title = "Episode $uuid",
+        publishedDate = Date(),
+    )
+
+    private fun discover(vararg rows: DiscoverRow) = Discover(
+        layout = rows.toList(),
+        regions = mapOf("us" to DiscoverRegion(name = "United States", flag = "flag", code = "us")),
+        regionCodeToken = "[regionCode]",
+        regionNameToken = "[regionName]",
+        defaultRegionCode = "us",
+    )
+
+    private fun row(
+        title: String,
+        source: String,
+        id: String? = null,
+        listUuid: String? = null,
+        type: ListType = ListType.PodcastList,
+        displayStyle: DisplayStyle = DisplayStyle.SmallList(),
+        curated: Boolean = false,
+        sponsored: Boolean = false,
+        authenticated: Boolean = false,
+        regions: List<String> = listOf("us"),
+    ) = DiscoverRow(
+        id = id,
+        type = type,
+        displayStyle = displayStyle,
+        expandedStyle = ExpandedStyle.PlainList(),
+        expandedTopItemLabel = null,
+        title = title,
+        source = source,
+        listUuid = listUuid,
+        categoryId = null,
+        regions = regions,
+        curated = curated,
+        sponsored = sponsored,
+        authenticated = authenticated,
+        mostPopularCategoriesId = null,
+        sponsoredCategoryIds = null,
+    )
+
+    private fun podcastFeed(vararg podcastUuids: String, title: String? = null) = listFeed(
+        title = title,
+        podcasts = podcastUuids.map { uuid ->
+            DiscoverPodcast(
+                uuid = uuid,
+                title = "Podcast $uuid",
+                url = null,
+                author = null,
+                category = null,
+                description = null,
+                language = null,
+                mediaType = null,
+            )
+        },
+    )
+
+    private fun episodeFeed(vararg episodeUuids: String) = listFeed(
+        episodes = episodeUuids.map { uuid ->
+            DiscoverEpisode(
+                uuid = uuid,
+                title = "Episode $uuid",
+                url = null,
+                published = null,
+                duration = null,
+                fileType = null,
+                size = null,
+                podcast_uuid = "podcast-$uuid",
+                podcast_title = "Podcast $uuid",
+                type = null,
+                season = null,
+                number = null,
+            )
+        },
+    )
+
+    private fun listFeed(
+        title: String? = null,
+        podcasts: List<DiscoverPodcast>? = null,
+        episodes: List<DiscoverEpisode>? = null,
+    ) = ListFeed(
+        title = title,
+        subtitle = null,
+        description = null,
+        shortDescription = null,
+        date = null,
+        podcasts = podcasts,
+        episodes = episodes,
+        podroll = null,
+        collectionImageUrl = null,
+        collectionRectangleImageUrl = null,
+        featureImage = null,
+        headerImageUrl = null,
+        tintColors = null,
+        collageImages = null,
+        webLinkUrl = null,
+        webLinkTitle = null,
+        promotion = null,
+    )
+}

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModelTest.kt
@@ -239,6 +239,33 @@ class TvHomeViewModelTest {
     }
 
     @Test
+    fun `category sponsor rows are excluded`() = runTest {
+        whenever(syncManager.isLoggedIn()).thenReturn(false)
+        whenever(listRepository.getDiscoverFeed()).thenReturn(
+            discover(
+                row(
+                    id = "category-ad",
+                    title = "Row Category Ad",
+                    source = "https://lists/category-ad.json",
+                    sponsored = true,
+                    categoryId = 3,
+                ),
+                row(id = "trending", title = "Row Trending", source = "https://lists/trending.json"),
+            ),
+        )
+        whenever(listRepository.getListFeed(eq("https://lists/trending.json"), any()))
+            .thenReturn(podcastFeed("podcast-trending"))
+
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val state = awaitItem() as TvHomeUiState.Ready
+            assertEquals(listOf("trending"), state.rows.map { it.id })
+        }
+        verify(listRepository, never()).getListFeed(eq("https://lists/category-ad.json"), any())
+    }
+
+    @Test
     fun `rows with duplicate ids are deduplicated`() = runTest {
         whenever(syncManager.isLoggedIn()).thenReturn(false)
         whenever(listRepository.getDiscoverFeed()).thenReturn(
@@ -327,6 +354,24 @@ class TvHomeViewModelTest {
             assertEquals(TvHomeUiState.Loading, awaitItem())
             val state = awaitItem() as TvHomeUiState.Ready
             assertEquals(listOf("trending"), state.rows.map { it.id })
+        }
+    }
+
+    @Test
+    fun `feed failure keeps local rows on screen`() = runTest {
+        whenever(syncManager.isLoggedIn()).thenReturn(false)
+        whenever(listRepository.getDiscoverFeed()).thenThrow(RuntimeException("Network error"))
+        whenever(upNextDao.getUpNextBaseEpisodes(any())).thenReturn(
+            listOf(episode(uuid = "episode-1", podcastUuid = "podcast-1")),
+        )
+        whenever(podcastDao.findAllIn(any()))
+            .thenReturn(listOf(Podcast(uuid = "podcast-1", title = "Podcast One")))
+
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val state = awaitItem() as TvHomeUiState.Ready
+            assertEquals(listOf(TvHomeViewModel.KEEP_LISTENING_ROW_ID), state.rows.map { it.id })
         }
     }
 
@@ -479,6 +524,7 @@ class TvHomeViewModelTest {
         sponsored: Boolean = false,
         authenticated: Boolean = false,
         regions: List<String> = listOf("us"),
+        categoryId: Int? = null,
     ) = DiscoverRow(
         id = id,
         type = type,
@@ -488,7 +534,7 @@ class TvHomeViewModelTest {
         title = title,
         source = source,
         listUuid = listUuid,
-        categoryId = null,
+        categoryId = categoryId,
         regions = regions,
         curated = curated,
         sponsored = sponsored,


### PR DESCRIPTION
## Description
This PR connects the Home tab with out backend systems and the app now fetches and displays actual data.
We can distinguish 2 cases - when the user is signed in (in this case the Up next, Keep listening sections also appear) and when they are not.
This PR only focuses on the data bits, you should not pay too much attention to the designs as they will be amended later to match the latest figma designs.

Fixes PCDROID-603 https://linear.app/a8c/issue/PCDROID-603/populate-home-tab-with-real-data

## Testing Instructions
A - Browse without sign in
1. Clean install TV app
2. Hit Browse without sign in
3. Observe Home tab content

B - Sign in
1. Clean install app
2. Sign in with QR 
3. Observe Home tab content.


## Screenshots or Screencast 
| Signed in | Not signed in |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/7294fbdd-9d3f-4abd-86e8-bd16a8b27924" /> | <video src="https://github.com/user-attachments/assets/d96c19af-00f4-4cf3-aa87-341595b46ece" /> |

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
