### PR TITLE
Resume explicit media play immediately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
     *   Add option to switch to the HLS video stream when playing a downloaded episode
         ([#5620](https://github.com/Automattic/pocket-casts-android/pull/5620))
 *   Bug Fixes
+    *   Fix Bluetooth play controls resuming slowly and playback repeatedly pausing on wireless Android Auto
+        ([#5645](https://github.com/Automattic/pocket-casts-android/pull/5645))
     *   Allow copying description and show notes links with a long press
         ([#5628](https://github.com/Automattic/pocket-casts-android/pull/5628))
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3SessionCallback.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3SessionCallback.kt
@@ -67,7 +67,17 @@ internal class Media3SessionCallback(
 
     private val scope: CoroutineScope get() = scopeProvider()
 
-    private val mediaEventQueue = MediaEventQueue(scopeProvider = scopeProvider)
+    private val mediaButtonEventHandler = MediaButtonEventHandler(
+        scopeProvider = scopeProvider,
+        onImmediatePlay = { playbackManager.playIfNotPlaying(sourceView = source) },
+        onMediaEvent = { event ->
+            when (event) {
+                MediaEvent.SingleTap -> handleMediaButtonSingleTap()
+                MediaEvent.DoubleTap -> handleMediaButtonDoubleTap()
+                MediaEvent.TripleTap -> handleMediaButtonTripleTap()
+            }
+        },
+    )
 
     override fun onConnect(
         session: MediaSession,
@@ -204,9 +214,10 @@ internal class Media3SessionCallback(
         LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Media3 media button event: keyCode=${keyEvent.keyCode}")
 
         // Dedicated pause key has explicit semantics — handle it directly.
-        // KEYCODE_MEDIA_PLAY is routed through the multi-tap system because some
-        // Bluetooth headphones (e.g. Pixel Buds) send it spuriously after multi-tap
-        // sequences, and the MediaEventQueue suppresses those duplicates.
+        // KEYCODE_MEDIA_PLAY stays in the multi-tap system because some Bluetooth
+        // headphones send it spuriously after multi-tap sequences. Its play-only
+        // action runs as soon as the queue accepts the first tap, without waiting
+        // for the multi-tap window to expire.
         when (keyEvent.keyCode) {
             KeyEvent.KEYCODE_MEDIA_PAUSE -> {
                 scope.launch { playbackManager.pauseSuspend(sourceView = source) }
@@ -244,37 +255,7 @@ internal class Media3SessionCallback(
             }
         }
 
-        val inputEvent = when (keyEvent.keyCode) {
-            KeyEvent.KEYCODE_MEDIA_PLAY,
-            KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE,
-            KeyEvent.KEYCODE_HEADSETHOOK,
-            -> MediaEvent.SingleTap
-
-            KeyEvent.KEYCODE_MEDIA_NEXT -> MediaEvent.DoubleTap
-
-            KeyEvent.KEYCODE_MEDIA_PREVIOUS -> MediaEvent.TripleTap
-
-            else -> null
-        }
-
-        if (inputEvent != null) {
-            scope.launch {
-                try {
-                    val outputEvent = mediaEventQueue.consumeEvent(inputEvent)
-                    when (outputEvent) {
-                        MediaEvent.SingleTap -> handleMediaButtonSingleTap()
-                        MediaEvent.DoubleTap -> handleMediaButtonDoubleTap()
-                        MediaEvent.TripleTap -> handleMediaButtonTripleTap()
-                        null -> Unit
-                    }
-                } catch (e: Exception) {
-                    Timber.e(e, "Media button event handling failed")
-                }
-            }
-            return true
-        }
-
-        return false
+        return mediaButtonEventHandler.handle(keyEvent)
     }
 
     private fun handleMediaButtonSingleTap() {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -252,6 +252,7 @@ class MediaSessionManager(
                                 LogBuffer.e(LogBuffer.TAG_PLAYBACK, "Failed to add command to queue: $tag")
                             }
                         },
+                        scopeProvider = { scope },
                     ),
                 )
             }
@@ -1218,48 +1219,50 @@ class MediaSessionManager(
         stateBuilder.addCustomAction(skipBackBuilder.build())
     }
 
-    inner class MediaSessionCallback(
+    internal inner class MediaSessionCallback(
         val playbackManager: PlaybackManager,
         val episodeManager: EpisodeManager,
         val enqueueCommand: (String, suspend () -> Unit) -> Unit,
+        scopeProvider: () -> CoroutineScope,
     ) : MediaSessionCompat.Callback() {
 
         private var playFromSearchDisposable: Disposable? = null
-        private val mediaEventQueue = MediaEventQueue(scopeProvider = { this@MediaSessionManager.scope })
+        private val mediaButtonEventHandler = MediaButtonEventHandler(
+            scopeProvider = scopeProvider,
+            onImmediatePlay = {
+                playbackManager.playIfNotPlaying(sourceView = source)
+            },
+            onMediaEvent = { event ->
+                LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Media button output event: $event")
+                when (event) {
+                    MediaEvent.SingleTap -> handleMediaButtonSingleTap()
+                    MediaEvent.DoubleTap -> handleMediaButtonDoubleTap()
+                    MediaEvent.TripleTap -> handleMediaButtonTripleTap()
+                }
+            },
+        )
 
         override fun onMediaButtonEvent(mediaButtonEvent: Intent): Boolean {
-            if (Intent.ACTION_MEDIA_BUTTON == mediaButtonEvent.action) {
-                val keyEvent = IntentCompat.getParcelableExtra(mediaButtonEvent, Intent.EXTRA_KEY_EVENT, KeyEvent::class.java) ?: return false
-                logEvent(keyEvent.toString())
-                if (keyEvent.action == KeyEvent.ACTION_DOWN) {
-                    LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Media button Android event: ${keyEvent.action}")
-                    val inputEvent = when (keyEvent.keyCode) {
-                        KeyEvent.KEYCODE_MEDIA_PLAY, KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE, KeyEvent.KEYCODE_HEADSETHOOK -> MediaEvent.SingleTap
-                        KeyEvent.KEYCODE_MEDIA_NEXT -> MediaEvent.DoubleTap
-                        KeyEvent.KEYCODE_MEDIA_PREVIOUS -> MediaEvent.TripleTap
-                        else -> null
-                    }
-                    LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Media button input event: ${keyEvent.action}")
-
-                    if (inputEvent != null) {
-                        scope.launch {
-                            val outputEvent = mediaEventQueue.consumeEvent(inputEvent)
-                            LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Media button output event: ${keyEvent.action}")
-                            when (outputEvent) {
-                                MediaEvent.SingleTap -> handleMediaButtonSingleTap()
-                                MediaEvent.DoubleTap -> handleMediaButtonDoubleTap()
-                                MediaEvent.TripleTap -> handleMediaButtonTripleTap()
-                                null -> Unit
-                            }
-                        }
-                        return true
-                    }
-                }
-            } else {
+            if (Intent.ACTION_MEDIA_BUTTON != mediaButtonEvent.action) {
                 logEvent("onMediaButtonEvent(${mediaButtonEvent.action ?: "unknown action"})")
+                return super.onMediaButtonEvent(mediaButtonEvent)
             }
 
-            return super.onMediaButtonEvent(mediaButtonEvent)
+            val keyEvent = IntentCompat.getParcelableExtra(
+                mediaButtonEvent,
+                Intent.EXTRA_KEY_EVENT,
+                KeyEvent::class.java,
+            ) ?: return false
+            logEvent(keyEvent.toString())
+            if (keyEvent.action == KeyEvent.ACTION_DOWN) {
+                LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Media button Android event: keyCode=${keyEvent.keyCode}")
+            }
+
+            return if (mediaButtonEventHandler.handle(keyEvent)) {
+                true
+            } else {
+                super.onMediaButtonEvent(mediaButtonEvent)
+            }
         }
 
         private fun onAddBookmark() {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -621,6 +621,24 @@ open class PlaybackManager @Inject constructor(
         }
     }
 
+    /**
+     * Plays the queue only if playback isn't already running, unlike the [playPause] toggle.
+     * Used for KEYCODE_MEDIA_PLAY, which has explicit play semantics: some head units
+     * (wireless Android Auto in particular) send it redundantly while playback is already
+     * running, and toggling would pause playback.
+     */
+    fun playIfNotPlaying(sourceView: SourceView = SourceView.UNKNOWN) {
+        if (isPlaying()) {
+            LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Ignoring play request because playback is already playing")
+        } else {
+            LogBuffer.i(
+                LogBuffer.TAG_PLAYBACK,
+                "Starting playback for explicit play request from source=$sourceView",
+            )
+            playQueue(sourceView)
+        }
+    }
+
     fun playQueue(
         sourceView: SourceView = SourceView.UNKNOWN,
         showedStreamWarning: Boolean = false,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -625,7 +625,8 @@ open class PlaybackManager @Inject constructor(
      * Plays the queue only if playback isn't already running, unlike the [playPause] toggle.
      * Used for KEYCODE_MEDIA_PLAY, which has explicit play semantics: some head units
      * (wireless Android Auto in particular) send it redundantly while playback is already
-     * running, and toggling would pause playback.
+     * running, and toggling would pause playback. Media-button callbacks invoke it immediately
+     * instead of waiting for multi-tap disambiguation.
      */
     fun playIfNotPlaying(sourceView: SourceView = SourceView.UNKNOWN) {
         if (isPlaying()) {
@@ -633,7 +634,7 @@ open class PlaybackManager @Inject constructor(
         } else {
             LogBuffer.i(
                 LogBuffer.TAG_PLAYBACK,
-                "Starting playback for explicit play request from source=$sourceView",
+                "Explicit play request from source=$sourceView",
             )
             playQueue(sourceView)
         }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3SessionCallbackTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3SessionCallbackTest.kt
@@ -20,8 +20,8 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import java.util.Date
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -67,7 +67,7 @@ class Media3SessionCallbackTest {
         bookmarkHelper = mock()
         mockSession = mock()
         mockController = mock()
-        testScope = TestScope(UnconfinedTestDispatcher())
+        testScope = TestScope(StandardTestDispatcher())
 
         callback = Media3SessionCallback(
             playbackManager = playbackManager,

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3SessionCallbackTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3SessionCallbackTest.kt
@@ -10,6 +10,7 @@ import androidx.media3.session.MediaSession
 import androidx.media3.session.SessionCommand
 import androidx.media3.session.SessionError
 import androidx.media3.session.SessionResult
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -31,6 +32,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doCallRealMethod
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -340,12 +342,74 @@ class Media3SessionCallbackTest {
     // --- Headphone action handler tests ---
 
     @Test
-    fun `KEYCODE_MEDIA_PLAY routes through multi-tap as single tap`() = runTest {
+    fun `KEYCODE_MEDIA_PLAY while paused starts playback before the multi-tap window expires`() = runTest {
+        doCallRealMethod().whenever(playbackManager).playIfNotPlaying(any())
+        whenever(playbackManager.isPlaying()).thenReturn(false)
+
+        sendMediaButtonEvent(KeyEvent.KEYCODE_MEDIA_PLAY)
+
+        // A dedicated play key must not wait 600 ms for tap disambiguation.
+        verify(playbackManager).playQueue(
+            sourceView = eq(SourceView.MEDIA_BUTTON_BROADCAST_ACTION),
+            showedStreamWarning = any(),
+        )
+        verify(playbackManager, never()).playPause(sourceView = any())
+
+        testScope.advanceUntilIdle()
+
+        // A lone dedicated play key has already been handled, so the delayed
+        // single-tap result must not toggle playback.
+        verify(playbackManager, never()).playPause(sourceView = any())
+    }
+
+    @Test
+    fun `KEYCODE_MEDIA_PLAY while paused resumes before the double-tap action`() = runTest {
+        mockHeadphoneNextAction(HeadphoneAction.ADD_BOOKMARK)
+        doCallRealMethod().whenever(playbackManager).playIfNotPlaying(any())
+        whenever(playbackManager.isPlaying()).thenReturn(false)
+
+        sendMediaButtonEvent(KeyEvent.KEYCODE_MEDIA_PLAY)
+        verify(playbackManager).playQueue(
+            sourceView = eq(SourceView.MEDIA_BUTTON_BROADCAST_ACTION),
+            showedStreamWarning = any(),
+        )
+
+        sendMediaButtonEvent(KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE)
+        testScope.advanceUntilIdle()
+        shadowOf(android.os.Looper.getMainLooper()).idle()
+
+        verify(bookmarkHelper).handleAddBookmarkAction(any(), any())
+        verify(playbackManager, never()).playPause(sourceView = any())
+    }
+
+    @Test
+    fun `KEYCODE_MEDIA_PLAY stays suppressed after KEYCODE_MEDIA_NEXT`() = runTest {
+        mockHeadphoneNextAction(HeadphoneAction.SKIP_FORWARD)
+        mockSkipSettings()
+        whenever(playbackManager.isPlaying()).thenReturn(true)
+
+        sendMediaButtonEvent(KeyEvent.KEYCODE_MEDIA_NEXT)
         sendMediaButtonEvent(KeyEvent.KEYCODE_MEDIA_PLAY)
         testScope.advanceUntilIdle()
 
-        // Routed through MediaEventQueue — single tap resolves as play/pause
-        verify(playbackManager).playPause(sourceView = any())
+        verify(playbackManager, never()).playIfNotPlaying(sourceView = any())
+        verify(playbackManager).skipForwardSuspend(
+            sourceView = any(),
+            jumpAmountSeconds = eq(30),
+        )
+    }
+
+    @Test
+    fun `KEYCODE_MEDIA_PLAY while already playing does not toggle`() = runTest {
+        doCallRealMethod().whenever(playbackManager).playIfNotPlaying(any())
+        whenever(playbackManager.isPlaying()).thenReturn(true)
+
+        sendMediaButtonEvent(KeyEvent.KEYCODE_MEDIA_PLAY)
+        testScope.advanceUntilIdle()
+
+        verify(playbackManager, never()).playQueue(any(), any())
+        verify(playbackManager, never()).pause(any(), any())
+        verify(playbackManager, never()).playPause(any())
     }
 
     @Test
@@ -380,18 +444,6 @@ class Media3SessionCallbackTest {
             sourceView = any(),
             jumpAmountSeconds = eq(30),
         )
-    }
-
-    @Test
-    fun `double tap with ADD_BOOKMARK setting calls bookmarkHelper`() = runTest {
-        mockHeadphoneNextAction(HeadphoneAction.ADD_BOOKMARK)
-
-        sendMediaButtonEvent(KeyEvent.KEYCODE_MEDIA_NEXT)
-        testScope.advanceUntilIdle()
-        // The bookmark action dispatches on Dispatchers.Main, so idle the main looper
-        shadowOf(android.os.Looper.getMainLooper()).idle()
-
-        verify(bookmarkHelper).handleAddBookmarkAction(any(), any())
     }
 
     @Test

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManagerCallbackTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManagerCallbackTest.kt
@@ -1,0 +1,107 @@
+package au.com.shiftyjelly.pocketcasts.repositories.playback
+
+import android.content.Intent
+import android.view.KeyEvent
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
+import au.com.shiftyjelly.pocketcasts.preferences.model.HeadphoneAction
+import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import com.automattic.eventhorizon.EventHorizon
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+@OptIn(ExperimentalCoroutinesApi::class)
+class MediaSessionManagerCallbackTest {
+    @Test
+    fun `legacy KEYCODE_MEDIA_PLAY runs play-only action before the multi-tap window expires`() = runTest {
+        val playbackManager = mock<PlaybackManager>()
+        val episodeManager = mock<EpisodeManager>()
+        val manager = createManager(this, playbackManager, episodeManager)
+        val callback = manager.createCallback(this, playbackManager, episodeManager)
+
+        callback.onMediaButtonEvent(mediaButtonIntent(KeyEvent.KEYCODE_MEDIA_PLAY))
+
+        verify(playbackManager).playIfNotPlaying(SourceView.MEDIA_BUTTON_BROADCAST_ACTION)
+        verify(playbackManager, never()).playPause(any())
+
+        advanceUntilIdle()
+        verify(playbackManager, never()).playPause(any())
+    }
+
+    @Test
+    fun `legacy KEYCODE_MEDIA_NEXT suppresses a following KEYCODE_MEDIA_PLAY`() = runTest {
+        val playbackManager = mock<PlaybackManager>()
+        val episodeManager = mock<EpisodeManager>()
+        val settings = mock<Settings>()
+        val nextAction = mock<UserSetting<HeadphoneAction>>()
+        whenever(settings.headphoneControlsNextAction).thenReturn(nextAction)
+        whenever(nextAction.value).thenReturn(HeadphoneAction.SKIP_FORWARD)
+        whenever(playbackManager.isPlaying()).thenReturn(true)
+        val manager = createManager(this, playbackManager, episodeManager, settings)
+        val queuedCommands = mutableListOf<String>()
+        val callback = manager.createCallback(
+            scope = this,
+            playbackManager = playbackManager,
+            episodeManager = episodeManager,
+            enqueueCommand = { tag, _ -> queuedCommands += tag },
+        )
+
+        callback.onMediaButtonEvent(mediaButtonIntent(KeyEvent.KEYCODE_MEDIA_NEXT))
+        callback.onMediaButtonEvent(mediaButtonIntent(KeyEvent.KEYCODE_MEDIA_PLAY))
+        advanceUntilIdle()
+
+        verify(playbackManager, never()).playIfNotPlaying(any())
+        assertEquals(listOf("skip forwards"), queuedCommands)
+    }
+
+    private fun createManager(
+        scope: CoroutineScope,
+        playbackManager: PlaybackManager,
+        episodeManager: EpisodeManager,
+        settings: Settings = mock(),
+    ) = MediaSessionManager(
+        playbackManager = playbackManager,
+        podcastManager = mock<PodcastManager>(),
+        episodeManager = episodeManager,
+        playlistManager = mock<PlaylistManager>(),
+        settings = settings,
+        context = RuntimeEnvironment.getApplication(),
+        eventHorizon = mock<EventHorizon>(),
+        bookmarkManager = mock<BookmarkManager>(),
+        browseTreeProvider = mock<BrowseTreeProvider>(),
+        applicationScope = scope,
+    )
+
+    private fun MediaSessionManager.createCallback(
+        scope: CoroutineScope,
+        playbackManager: PlaybackManager,
+        episodeManager: EpisodeManager,
+        enqueueCommand: (String, suspend () -> Unit) -> Unit = { _, _ -> },
+    ) = MediaSessionCallback(
+        playbackManager = playbackManager,
+        episodeManager = episodeManager,
+        enqueueCommand = enqueueCommand,
+        scopeProvider = { scope },
+    )
+
+    private fun mediaButtonIntent(keyCode: Int) = Intent(Intent.ACTION_MEDIA_BUTTON).apply {
+        putExtra(Intent.EXTRA_KEY_EVENT, KeyEvent(KeyEvent.ACTION_DOWN, keyCode))
+    }
+}

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManagerCallbackTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManagerCallbackTest.kt
@@ -71,6 +71,49 @@ class MediaSessionManagerCallbackTest {
         assertEquals(listOf("skip forwards"), queuedCommands)
     }
 
+    @Test
+    fun `legacy KEYCODE_HEADSETHOOK resolves to play pause`() = runTest {
+        val playbackManager = mock<PlaybackManager>()
+        val episodeManager = mock<EpisodeManager>()
+        val manager = createManager(this, playbackManager, episodeManager)
+        val callback = manager.createCallback(this, playbackManager, episodeManager)
+
+        callback.onMediaButtonEvent(mediaButtonIntent(KeyEvent.KEYCODE_HEADSETHOOK))
+        advanceUntilIdle()
+
+        verify(playbackManager).playPause(SourceView.MEDIA_BUTTON_BROADCAST_ACTION)
+        verify(playbackManager, never()).playIfNotPlaying(any())
+    }
+
+    @Test
+    fun `legacy rapid KEYCODE_MEDIA_PLAY resolves previous action after immediate play`() = runTest {
+        val playbackManager = mock<PlaybackManager>()
+        val episodeManager = mock<EpisodeManager>()
+        val settings = mock<Settings>()
+        val previousAction = mock<UserSetting<HeadphoneAction>>()
+        whenever(settings.headphoneControlsPreviousAction).thenReturn(previousAction)
+        whenever(previousAction.value).thenReturn(HeadphoneAction.SKIP_BACK)
+        val manager = createManager(this, playbackManager, episodeManager, settings)
+        val queuedCommands = mutableListOf<String>()
+        val callback = manager.createCallback(
+            scope = this,
+            playbackManager = playbackManager,
+            episodeManager = episodeManager,
+            enqueueCommand = { tag, _ -> queuedCommands += tag },
+        )
+
+        repeat(3) {
+            callback.onMediaButtonEvent(mediaButtonIntent(KeyEvent.KEYCODE_MEDIA_PLAY))
+        }
+
+        verify(playbackManager).playIfNotPlaying(SourceView.MEDIA_BUTTON_BROADCAST_ACTION)
+
+        advanceUntilIdle()
+
+        assertEquals(listOf("skip backwards"), queuedCommands)
+        verify(playbackManager, never()).playPause(any())
+    }
+
     private fun createManager(
         scope: CoroutineScope,
         playbackManager: PlaybackManager,


### PR DESCRIPTION
## Stack / review order

1. Review and merge prerequisite #5646 first. It contains the concurrency-safe
   media-button processor and its focused unit tests.
2. Review this PR second. It integrates that processor into the Media3 and legacy
   callbacks and adds the user-facing playback behavior.

This PR is intentionally based on `codex/serialize-media-button-events`. After
#5646 merges, retarget this PR to `main`.

## Description

`KEYCODE_MEDIA_PLAY` currently waits for the 600 ms multi-tap window before
resuming playback. When the phone has been idle with the screen off, that
coroutine can remain suspended for several seconds, so Bluetooth play controls
appear unresponsive until the device wakes.

This PR builds on #5646 and supersedes #5535:

- Wire the shared ordered button processor into both Media3 and legacy media
  sessions.
- Keep explicit play semantics, so redundant `KEYCODE_MEDIA_PLAY` events never
  toggle active playback into a pause.
- Run the play-only action as soon as the queue accepts the first tap instead of
  waiting for the multi-tap timeout.
- Keep the first tap registered so second and third taps still resolve to the
  configured headphone action.
- Continue suppressing the spurious `KEYCODE_MEDIA_PLAY` some headphones send
  after `KEYCODE_MEDIA_NEXT` or `KEYCODE_MEDIA_PREVIOUS`.
- Log when the explicit-play fast path starts playback.

The release-default phone path is the legacy media session unless Firebase Remote
Config enables `Media3 MediaSession`; debug and prototype builds default to
Media3. Both paths have direct unit coverage.

### Behavior notes

- If a paused headset double-tap begins with `KEYCODE_MEDIA_PLAY`, playback now
  resumes immediately and the resolved double-tap action still runs. For example,
  an `ADD_BOOKMARK` double tap resumes and then bookmarks.
- `KEYCODE_MEDIA_PLAY` is intentionally play-only. While already playing it does
  not pause; headsets using a toggle command must send `KEYCODE_MEDIA_PLAY_PAUSE`
  or `KEYCODE_MEDIA_PAUSE` for pause behavior.

Fixes #5631

## Testing Instructions

### Automated

1. Run the focused suites:

   ```shell
   ./gradlew :modules:services:repositories:testDebugUnitTest \
     --tests '*MediaEventQueueTest*' \
     --tests '*MediaButtonEventHandlerTest*' \
     --tests '*MediaSessionManagerCallbackTest*' \
     --tests '*Media3SessionCallbackTest*'
   ```

2. Confirm all 57 focused tests pass.
3. Run `./gradlew :modules:services:repositories:testDebugUnitTest` and confirm all
   860 tests pass.
4. Run `./gradlew spotlessCheck`.

### Manual: test the release-default legacy path first

1. In a debug/debugProd build, open Settings → Beta Features and turn
   **Media3 MediaSession** off.
2. Force-stop and relaunch the app because media-session selection is cached for
   the process.
3. Confirm LogBuffer contains `Legacy playback service created`.
4. Connect Bluetooth headphones, start playback, pause it, turn the screen off,
   and leave the phone idle for several minutes.
5. Press the dedicated play control and confirm playback resumes immediately.
6. Confirm rapid repeated play commands start playback only once, and a redundant
   play command while already playing does not pause it.
7. Confirm `NEXT`/`PREVIOUS` still run their configured actions and a following
   spurious play event does not trigger a single-tap action.
8. While paused, confirm a double tap resumes immediately and then runs the
   configured double-tap action, including `ADD_BOOKMARK`.
9. Turn **Media3 MediaSession** on, force-stop and relaunch, and repeat steps 4–8
   for the Media3 path.

### Manual result (2026-08-07)

Installed GitHub's stacked merge result
`c20537ff7c021b7431c0f33c332cb52084505338` on a physical Samsung SM-G990E
running Android 16. Both the release-default legacy session and the Media3
session passed:

- A dedicated `KEYCODE_MEDIA_PLAY` resumed paused playback while the display
  remained dozing; the explicit-play handler ran in approximately 5 ms on the
  legacy path and 10 ms on Media3, rather than after the 600 ms tap window.
- A redundant play command while already playing remained a no-op.
- Rapid repeated play commands started playback once and still resolved the
  configured double-tap skip-forward action after the window.
- `NEXT`/`PREVIOUS` followed immediately by the spurious `PLAY` event kept
  the configured skip action and suppressed the trailing play action.
- No crash or ANR was recorded.

Playback was left paused, the Media3 beta flag was restored to its original
enabled state, and the display was returned to dozing. No Bluetooth audio
accessory was connected, so media keys were injected through Android's media-key
dispatcher with `adb`. This verifies the app/session and screen-off behavior,
but not a physical headset's Bluetooth transport behavior.

## Screenshots or Screencast

Not applicable; there are no UI changes.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

#### I have tested any UI changes...

Not applicable; there are no UI changes.
