### PR TITLE
[TV] Show playlists on the Playlists tab

### DIFF
--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -255,6 +255,9 @@
     <string name="tv_profile_starred_episodes">Starred Episodes</string>
     <string name="tv_sign_in_or_enter_code">or enter the following code</string>
     <string name="tv_sign_in_go_to_url">going to %1$s</string>
+    <string name="tv_playlists_empty_title">Your playlists live here</string>
+    <string name="tv_playlists_empty_subtitle">Build one manually or let Smart Rules do the sorting for you.</string>
+    <string name="tv_playlists_empty_action_title">Create a playlist</string>
     <string name="unavailable">Unavailable</string>
     <string name="browse_podcasts">Browse podcasts</string>
     <string name="pocket_casts_plus_badge">Pocket Casts Plus badge</string>

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEmptyState.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEmptyState.kt
@@ -1,0 +1,53 @@
+package au.com.shiftyjelly.pocketcasts.component
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.OutlinedButton
+import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.theme.TvColors
+import au.com.shiftyjelly.pocketcasts.theme.TvTextStyles
+
+@Composable
+fun TvEmptyState(
+    title: String,
+    subtitle: String,
+    actionLabel: String,
+    onAction: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = modifier,
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text = title,
+                style = TvTextStyles.ScreenTitle,
+                color = Color.White,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = subtitle,
+                style = MaterialTheme.typography.bodyLarge,
+                color = TvColors.TextSecondary,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.widthIn(max = 400.dp),
+            )
+            Spacer(modifier = Modifier.height(32.dp))
+            OutlinedButton(onClick = onAction) {
+                Text(actionLabel)
+            }
+        }
+    }
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPlaylistCard.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPlaylistCard.kt
@@ -193,7 +193,7 @@ private fun PlaylistCover(
         label = "PlaylistCoverRotation",
     )
     val scale by animateFloatAsState(
-        targetValue = if (isFocused) 1.25f else 1f,
+        targetValue = if (isFocused) 1.1f else 1f,
         animationSpec = animationSpec,
         label = "PlaylistCoverScale",
     )

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPlaylistCard.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPlaylistCard.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
@@ -205,8 +206,11 @@ private fun PlaylistCover(
     val offsetX = (if (isBackCover) 0.7f else -16f) + restingOffset
     val offsetY = (if (isBackCover) 66.7f else 44.7f) + restingOffset
 
+    val coverPlaceholder = remember { ColorPainter(Color.Black.copy(alpha = 0.2f)) }
     AsyncImage(
         model = artworkUrl,
+        placeholder = coverPlaceholder,
+        error = coverPlaceholder,
         contentDescription = null,
         contentScale = ContentScale.Crop,
         modifier = Modifier

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPlaylistCard.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPlaylistCard.kt
@@ -1,0 +1,242 @@
+package au.com.shiftyjelly.pocketcasts.component
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.tv.material3.CardDefaults
+import androidx.tv.material3.Glow
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.theme.TvColors
+import au.com.shiftyjelly.pocketcasts.theme.TvTextStyles
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import coil3.compose.AsyncImage
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+fun TvPlaylistCard(
+    title: String,
+    isSmartPlaylist: Boolean,
+    episodeCount: Int?,
+    artworkUrls: List<String>,
+    cardColor: Color,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isFocused by interactionSource.collectIsFocusedAsState()
+
+    val backgroundColor by animateColorAsState(
+        targetValue = if (isFocused) TvColors.LightGray else cardColor,
+        animationSpec = tween(durationMillis = 200),
+        label = "PlaylistCardBackground",
+    )
+    val titleColor by animateColorAsState(
+        targetValue = if (isFocused) TvColors.Dark else Color.White,
+        animationSpec = tween(durationMillis = 200),
+        label = "PlaylistCardTitleColor",
+    )
+    val captionColor by animateColorAsState(
+        targetValue = if (isFocused) TvColors.TextSecondaryActive else TvColors.TextSecondary,
+        animationSpec = tween(durationMillis = 200),
+        label = "PlaylistCardCaptionColor",
+    )
+    val highlightAlpha by animateFloatAsState(
+        targetValue = if (isFocused) 1f else 0f,
+        animationSpec = tween(durationMillis = 200),
+        label = "PlaylistCardHighlight",
+    )
+
+    TvTile(
+        onClick = onClick,
+        scale = CardDefaults.scale(focusedScale = 1.05f),
+        shape = CardDefaults.shape(RoundedCornerShape(11.dp)),
+        colors = CardDefaults.colors(
+            containerColor = Color.Transparent,
+            focusedContainerColor = Color.Transparent,
+        ),
+        glow = CardDefaults.glow(
+            focusedGlow = Glow(elevationColor = Color.Black, elevation = 16.dp),
+        ),
+        interactionSource = interactionSource,
+        modifier = modifier,
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(172.dp)
+                .background(backgroundColor),
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 24.dp, vertical = 16.dp),
+            ) {
+                Text(
+                    text = title,
+                    style = TvTextStyles.PlaylistCardTitle,
+                    color = titleColor,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                if (isSmartPlaylist) {
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = stringResource(LR.string.smart_playlist),
+                        style = TvTextStyles.PlaylistCardCaption,
+                        color = captionColor,
+                    )
+                }
+                Spacer(modifier = Modifier.weight(1f))
+                if (episodeCount != null) {
+                    Text(
+                        text = pluralStringResource(LR.plurals.episode_count, episodeCount, episodeCount),
+                        style = TvTextStyles.PlaylistCardCaption,
+                        color = captionColor,
+                    )
+                }
+            }
+
+            PlaylistCovers(
+                artworkUrls = artworkUrls,
+                isFocused = isFocused,
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(end = 24.dp),
+            )
+
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .alpha(highlightAlpha)
+                    .background(
+                        Brush.linearGradient(
+                            colorStops = arrayOf(
+                                0f to Color.White.copy(alpha = 0.16f),
+                                0.2f to Color.White.copy(alpha = 0.06f),
+                                0.4f to Color.White.copy(alpha = 0.02f),
+                                0.6f to Color.Transparent,
+                            ),
+                        ),
+                    ),
+            )
+        }
+    }
+}
+
+@Composable
+private fun PlaylistCovers(
+    artworkUrls: List<String>,
+    isFocused: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    Box(modifier = modifier) {
+        artworkUrls.take(2).reversed().forEachIndexed { index, artworkUrl ->
+            PlaylistCover(
+                artworkUrl = artworkUrl,
+                isFocused = isFocused,
+                isBackCover = index == 0,
+            )
+        }
+    }
+}
+
+@Composable
+private fun PlaylistCover(
+    artworkUrl: String,
+    isFocused: Boolean,
+    isBackCover: Boolean,
+) {
+    val animationSpec = spring<Float>(dampingRatio = 0.6f, stiffness = Spring.StiffnessMediumLow)
+    val rotation by animateFloatAsState(
+        targetValue = when {
+            !isFocused -> 0f
+            isBackCover -> 15f
+            else -> -15f
+        },
+        animationSpec = animationSpec,
+        label = "PlaylistCoverRotation",
+    )
+    val scale by animateFloatAsState(
+        targetValue = if (isFocused) 1.25f else 1f,
+        animationSpec = animationSpec,
+        label = "PlaylistCoverScale",
+    )
+    val restingOffset by animateFloatAsState(
+        targetValue = if (isBackCover && !isFocused) 5.3f else 0f,
+        animationSpec = animationSpec,
+        label = "PlaylistCoverOffset",
+    )
+
+    val offsetX = (if (isBackCover) 0.7f else -16f) + restingOffset
+    val offsetY = (if (isBackCover) 66.7f else 44.7f) + restingOffset
+
+    AsyncImage(
+        model = artworkUrl,
+        contentDescription = null,
+        contentScale = ContentScale.Crop,
+        modifier = Modifier
+            .offset(x = offsetX.dp, y = offsetY.dp)
+            .size(104.dp)
+            .graphicsLayer {
+                rotationZ = rotation
+                scaleX = scale
+                scaleY = scale
+            }
+            .shadow(elevation = 8.dp, shape = RoundedCornerShape(4.dp))
+            .clip(RoundedCornerShape(4.dp)),
+    )
+}
+
+@Preview(device = Devices.TV_1080p)
+@Composable
+private fun TvPlaylistCardPreview() {
+    AppTheme(themeType = Theme.ThemeType.EXTRA_DARK) {
+        MaterialTheme {
+            Box(modifier = Modifier.background(TvColors.Dark).padding(32.dp)) {
+                TvPlaylistCard(
+                    title = "New Releases",
+                    isSmartPlaylist = true,
+                    episodeCount = 24,
+                    artworkUrls = listOf("", ""),
+                    cardColor = TvPlaylistCardColors.cardColor(podcastTint = null, seed = "new-releases"),
+                    onClick = {},
+                )
+            }
+        }
+    }
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPlaylistCardColors.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPlaylistCardColors.kt
@@ -1,0 +1,51 @@
+package au.com.shiftyjelly.pocketcasts.component
+
+import androidx.compose.ui.graphics.Color
+
+object TvPlaylistCardColors {
+
+    fun cardColor(podcastTint: Int?, seed: String): Color {
+        return podcastTint?.let(::clampedTint) ?: fallbackColor(seed)
+    }
+
+    private fun clampedTint(tint: Int): Color? {
+        val (hue, saturation, value) = tint.toHsv()
+        if (saturation <= 0.15f || value <= 0.1f) return null
+        return Color.hsv(
+            hue = hue,
+            saturation = saturation.coerceIn(0.5f, 0.85f),
+            value = value.coerceIn(0.3f, 0.45f),
+        )
+    }
+
+    private fun fallbackColor(seed: String): Color {
+        val index = seed.sumOf { character -> character.code } % fallbackPalette.size
+        return fallbackPalette[index]
+    }
+
+    private fun Int.toHsv(): Triple<Float, Float, Float> {
+        val red = (this shr 16 and 0xFF) / 255f
+        val green = (this shr 8 and 0xFF) / 255f
+        val blue = (this and 0xFF) / 255f
+        val max = maxOf(red, green, blue)
+        val min = minOf(red, green, blue)
+        val delta = max - min
+        val hue = when {
+            delta == 0f -> 0f
+            max == red -> 60f * (((green - blue) / delta).mod(6f))
+            max == green -> 60f * ((blue - red) / delta + 2f)
+            else -> 60f * ((red - green) / delta + 4f)
+        }
+        val saturation = if (max == 0f) 0f else delta / max
+        return Triple(hue, saturation, max)
+    }
+
+    private val fallbackPalette = listOf(
+        Color(red = 0.15f, green = 0.25f, blue = 0.5f),
+        Color(red = 0.5f, green = 0.17f, blue = 0.15f),
+        Color(red = 0.21f, green = 0.22f, blue = 0.14f),
+        Color(red = 0.5f, green = 0.35f, blue = 0.12f),
+        Color(red = 0.15f, green = 0.4f, blue = 0.3f),
+        Color(red = 0.3f, green = 0.2f, blue = 0.45f),
+    )
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
@@ -19,6 +19,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.MaterialTheme
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.playlists.TvPlaylistsScreen
 import au.com.shiftyjelly.pocketcasts.theme.TvColors
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 
@@ -42,6 +43,7 @@ fun TvScaffold(
     ) { tab ->
         when (tab) {
             is TvTab.Home -> TvHomeScreen()
+            is TvTab.Playlists -> TvPlaylistsScreen()
             else -> TvTabPlaceholder(tab = tab)
         }
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsScreen.kt
@@ -44,6 +44,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.OutlinedButton
 import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.component.TvEmptyState
 import au.com.shiftyjelly.pocketcasts.component.TvPlaylistCard
 import au.com.shiftyjelly.pocketcasts.component.TvPlaylistCardColors
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
@@ -218,30 +219,13 @@ private fun TvPlaylistGridItem(
 private fun TvPlaylistsEmpty(
     modifier: Modifier = Modifier,
 ) {
-    Box(
-        contentAlignment = Alignment.Center,
+    TvEmptyState(
+        title = stringResource(LR.string.tv_playlists_empty_title),
+        subtitle = stringResource(LR.string.tv_playlists_empty_subtitle),
+        actionLabel = stringResource(LR.string.tv_playlists_empty_action_title),
+        onAction = {},
         modifier = modifier,
-    ) {
-        Column(horizontalAlignment = Alignment.CenterHorizontally) {
-            Text(
-                text = stringResource(LR.string.tv_playlists_empty_title),
-                style = TvTextStyles.ScreenTitle,
-                color = Color.White,
-                textAlign = TextAlign.Center,
-            )
-            Spacer(modifier = Modifier.height(12.dp))
-            Text(
-                text = stringResource(LR.string.tv_playlists_empty_subtitle),
-                style = MaterialTheme.typography.bodyLarge,
-                color = TvColors.TextSecondary,
-                textAlign = TextAlign.Center,
-            )
-            Spacer(modifier = Modifier.height(32.dp))
-            OutlinedButton(onClick = {}) {
-                Text(stringResource(LR.string.tv_playlists_empty_action_title))
-            }
-        }
-    }
+    )
 }
 
 @Preview(device = Devices.TV_1080p)

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsScreen.kt
@@ -1,0 +1,293 @@
+package au.com.shiftyjelly.pocketcasts.playlists
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.background
+import androidx.compose.foundation.focusGroup
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.itemsIndexed
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.OutlinedButton
+import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.component.TvPlaylistCard
+import au.com.shiftyjelly.pocketcasts.component.TvPlaylistCardColors
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.compose.loading.LoadingView
+import au.com.shiftyjelly.pocketcasts.models.to.PlaylistIcon
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules
+import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImage
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.Playlist
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistPreview
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.SmartPlaylistPreview
+import au.com.shiftyjelly.pocketcasts.theme.TvColors
+import au.com.shiftyjelly.pocketcasts.theme.TvTextStyles
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+fun TvPlaylistsScreen(
+    modifier: Modifier = Modifier,
+    viewModel: TvPlaylistsViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    TvPlaylistsContent(
+        uiState = uiState,
+        getArtworkUuidsFlow = viewModel::getArtworkUuidsFlow,
+        getEpisodeCountFlow = viewModel::getEpisodeCountFlow,
+        refreshArtworkUuids = viewModel::refreshArtworkUuids,
+        refreshEpisodeCount = viewModel::refreshEpisodeCount,
+        findPodcastTint = viewModel::findPodcastTint,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun TvPlaylistsContent(
+    uiState: TvPlaylistsUiState,
+    getArtworkUuidsFlow: (String) -> StateFlow<List<String>?>,
+    getEpisodeCountFlow: (String) -> StateFlow<Int?>,
+    refreshArtworkUuids: suspend (String) -> Unit,
+    refreshEpisodeCount: suspend (String) -> Unit,
+    findPodcastTint: suspend (String) -> Int?,
+    modifier: Modifier = Modifier,
+) {
+    AnimatedContent(
+        targetState = uiState,
+        transitionSpec = { fadeIn(tween(durationMillis = 300)) togetherWith fadeOut(tween(durationMillis = 300)) },
+        contentKey = { state ->
+            when (state) {
+                is TvPlaylistsUiState.Loading -> "loading"
+                is TvPlaylistsUiState.Loaded -> if (state.playlists.isEmpty()) "empty" else "content"
+            }
+        },
+        label = "TvPlaylistsContent",
+        modifier = modifier,
+    ) { state ->
+        when (state) {
+            is TvPlaylistsUiState.Loading -> LoadingView(color = Color.White, modifier = Modifier.fillMaxSize())
+
+            is TvPlaylistsUiState.Loaded -> if (state.playlists.isEmpty()) {
+                TvPlaylistsEmpty(modifier = Modifier.fillMaxSize())
+            } else {
+                TvPlaylistsGrid(
+                    playlists = state.playlists,
+                    getArtworkUuidsFlow = getArtworkUuidsFlow,
+                    getEpisodeCountFlow = getEpisodeCountFlow,
+                    refreshArtworkUuids = refreshArtworkUuids,
+                    refreshEpisodeCount = refreshEpisodeCount,
+                    findPodcastTint = findPodcastTint,
+                    modifier = Modifier.fillMaxSize(),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun TvPlaylistsGrid(
+    playlists: List<PlaylistPreview>,
+    getArtworkUuidsFlow: (String) -> StateFlow<List<String>?>,
+    getEpisodeCountFlow: (String) -> StateFlow<Int?>,
+    refreshArtworkUuids: suspend (String) -> Unit,
+    refreshEpisodeCount: suspend (String) -> Unit,
+    findPodcastTint: suspend (String) -> Int?,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.padding(horizontal = 32.dp)) {
+        Text(
+            text = stringResource(LR.string.playlists),
+            style = TvTextStyles.ScreenTitle,
+            color = Color.White,
+            modifier = Modifier.padding(top = 8.dp, bottom = 26.dp),
+        )
+        var lastFocusedIndex by rememberSaveable(playlists) { mutableIntStateOf(0) }
+        val focusRequesters = remember(playlists) { List(playlists.size) { FocusRequester() } }
+
+        LazyVerticalGrid(
+            columns = GridCells.Fixed(3),
+            horizontalArrangement = Arrangement.spacedBy(32.dp),
+            verticalArrangement = Arrangement.spacedBy(32.dp),
+            contentPadding = PaddingValues(bottom = 32.dp),
+            modifier = Modifier
+                .focusGroup()
+                .focusProperties {
+                    onEnter = {
+                        focusRequesters.getOrNull(lastFocusedIndex)?.requestFocus()
+                    }
+                },
+        ) {
+            itemsIndexed(
+                items = playlists,
+                key = { _, playlist -> playlist.uuid },
+            ) { index, playlist ->
+                TvPlaylistGridItem(
+                    playlist = playlist,
+                    getArtworkUuidsFlow = getArtworkUuidsFlow,
+                    getEpisodeCountFlow = getEpisodeCountFlow,
+                    refreshArtworkUuids = refreshArtworkUuids,
+                    refreshEpisodeCount = refreshEpisodeCount,
+                    findPodcastTint = findPodcastTint,
+                    modifier = Modifier
+                        .focusRequester(focusRequesters[index])
+                        .onFocusChanged { focusState ->
+                            if (focusState.hasFocus) {
+                                lastFocusedIndex = index
+                            }
+                        },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun TvPlaylistGridItem(
+    playlist: PlaylistPreview,
+    getArtworkUuidsFlow: (String) -> StateFlow<List<String>?>,
+    getEpisodeCountFlow: (String) -> StateFlow<Int?>,
+    refreshArtworkUuids: suspend (String) -> Unit,
+    refreshEpisodeCount: suspend (String) -> Unit,
+    findPodcastTint: suspend (String) -> Int?,
+    modifier: Modifier = Modifier,
+) {
+    val artworkUuids by remember(playlist.uuid) { getArtworkUuidsFlow(playlist.uuid) }.collectAsState()
+    val episodeCount by remember(playlist.uuid) { getEpisodeCountFlow(playlist.uuid) }.collectAsState()
+
+    LaunchedEffect(playlist.uuid, refreshArtworkUuids) {
+        refreshArtworkUuids(playlist.uuid)
+    }
+    LaunchedEffect(playlist.uuid, refreshEpisodeCount) {
+        refreshEpisodeCount(playlist.uuid)
+    }
+
+    var podcastTint by remember(playlist.uuid) { mutableStateOf<Int?>(null) }
+    val coverPodcastUuid = artworkUuids?.firstOrNull()
+    LaunchedEffect(coverPodcastUuid, findPodcastTint) {
+        podcastTint = coverPodcastUuid?.let { findPodcastTint(it) }
+    }
+
+    TvPlaylistCard(
+        title = playlist.title,
+        isSmartPlaylist = playlist.type == Playlist.Type.Smart,
+        episodeCount = episodeCount,
+        artworkUrls = artworkUuids.orEmpty().map(PodcastImage::getMediumArtworkUrl),
+        cardColor = TvPlaylistCardColors.cardColor(podcastTint, seed = playlist.uuid),
+        onClick = {},
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun TvPlaylistsEmpty(
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = modifier,
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text = stringResource(LR.string.tv_playlists_empty_title),
+                style = TvTextStyles.ScreenTitle,
+                color = Color.White,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = stringResource(LR.string.tv_playlists_empty_subtitle),
+                style = MaterialTheme.typography.bodyLarge,
+                color = TvColors.TextSecondary,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(modifier = Modifier.height(32.dp))
+            OutlinedButton(onClick = {}) {
+                Text(stringResource(LR.string.tv_playlists_empty_action_title))
+            }
+        }
+    }
+}
+
+@Preview(device = Devices.TV_1080p)
+@Composable
+private fun TvPlaylistsGridPreview() {
+    AppTheme(themeType = Theme.ThemeType.EXTRA_DARK) {
+        MaterialTheme {
+            Box(modifier = Modifier.background(TvColors.Dark)) {
+                TvPlaylistsContent(
+                    uiState = TvPlaylistsUiState.Loaded(
+                        playlists = List(5) { index -> previewPlaylist(index) },
+                    ),
+                    getArtworkUuidsFlow = { MutableStateFlow(listOf("podcast-1", "podcast-2")) },
+                    getEpisodeCountFlow = { MutableStateFlow(42) },
+                    refreshArtworkUuids = {},
+                    refreshEpisodeCount = {},
+                    findPodcastTint = { null },
+                )
+            }
+        }
+    }
+}
+
+@Preview(device = Devices.TV_1080p)
+@Composable
+private fun TvPlaylistsEmptyPreview() {
+    AppTheme(themeType = Theme.ThemeType.EXTRA_DARK) {
+        MaterialTheme {
+            Box(modifier = Modifier.background(TvColors.Dark)) {
+                TvPlaylistsContent(
+                    uiState = TvPlaylistsUiState.Loaded(playlists = emptyList()),
+                    getArtworkUuidsFlow = { MutableStateFlow(null) },
+                    getEpisodeCountFlow = { MutableStateFlow(null) },
+                    refreshArtworkUuids = {},
+                    refreshEpisodeCount = {},
+                    findPodcastTint = { null },
+                )
+            }
+        }
+    }
+}
+
+private fun previewPlaylist(index: Int) = SmartPlaylistPreview(
+    uuid = "playlist-$index",
+    title = "Playlist $index",
+    settings = Playlist.Settings.ForPreview,
+    icon = PlaylistIcon(0),
+    smartRules = SmartRules.Default,
+)

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsViewModel.kt
@@ -2,11 +2,11 @@ package au.com.shiftyjelly.pocketcasts.playlists
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import au.com.shiftyjelly.pocketcasts.models.db.dao.PodcastDao
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistPreview
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.SmartPlaylistPreview
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.milliseconds
@@ -19,7 +19,7 @@ import kotlinx.coroutines.flow.stateIn
 @HiltViewModel
 class TvPlaylistsViewModel @Inject constructor(
     private val playlistManager: PlaylistManager,
-    private val podcastDao: PodcastDao,
+    private val podcastManager: PodcastManager,
 ) : ViewModel() {
 
     val uiState: StateFlow<TvPlaylistsUiState> = playlistManager.playlistPreviewsFlow()
@@ -45,7 +45,7 @@ class TvPlaylistsViewModel @Inject constructor(
     }
 
     suspend fun findPodcastTint(podcastUuid: String): Int? {
-        return podcastDao.findPodcastByUuid(podcastUuid)?.tintColorForLightBg?.takeIf { it != 0 }
+        return podcastManager.findPodcastByUuid(podcastUuid)?.tintColorForLightBg?.takeIf { it != 0 }
     }
 
     private fun isDownloadPlaylist(preview: PlaylistPreview): Boolean {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsViewModel.kt
@@ -1,0 +1,59 @@
+package au.com.shiftyjelly.pocketcasts.playlists
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.models.db.dao.PodcastDao
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistPreview
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.SmartPlaylistPreview
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.WhileSubscribed
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+
+@HiltViewModel
+class TvPlaylistsViewModel @Inject constructor(
+    private val playlistManager: PlaylistManager,
+    private val podcastDao: PodcastDao,
+) : ViewModel() {
+
+    val uiState: StateFlow<TvPlaylistsUiState> = playlistManager.playlistPreviewsFlow()
+        .map<List<PlaylistPreview>, TvPlaylistsUiState> { previews ->
+            TvPlaylistsUiState.Loaded(previews.sortedBy(::isDownloadPlaylist))
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(stopTimeout = 300.milliseconds), TvPlaylistsUiState.Loading)
+
+    fun getArtworkUuidsFlow(playlistUuid: String): StateFlow<List<String>?> {
+        return playlistManager.getArtworkUuidsFlow(playlistUuid)
+    }
+
+    fun getEpisodeCountFlow(playlistUuid: String): StateFlow<Int?> {
+        return playlistManager.getEpisodeCountFlow(playlistUuid)
+    }
+
+    suspend fun refreshArtworkUuids(playlistUuid: String) {
+        playlistManager.refreshArtworkUuids(playlistUuid)
+    }
+
+    suspend fun refreshEpisodeCount(playlistUuid: String) {
+        playlistManager.refreshEpisodeCount(playlistUuid)
+    }
+
+    suspend fun findPodcastTint(podcastUuid: String): Int? {
+        return podcastDao.findPodcastByUuid(podcastUuid)?.tintColorForLightBg?.takeIf { it != 0 }
+    }
+
+    private fun isDownloadPlaylist(preview: PlaylistPreview): Boolean {
+        return preview is SmartPlaylistPreview && preview.smartRules.downloadStatus == SmartRules.DownloadStatusRule.Downloaded
+    }
+}
+
+sealed interface TvPlaylistsUiState {
+    data object Loading : TvPlaylistsUiState
+    data class Loaded(val playlists: List<PlaylistPreview>) : TvPlaylistsUiState
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvColors.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvColors.kt
@@ -6,9 +6,12 @@ object TvColors {
     val Dark = Color(0xFF161718)
     val DarkGray = Color(0xFF292B2E)
     val Gray = Color(0xFF3C3E42)
+    val LightGray = Color(0xFFD4D6DB)
     val TextPrimary = Color(0xFFFBFBFC)
     val TextPrimary20 = Color(0x33FBFBFC)
     val TextSecondary = Color(0xFFB0B3B8)
+    val TextSecondaryActive = Color(0xFF3D4044)
     val BgActive = Color(0xFFD4D6DB)
+    val BgActive20 = Color(0x33FBFBFC)
     val Divider = Color(0xFF4A4D51)
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvTextStyles.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvTextStyles.kt
@@ -27,6 +27,24 @@ object TvTextStyles {
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 
+    val ScreenTitle = TextStyle(
+        fontSize = 28.sp,
+        fontWeight = FontWeight.SemiBold,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    val PlaylistCardTitle = TextStyle(
+        fontSize = 24.sp,
+        fontWeight = FontWeight.SemiBold,
+        lineHeight = 28.sp,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    val PlaylistCardCaption = TextStyle(
+        fontSize = 15.sp,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
     val FeaturedTileSponsoredLabel = TextStyle(
         fontSize = 14.sp,
         platformStyle = PlatformTextStyle(includeFontPadding = false),

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/component/TvPlaylistCardColorsTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/component/TvPlaylistCardColorsTest.kt
@@ -1,0 +1,52 @@
+package au.com.shiftyjelly.pocketcasts.component
+
+import androidx.compose.ui.graphics.Color
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class TvPlaylistCardColorsTest {
+
+    @Test
+    fun `saturated tint is clamped to the card range`() {
+        val color = TvPlaylistCardColors.cardColor(podcastTint = 0xFFFF0000.toInt(), seed = "seed")
+
+        assertEquals(Color.hsv(hue = 0f, saturation = 0.85f, value = 0.45f), color)
+    }
+
+    @Test
+    fun `mid tone tint keeps its hue`() {
+        val color = TvPlaylistCardColors.cardColor(podcastTint = 0xFF406080.toInt(), seed = "seed")
+        val expected = Color.hsv(hue = 210f, saturation = 0.5f, value = 0.45f)
+
+        assertEquals(expected.red, color.red, 0.005f)
+        assertEquals(expected.green, color.green, 0.005f)
+        assertEquals(expected.blue, color.blue, 0.005f)
+    }
+
+    @Test
+    fun `grey tint falls back to the seeded palette`() {
+        val greyColor = TvPlaylistCardColors.cardColor(podcastTint = 0xFF808080.toInt(), seed = "seed")
+        val seededColor = TvPlaylistCardColors.cardColor(podcastTint = null, seed = "seed")
+
+        assertEquals(seededColor, greyColor)
+    }
+
+    @Test
+    fun `near black tint falls back to the seeded palette`() {
+        val darkColor = TvPlaylistCardColors.cardColor(podcastTint = 0xFF1E1F1E.toInt(), seed = "seed")
+        val seededColor = TvPlaylistCardColors.cardColor(podcastTint = null, seed = "seed")
+
+        assertEquals(seededColor, darkColor)
+    }
+
+    @Test
+    fun `fallback color is stable for a seed`() {
+        val first = TvPlaylistCardColors.cardColor(podcastTint = null, seed = "playlist-uuid")
+        val second = TvPlaylistCardColors.cardColor(podcastTint = null, seed = "playlist-uuid")
+        val other = TvPlaylistCardColors.cardColor(podcastTint = null, seed = "different-uuid")
+
+        assertEquals(first, second)
+        assertNotEquals(first, other)
+    }
+}

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsViewModelTest.kt
@@ -1,0 +1,137 @@
+package au.com.shiftyjelly.pocketcasts.playlists
+
+import app.cash.turbine.test
+import au.com.shiftyjelly.pocketcasts.models.db.dao.PodcastDao
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.to.PlaylistIcon
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.ManualPlaylistPreview
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.Playlist
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistPreview
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.SmartPlaylistPreview
+import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TvPlaylistsViewModelTest {
+
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
+
+    private val playlistPreviews = MutableSharedFlow<List<PlaylistPreview>>(replay = 1)
+    private val playlistManager = mock<PlaylistManager> {
+        on { playlistPreviewsFlow() } doReturn playlistPreviews
+    }
+    private val podcastDao = mock<PodcastDao>()
+
+    @Test
+    fun `state starts as loading`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            assertEquals(TvPlaylistsUiState.Loading, awaitItem())
+        }
+    }
+
+    @Test
+    fun `playlists load in manager order`() = runTest {
+        val playlists = listOf(
+            smartPreview(uuid = "playlist-1"),
+            manualPreview(uuid = "playlist-2"),
+            smartPreview(uuid = "playlist-3"),
+        )
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            assertEquals(TvPlaylistsUiState.Loading, awaitItem())
+
+            playlistPreviews.emit(playlists)
+
+            assertEquals(TvPlaylistsUiState.Loaded(playlists), awaitItem())
+        }
+    }
+
+    @Test
+    fun `download playlists are sorted last`() = runTest {
+        val downloadPlaylist = smartPreview(
+            uuid = "playlist-1",
+            downloadStatus = SmartRules.DownloadStatusRule.Downloaded,
+        )
+        val smartPlaylist = smartPreview(uuid = "playlist-2")
+        val manualPlaylist = manualPreview(uuid = "playlist-3")
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            assertEquals(TvPlaylistsUiState.Loading, awaitItem())
+
+            playlistPreviews.emit(listOf(downloadPlaylist, smartPlaylist, manualPlaylist))
+
+            assertEquals(
+                TvPlaylistsUiState.Loaded(listOf(smartPlaylist, manualPlaylist, downloadPlaylist)),
+                awaitItem(),
+            )
+        }
+    }
+
+    @Test
+    fun `empty playlists load as an empty list`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            assertEquals(TvPlaylistsUiState.Loading, awaitItem())
+
+            playlistPreviews.emit(listOf(smartPreview(uuid = "playlist-1")))
+            assertEquals(TvPlaylistsUiState.Loaded(listOf(smartPreview(uuid = "playlist-1"))), awaitItem())
+
+            playlistPreviews.emit(emptyList())
+            assertEquals(TvPlaylistsUiState.Loaded(emptyList()), awaitItem())
+        }
+    }
+
+    @Test
+    fun `podcast tint is looked up from the database`() = runTest {
+        val tintedPodcast = Podcast(uuid = "podcast-1").apply { tintColorForLightBg = 0xFF123456.toInt() }
+        val untintedPodcast = Podcast(uuid = "podcast-2")
+        val podcastDao = mock<PodcastDao> {
+            on { findPodcastByUuid("podcast-1") } doReturn tintedPodcast
+            on { findPodcastByUuid("podcast-2") } doReturn untintedPodcast
+        }
+        val viewModel = createViewModel(podcastDao = podcastDao)
+
+        assertEquals(0xFF123456.toInt(), viewModel.findPodcastTint("podcast-1"))
+        assertNull(viewModel.findPodcastTint("podcast-2"))
+        assertNull(viewModel.findPodcastTint("podcast-3"))
+    }
+
+    private fun createViewModel(podcastDao: PodcastDao = this.podcastDao) = TvPlaylistsViewModel(
+        playlistManager = playlistManager,
+        podcastDao = podcastDao,
+    )
+
+    private fun smartPreview(
+        uuid: String,
+        downloadStatus: SmartRules.DownloadStatusRule = SmartRules.DownloadStatusRule.Any,
+    ) = SmartPlaylistPreview(
+        uuid = uuid,
+        title = "Playlist $uuid",
+        settings = Playlist.Settings.ForPreview,
+        icon = PlaylistIcon(0),
+        smartRules = SmartRules.Default.copy(downloadStatus = downloadStatus),
+    )
+
+    private fun manualPreview(uuid: String) = ManualPlaylistPreview(
+        uuid = uuid,
+        title = "Playlist $uuid",
+        settings = Playlist.Settings.ForPreview,
+        icon = PlaylistIcon(0),
+    )
+}

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsViewModelTest.kt
@@ -1,7 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.playlists
 
 import app.cash.turbine.test
-import au.com.shiftyjelly.pocketcasts.models.db.dao.PodcastDao
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.PlaylistIcon
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules
@@ -10,6 +9,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.playlist.Playlist
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistPreview
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.SmartPlaylistPreview
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -31,7 +31,7 @@ class TvPlaylistsViewModelTest {
     private val playlistManager = mock<PlaylistManager> {
         on { playlistPreviewsFlow() } doReturn playlistPreviews
     }
-    private val podcastDao = mock<PodcastDao>()
+    private val podcastManager = mock<PodcastManager>()
 
     @Test
     fun `state starts as loading`() = runTest {
@@ -101,20 +101,20 @@ class TvPlaylistsViewModelTest {
     fun `podcast tint is looked up from the database`() = runTest {
         val tintedPodcast = Podcast(uuid = "podcast-1").apply { tintColorForLightBg = 0xFF123456.toInt() }
         val untintedPodcast = Podcast(uuid = "podcast-2")
-        val podcastDao = mock<PodcastDao> {
+        val podcastManager = mock<PodcastManager> {
             on { findPodcastByUuid("podcast-1") } doReturn tintedPodcast
             on { findPodcastByUuid("podcast-2") } doReturn untintedPodcast
         }
-        val viewModel = createViewModel(podcastDao = podcastDao)
+        val viewModel = createViewModel(podcastManager = podcastManager)
 
         assertEquals(0xFF123456.toInt(), viewModel.findPodcastTint("podcast-1"))
         assertNull(viewModel.findPodcastTint("podcast-2"))
         assertNull(viewModel.findPodcastTint("podcast-3"))
     }
 
-    private fun createViewModel(podcastDao: PodcastDao = this.podcastDao) = TvPlaylistsViewModel(
+    private fun createViewModel(podcastManager: PodcastManager = this.podcastManager) = TvPlaylistsViewModel(
         playlistManager = playlistManager,
-        podcastDao = podcastDao,
+        podcastManager = podcastManager,
     )
 
     private fun smartPreview(


### PR DESCRIPTION
## Description
Implements the content of the Playlists tab in the TV app, mirroring the tvOS implementation:

- `TvPlaylistsViewModel` loads the synced playlists through `PlaylistManager.playlistPreviewsFlow()`, keeping the manager's order but pushing download-filtered smart playlists to the end (parity with tvOS).
- `TvPlaylistCard` mirrors the tvOS `PlaylistCell`: a card tinted from the first cover podcast's colour (clamped in HSV, with a seeded fallback palette — a direct port of the tvOS `pillColor` logic), stacked cover artwork hanging off the bottom edge, the playlist name, a "Smart playlist" caption and the episode count.
- Focus animations match tvOS: the card background animates to a light surface with inverted text colours, the covers fan out (±15°) and scale up with a spring, and a diagonal specular highlight fades in.
- The tab animates between loading, empty, and populated states; the empty state mirrors the tvOS copy with a create action (handler intentionally not wired yet).
- Entering the grid focuses the first card (or the last focused one), mirroring `TvRow`'s behaviour.

Click handlers (opening a playlist, creating one) are intentionally left as no-ops for a follow-up.

Stacked on top of #5651 (`feat/tv-profile-modal`).

Fixes PCDROID-692 https://linear.app/a8c/issue/PCDROID-692/playlist-tab

## Testing Instructions
1. Run the `tv` app on an Android TV device/emulator with a signed-in account that has playlists (or local default playlists).
2. Open the **Playlists** tab.
3. Verify the grid shows all playlists with colours, covers and episode counts, and that download-filtered playlists appear last.
4. Move focus into the grid and verify the focus animation (light card, fanned covers, highlight).
5. With no playlists, verify the empty state copy and button.

## Screenshots or Screencast

https://github.com/user-attachments/assets/62cf8f8e-7d50-4386-9b6e-862487c1e022



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

#### I have tested any UI changes...
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
