### PR TITLE
Copy description and show notes links with a long press

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 8.18
 -----
-
+*   Bug Fixes
+    *   Allow copying description and show notes links with a long press
+        ([#5628](https://github.com/Automattic/pocket-casts-android/pull/5628))
 
 8.17
 -----

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/NotesFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/NotesFragment.kt
@@ -24,6 +24,7 @@ import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
 import au.com.shiftyjelly.pocketcasts.utils.extensions.toSecondsFromColonFormattedString
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.views.extensions.cleanup
+import au.com.shiftyjelly.pocketcasts.views.extensions.copyLinkOnLongPress
 import au.com.shiftyjelly.pocketcasts.views.extensions.show
 import au.com.shiftyjelly.pocketcasts.views.extensions.showIf
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
@@ -124,6 +125,7 @@ class NotesFragment : BaseFragment() {
                 // stop the web view jumping after loading
                 isFocusable = false
                 setBackgroundColor(Color.TRANSPARENT)
+                copyLinkOnLongPress()
                 webViewClient = object : WebViewClient() {
                     override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
                         val url = request.url.toString()

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -152,6 +152,7 @@ import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.utils.parceler.DurationParceler
 import au.com.shiftyjelly.pocketcasts.views.dialog.OptionsDialog
 import au.com.shiftyjelly.pocketcasts.views.extensions.cleanup
+import au.com.shiftyjelly.pocketcasts.views.extensions.copyLinkOnLongPress
 import au.com.shiftyjelly.pocketcasts.views.extensions.hide
 import au.com.shiftyjelly.pocketcasts.views.extensions.show
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
@@ -1339,6 +1340,7 @@ class EpisodeFragment : BaseFragment() {
                     isVerticalScrollBarEnabled = false
                     // stop the web view jumping after loading
                     isFocusable = false
+                    copyLinkOnLongPress()
                     webViewClient = object : WebViewClient() {
                         override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
                             val url = request.url.toString()

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastHeader.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastHeader.kt
@@ -117,6 +117,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageReques
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
+import au.com.shiftyjelly.pocketcasts.views.extensions.copyLinkToClipboard
 import coil3.compose.rememberAsyncImagePainter
 import kotlin.math.roundToInt
 import au.com.shiftyjelly.pocketcasts.images.R as IR
@@ -736,6 +737,7 @@ private fun PodcastDetails(
     onClickShowNotes: () -> Unit,
     onClickWebsiteLink: () -> Unit,
 ) {
+    val context = LocalContext.current
     Column {
         if (description.isNotEmpty()) {
             Spacer(
@@ -749,6 +751,8 @@ private fun PodcastDetails(
                     color = MaterialTheme.theme.colors.primaryText01,
                 ),
                 maxLines = 4,
+                onLinkLongPress = { url -> context.copyLinkToClipboard(url) },
+                copyLinkAccessibilityLabel = stringResource(LR.string.share_label_copy_link),
                 modifier = Modifier
                     .fillMaxWidth()
                     .clickable(

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/ExpandableText.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/ExpandableText.kt
@@ -3,6 +3,8 @@ package au.com.shiftyjelly.pocketcasts.compose.components
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -15,8 +17,18 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.AwaitPointerEventScope
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.PointerId
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.semantics.CustomAccessibilityAction
+import androidx.compose.ui.semantics.customActions
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
@@ -26,6 +38,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import kotlin.math.roundToInt
+import kotlinx.coroutines.withTimeoutOrNull
 
 @Composable
 fun ExpandableText(
@@ -35,6 +48,8 @@ fun ExpandableText(
     style: TextStyle,
     maxLines: Int,
     modifier: Modifier = Modifier,
+    onLinkLongPress: ((String) -> Unit)? = null,
+    copyLinkAccessibilityLabel: String? = null,
 ) {
     BoxWithConstraints(
         modifier = modifier.animateContentSize(),
@@ -65,9 +80,106 @@ fun ExpandableText(
                 text
             }
         }
+        var textLayoutResult by remember { mutableStateOf<TextLayoutResult?>(null) }
         Text(
             text = displayedText,
             style = style,
+            onTextLayout = { textLayoutResult = it },
+            modifier = Modifier.copyLinkOnLongPress(
+                text = displayedText,
+                textLayoutResult = textLayoutResult,
+                accessibilityLabel = copyLinkAccessibilityLabel,
+                onLinkLongPress = onLinkLongPress,
+            ),
+        )
+    }
+}
+
+private fun Modifier.copyLinkOnLongPress(
+    text: AnnotatedString,
+    textLayoutResult: TextLayoutResult?,
+    accessibilityLabel: String?,
+    onLinkLongPress: ((String) -> Unit)?,
+): Modifier {
+    if (onLinkLongPress == null) return this
+
+    val longPressModifier = pointerInput(text, textLayoutResult, onLinkLongPress) {
+        awaitEachGesture {
+            val down = awaitFirstDown(
+                requireUnconsumed = false,
+                pass = PointerEventPass.Initial,
+            )
+            val url = textLayoutResult?.urlAt(down.position) ?: return@awaitEachGesture
+            if (awaitLongPress(down.id, down.position)) {
+                onLinkLongPress(url)
+                consumeUntilUp()
+            }
+        }
+    }
+    val urls = text.urlRanges().map(UrlRange::url).distinct()
+    return if (accessibilityLabel == null || urls.isEmpty()) {
+        then(longPressModifier)
+    } else {
+        then(longPressModifier).semantics {
+            customActions = urls.map { url ->
+                CustomAccessibilityAction(
+                    label = "$accessibilityLabel: $url",
+                    action = {
+                        onLinkLongPress(url)
+                        true
+                    },
+                )
+            }
+        }
+    }
+}
+
+private fun TextLayoutResult.urlAt(position: Offset): String? {
+    val offset = getOffsetForPosition(position)
+    val range = layoutInput.text.urlRangeAt(offset) ?: layoutInput.text.urlRangeAt(offset - 1) ?: return null
+    val isInsideLink = (range.start until range.end).any { position in getBoundingBox(it) }
+    return range.url.takeIf { isInsideLink }
+}
+
+private suspend fun AwaitPointerEventScope.awaitLongPress(
+    pointerId: PointerId,
+    initialPosition: Offset,
+): Boolean {
+    val cancelled = withTimeoutOrNull(viewConfiguration.longPressTimeoutMillis) {
+        while (true) {
+            val change = awaitPointerEvent(PointerEventPass.Initial).changes.firstOrNull { it.id == pointerId }
+            if (change == null || !change.pressed || (change.position - initialPosition).getDistance() > viewConfiguration.touchSlop) {
+                return@withTimeoutOrNull true
+            }
+        }
+    }
+    return cancelled == null
+}
+
+private suspend fun AwaitPointerEventScope.consumeUntilUp() {
+    do {
+        val event = awaitPointerEvent(PointerEventPass.Initial)
+        event.changes.forEach { it.consume() }
+    } while (event.changes.any { it.pressed })
+}
+
+internal data class UrlRange(
+    val url: String,
+    val start: Int,
+    val end: Int,
+)
+
+internal fun AnnotatedString.urlRangeAt(offset: Int): UrlRange? = urlRanges().firstOrNull { offset in it.start until it.end }
+
+private fun AnnotatedString.urlRanges(): List<UrlRange> = getLinkAnnotations(0, length).mapNotNull { range ->
+    val link = range.item as? LinkAnnotation.Url
+    if (link == null || link.url.isBlank() || range.start >= range.end) {
+        null
+    } else {
+        UrlRange(
+            url = link.url,
+            start = range.start,
+            end = range.end,
         )
     }
 }

--- a/modules/services/compose/src/test/java/au/com/shiftyjelly/pocketcasts/compose/components/ExpandableTextTest.kt
+++ b/modules/services/compose/src/test/java/au/com/shiftyjelly/pocketcasts/compose/components/ExpandableTextTest.kt
@@ -1,0 +1,87 @@
+package au.com.shiftyjelly.pocketcasts.compose.components
+
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.LinkInteractionListener
+import androidx.compose.ui.text.buildAnnotatedString
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ExpandableTextTest {
+    @Test
+    fun `returns link at the given text offset`() {
+        val text = buildAnnotatedString {
+            append("Visit ")
+            pushLink(LinkAnnotation.Url("https://pocketcasts.com"))
+            append("Pocket Casts")
+            pop()
+            append(" today")
+        }
+
+        assertEquals(
+            UrlRange(
+                url = "https://pocketcasts.com",
+                start = 6,
+                end = 18,
+            ),
+            text.urlRangeAt(offset = 10),
+        )
+    }
+
+    @Test
+    fun `does not return a link outside the linked text`() {
+        val text = buildAnnotatedString {
+            append("Visit ")
+            pushLink(LinkAnnotation.Url("https://pocketcasts.com"))
+            append("Pocket Casts")
+            pop()
+            append(" today")
+        }
+
+        assertNull(text.urlRangeAt(offset = 5))
+        assertNull(text.urlRangeAt(offset = 18))
+    }
+
+    @Test
+    fun `ignores blank link targets`() {
+        val text = buildAnnotatedString {
+            pushLink(LinkAnnotation.Url(""))
+            append("Empty link")
+            pop()
+        }
+
+        assertNull(text.urlRangeAt(offset = 2))
+    }
+
+    @Test
+    fun `returns the correct target when text contains multiple links`() {
+        val text = buildAnnotatedString {
+            pushLink(LinkAnnotation.Url("https://example.com/one"))
+            append("First")
+            pop()
+            append(" and ")
+            pushLink(LinkAnnotation.Url("https://example.com/two"))
+            append("second")
+            pop()
+        }
+
+        assertEquals("https://example.com/one", text.urlRangeAt(offset = 2)?.url)
+        assertEquals("https://example.com/two", text.urlRangeAt(offset = 12)?.url)
+    }
+
+    @Test
+    fun `ignores clickable annotations that are not URLs`() {
+        val text = buildAnnotatedString {
+            pushLink(
+                LinkAnnotation.Clickable(
+                    tag = "action",
+                    linkInteractionListener = LinkInteractionListener {},
+                ),
+            )
+            append("Action")
+            pop()
+        }
+
+        assertNull(text.urlRangeAt(offset = 2))
+    }
+}

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/extensions/Clipboard.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/extensions/Clipboard.kt
@@ -9,12 +9,23 @@ import androidx.core.content.getSystemService
 import au.com.shiftyjelly.pocketcasts.localization.R
 
 fun Context.copyLinkToClipboard(url: String) {
-    if (url.isBlank()) return
+    val text = linkClipboardText(url) ?: return
 
     requireNotNull(getSystemService<ClipboardManager>()).setPrimaryClip(
-        ClipData.newPlainText(getString(R.string.share_label_copy_link), url),
+        ClipData.newPlainText(getString(R.string.share_label_copy_link), text),
     )
     if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2) {
         Toast.makeText(this, R.string.share_link_copied_feedback, Toast.LENGTH_SHORT).show()
     }
 }
+
+internal fun linkClipboardText(url: String): String? {
+    val text = if (url.startsWith(MAILTO_SCHEME, ignoreCase = true)) {
+        url.drop(MAILTO_SCHEME.length)
+    } else {
+        url
+    }
+    return text.takeIf(String::isNotBlank)
+}
+
+private const val MAILTO_SCHEME = "mailto:"

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/extensions/Clipboard.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/extensions/Clipboard.kt
@@ -1,0 +1,20 @@
+package au.com.shiftyjelly.pocketcasts.views.extensions
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.os.Build
+import android.widget.Toast
+import androidx.core.content.getSystemService
+import au.com.shiftyjelly.pocketcasts.localization.R
+
+fun Context.copyLinkToClipboard(url: String) {
+    if (url.isBlank()) return
+
+    requireNotNull(getSystemService<ClipboardManager>()).setPrimaryClip(
+        ClipData.newPlainText(getString(R.string.share_label_copy_link), url),
+    )
+    if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2) {
+        Toast.makeText(this, R.string.share_link_copied_feedback, Toast.LENGTH_SHORT).show()
+    }
+}

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/extensions/WebView.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/extensions/WebView.kt
@@ -3,6 +3,19 @@ package au.com.shiftyjelly.pocketcasts.views.extensions
 import android.view.ViewGroup
 import android.webkit.WebView
 
+fun WebView.copyLinkOnLongPress() {
+    setOnLongClickListener {
+        val url = webViewLinkUrl(hitTestResult.type, hitTestResult.extra) ?: return@setOnLongClickListener false
+        context.copyLinkToClipboard(url)
+        true
+    }
+}
+
+internal fun webViewLinkUrl(type: Int, url: String?): String? {
+    val isLink = type == WebView.HitTestResult.SRC_ANCHOR_TYPE || type == WebView.HitTestResult.SRC_IMAGE_ANCHOR_TYPE
+    return url?.takeIf { isLink && it.isNotBlank() }
+}
+
 @Suppress("DEPRECATION")
 fun WebView?.cleanup() {
     this ?: return

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/extensions/WebView.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/extensions/WebView.kt
@@ -1,19 +1,51 @@
 package au.com.shiftyjelly.pocketcasts.views.extensions
 
+import android.os.Handler
+import android.os.Looper
 import android.view.ViewGroup
 import android.webkit.WebView
 
+private const val FOCUSED_NODE_URL_KEY = "url"
+
 fun WebView.copyLinkOnLongPress() {
     setOnLongClickListener {
-        val url = webViewLinkUrl(hitTestResult.type, hitTestResult.extra) ?: return@setOnLongClickListener false
-        context.copyLinkToClipboard(url)
-        true
+        val result = hitTestResult
+        when (result.type) {
+            WebView.HitTestResult.SRC_ANCHOR_TYPE -> {
+                val url = webViewLinkUrl(result.type, result.extra) ?: return@setOnLongClickListener false
+                context.copyLinkToClipboard(url)
+                true
+            }
+
+            WebView.HitTestResult.SRC_IMAGE_ANCHOR_TYPE -> {
+                requestFocusNodeHref(
+                    Handler(Looper.getMainLooper()) { message ->
+                        webViewLinkUrl(
+                            type = WebView.HitTestResult.SRC_IMAGE_ANCHOR_TYPE,
+                            focusedNodeUrl = message.data.getString(FOCUSED_NODE_URL_KEY),
+                        )?.let(context::copyLinkToClipboard)
+                        true
+                    }.obtainMessage(),
+                )
+                true
+            }
+
+            else -> false
+        }
     }
 }
 
-internal fun webViewLinkUrl(type: Int, url: String?): String? {
-    val isLink = type == WebView.HitTestResult.SRC_ANCHOR_TYPE || type == WebView.HitTestResult.SRC_IMAGE_ANCHOR_TYPE
-    return url?.takeIf { isLink && it.isNotBlank() }
+internal fun webViewLinkUrl(
+    type: Int,
+    hitTestUrl: String? = null,
+    focusedNodeUrl: String? = null,
+): String? {
+    val url = when (type) {
+        WebView.HitTestResult.SRC_ANCHOR_TYPE -> hitTestUrl
+        WebView.HitTestResult.SRC_IMAGE_ANCHOR_TYPE -> focusedNodeUrl
+        else -> null
+    }
+    return url?.takeIf(String::isNotBlank)
 }
 
 @Suppress("DEPRECATION")

--- a/modules/services/views/src/test/java/au/com/shiftyjelly/pocketcasts/views/extensions/ClipboardTest.kt
+++ b/modules/services/views/src/test/java/au/com/shiftyjelly/pocketcasts/views/extensions/ClipboardTest.kt
@@ -1,0 +1,29 @@
+package au.com.shiftyjelly.pocketcasts.views.extensions
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ClipboardTest {
+    @Test
+    fun `returns web link unchanged`() {
+        assertEquals("https://pocketcasts.com", linkClipboardText("https://pocketcasts.com"))
+    }
+
+    @Test
+    fun `removes mailto scheme from email link`() {
+        assertEquals("lovetrappedpod@gmail.com", linkClipboardText("mailto:lovetrappedpod@gmail.com"))
+    }
+
+    @Test
+    fun `removes mailto scheme ignoring case`() {
+        assertEquals("lovetrappedpod@gmail.com", linkClipboardText("MAILTO:lovetrappedpod@gmail.com"))
+    }
+
+    @Test
+    fun `ignores blank links`() {
+        assertNull(linkClipboardText(""))
+        assertNull(linkClipboardText(" "))
+        assertNull(linkClipboardText("mailto:"))
+    }
+}

--- a/modules/services/views/src/test/java/au/com/shiftyjelly/pocketcasts/views/extensions/WebViewTest.kt
+++ b/modules/services/views/src/test/java/au/com/shiftyjelly/pocketcasts/views/extensions/WebViewTest.kt
@@ -1,0 +1,35 @@
+package au.com.shiftyjelly.pocketcasts.views.extensions
+
+import android.webkit.WebView
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class WebViewTest {
+    @Test
+    fun `returns URL for a text link`() {
+        assertEquals(
+            "https://pocketcasts.com",
+            webViewLinkUrl(WebView.HitTestResult.SRC_ANCHOR_TYPE, "https://pocketcasts.com"),
+        )
+    }
+
+    @Test
+    fun `returns URL for an image link`() {
+        assertEquals(
+            "https://pocketcasts.com",
+            webViewLinkUrl(WebView.HitTestResult.SRC_IMAGE_ANCHOR_TYPE, "https://pocketcasts.com"),
+        )
+    }
+
+    @Test
+    fun `ignores non-link hit test results`() {
+        assertNull(webViewLinkUrl(WebView.HitTestResult.UNKNOWN_TYPE, "https://pocketcasts.com"))
+    }
+
+    @Test
+    fun `ignores missing or blank URLs`() {
+        assertNull(webViewLinkUrl(WebView.HitTestResult.SRC_ANCHOR_TYPE, null))
+        assertNull(webViewLinkUrl(WebView.HitTestResult.SRC_ANCHOR_TYPE, ""))
+    }
+}

--- a/modules/services/views/src/test/java/au/com/shiftyjelly/pocketcasts/views/extensions/WebViewTest.kt
+++ b/modules/services/views/src/test/java/au/com/shiftyjelly/pocketcasts/views/extensions/WebViewTest.kt
@@ -15,10 +15,24 @@ class WebViewTest {
     }
 
     @Test
-    fun `returns URL for an image link`() {
+    fun `returns focused node URL for an image link`() {
         assertEquals(
-            "https://pocketcasts.com",
-            webViewLinkUrl(WebView.HitTestResult.SRC_IMAGE_ANCHOR_TYPE, "https://pocketcasts.com"),
+            "https://pocketcasts.com/destination",
+            webViewLinkUrl(
+                type = WebView.HitTestResult.SRC_IMAGE_ANCHOR_TYPE,
+                hitTestUrl = "https://pocketcasts.com/image.jpg",
+                focusedNodeUrl = "https://pocketcasts.com/destination",
+            ),
+        )
+    }
+
+    @Test
+    fun `does not use image source URL for an image link`() {
+        assertNull(
+            webViewLinkUrl(
+                type = WebView.HitTestResult.SRC_IMAGE_ANCHOR_TYPE,
+                hitTestUrl = "https://pocketcasts.com/image.jpg",
+            ),
         )
     }
 
@@ -31,5 +45,12 @@ class WebViewTest {
     fun `ignores missing or blank URLs`() {
         assertNull(webViewLinkUrl(WebView.HitTestResult.SRC_ANCHOR_TYPE, null))
         assertNull(webViewLinkUrl(WebView.HitTestResult.SRC_ANCHOR_TYPE, ""))
+        assertNull(
+            webViewLinkUrl(
+                type = WebView.HitTestResult.SRC_IMAGE_ANCHOR_TYPE,
+                hitTestUrl = "https://pocketcasts.com/image.jpg",
+                focusedNodeUrl = "",
+            ),
+        )
     }
 }


### PR DESCRIPTION
## Description

Copies the exact target URL when a link is long-pressed in:

- podcast descriptions
- Now Playing > Details
- Episode > Details

Compose previously supported link taps only, while the two WebViews kept Android's default URL-preview popup because no link long-click listener was installed. This adds reusable Compose and WebView handling plus one shared, version-aware clipboard helper. Regular taps and non-link interactions remain unchanged.

Linear: [PCDROID-681](https://linear.app/a8c/issue/PCDROID-681/android-copy-description-and-show-notes-links-with-a-long-press)

## Testing Instructions

1. Open a podcast with a linked podcast description, expand it, then long-press the link.
2. Confirm the URL is copied once and a regular tap still opens it.
3. Open Now Playing > Details and long-press an external show-notes link.
4. Open Episode > Details and repeat.
5. Long-press non-link text and confirm it is not copied.

Automated checks:

- `:modules:services:views:testDebugUnitTest --tests '*WebViewTest'`
- `:modules:services:compose:testDebugUnitTest --tests '*ExpandableTextTest'`
- player and podcasts Kotlin compilation
- `spotlessCheck`
- views, player, and podcasts lint
- `:app:assembleDebugProd`

Physical validation on a Samsung SM-G990E running Android 16 covered all three surfaces, regular link taps, non-link long presses, and fatal-crash monitoring.

## Screenshots or Screencast

Not included. The system clipboard confirmation was verified on the physical test device.

## Checklist

- [x] If user-facing, added an entry to `CHANGELOG.md`
- [x] All checks and linter rules pass locally
- [x] Added unit tests for the shared Compose and WebView handlers
- [x] No new strings required; the existing localized clipboard confirmation is reused where Android does not provide one
- [x] Existing Compose previews continue to cover the changed component
- [x] No analytics changes required

#### I have tested the UI changes on:

- [x] Light and dark themes
- [ ] Landscape orientation
- [ ] Large display size and font
- [ ] TalkBack
