### PR TITLE
Please ignore: External contribution build of "Fix status bar icon contrast in bookmark dialogs"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
     *   HLS support
         ([#5602](https://github.com/Automattic/pocket-casts-android/pull/5602))
 *   Bug Fixes
+    *   Fix status bar icon contrast in light-themed bookmark dialogs
+        ([#2127](https://github.com/Automattic/pocket-casts-android/issues/2127))
     *   Fix episodes being cached over mobile data when Warn before using data is enabled
         ([#5567](https://github.com/Automattic/pocket-casts-android/pull/5567))
     *   Reduce the chance of episode playback progress reverting during listening history sync

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksContainerFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksContainerFragment.kt
@@ -51,7 +51,7 @@ class BookmarksContainerFragment : BaseDialogFragment() {
         get() = if (sourceView == SourceView.PROFILE) {
             StatusBarIconColor.Theme
         } else {
-            StatusBarIconColor.Light
+            StatusBarIconColor.ThemeNoToolbar
         }
 
     var binding: FragmentBookmarksContainerBinding? = null


### PR DESCRIPTION
## Description
This PR is just to get the CI steps to run for the external contribution https://github.com/Automattic/pocket-casts-android/pull/5617

Fixes # <!-- issue number, if applicable -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

## Screenshots or Screencast 
<!-- if applicable -->

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
