### PR TITLE
Rename already-suspend updateTrimModeBlocking to updateTrimMode

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastSettingsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastSettingsViewModel.kt
@@ -273,7 +273,7 @@ class PodcastSettingsViewModel @AssistedInject constructor(
 
             podcastFlow.update { it?.copy(trimMode = mode) }
             updatePlayerEffects()
-            podcastManager.updateTrimModeBlocking(podcast, mode)
+            podcastManager.updateTrimMode(podcast, mode)
         }
     }
 
@@ -291,7 +291,7 @@ class PodcastSettingsViewModel @AssistedInject constructor(
 
             podcastFlow.update { it?.copy(trimMode = mode) }
             updatePlayerEffects()
-            podcastManager.updateTrimModeBlocking(podcast, mode)
+            podcastManager.updateTrimMode(podcast, mode)
         }
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/VersionMigrationsWorker.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/VersionMigrationsWorker.kt
@@ -326,7 +326,7 @@ class VersionMigrationsWorker @AssistedInject constructor(
             val podcasts = podcastManager.findSubscribedBlocking()
             podcasts.forEach { podcast ->
                 if (podcast.isSilenceRemoved && podcast.trimMode == TrimMode.OFF) {
-                    podcastManager.updateTrimModeBlocking(podcast, TrimMode.LOW)
+                    podcastManager.updateTrimMode(podcast, TrimMode.LOW)
                 }
             }
         } catch (e: Exception) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
@@ -82,7 +82,7 @@ interface PodcastManager {
     suspend fun updateAutoAddToUpNexts(podcastUuids: List<String>, autoAddToUpNext: Podcast.AutoAddUpNext)
     suspend fun updateAutoAddToUpNextsIf(podcastUuids: List<String>, newValue: Podcast.AutoAddUpNext, onlyIfValue: Podcast.AutoAddUpNext)
     fun updateOverrideGlobalEffectsBlocking(podcast: Podcast, override: Boolean)
-    suspend fun updateTrimModeBlocking(podcast: Podcast, trimMode: TrimMode)
+    suspend fun updateTrimMode(podcast: Podcast, trimMode: TrimMode)
     fun updateVolumeBoostedBlocking(podcast: Podcast, override: Boolean)
     fun updatePlaybackSpeedBlocking(podcast: Podcast, speed: Double)
     fun updateEffectsBlocking(podcast: Podcast, effects: PlaybackEffects)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -540,7 +540,7 @@ class PodcastManagerImpl @Inject constructor(
         podcastDao.updateOverrideGlobalEffectsBlocking(override, podcast.uuid)
     }
 
-    override suspend fun updateTrimModeBlocking(podcast: Podcast, trimMode: TrimMode) {
+    override suspend fun updateTrimMode(podcast: Podcast, trimMode: TrimMode) {
         podcastDao.updateTrimSilenceModeBlocking(trimMode, podcast.uuid)
     }
 
@@ -555,7 +555,7 @@ class PodcastManagerImpl @Inject constructor(
     override fun updateEffectsBlocking(podcast: Podcast, effects: PlaybackEffects) {
         podcastDao.updateEffectsBlocking(effects.playbackSpeed, effects.isVolumeBoosted, effects.trimMode, podcast.uuid)
         launch {
-            updateTrimModeBlocking(podcast, effects.trimMode)
+            updateTrimMode(podcast, effects.trimMode)
         }
     }
 


### PR DESCRIPTION
## Description
`PodcastManager.updateTrimModeBlocking` is already a `suspend` function but kept the `Blocking` suffix, which this codebase reserves for blocking Room calls. This renames it to `updateTrimMode` in the interface, `PodcastManagerImpl`, and its three call sites (`PodcastSettingsViewModel`, `VersionMigrationsWorker`). Rename only, no behaviour change.

First step of the Room blocking → suspend migration: clearing up the misnamed methods so the `Blocking` suffix reliably marks real blocking calls.

Fixes # <!-- no linked issue -->

## Testing Instructions
No behaviour change; compilation is the main check.
1. Open a podcast's settings and change Trim Silence.
2. Reopen the settings and confirm the value persisted.

## Screenshots or Screencast 
N/A, no UI changes.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack

🤖 Generated with [Claude Code](https://claude.com/claude-code)