### PR TITLE
Remove unused BookmarkManager.findBookmarksToSyncBlocking

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManager.kt
@@ -32,7 +32,6 @@ interface BookmarkManager {
     suspend fun deleteToSync(bookmarkUuid: String)
     suspend fun deleteSynced(bookmarkUuid: String)
     suspend fun upsertSynced(bookmark: Bookmark): Bookmark
-    fun findBookmarksToSyncBlocking(): List<Bookmark>
     suspend fun searchInPodcastByTitle(podcastUuid: String, title: String): List<String>
     suspend fun searchByBookmarkOrEpisodeTitle(title: String): List<String>
     fun findUserEpisodesBookmarksFlow(): Flow<List<Bookmark>>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerImpl.kt
@@ -218,13 +218,6 @@ class BookmarkManagerImpl @Inject constructor(
     }
 
     /**
-     * Find all bookmarks that need to be synced.
-     */
-    override fun findBookmarksToSyncBlocking(): List<Bookmark> {
-        return bookmarkDao.findNotSyncedBlocking()
-    }
-
-    /**
      * Upsert the bookmarks from the server. The insert will replace the bookmark if the UUID already exists.
      */
     override suspend fun upsertSynced(bookmark: Bookmark): Bookmark {


### PR DESCRIPTION
## Description
`BookmarkManager.findBookmarksToSyncBlocking()` has no callers anywhere in the codebase. This removes the dead interface declaration and its implementation.

Part of the wider Room blocking → `suspend` migration: it is one fewer blocking method to migrate, and it retires the only production use of `BookmarkDao.findNotSyncedBlocking` so that DAO method can be deleted in a follow-up.

No behaviour change.

## Testing Instructions
No behaviour change; compilation is the main check.
1. Add a bookmark while playing an episode.
2. Force a sync and confirm the bookmark still appears under Profile → Bookmarks.

## Screenshots or Screencast
N/A, no UI changes.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack