### PR TITLE
Use the suspend episode lookup in PodcastViewModel

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
@@ -299,7 +299,7 @@ class PodcastViewModel @Inject constructor(
     fun onUnarchiveClicked() {
         launch {
             val p = podcast.value ?: return@launch
-            val episodes = episodeManager.findEpisodesByPodcastOrderedBlocking(p)
+            val episodes = episodeManager.findEpisodesByPodcastOrderedSuspend(p)
             episodeManager.unarchiveAllInListBlocking(episodes)
             eventHorizon.track(
                 EpisodeBulkUnarchivedEvent(
@@ -410,7 +410,7 @@ class PodcastViewModel @Inject constructor(
     fun archivePlayed() {
         val podcast = this.podcast.value ?: return
         launch {
-            val episodes = episodeManager.findEpisodesByPodcastOrderedBlocking(podcast).filter { it.isFinished }
+            val episodes = episodeManager.findEpisodesByPodcastOrderedSuspend(podcast).filter { it.isFinished }
             episodeManager.archiveAllInList(episodes, playbackManager)
             eventHorizon.track(
                 EpisodeBulkArchivedEvent(

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
@@ -299,7 +299,7 @@ class PodcastViewModel @Inject constructor(
     fun onUnarchiveClicked() {
         launch {
             val p = podcast.value ?: return@launch
-            val episodes = episodeManager.findEpisodesByPodcastOrderedSuspend(p)
+            val episodes = episodeManager.findEpisodesByPodcastOrdered(p)
             episodeManager.unarchiveAllInListBlocking(episodes)
             eventHorizon.track(
                 EpisodeBulkUnarchivedEvent(
@@ -410,7 +410,7 @@ class PodcastViewModel @Inject constructor(
     fun archivePlayed() {
         val podcast = this.podcast.value ?: return
         launch {
-            val episodes = episodeManager.findEpisodesByPodcastOrderedSuspend(podcast).filter { it.isFinished }
+            val episodes = episodeManager.findEpisodesByPodcastOrdered(podcast).filter { it.isFinished }
             episodeManager.archiveAllInList(episodes, playbackManager)
             eventHorizon.track(
                 EpisodeBulkArchivedEvent(

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperViewModel.kt
@@ -136,7 +136,7 @@ class DeveloperViewModel
                     .shuffled()
                     .asFlow()
                     .flatMapConcat {
-                        episodeManager.findEpisodesByPodcastOrderedSuspend(it).asFlow()
+                        episodeManager.findEpisodesByPodcastOrdered(it).asFlow()
                     }
                     .take(5)
                     .toList()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/AutoDownloadEpisodeProvider.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/AutoDownloadEpisodeProvider.kt
@@ -40,7 +40,7 @@ class AutoDownloadEpisodeProvider @Inject constructor(
                 .filter(Podcast::isAutoDownloadNewEpisodes)
                 .flatMapTo(mutableSetOf()) { podcast ->
                     episodeManager
-                        .findEpisodesByPodcastOrderedSuspend(podcast)
+                        .findEpisodesByPodcastOrdered(podcast)
                         .asSequence()
                         .filter { episode -> episode.uuid in newEpisodeUuidSet }
                         .filter { episode ->

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/AutoPlaySelector.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/AutoPlaySelector.kt
@@ -69,7 +69,7 @@ class AutoPlaySelector @Inject constructor(
         currentEpisodeUuid: String?,
     ): List<PodcastEpisode> {
         val episodes = episodeManager
-            .findEpisodesByPodcastOrderedSuspend(podcast)
+            .findEpisodesByPodcastOrdered(podcast)
             .filter { episode ->
                 (!episode.isArchived && !episode.isFinished) ||
                     episode.uuid == currentEpisodeUuid

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/BrowseTreeProvider.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/BrowseTreeProvider.kt
@@ -316,7 +316,7 @@ class BrowseTreeProvider @Inject constructor(
                 ?: podcastManager.findOrDownloadPodcastRxSingle(parentId).toMaybe().onErrorComplete().awaitSingleOrNull()
             podcastFound?.let { podcast ->
                 val episodes = episodeManager
-                    .findEpisodesByPodcastOrderedBlocking(podcast)
+                    .findEpisodesByPodcastOrdered(podcast)
                     .filterNot { !showPlayed && (it.isFinished || it.isArchived) }
                     .take(EPISODE_LIMIT)
                     .toMutableList()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -34,7 +34,7 @@ interface EpisodeManager {
 
     fun findEpisodesWhereBlocking(queryAfterWhere: String, forSubscribedPodcastsOnly: Boolean = true): List<PodcastEpisode>
     fun findEpisodesByPodcastOrderedBlocking(podcast: Podcast): List<PodcastEpisode>
-    suspend fun findEpisodesByPodcastOrderedSuspend(podcast: Podcast): List<PodcastEpisode>
+    suspend fun findEpisodesByPodcastOrdered(podcast: Podcast): List<PodcastEpisode>
     fun findEpisodesByPodcastOrderedByPublishDateBlocking(podcast: Podcast): List<PodcastEpisode>
     suspend fun findEpisodesByPodcastOrderedByPublishDate(podcast: Podcast): List<PodcastEpisode>
     fun findNotificationEpisodesBlocking(date: Date): List<PodcastEpisode>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -149,7 +149,7 @@ class EpisodeManagerImpl @Inject constructor(
         }
     }
 
-    override suspend fun findEpisodesByPodcastOrderedSuspend(podcast: Podcast): List<PodcastEpisode> {
+    override suspend fun findEpisodesByPodcastOrdered(podcast: Podcast): List<PodcastEpisode> {
         return when (podcast.episodesSortType) {
             EpisodesSortType.EPISODES_SORT_BY_TITLE_ASC -> episodeDao.findByPodcastOrderTitleAsc(podcastUuid = podcast.uuid)
             EpisodesSortType.EPISODES_SORT_BY_TITLE_DESC -> episodeDao.findByPodcastOrderTitleDesc(podcastUuid = podcast.uuid)

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/download/AutoDownloadEpisodeProviderTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/download/AutoDownloadEpisodeProviderTest.kt
@@ -38,7 +38,7 @@ class AutoDownloadEpisodeProviderTest {
     }
 
     private val episodeManager = mock<EpisodeManager> {
-        on { findEpisodesByPodcastOrderedSuspend(any()) } doAnswer { invocation ->
+        on { findEpisodesByPodcastOrdered(any()) } doAnswer { invocation ->
             podcastEpisodes[invocation.arguments[0]].orEmpty()
         }
     }


### PR DESCRIPTION
## Description
`PodcastViewModel.onUnarchiveClicked()` and `archivePlayed()` both fetch the podcast's episodes with the blocking `EpisodeManager.findEpisodesByPodcastOrderedBlocking`, even though both call sites already run inside a `launch { }` block. This points them at the existing `suspend` twin `findEpisodesByPodcastOrderedSuspend`, which runs the same query through the same `when (podcast.episodesSortType)` branch, so the results are identical. The difference is that Room now dispatches the query on its own executor instead of blocking the coroutine's thread.

Part of the wider Room blocking → `suspend` migration, chipping away at the caller side where a `suspend` twin already exists so no DAO or interface changes are needed.

## Testing Instructions
1. Open a podcast with several episodes and archive a few of them.
2. Tap the podcast's overflow menu → **Unarchive all** and confirm every episode comes back, in the sort order currently selected.
3. Change the episode sort order (title, oldest to newest, duration) and repeat step 2 to confirm ordering is unaffected.
4. Play an episode to completion, then use **Archive played** and confirm only the played episodes are archived.

## Screenshots or Screencast
N/A, no UI changes.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack