### PR TITLE
Use suspend lookups in DeveloperViewModel

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperViewModel.kt
@@ -62,7 +62,7 @@ class DeveloperViewModel
                     for (podcast in podcasts) {
                         if (podcast.isShowNotifications) {
                             // find first podcast with more than one episode
-                            val episodes = episodeManager.findEpisodesByPodcastOrderedByPublishDateBlocking(podcast)
+                            val episodes = episodeManager.findEpisodesByPodcastOrderedByPublishDate(podcast)
                             if (episodes.size <= 1) {
                                 continue
                             } else {
@@ -99,7 +99,7 @@ class DeveloperViewModel
                 val podcasts = podcastManager.findSubscribedBlocking()
                 for (podcast in podcasts) {
                     // find first podcast with more than one episode
-                    val episodes = episodeManager.findEpisodesByPodcastOrderedByPublishDateBlocking(podcast)
+                    val episodes = episodeManager.findEpisodesByPodcastOrderedByPublishDate(podcast)
                     if (episodes.size <= 1) {
                         continue
                     } else {
@@ -111,7 +111,7 @@ class DeveloperViewModel
 
                         podcast.latestEpisodeUuid = newLatest?.uuid
                         podcast.latestEpisodeDate = newLatest?.publishedDate
-                        podcastManager.updatePodcastBlocking(podcast)
+                        podcastManager.updatePodcast(podcast)
 
                         continue
                     }


### PR DESCRIPTION
## Description
`DeveloperViewModel.triggerNotification()` and `deleteFirstEpisode()` both run inside `viewModelScope.launch(Dispatchers.IO)` but call blocking Room wrappers. This points them at the `suspend` twins that already exist:

- `EpisodeManager.findEpisodesByPodcastOrderedByPublishDateBlocking` → `findEpisodesByPodcastOrderedByPublishDate` (2 call sites)
- `PodcastManager.updatePodcastBlocking` → `updatePodcast` (1 call site)

Both twins run the same query as their blocking counterparts, so behaviour is unchanged; Room just dispatches the work itself rather than the coroutine blocking its thread. This screen is the internal developer menu, so the blast radius is small.

Part of the wider Room blocking → `suspend` migration, chipping away at the caller side where a `suspend` twin already exists so no DAO or interface changes are needed.

## Testing Instructions
The developer menu is only available in debug builds.
1. Install a debug build and go to **Profile → Settings → Developer**.
2. Tap **Trigger notification** with at least one podcast that has notifications enabled, and confirm the "Refresh started" toast appears and a new-episode notification arrives.
3. Tap **Delete first episode**, confirm the "Episodes deleted" toast, and check the affected podcasts now show the next episode as their latest.

## Screenshots or Screencast
N/A, no UI changes.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack