### PR TITLE
Remove the recommendations feature flag

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/podcast/RecommendationsHandler.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/podcast/RecommendationsHandler.kt
@@ -4,8 +4,6 @@ import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.lists.ListRepository
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.servers.model.ListFeed
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import io.reactivex.BackpressureStrategy
 import io.reactivex.Flowable
 import io.reactivex.Maybe
@@ -29,9 +27,7 @@ class RecommendationsHandler @Inject constructor(
     private val retryCountObservable = BehaviorSubject.createDefault(0)
 
     fun setEnabled(enabled: Boolean) {
-        if (FeatureFlag.isEnabled(Feature.RECOMMENDATIONS)) {
-            enabledObservable.onNext(enabled)
-        }
+        enabledObservable.onNext(enabled)
     }
 
     fun getRecommendationsFlowable(podcastUuid: String): Flowable<RecommendationsResult> {

--- a/modules/features/podcasts/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/podcast/RecommendationsHandlerTest.kt
+++ b/modules/features/podcasts/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/podcast/RecommendationsHandlerTest.kt
@@ -7,9 +7,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverPodcast
 import au.com.shiftyjelly.pocketcasts.servers.model.ListFeed
 import au.com.shiftyjelly.pocketcasts.servers.server.ListWebService
-import au.com.shiftyjelly.pocketcasts.sharedtest.InMemoryFeatureFlagRule
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import io.reactivex.Flowable
 import io.reactivex.Single
 import java.util.UUID
@@ -17,16 +14,12 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
 class RecommendationsHandlerTest {
-
-    @get:Rule
-    val featureFlagRule = InMemoryFeatureFlagRule()
 
     private lateinit var listWebService: ListWebService
     private lateinit var podcastManager: PodcastManager
@@ -62,28 +55,7 @@ class RecommendationsHandlerTest {
     }
 
     @Test
-    fun `do not load recommendations when feature flag is disabled`() = runTest {
-        // feature flag is disabled
-        FeatureFlag.setEnabled(feature = Feature.RECOMMENDATIONS, enabled = false)
-        recommendations.setEnabled(true)
-
-        whenever(listWebService.getListFeed(any())).thenReturn(testListFeed)
-
-        val values = recommendations.getRecommendationsFlowable(testPodcastUuid)
-            .test()
-            .awaitCount(2)
-            .assertNoErrors()
-            .values()
-
-        // no podcasts should be found
-        assertTrue(values[0] is RecommendationsResult.Loading)
-        assertTrue(values[1] is RecommendationsResult.Empty)
-    }
-
-    @Test
     fun `do not load recommendations when recommendations are disabled`() = runTest {
-        // feature flag is disabled
-        FeatureFlag.setEnabled(feature = Feature.RECOMMENDATIONS, enabled = true)
         recommendations.setEnabled(false)
 
         whenever(listWebService.getListFeed(any())).thenReturn(testListFeed)
@@ -101,7 +73,6 @@ class RecommendationsHandlerTest {
 
     @Test
     fun `load recommendations when podcasts are available`() = runTest {
-        FeatureFlag.setEnabled(feature = Feature.RECOMMENDATIONS, enabled = true)
         recommendations.setEnabled(true)
 
         // expected URL for the list recommendation
@@ -137,7 +108,6 @@ class RecommendationsHandlerTest {
 
     @Test
     fun `load recommendations when podroll is available`() = runTest {
-        FeatureFlag.setEnabled(feature = Feature.RECOMMENDATIONS, enabled = true)
         recommendations.setEnabled(true)
 
         // expected URL for the list recommendation
@@ -173,7 +143,6 @@ class RecommendationsHandlerTest {
 
     @Test
     fun `do not load recommendations when neither podcasts or podroll are available`() = runTest {
-        FeatureFlag.setEnabled(feature = Feature.RECOMMENDATIONS, enabled = true)
         recommendations.setEnabled(true)
 
         // expected URL for the list recommendation

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/lists/ListRepository.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/lists/ListRepository.kt
@@ -6,8 +6,6 @@ import au.com.shiftyjelly.pocketcasts.servers.model.Discover
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
 import au.com.shiftyjelly.pocketcasts.servers.model.ListFeed
 import au.com.shiftyjelly.pocketcasts.servers.server.ListWebService
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import timber.log.Timber
 
 class ListRepository(
@@ -17,8 +15,7 @@ class ListRepository(
 ) {
 
     suspend fun getDiscoverFeed(): Discover {
-        val version = if (platform == PLATFORM_TV || FeatureFlag.isEnabled(Feature.RECOMMENDATIONS)) 3 else 2
-        return listWebService.getDiscoverFeed(platform = platform, version = version)
+        return listWebService.getDiscoverFeed(platform = platform, version = 3)
     }
 
     suspend fun getListFeed(url: String, authenticated: Boolean? = false): ListFeed? {

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -125,15 +125,6 @@ enum class Feature(
         hasDevToggle = true,
         addedOn = LocalDate.parse("2025-04-11"),
     ),
-    RECOMMENDATIONS(
-        key = "recommendations",
-        title = "Recommendations",
-        defaultValue = isDebugOrPrototypeBuild,
-        tier = FeatureTier.Free,
-        hasFirebaseRemoteFlag = true,
-        hasDevToggle = true,
-        addedOn = LocalDate.parse("2025-04-04"),
-    ),
     NOTIFICATIONS_REVAMP(
         key = "notifications_revamp",
         title = "Notifications Revamp",


### PR DESCRIPTION
## Description
Removes the `Feature.RECOMMENDATIONS` feature flag. The feature has been fully rolled out for a long time, so the flag no longer serves a purpose.

As suggested by @geekygecko in https://github.com/Automattic/pocket-casts-android/pull/5619#discussion_r3643271899:
> This is probably a separate PR, but I think we can remove the recommendations feature flag, it has been available for ages.

With the flag gone:
- `ListRepository.getDiscoverFeed` always requests `content_v3.json` (previously v2 when the flag was off; TV was already pinned to v3).
- `RecommendationsHandler.setEnabled` no longer gates on the flag, so the podcast screen's recommendations tab loads unconditionally.
- The flag-disabled test case is removed; the remaining `RecommendationsHandler` tests no longer need the feature flag rule.


## Testing Instructions
1. Open the Discover tab and confirm it loads normally (it is now always served from `content_v3.json`).
2. Open a podcast and check the You Might Like tab still loads recommendations.
3. Check Settings → Beta Features (debug build): the Recommendations toggle is gone.


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
