### PR TITLE
Use the suspend subscribed-podcast lookup in PodcastSelectViewModel

### DIFF
--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/viewmodels/PodcastSelectViewModel.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/viewmodels/PodcastSelectViewModel.kt
@@ -16,11 +16,9 @@ import com.automattic.eventhorizon.SettingsSelectPodcastsSelectNoneTappedEvent
 import com.automattic.eventhorizon.SettingsSelectPodcastsShownEvent
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 @HiltViewModel
 class PodcastSelectViewModel @Inject constructor(
@@ -33,9 +31,7 @@ class PodcastSelectViewModel @Inject constructor(
 
     fun loadSelectablePodcasts(selectedUuids: List<String>) {
         viewModelScope.launch {
-            val podcasts = withContext(Dispatchers.IO) {
-                podcastManager.findSubscribedBlocking()
-            }
+            val podcasts = podcastManager.findSubscribedNoOrder()
 
             val sortedSelectable = podcasts
                 .sortedBy { PodcastsSortType.cleanStringForSort(it.title) }

--- a/modules/services/views/src/test/java/au/com/shiftyjelly/pocketcasts/views/viewmodels/PodcastSelectViewModelTest.kt
+++ b/modules/services/views/src/test/java/au/com/shiftyjelly/pocketcasts/views/viewmodels/PodcastSelectViewModelTest.kt
@@ -33,7 +33,7 @@ class PodcastSelectViewModelTest {
         val podcast1 = Podcast(uuid = uuid1, title = "Apple")
         val podcast2 = Podcast(uuid = uuid2, title = "Zebra")
 
-        whenever(podcastManager.findSubscribedBlocking()).thenReturn(listOf(podcast1, podcast2))
+        whenever(podcastManager.findSubscribedNoOrder()).thenReturn(listOf(podcast1, podcast2))
 
         val viewModel = PodcastSelectViewModel(
             podcastManager = podcastManager,


### PR DESCRIPTION
## Description
`PodcastSelectViewModel.loadSelectablePodcasts` wrapped `PodcastManager.findSubscribedBlocking()` in `withContext(Dispatchers.IO)` purely so the blocking Room call had a thread to block. The `suspend` twin `findSubscribedNoOrder()` dispatches the query itself, so the `withContext` hop goes away with it.

The dropped ordering does not matter here: `findSubscribedBlocking` orders by `LOWER(title) ASC`, but the view model immediately re-sorts the list with `PodcastsSortType.cleanStringForSort`, so the query's ordering was being discarded either way. The existing unit test covers the resulting order and still passes (`./gradlew :modules:services:views:testDebugUnitTest --tests "*PodcastSelectViewModelTest*"`).

Part of the wider Room blocking → `suspend` migration, moving callers onto `suspend` twins that already exist so no DAO or interface changes are needed.

## Testing Instructions
This view model backs the "select podcasts" sheet, which is reached from a few places:
1. Go to **Profile → Settings → Auto Add to Up Next → Choose podcasts** and confirm the sheet lists your subscribed podcasts sorted by title, with the already-chosen ones ticked.
2. Change the selection, confirm, then reopen the sheet and check it was saved.
3. Repeat from **Profile → Settings → Notifications → New episodes → Choose podcasts**.
4. Check **Select all** and **Select none** still behave.

## Screenshots or Screencast
N/A, no UI changes.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack