### PR TITLE
Fix audio_only_mode HLS analytics parity (cherry-pick to 8.17)

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -371,10 +371,12 @@ open class PlaybackManager @Inject constructor(
             }
         }
 
+        val autoPlayOffersHls = alternateEnclosureManager.findForEpisode(autoPlayEpisode.uuid).firstHlsStreamUrl() != null
         eventHorizon.track(
             PlaybackEpisodeAutoplayedEvent(
                 episodeUuid = autoPlayEpisode.uuid,
-                hlsAvailable = alternateEnclosureManager.findForEpisode(autoPlayEpisode.uuid).firstHlsStreamUrl() != null,
+                hlsAvailable = autoPlayOffersHls,
+                audioOnlyMode = if (autoPlayOffersHls) settings.audioOnly.value else null,
             ),
         )
         return autoPlayEpisode
@@ -411,8 +413,8 @@ open class PlaybackManager @Inject constructor(
     }
 
     private fun audioOnlyModeOrNull(): Boolean? {
-        if (getCurrentEpisode()?.isStreamUrlHls != true) return null
-        return _streamVideoState.value == StreamVideoState.AudioOnly || !_videoRenderingEnabled.value
+        if (getCurrentEpisode()?.isStreamUrlHls != true || player?.isStreaming != true) return null
+        return settings.audioOnly.value || !_videoRenderingEnabled.value
     }
 
     private fun playbackContentTypeFor(episode: BaseEpisode?): PlaybackContentType {


### PR DESCRIPTION
## Description

Cherry-pick of #5644 into `release/8.17`.

> **This change was already reviewed and merged on `main`.** This PR exists to land it in the upcoming release. CI and a quick review should still
> run to confirm the cherry-pick applies cleanly and introduces no issues on the release branch, since `release/8.17` may have diverged from `main`.

- Original PR: https://github.com/Automattic/pocket-casts-android/pull/5644
- Cherry-picked commit: `ab741a1518`

### Conflict resolution note

The cherry-pick conflicted in `audioOnlyModeOrNull()` because `main` (via #5620) added a `player?.isStreaming != true` guard that is not on `release/8.17`. Resolved by taking `main`'s version verbatim, guard included: the guard is self-contained (`Player.isStreaming` already exists on the release branch), it makes `audio_only_mode` reporting identical to `main`/8.18 (null for local-file playback instead of a value), and it keeps the eventual backmerge of `release/8.17` into `main` conflict-free in this file (verified with `git merge-tree`).

## Testing Instructions

See the original PR (https://github.com/Automattic/pocket-casts-android/pull/5644) for full testing steps. In addition, verify the change behaves as described on top of `release/8.17`.