### PR TITLE
Remove three unused EpisodeManager blocking methods

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -46,8 +46,6 @@ interface EpisodeManager {
     suspend fun findEpisodesToSync(): List<PodcastEpisode>
     fun findEpisodesForHistorySyncBlocking(): List<PodcastEpisode>
 
-    fun findEpisodesDownloadingBlocking(): List<PodcastEpisode>
-
     fun findDownloadEpisodesFlow(): Flow<List<PodcastEpisode>>
     fun findDownloadedEpisodesRxFlowable(): Flowable<List<PodcastEpisode>>
     fun findStarredEpisodesFlow(): Flow<List<PodcastEpisode>>
@@ -76,7 +74,6 @@ interface EpisodeManager {
     fun updateDownloadFilePathBlocking(episode: BaseEpisode?, filePath: String, markAsDownloaded: Boolean)
     fun updateFileTypeBlocking(episode: BaseEpisode?, fileType: String)
     fun updateSizeInBytesBlocking(episode: BaseEpisode?, sizeInBytes: Long)
-    fun updateDownloadErrorDetailsBlocking(episode: BaseEpisode?, message: String?)
 
     fun updateAllEpisodeStatusBlocking(episodeStatus: EpisodeDownloadStatus)
 
@@ -109,7 +106,6 @@ interface EpisodeManager {
 
     /** Utility methods  */
     suspend fun countEpisodes(): Int
-    fun countEpisodesWhereBlocking(queryAfterWhere: String): Int
     fun downloadMissingEpisodeRxMaybe(episodeUuid: String, podcastUuid: String, skeletonEpisode: PodcastEpisode, podcastManager: PodcastManager, downloadMetaData: Boolean, source: SourceView): Maybe<BaseEpisode>
     suspend fun downloadMissingPodcastEpisode(episodeUuid: String, podcastUuid: String): PodcastEpisode?
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -5,7 +5,6 @@ import androidx.media3.common.util.UnstableApi
 import androidx.room.withTransaction
 import androidx.sqlite.db.SimpleSQLiteQuery
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
-import au.com.shiftyjelly.pocketcasts.models.converter.EpisodeDownloadStatusConverter
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
@@ -283,16 +282,6 @@ class EpisodeManagerImpl @Inject constructor(
         }
     }
 
-    override fun updateDownloadErrorDetailsBlocking(episode: BaseEpisode?, message: String?) {
-        if (episode == null) return
-        episode.downloadErrorDetails = message
-        if (episode is PodcastEpisode) {
-            episodeDao.updateBlocking(episode)
-        } else if (episode is UserEpisode) {
-            runBlocking { userEpisodeManager.updateDownloadErrorDetails(episode, message) }
-        }
-    }
-
     override suspend fun updatePlaybackInteractionDate(episode: BaseEpisode?) {
         if (episode == null) {
             return
@@ -536,10 +525,6 @@ class EpisodeManagerImpl @Inject constructor(
         return episodeDao.count()
     }
 
-    override fun countEpisodesWhereBlocking(queryAfterWhere: String): Int {
-        return episodeDao.countWhereBlocking(queryAfterWhere, appDatabase)
-    }
-
     override fun addBlocking(episode: PodcastEpisode, downloadMetaData: Boolean): Boolean {
         val episodes = ArrayList<PodcastEpisode>()
         episodes.add(episode)
@@ -726,18 +711,6 @@ class EpisodeManagerImpl @Inject constructor(
 
     override suspend fun findStarredEpisodes(): List<PodcastEpisode> {
         return episodeDao.findStarredEpisodes()
-    }
-
-    override fun findEpisodesDownloadingBlocking(): List<PodcastEpisode> {
-        val statuses = EpisodeDownloadStatus.entries.filter { it.isCancellable }
-        val converter = EpisodeDownloadStatusConverter()
-        val sql = statuses.joinToString(
-            prefix = "(",
-            postfix = ")",
-            separator = " OR ",
-            transform = { "episode_status = ${converter.toInt(it)}" },
-        )
-        return findEpisodesWhereBlocking(sql)
     }
 
     override fun addBlocking(episodes: List<PodcastEpisode>, podcastUuid: String, downloadMetaData: Boolean): List<PodcastEpisode> {


### PR DESCRIPTION
## Description
Three `EpisodeManager` methods have no callers anywhere in the codebase, so this removes them along with their implementations:

- `findEpisodesDownloadingBlocking()`
- `updateDownloadErrorDetailsBlocking()`
- `countEpisodesWhereBlocking()`

Part of the wider Room blocking → `suspend` migration. Each one is a method that would otherwise have to be converted and propagated up through `EpisodeManagerImpl` and its callers. `countEpisodesWhereBlocking` in particular was the only caller of `EpisodeDao.countWhereBlocking`, which is one of the awkward cases: it takes an `AppDatabase` and builds a raw query through `QueryHelper`. Deleting the manager method removes the need to migrate that path at all.

Two follow-ups this makes possible, deliberately left out to keep the diff small:
- `EpisodeDao.countWhereBlocking` (and its `QueryHelper` support) is now unreferenced in production.
- `UserEpisodeManager.updateDownloadErrorDetails` loses its only caller.

No behaviour change.

## Testing Instructions
No behaviour change; compilation is the main check.
1. Download an episode and confirm the download progresses and completes.
2. Turn off the network mid-download and confirm the episode shows a download error.
3. Open a filter with an episode-count badge and confirm the count is correct.

## Screenshots or Screencast
N/A, no UI changes.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack