### PR TITLE
Remove unused FolderManager.findFoldersToSyncBlocking

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/FolderManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/FolderManager.kt
@@ -26,7 +26,6 @@ interface FolderManager {
     fun findFoldersSingle(): Single<List<Folder>>
     suspend fun updatePositions(folders: List<Folder>)
     suspend fun updateSortPosition(folderItems: List<FolderItem>)
-    fun findFoldersToSyncBlocking(): List<Folder>
     suspend fun findFoldersToSync(): List<Folder>
     suspend fun markAllSynced()
     suspend fun countFolders(): Int

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/FolderManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/FolderManagerImpl.kt
@@ -147,10 +147,6 @@ class FolderManagerImpl @Inject constructor(
         updatePositions(folders)
     }
 
-    override fun findFoldersToSyncBlocking(): List<Folder> {
-        return folderDao.findNotSyncedBlocking()
-    }
-
     override suspend fun findFoldersToSync(): List<Folder> {
         return folderDao.findNotSynced()
     }


### PR DESCRIPTION
## Description
`FolderManager.findFoldersToSyncBlocking()` has no callers anywhere in the codebase. Folder syncing goes through the `suspend` twin `findFoldersToSync()`, which `FoldersSync` already uses. This removes the dead interface declaration and its implementation.

Part of the wider Room blocking → `suspend` migration: it is one fewer blocking method to migrate, and it retires the last production use of `FolderDao.findNotSyncedBlocking` so that DAO method can be deleted in a follow-up.

No behaviour change.

## Testing Instructions
No behaviour change; compilation is the main check.
1. Create a folder and add a couple of podcasts to it.
2. Force a sync (pull to refresh on the Podcasts tab) and confirm the folder appears on another signed-in device or after a re-login.

## Screenshots or Screencast
N/A, no UI changes.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack