### PR TITLE
Remove two unused EpisodeManager Rx flowables

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -118,7 +118,6 @@ interface EpisodeManager {
     suspend fun findEpisodeByUuid(uuid: String): BaseEpisode?
     suspend fun findEpisodesByUuids(uuids: List<String>): List<BaseEpisode>
     fun findDownloadingEpisodesRxFlowable(): Flowable<List<BaseEpisode>>
-    fun episodeCountRxFlowable(queryAfterWhere: String): Flowable<Int>
     suspend fun updatePlaybackInteractionDate(episode: BaseEpisode?)
     suspend fun updatePlaybackInteraction(episodeUuid: String, interactionDate: Long, syncStatus: Long)
     suspend fun findStaleDownloads(): List<PodcastEpisode>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -41,7 +41,6 @@ interface EpisodeManager {
     fun findLatestUnfinishedEpisodeByPodcastBlocking(podcast: Podcast): PodcastEpisode?
     fun findLatestEpisodeToPlayBlocking(): PodcastEpisode?
     fun findEpisodesByPodcastOrderedFlow(podcast: Podcast): Flow<List<PodcastEpisode>>
-    fun findEpisodesWhereRxFlowable(queryAfterWhere: String): Flowable<List<PodcastEpisode>>
 
     suspend fun findEpisodesToSync(): List<PodcastEpisode>
     fun findEpisodesForHistorySyncBlocking(): List<PodcastEpisode>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -179,30 +179,6 @@ class EpisodeManagerImpl @Inject constructor(
         return episodeDao.findEpisodesBlocking(SimpleSQLiteQuery(query))
     }
 
-    override fun episodeCountRxFlowable(queryAfterWhere: String): Flowable<Int> {
-        return appDatabase.podcastDao().findUnsubscribedUuidRxFlowable()
-            .switchMap {
-                val podcastList = it.joinToString(separator = "', '", prefix = "podcast_id NOT IN ('", postfix = "')")
-                val query = "SELECT COUNT(*) FROM podcast_episodes WHERE $podcastList AND $queryAfterWhere"
-                return@switchMap Flowable.just(query)
-            }
-            .switchMap {
-                episodeDao.countRxFlowable(SimpleSQLiteQuery(it))
-            }
-    }
-
-    override fun findEpisodesWhereRxFlowable(queryAfterWhere: String): Flowable<List<PodcastEpisode>> {
-        return appDatabase.podcastDao().findUnsubscribedUuidRxFlowable()
-            .switchMap {
-                val podcastList = it.joinToString(separator = "', '", prefix = "podcast_id NOT IN ('", postfix = "')")
-                val query = "SELECT podcast_episodes.* FROM podcast_episodes WHERE $podcastList AND $queryAfterWhere"
-                return@switchMap Flowable.just(query)
-            }
-            .switchMap {
-                episodeDao.findEpisodesRxFlowable(SimpleSQLiteQuery(it))
-            }
-    }
-
     override fun findPlaybackHistoryEpisodesFlow(): Flow<List<PodcastEpisode>> {
         return episodeDao.findPlaybackHistoryFlow()
     }


### PR DESCRIPTION
## Description
`EpisodeManager.episodeCountRxFlowable` and `EpisodeManager.findEpisodesWhereRxFlowable` have no callers anywhere in `app`, `automotive`, `wear` or any module, tests included: the only references were the interface declaration and its implementation. Both build a raw SQL string by hand and hand it to a `Flowable` DAO method, so they are two of the Rx shims that the Room blocking → `suspend` migration would otherwise have to convert.

Deleting them is a straight removal with no behaviour change. It also leaves `PodcastDao.findUnsubscribedUuidRxFlowable`, `EpisodeDao.countRxFlowable` and `EpisodeDao.findEpisodesRxFlowable` with zero production callers, so they can be deleted in a later `model/` PR (that module needs a human reviewer, so it is kept out of this one).

Part of the wider Room blocking → `suspend` migration, working on the caller side first so the eventual DAO PRs are smaller.

## Testing Instructions
There is nothing to exercise at runtime since the deleted methods were unreachable, so this is a compile-and-smoke check:
1. Build and install the app: `./gradlew :app:installDebugProd`.
2. Open the Filters tab, open a filter, and confirm the episode list and its episode count badge still populate (these use the `Flow`-based lookups, not the deleted Rx ones).
3. Open a podcast and confirm its episode list loads.

## Screenshots or Screencast
N/A, no UI changes.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack