### PR TITLE
Harden media button event sequencing

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaButtonEventHandler.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaButtonEventHandler.kt
@@ -47,7 +47,7 @@ internal class MediaButtonEventHandler(
         } ?: return false
 
         val immediateSingleTapHandler = if (keyEvent.keyCode == KeyEvent.KEYCODE_MEDIA_PLAY) {
-            onImmediatePlay
+            ::handleImmediatePlay
         } else {
             null
         }
@@ -73,5 +73,15 @@ internal class MediaButtonEventHandler(
             }
         }
         return true
+    }
+
+    private fun handleImmediatePlay() {
+        try {
+            onImmediatePlay()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            onError(e)
+        }
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaButtonEventHandler.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaButtonEventHandler.kt
@@ -1,18 +1,28 @@
 package au.com.shiftyjelly.pocketcasts.repositories.playback
 
 import android.view.KeyEvent
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.yield
-import timber.log.Timber
 
+/**
+ * Serializes media-button key events before dispatching their resolved actions.
+ *
+ * Event registration starts synchronously to preserve framework callback order. [onImmediatePlay] may therefore run
+ * on the caller's stack and must stay fast. [onMediaEvent] runs only after a suspension boundary, outside that
+ * synchronous registration section.
+ */
 internal class MediaButtonEventHandler(
     private val scopeProvider: () -> CoroutineScope,
     private val onImmediatePlay: () -> Unit,
     private val onMediaEvent: (MediaEvent) -> Unit,
-    private val onError: (Exception) -> Unit = { Timber.e(it, "Media button event handling failed") },
+    private val onError: (Exception) -> Unit = {
+        LogBuffer.e(LogBuffer.TAG_PLAYBACK, it, "Media button event handling failed")
+    },
 ) {
     private val mediaEventQueue = MediaEventQueue(scopeProvider)
 
@@ -36,15 +46,20 @@ internal class MediaButtonEventHandler(
             else -> null
         } ?: return false
 
+        val immediateSingleTapHandler = if (keyEvent.keyCode == KeyEvent.KEYCODE_MEDIA_PLAY) {
+            onImmediatePlay
+        } else {
+            null
+        }
+
         // Register the event before returning to the framework callback. This preserves
         // delivery order while the queue's timeout still resumes on the provided scope.
         scope.launch(start = CoroutineStart.UNDISPATCHED) {
             try {
+                coroutineContext.ensureActive()
                 val outputEvent = mediaEventQueue.consumeEvent(
                     event = inputEvent,
-                    onImmediateSingleTap = onImmediatePlay.takeIf {
-                        keyEvent.keyCode == KeyEvent.KEYCODE_MEDIA_PLAY
-                    },
+                    onImmediateSingleTap = immediateSingleTapHandler,
                 )
                 if (outputEvent != null) {
                     // Output actions historically ran asynchronously on the callback scope.

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaButtonEventHandler.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaButtonEventHandler.kt
@@ -1,0 +1,62 @@
+package au.com.shiftyjelly.pocketcasts.repositories.playback
+
+import android.view.KeyEvent
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.yield
+import timber.log.Timber
+
+internal class MediaButtonEventHandler(
+    private val scopeProvider: () -> CoroutineScope,
+    private val onImmediatePlay: () -> Unit,
+    private val onMediaEvent: (MediaEvent) -> Unit,
+    private val onError: (Exception) -> Unit = { Timber.e(it, "Media button event handling failed") },
+) {
+    private val mediaEventQueue = MediaEventQueue(scopeProvider)
+
+    private val scope: CoroutineScope get() = scopeProvider()
+
+    fun handle(keyEvent: KeyEvent): Boolean {
+        if (keyEvent.action != KeyEvent.ACTION_DOWN) {
+            return false
+        }
+
+        val inputEvent = when (keyEvent.keyCode) {
+            KeyEvent.KEYCODE_MEDIA_PLAY,
+            KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE,
+            KeyEvent.KEYCODE_HEADSETHOOK,
+            -> MediaEvent.SingleTap
+
+            KeyEvent.KEYCODE_MEDIA_NEXT -> MediaEvent.DoubleTap
+
+            KeyEvent.KEYCODE_MEDIA_PREVIOUS -> MediaEvent.TripleTap
+
+            else -> null
+        } ?: return false
+
+        // Register the event before returning to the framework callback. This preserves
+        // delivery order while the queue's timeout still resumes on the provided scope.
+        scope.launch(start = CoroutineStart.UNDISPATCHED) {
+            try {
+                val outputEvent = mediaEventQueue.consumeEvent(
+                    event = inputEvent,
+                    onImmediateSingleTap = onImmediatePlay.takeIf {
+                        keyEvent.keyCode == KeyEvent.KEYCODE_MEDIA_PLAY
+                    },
+                )
+                if (outputEvent != null) {
+                    // Output actions historically ran asynchronously on the callback scope.
+                    yield()
+                    onMediaEvent(outputEvent)
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                onError(e)
+            }
+        }
+        return true
+    }
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaEventQueue.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaEventQueue.kt
@@ -42,7 +42,17 @@ internal class MediaEventQueue(
             }
         } ?: return null
 
-        onImmediateSingleTap?.invoke()
+        try {
+            onImmediateSingleTap?.invoke()
+        } catch (e: Exception) {
+            stateMutex.withLock {
+                if (singleTapJob === newSingleTapJob) {
+                    singleTapJob = null
+                    newSingleTapJob.cancel()
+                }
+            }
+            throw e
+        }
         newSingleTapJob.await()
         return stateMutex.withLock {
             // The immediate callback owns a resolved SingleTap. Follow-up taps still
@@ -70,6 +80,8 @@ internal class MediaEventQueue(
         val isActive get() = job.isActive
 
         suspend fun await() = job.join()
+
+        fun cancel() = job.cancel()
 
         fun incrementTaps() {
             counter++

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaEventQueue.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaEventQueue.kt
@@ -4,49 +4,60 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 internal class MediaEventQueue(
     private val scopeProvider: () -> CoroutineScope,
 ) {
     private var singleTapJob: SingleTapJob? = null
     private var multiTapJob: Job? = null
+    private val stateMutex = Mutex()
 
     private val scope: CoroutineScope get() = scopeProvider()
 
-    suspend fun consumeEvent(event: MediaEvent) = when (event) {
-        MediaEvent.SingleTap -> handleSingleTapEvent()
+    suspend fun consumeEvent(
+        event: MediaEvent,
+        onImmediateSingleTap: (() -> Unit)? = null,
+    ) = when (event) {
+        MediaEvent.SingleTap -> handleSingleTapEvent(onImmediateSingleTap)
         MediaEvent.DoubleTap, MediaEvent.TripleTap -> handleMultiTapEvent(event)
     }
 
-    private suspend fun handleSingleTapEvent(): MediaEvent? {
-        val currentSingleTapJob = singleTapJob
-        return when {
-            // Pixel Buds (and possibly other headphones) trigger KEYCODE_MEDIA_PLAY
-            // after KEYCODE_MEDIA_NEXT or KEYCODE_MEDIA_PREVIOUS.
-            // We need to ignore it so the single tap action isn't triggered in such cases.
-            multiTapJob?.isActive == true -> {
-                null
-            }
+    private suspend fun handleSingleTapEvent(onImmediateSingleTap: (() -> Unit)?): MediaEvent? {
+        val newSingleTapJob = stateMutex.withLock {
+            val currentSingleTapJob = singleTapJob
+            when {
+                // Pixel Buds (and possibly other headphones) trigger KEYCODE_MEDIA_PLAY
+                // after KEYCODE_MEDIA_NEXT or KEYCODE_MEDIA_PREVIOUS.
+                // We need to ignore it so the single tap action isn't triggered in such cases.
+                multiTapJob?.isActive == true -> null
 
-            currentSingleTapJob?.isActive == true -> {
-                currentSingleTapJob.incrementTaps()
-                null
-            }
+                currentSingleTapJob?.isActive == true -> {
+                    currentSingleTapJob.incrementTaps()
+                    null
+                }
 
-            else -> {
-                val newSingleTapJob = SingleTapJob(scope)
-                singleTapJob = newSingleTapJob
-                newSingleTapJob.await()
-                newSingleTapJob.event()
+                else -> SingleTapJob(scope).also { singleTapJob = it }
+            }
+        } ?: return null
+
+        onImmediateSingleTap?.invoke()
+        newSingleTapJob.await()
+        return stateMutex.withLock {
+            // The immediate callback owns a resolved SingleTap. Follow-up taps still
+            // return their DoubleTap or TripleTap action after the window closes.
+            newSingleTapJob.event().takeUnless {
+                it == MediaEvent.SingleTap && onImmediateSingleTap != null
             }
         }
     }
 
-    private fun handleMultiTapEvent(event: MediaEvent): MediaEvent {
+    private suspend fun handleMultiTapEvent(event: MediaEvent): MediaEvent = stateMutex.withLock {
         val currentJob = multiTapJob
         multiTapJob = scope.launch { delay(250) }
         currentJob?.cancel()
-        return event
+        event
     }
 
     private class SingleTapJob(

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaButtonEventHandlerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaButtonEventHandlerTest.kt
@@ -1,8 +1,11 @@
 package au.com.shiftyjelly.pocketcasts.repositories.playback
 
 import android.view.KeyEvent
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -68,6 +71,39 @@ class MediaButtonEventHandlerTest {
 
         advanceUntilIdle()
         assertEquals(listOf(MediaEvent.DoubleTap), events)
+    }
+
+    @Test
+    fun `resolved multi tap actions are deferred beyond event registration`() = runTest {
+        val events = mutableListOf<MediaEvent>()
+        val handler = MediaButtonEventHandler(
+            scopeProvider = { this },
+            onImmediatePlay = {},
+            onMediaEvent = events::add,
+        )
+
+        assertTrue(handler.handle(keyEvent(KeyEvent.KEYCODE_MEDIA_NEXT)))
+        assertEquals(emptyList<MediaEvent>(), events)
+
+        runCurrent()
+        assertEquals(listOf(MediaEvent.DoubleTap), events)
+    }
+
+    @Test
+    fun `cancelled scope does not handle events`() = runTest {
+        val cancelledJob = Job().apply { cancel() }
+        val cancelledScope = CoroutineScope(coroutineContext + cancelledJob)
+        var immediatePlayCount = 0
+        val events = mutableListOf<MediaEvent>()
+        val handler = MediaButtonEventHandler(
+            scopeProvider = { cancelledScope },
+            onImmediatePlay = { immediatePlayCount++ },
+            onMediaEvent = events::add,
+        )
+
+        assertTrue(handler.handle(keyEvent(KeyEvent.KEYCODE_MEDIA_PLAY)))
+        assertEquals(0, immediatePlayCount)
+        assertEquals(emptyList<MediaEvent>(), events)
     }
 
     @Test

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaButtonEventHandlerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaButtonEventHandlerTest.kt
@@ -55,6 +55,26 @@ class MediaButtonEventHandlerTest {
     }
 
     @Test
+    fun `immediate play failure is reported without losing the resolved double tap`() = runTest {
+        val failure = IllegalStateException("Immediate action failed")
+        val errors = mutableListOf<Exception>()
+        val events = mutableListOf<MediaEvent>()
+        val handler = MediaButtonEventHandler(
+            scopeProvider = { this },
+            onImmediatePlay = { throw failure },
+            onMediaEvent = events::add,
+            onError = errors::add,
+        )
+
+        assertTrue(handler.handle(keyEvent(KeyEvent.KEYCODE_MEDIA_PLAY)))
+        assertTrue(handler.handle(keyEvent(KeyEvent.KEYCODE_MEDIA_PLAY)))
+
+        advanceUntilIdle()
+        assertEquals(listOf(failure), errors)
+        assertEquals(listOf(MediaEvent.DoubleTap), events)
+    }
+
+    @Test
     fun `KEYCODE_MEDIA_NEXT suppresses a following KEYCODE_MEDIA_PLAY`() = runTest {
         var immediatePlayCount = 0
         val events = mutableListOf<MediaEvent>()

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaButtonEventHandlerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaButtonEventHandlerTest.kt
@@ -1,0 +1,89 @@
+package au.com.shiftyjelly.pocketcasts.repositories.playback
+
+import android.view.KeyEvent
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+@OptIn(ExperimentalCoroutinesApi::class)
+class MediaButtonEventHandlerTest {
+    @Test
+    fun `KEYCODE_MEDIA_PLAY runs the immediate action without a delayed single tap`() = runTest {
+        var immediatePlayCount = 0
+        val events = mutableListOf<MediaEvent>()
+        val handler = MediaButtonEventHandler(
+            scopeProvider = { this },
+            onImmediatePlay = { immediatePlayCount++ },
+            onMediaEvent = events::add,
+        )
+
+        assertTrue(handler.handle(keyEvent(KeyEvent.KEYCODE_MEDIA_PLAY)))
+        assertEquals(1, immediatePlayCount)
+        assertEquals(emptyList<MediaEvent>(), events)
+
+        advanceUntilIdle()
+        assertEquals(emptyList<MediaEvent>(), events)
+    }
+
+    @Test
+    fun `rapid KEYCODE_MEDIA_PLAY events run the immediate action once and emit a double tap`() = runTest {
+        var immediatePlayCount = 0
+        val events = mutableListOf<MediaEvent>()
+        val handler = MediaButtonEventHandler(
+            scopeProvider = { this },
+            onImmediatePlay = { immediatePlayCount++ },
+            onMediaEvent = events::add,
+        )
+
+        handler.handle(keyEvent(KeyEvent.KEYCODE_MEDIA_PLAY))
+        handler.handle(keyEvent(KeyEvent.KEYCODE_MEDIA_PLAY))
+
+        assertEquals(1, immediatePlayCount)
+
+        advanceUntilIdle()
+        assertEquals(listOf(MediaEvent.DoubleTap), events)
+    }
+
+    @Test
+    fun `KEYCODE_MEDIA_NEXT suppresses a following KEYCODE_MEDIA_PLAY`() = runTest {
+        var immediatePlayCount = 0
+        val events = mutableListOf<MediaEvent>()
+        val handler = MediaButtonEventHandler(
+            scopeProvider = { this },
+            onImmediatePlay = { immediatePlayCount++ },
+            onMediaEvent = events::add,
+        )
+
+        handler.handle(keyEvent(KeyEvent.KEYCODE_MEDIA_NEXT))
+        handler.handle(keyEvent(KeyEvent.KEYCODE_MEDIA_PLAY))
+
+        assertEquals(0, immediatePlayCount)
+
+        advanceUntilIdle()
+        assertEquals(listOf(MediaEvent.DoubleTap), events)
+    }
+
+    @Test
+    fun `unhandled key events return false`() = runTest {
+        val handler = MediaButtonEventHandler(
+            scopeProvider = { this },
+            onImmediatePlay = {},
+            onMediaEvent = {},
+        )
+
+        assertFalse(handler.handle(keyEvent(KeyEvent.KEYCODE_VOLUME_UP)))
+        assertFalse(handler.handle(keyEvent(KeyEvent.KEYCODE_MEDIA_PLAY, KeyEvent.ACTION_UP)))
+    }
+
+    private fun keyEvent(
+        keyCode: Int,
+        action: Int = KeyEvent.ACTION_DOWN,
+    ) = KeyEvent(action, keyCode)
+}

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaEventQueueTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaEventQueueTest.kt
@@ -11,7 +11,9 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.yield
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class MediaEventQueueTest {
@@ -82,6 +84,44 @@ class MediaEventQueueTest {
     }
 
     @Test
+    fun `handle an immediate single tap before the multi tap window expires`() = runTest {
+        val handler = MediaEventQueue(scopeProvider = { this })
+        var isHandled = false
+
+        val event = async {
+            handler.consumeEvent(MediaEvent.SingleTap) {
+                isHandled = true
+            }
+        }
+
+        yield()
+        assertTrue(isHandled)
+        assertNull(event.await())
+    }
+
+    @Test
+    fun `map immediate single taps to multi tap events`() = runTest {
+        val handler = MediaEventQueue(scopeProvider = { this })
+        var immediateTapCount = 0
+
+        val firstEvent = async {
+            handler.consumeEvent(MediaEvent.SingleTap) {
+                immediateTapCount++
+            }
+        }
+
+        yield()
+        assertNull(
+            handler.consumeEvent(MediaEvent.SingleTap) {
+                immediateTapCount++
+            },
+        )
+
+        assertEquals(1, immediateTapCount)
+        assertEquals(MediaEvent.DoubleTap, firstEvent.await())
+    }
+
+    @Test
     fun `handle concurrent immediate single taps exactly once`() = runBlocking {
         val handler = MediaEventQueue(scopeProvider = { this })
         val immediateTapCount = AtomicInteger()
@@ -101,6 +141,21 @@ class MediaEventQueueTest {
         }
 
         assertEquals(1, immediateTapCount.get())
+    }
+
+    @Test
+    fun `do not handle immediate single tap while multi tap window is active`() = runTest {
+        val handler = MediaEventQueue(scopeProvider = { this })
+        var isHandled = false
+
+        handler.consumeEvent(MediaEvent.DoubleTap)
+
+        assertNull(
+            handler.consumeEvent(MediaEvent.SingleTap) {
+                isHandled = true
+            },
+        )
+        assertFalse(isHandled)
     }
 
     @Test

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaEventQueueTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaEventQueueTest.kt
@@ -1,7 +1,13 @@
 package au.com.shiftyjelly.pocketcasts.repositories.playback
 
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.yield
 import org.junit.Assert.assertEquals
@@ -73,6 +79,28 @@ class MediaEventQueueTest {
         }
 
         assertEquals(MediaEvent.TripleTap, firstEvent.await())
+    }
+
+    @Test
+    fun `handle concurrent immediate single taps exactly once`() = runBlocking {
+        val handler = MediaEventQueue(scopeProvider = { this })
+        val immediateTapCount = AtomicInteger()
+        val eventCount = 8
+        val startBarrier = CyclicBarrier(eventCount)
+        val dispatcher = Executors.newFixedThreadPool(eventCount).asCoroutineDispatcher()
+
+        dispatcher.use {
+            List(eventCount) {
+                async(dispatcher) {
+                    startBarrier.await()
+                    handler.consumeEvent(MediaEvent.SingleTap) {
+                        immediateTapCount.incrementAndGet()
+                    }
+                }
+            }.awaitAll()
+        }
+
+        assertEquals(1, immediateTapCount.get())
     }
 
     @Test

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaEventQueueTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaEventQueueTest.kt
@@ -122,6 +122,19 @@ class MediaEventQueueTest {
     }
 
     @Test
+    fun `immediate single tap failure does not orphan the tap window`() = runTest {
+        val handler = MediaEventQueue(scopeProvider = { this })
+        val failure = IllegalStateException("Immediate action failed")
+
+        val thrown = runCatching {
+            handler.consumeEvent(MediaEvent.SingleTap) { throw failure }
+        }.exceptionOrNull()
+
+        assertEquals(failure, thrown)
+        assertEquals(MediaEvent.SingleTap, handler.consumeEvent(MediaEvent.SingleTap))
+    }
+
+    @Test
     fun `handle concurrent immediate single taps exactly once`() = runBlocking {
         val handler = MediaEventQueue(scopeProvider = { this })
         val immediateTapCount = AtomicInteger()


### PR DESCRIPTION
## Description

Media-button callbacks currently launch queue work onto a shared multi-threaded
scope. `MediaEventQueue` stores its tap jobs and counter in unsynchronized mutable
state, so concurrent callbacks can create multiple tap windows or observe events
out of order.

This PR is the first, independently tested part of the #5645 stack:

- Protect tap-window state and the tap counter with a mutex without holding the
  mutex across the 600 ms disambiguation window.
- Introduce a shared `MediaButtonEventHandler` that owns key-code mapping, error
  handling, and ordered event registration.
- Register each event before returning to the framework callback, while keeping
  resolved media actions asynchronous on the supplied scope.
- Preserve Pixel Buds `NEXT`/`PREVIOUS` followed by spurious `PLAY` suppression.
- Add eight-thread contention coverage plus focused handler behavior tests.

The follow-up PR #5645 wires this processor into the Media3 and legacy session
callbacks and contains the user-facing explicit-play behavior. Keeping the
processor and its unit tests here leaves both PRs below the 500-line review
threshold.

Related to #5631

## Testing Instructions

1. Run:

   ```shell
   ./gradlew :modules:services:repositories:testDebugUnitTest \
     --tests '*MediaEventQueueTest*' \
     --tests '*MediaButtonEventHandlerTest*'
   ```

2. Confirm all 23 focused tests pass.
3. Run `./gradlew :modules:services:repositories:testDebugUnitTest` and confirm
   all 860 tests pass.
4. Run `./gradlew spotlessCheck`.

No manual playback verification is needed for this preparatory PR because the
handler is integrated into the application callbacks in #5645.

### On-device verification of the stacked integration (2026-08-07)

Installed GitHub's merge result `c20537ff7c021b7431c0f33c332cb52084505338`,
which combines this PR at `9d4471ea4cc870a22a2cba06457045fe4fa679b5`
with #5645 at `361b8f64e5f0052d36751cf5d96ddfda00afb43f`, on a physical
Samsung SM-G990E running Android 16. Both the legacy and Media3 session paths
passed:

- A dedicated `KEYCODE_MEDIA_PLAY` resumed paused playback while the display
  remained dozing; the explicit-play handler ran in approximately 5–10 ms rather
  than after the 600 ms tap window.
- A redundant play command while already playing remained a no-op.
- Rapid repeated play commands started playback once and still resolved the
  configured double-tap action after the window.
- `NEXT`/`PREVIOUS` followed immediately by the spurious `PLAY` event kept
  the configured skip action and suppressed the trailing play action.
- No crash or ANR was recorded.

Playback was left paused, the Media3 beta flag was restored to its original
enabled state, and the display was returned to dozing. No Bluetooth audio
accessory was connected, so media keys were injected through Android's media-key
dispatcher with `adb`. This verifies the app/session and screen-off behavior,
but not a physical headset's Bluetooth transport behavior.

## Screenshots or Screencast

Not applicable; there are no UI changes.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md — not user-facing on its own
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml` — no strings
- [x] Any jetpack compose components I added or changed are covered by compose previews — no UI
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics — no analytics changes

#### I have tested any UI changes...

Not applicable; there are no UI changes.
