### PR TITLE
Fix audio_only_mode HLS analytics parity

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -390,6 +390,7 @@ open class PlaybackManager @Inject constructor(
             PlaybackEpisodeAutoplayedEvent(
                 episodeUuid = autoPlayEpisode.uuid,
                 hlsAvailable = alternateEnclosureManager.findForEpisode(autoPlayEpisode.uuid).firstHlsStreamUrl() != null,
+                audioOnlyMode = audioOnlyModeOrNull(),
             ),
         )
         return autoPlayEpisode

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -386,11 +386,12 @@ open class PlaybackManager @Inject constructor(
             }
         }
 
+        val autoPlayOffersHls = alternateEnclosureManager.findForEpisode(autoPlayEpisode.uuid).firstHlsStreamUrl() != null
         eventHorizon.track(
             PlaybackEpisodeAutoplayedEvent(
                 episodeUuid = autoPlayEpisode.uuid,
-                hlsAvailable = alternateEnclosureManager.findForEpisode(autoPlayEpisode.uuid).firstHlsStreamUrl() != null,
-                audioOnlyMode = audioOnlyModeOrNull(),
+                hlsAvailable = autoPlayOffersHls,
+                audioOnlyMode = if (autoPlayOffersHls) settings.audioOnly.value else null,
             ),
         )
         return autoPlayEpisode

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -484,7 +484,7 @@ open class PlaybackManager @Inject constructor(
 
     private fun audioOnlyModeOrNull(): Boolean? {
         if (getCurrentEpisode()?.isStreamUrlHls != true || player?.isStreaming != true) return null
-        return _streamVideoState.value == StreamVideoState.AudioOnly || !_videoRenderingEnabled.value
+        return settings.audioOnly.value || !_videoRenderingEnabled.value
     }
 
     private fun playbackContentTypeFor(episode: BaseEpisode?): PlaybackContentType {


### PR DESCRIPTION
## Description
Two `audio_only_mode` fixes for HLS analytics parity with iOS and web:

1. **Add `audio_only_mode` to `playback_episode_autoplayed`** — it was the only HLS lifecycle event missing it (`playback_play` and `player_episode_completed` already send it).
2. **Base `audio_only_mode` on the "Audio only" setting, not stream video state** — `audioOnlyModeOrNull()` counted a stream that merely *lacks a video track* (`_streamVideoState == AudioOnly`, set by `onVideoTrackChanged`) as audio-only, which is not a user choice. It now reports `settings.audioOnly.value || !_videoRenderingEnabled.value` — the global "Audio only" setting **or** the per-stream toggle. This is the agreed cross-platform definition ("effective audio-only listening state").

Both gated behind `Feature.HLS_STREAMING`. The EventHorizon `PlaybackEpisodeAutoplayedEvent` already accepts `audioOnlyMode`, so no schema/library change is required (see EventHorizonSchemas#114 for the description update).

### Changes
- Pass `audioOnlyMode = audioOnlyModeOrNull()` to `PlaybackEpisodeAutoplayedEvent`
- `audioOnlyModeOrNull()` → `settings.audioOnly.value || !_videoRenderingEnabled.value`

## Testing Instructions
Enable the `HLS_STREAMING` feature flag.

1. **Autoplay carries the property** — Turn on Autoplay (Settings → General) → play an HLS episode and let it finish → when the next episode autoplays, verify `playback_episode_autoplayed` includes `audio_only_mode` alongside `hls_available`.
2. **Global setting drives it** — Turn on the "Audio only" setting (Settings → Playback) → play an HLS episode → verify `playback_play` / `player_episode_completed` report `audio_only_mode = true`.
3. **Per-stream toggle drives it** — With "Audio only" off, play an HLS video episode → tap the player video/audio toggle to audio → verify `audio_only_mode = true`; toggle back → `false`.
4. **No-video stream is NOT audio-only** — Play an HLS stream that has no video track, with "Audio only" off and no toggle → verify `audio_only_mode = false` (previously `true`).

Related: pocket-casts-ios#4823, pocket-casts-webplayer#4747, EventHorizonSchemas#114.
