### PR TITLE
Rename already-suspend findFolderPodcastsOrderByLatestEpisodeBlocking

### DIFF
--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
@@ -185,7 +185,7 @@ abstract class PodcastDao {
 
     @Transaction
     @Query("SELECT podcasts.* FROM podcasts LEFT JOIN podcast_episodes ON podcasts.uuid = podcast_episodes.podcast_id AND podcast_episodes.uuid = (SELECT podcast_episodes.uuid FROM podcast_episodes WHERE podcast_episodes.podcast_id = podcasts.uuid AND podcast_episodes.playing_status != 2 ORDER BY podcast_episodes.published_date DESC LIMIT 1) WHERE podcasts.subscribed = 1 AND folder_uuid = :folderUuid ORDER BY CASE WHEN podcast_episodes.published_date IS NULL THEN 1 ELSE 0 END, podcast_episodes.published_date DESC, podcasts.latest_episode_date DESC")
-    abstract suspend fun findFolderPodcastsOrderByLatestEpisodeBlocking(folderUuid: String): List<Podcast>
+    abstract suspend fun findFolderPodcastsOrderByLatestEpisode(folderUuid: String): List<Podcast>
 
     @Transaction
     @Query(

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -400,7 +400,7 @@ class PodcastManagerImpl @Inject constructor(
     }
 
     override suspend fun findFolderPodcastsOrderByLatestEpisode(folderUuid: String): List<Podcast> {
-        return podcastDao.findFolderPodcastsOrderByLatestEpisodeBlocking(folderUuid)
+        return podcastDao.findFolderPodcastsOrderByLatestEpisode(folderUuid)
     }
 
     override suspend fun findPodcastsOrderByRecentlyPlayedEpisode(): List<Podcast> {


### PR DESCRIPTION
## Description
`PodcastDao.findFolderPodcastsOrderByLatestEpisodeBlocking` is already a `suspend` function but kept the `Blocking` suffix, which this codebase reserves for blocking Room calls. This renames it to `findFolderPodcastsOrderByLatestEpisode`, matching the name the `PodcastManager` layer already uses, and updates its single caller in `PodcastManagerImpl`. Rename only, no behaviour change.

Together with #5635 this completes the renames of the two misnamed already-suspend methods, so the `Blocking` suffix now reliably marks real blocking calls ahead of the wider Room blocking → suspend migration.

## Testing Instructions
No behaviour change; compilation (including Room's KSP validation) is the main check.
1. Create a folder with a few podcasts.
2. Sort the folder by "Newest episode" and confirm the order is correct.

## Screenshots or Screencast 
N/A, no UI changes.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack

