### PR TITLE
Allow the create-pr skill to run in Claude Code app environments

### DIFF
--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: create-pr
 description: Create a pull request
-disable-model-invocation: true
 allowed-tools: Read, Bash(which gh), Bash(git diff *), Bash(git log *), Bash(gh pr create --repo Automattic/pocket-casts-android *), Bash(gh pr edit --repo Automattic/pocket-casts-android *), Bash(gh label list --repo Automattic/pocket-casts-android *), Bash(gh api repos/Automattic/pocket-casts-android/*)
 ---
 


### PR DESCRIPTION
## Description

Removes the `disable-model-invocation: true` flag from the `create-pr` skill. When running other AI tasks it's handy to ask it to run the create PR skill at the end so it follows the steps such as applying the correct GitHub labels.

## Testing Instructions

1. Open this branch in the Claude Code desktop or web app (not the terminal CLI).
2. Make any trivial change on a scratch branch so there is something to open a PR for.
3. Run `/create-pr`.
4. Confirm it runs instead of failing with `cannot be used with Skill tool due to disable-model-invocation`.
5. In an interactive `claude` terminal session, run `/create-pr` and confirm it still behaves as before.

