### PR TITLE
Prevent stale Cast resumes from breaking local playback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 *   Bug Fixes
     *   Allow copying description and show notes links with a long press
         ([#5628](https://github.com/Automattic/pocket-casts-android/pull/5628))
+    *   Prevent a failed Cast session resume from interrupting local playback or removing playback controls
+        ([#5656](https://github.com/Automattic/pocket-casts-android/pull/5656))
 
 8.17
 -----

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/chromecast/CastManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/chromecast/CastManager.kt
@@ -6,6 +6,11 @@ interface CastManager {
 
     val isConnectedFlow: StateFlow<Boolean>
 
+    enum class SessionFailureType {
+        START,
+        RESUME,
+    }
+
     suspend fun isAvailable(): Boolean
     suspend fun isConnected(): Boolean
     suspend fun endSession()
@@ -17,6 +22,6 @@ interface CastManager {
         fun sessionStarted()
         fun sessionEnded()
         fun sessionReconnected()
-        fun sessionFailed(errorCode: Int) {}
+        fun sessionFailed(errorCode: Int, failureType: SessionFailureType) {}
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/chromecast/CastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/chromecast/CastManagerImpl.kt
@@ -124,7 +124,7 @@ class CastManagerImpl @Inject constructor(
 
         override fun onSessionStartFailed(session: Session, i: Int) {
             LogBuffer.e(LogBuffer.TAG_PLAYBACK, "Cast session start failed with error code $i")
-            sessionListener?.sessionFailed(i)
+            sessionListener?.sessionFailed(i, CastManager.SessionFailureType.START)
         }
 
         override fun onSessionEnding(session: Session) {
@@ -150,7 +150,7 @@ class CastManagerImpl @Inject constructor(
 
         override fun onSessionResumeFailed(session: Session, i: Int) {
             LogBuffer.e(LogBuffer.TAG_PLAYBACK, "Cast session resume failed with error code $i")
-            sessionListener?.sessionFailed(i)
+            sessionListener?.sessionFailed(i, CastManager.SessionFailureType.RESUME)
         }
 
         override fun onSessionSuspended(session: Session, i: Int) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -308,7 +308,16 @@ open class PlaybackManager @Inject constructor(
                     castReconnected()
                 }
 
-                override fun sessionFailed(errorCode: Int) {
+                override fun sessionFailed(errorCode: Int, failureType: CastManager.SessionFailureType) {
+                    // The Cast SDK can resume a saved session without user interaction. A failed cold resume must not
+                    // turn healthy local playback into an error or tear down its media notification.
+                    if (!shouldSurfaceCastSessionFailure(failureType, isCastPlayerActive = player?.isRemote == true)) {
+                        LogBuffer.i(
+                            LogBuffer.TAG_PLAYBACK,
+                            "Ignoring Cast session resume failure with error code $errorCode during local playback",
+                        )
+                        return
+                    }
                     LogBuffer.e(LogBuffer.TAG_PLAYBACK, "Cast session failed with error code $errorCode")
                     launch(Dispatchers.Main) {
                         val message = application.getString(LR.string.error_cast_connection_failed)
@@ -2925,6 +2934,16 @@ open class PlaybackManager @Inject constructor(
         OnUpdatePausedPlaybackState("updatePausedPlaybackState"),
         OnUpdateSleepTimerStatus("updateSleepTimerStatus"),
         OnUserSeeking("onUserSeeking"),
+    }
+}
+
+internal fun shouldSurfaceCastSessionFailure(
+    failureType: CastManager.SessionFailureType,
+    isCastPlayerActive: Boolean,
+): Boolean {
+    return when (failureType) {
+        CastManager.SessionFailureType.START -> true
+        CastManager.SessionFailureType.RESUME -> isCastPlayerActive
     }
 }
 

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CastSessionFailureTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CastSessionFailureTest.kt
@@ -1,0 +1,39 @@
+package au.com.shiftyjelly.pocketcasts.repositories.playback
+
+import au.com.shiftyjelly.pocketcasts.repositories.chromecast.CastManager
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CastSessionFailureTest {
+
+    @Test
+    fun `start failure is surfaced during local playback`() {
+        val shouldSurface = shouldSurfaceCastSessionFailure(
+            failureType = CastManager.SessionFailureType.START,
+            isCastPlayerActive = false,
+        )
+
+        assertTrue(shouldSurface)
+    }
+
+    @Test
+    fun `resume failure is ignored during local playback`() {
+        val shouldSurface = shouldSurfaceCastSessionFailure(
+            failureType = CastManager.SessionFailureType.RESUME,
+            isCastPlayerActive = false,
+        )
+
+        assertFalse(shouldSurface)
+    }
+
+    @Test
+    fun `resume failure is surfaced when Cast player is active`() {
+        val shouldSurface = shouldSurfaceCastSessionFailure(
+            failureType = CastManager.SessionFailureType.RESUME,
+            isCastPlayerActive = true,
+        )
+
+        assertTrue(shouldSurface)
+    }
+}


### PR DESCRIPTION
## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

A failed Cast SDK saved-session resume was routed through the same error path as a user-initiated Cast start. When the saved receiver was unavailable, the callback changed healthy local playback to an error state, removing the media notification and breaking lock-screen, headphone, and Android Auto controls.

This change preserves whether a Cast session failure came from an explicit start or an automatic resume. Resume failures are ignored only while local playback is active, while explicit Cast start failures and failures affecting an installed Cast player remain visible.

Fixes #5248
Fixes [PCDROID-554](https://linear.app/a8c/issue/PCDROID-554/android-stale-cast-session-auto-resume-error-2152-tears-down-the-media)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

1. Cast an episode to a receiver.
2. Leave the Cast session without tapping **Stop Casting**, then make the receiver unavailable.
3. Start local playback and bring Pocket Casts to the foreground.
4. Wait for the saved Cast session resume attempt to time out.
5. Verify local playback continues without an error toast or banner.
6. Verify the media notification remains visible and lock-screen, headphone, and Android Auto controls still work.
7. Start a new Cast connection to an unavailable receiver and verify the explicit connection failure is still shown.

Automated validation:

`JAVA_HOME='/Applications/Android Studio.app/Contents/jbr/Contents/Home' ./gradlew spotlessCheck :modules:services:repositories:testDebugUnitTest`

## Screenshots or Screencast 
<!-- if applicable -->

Not applicable — no UI changes.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
