### PR TITLE
[TV] Show a download app modal when creating a playlist

### DIFF
--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -258,6 +258,8 @@
     <string name="tv_playlists_empty_title">Your playlists live here</string>
     <string name="tv_playlists_empty_subtitle">Build one manually or let Smart Rules do the sorting for you.</string>
     <string name="tv_playlists_empty_action_title">Create a playlist</string>
+    <string name="tv_playlists_download_title">Create playlists on your phone</string>
+    <string name="tv_playlists_download_subtitle">They’ll be waiting here when you’re done. Scan to get the app</string>
     <string name="unavailable">Unavailable</string>
     <string name="browse_podcasts">Browse podcasts</string>
     <string name="pocket_casts_plus_badge">Pocket Casts Plus badge</string>

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEmptyState.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEmptyState.kt
@@ -15,10 +15,11 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.tv.material3.Button
 import androidx.tv.material3.MaterialTheme
-import androidx.tv.material3.OutlinedButton
 import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
 import au.com.shiftyjelly.pocketcasts.theme.TvColors
 import au.com.shiftyjelly.pocketcasts.theme.TvTextStyles
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
@@ -51,7 +52,10 @@ fun TvEmptyState(
                 modifier = Modifier.widthIn(max = 400.dp),
             )
             Spacer(modifier = Modifier.height(32.dp))
-            OutlinedButton(onClick = onAction) {
+            Button(
+                onClick = onAction,
+                colors = TvButtonDefaults.filledButtonColors(),
+            ) {
                 Text(actionLabel)
             }
         }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvModal.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
@@ -35,6 +36,7 @@ import java.util.function.Consumer
 fun TvModal(
     onDismissRequest: () -> Unit,
     modifier: Modifier = Modifier,
+    width: Dp = DefaultModalWidth,
     content: @Composable ColumnScope.() -> Unit,
 ) {
     Dialog(
@@ -45,6 +47,7 @@ fun TvModal(
         TvModalWindowEffects(isBlurBehindEnabled = isBlurBehindEnabled)
         TvModalSurface(
             isTranslucent = isBlurBehindEnabled,
+            width = width,
             modifier = modifier,
             content = content,
         )
@@ -55,6 +58,7 @@ fun TvModal(
 internal fun TvModalSurface(
     modifier: Modifier = Modifier,
     isTranslucent: Boolean = false,
+    width: Dp = DefaultModalWidth,
     content: @Composable ColumnScope.() -> Unit,
 ) {
     Column(
@@ -62,7 +66,7 @@ internal fun TvModalSurface(
         verticalArrangement = Arrangement.spacedBy(16.dp),
         content = content,
         modifier = modifier
-            .width(400.dp)
+            .width(width)
             .clip(ModalShape)
             .background(if (isTranslucent) TranslucentContainerColor else OpaqueContainerColor)
             .background(HighlightBrush)
@@ -105,6 +109,7 @@ private fun rememberIsBlurBehindEnabled(): State<Boolean> {
     return isBlurBehindEnabled
 }
 
+private val DefaultModalWidth = 400.dp
 private val ModalShape = RoundedCornerShape(28.dp)
 private val TranslucentContainerColor = TvColors.Dark.copy(alpha = 0.6f)
 private val OpaqueContainerColor = TvColors.Dark.copy(alpha = 0.94f)

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvDownloadAppModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvDownloadAppModal.kt
@@ -1,0 +1,104 @@
+package au.com.shiftyjelly.pocketcasts.playlists
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.tv.material3.Button
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.component.TvModal
+import au.com.shiftyjelly.pocketcasts.component.TvModalSurface
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.qr.rememberQrPainter
+import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
+import au.com.shiftyjelly.pocketcasts.theme.TvColors
+import au.com.shiftyjelly.pocketcasts.theme.TvTextStyles
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+fun TvDownloadAppModal(
+    onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    TvModal(
+        onDismissRequest = onDismissRequest,
+        width = 600.dp,
+        modifier = modifier,
+    ) {
+        TvDownloadAppModalContent(onDone = onDismissRequest)
+    }
+}
+
+@Composable
+private fun ColumnScope.TvDownloadAppModalContent(
+    onDone: () -> Unit,
+) {
+    val focusRequester = remember { FocusRequester() }
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+
+    Text(
+        text = stringResource(LR.string.tv_playlists_download_title),
+        color = Color.White,
+        style = TvTextStyles.ModalTitle,
+    )
+    Text(
+        text = stringResource(LR.string.tv_playlists_download_subtitle),
+        color = TvColors.TextSecondary,
+        style = TvTextStyles.ModalBody,
+    )
+    Image(
+        painter = rememberQrPainter(content = DOWNLOAD_URL, size = QrCodeSize),
+        contentDescription = stringResource(LR.string.tv_playlists_download_subtitle),
+        modifier = Modifier
+            .padding(vertical = 16.dp)
+            .background(Color.White, RoundedCornerShape(8.dp))
+            .padding(10.dp)
+            .size(QrCodeSize),
+    )
+    Text(
+        text = DOWNLOAD_URL_LABEL,
+        color = TvColors.TextSecondary,
+        style = TvTextStyles.ModalBody,
+    )
+    Button(
+        onClick = onDone,
+        colors = TvButtonDefaults.filledButtonColors(),
+        modifier = Modifier
+            .padding(top = 16.dp)
+            .focusRequester(focusRequester),
+    ) {
+        Text(stringResource(LR.string.done))
+    }
+}
+
+private const val DOWNLOAD_URL = "https://www.pocketcasts.com/downloads"
+private const val DOWNLOAD_URL_LABEL = "pocketcasts.com/downloads"
+private val QrCodeSize = 144.dp
+
+@Preview
+@Composable
+private fun TvDownloadAppModalPreview() {
+    AppTheme(themeType = Theme.ThemeType.EXTRA_DARK) {
+        MaterialTheme {
+            TvModalSurface(width = 600.dp) {
+                TvDownloadAppModalContent(onDone = {})
+            }
+        }
+    }
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvDownloadAppModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvDownloadAppModal.kt
@@ -64,7 +64,7 @@ private fun ColumnScope.TvDownloadAppModalContent(
     )
     Image(
         painter = rememberQrPainter(content = DOWNLOAD_URL, size = QrCodeSize),
-        contentDescription = stringResource(LR.string.tv_playlists_download_subtitle),
+        contentDescription = null,
         modifier = Modifier
             .padding(vertical = 16.dp)
             .background(Color.White, RoundedCornerShape(8.dp))
@@ -88,7 +88,7 @@ private fun ColumnScope.TvDownloadAppModalContent(
 }
 
 private const val DOWNLOAD_URL = "https://www.pocketcasts.com/downloads"
-private const val DOWNLOAD_URL_LABEL = "pocketcasts.com/downloads"
+private val DOWNLOAD_URL_LABEL = DOWNLOAD_URL.removePrefix("https://www.")
 private val QrCodeSize = 144.dp
 
 @Preview

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvDownloadAppModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvDownloadAppModal.kt
@@ -87,8 +87,8 @@ private fun ColumnScope.TvDownloadAppModalContent(
     }
 }
 
-private const val DOWNLOAD_URL = "https://www.pocketcasts.com/downloads"
-private val DOWNLOAD_URL_LABEL = DOWNLOAD_URL.removePrefix("https://www.")
+private const val DOWNLOAD_URL = "https://pocketcasts.com/downloads"
+private val DOWNLOAD_URL_LABEL = DOWNLOAD_URL.removePrefix("https://")
 private val QrCodeSize = 144.dp
 
 @Preview

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsScreen.kt
@@ -68,6 +68,8 @@ fun TvPlaylistsScreen(
     viewModel: TvPlaylistsViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    var isDownloadModalVisible by rememberSaveable { mutableStateOf(false) }
+
     TvPlaylistsContent(
         uiState = uiState,
         getArtworkUuidsFlow = viewModel::getArtworkUuidsFlow,
@@ -75,8 +77,15 @@ fun TvPlaylistsScreen(
         refreshArtworkUuids = viewModel::refreshArtworkUuids,
         refreshEpisodeCount = viewModel::refreshEpisodeCount,
         findPodcastTint = viewModel::findPodcastTint,
+        onCreatePlaylist = { isDownloadModalVisible = true },
         modifier = modifier,
     )
+
+    if (isDownloadModalVisible) {
+        TvDownloadAppModal(
+            onDismissRequest = { isDownloadModalVisible = false },
+        )
+    }
 }
 
 @Composable
@@ -87,6 +96,7 @@ private fun TvPlaylistsContent(
     refreshArtworkUuids: suspend (String) -> Unit,
     refreshEpisodeCount: suspend (String) -> Unit,
     findPodcastTint: suspend (String) -> Int?,
+    onCreatePlaylist: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     AnimatedContent(
@@ -105,7 +115,10 @@ private fun TvPlaylistsContent(
             is TvPlaylistsUiState.Loading -> LoadingView(color = Color.White, modifier = Modifier.fillMaxSize())
 
             is TvPlaylistsUiState.Loaded -> if (state.playlists.isEmpty()) {
-                TvPlaylistsEmpty(modifier = Modifier.fillMaxSize())
+                TvPlaylistsEmpty(
+                    onCreatePlaylist = onCreatePlaylist,
+                    modifier = Modifier.fillMaxSize(),
+                )
             } else {
                 TvPlaylistsGrid(
                     playlists = state.playlists,
@@ -217,13 +230,14 @@ private fun TvPlaylistGridItem(
 
 @Composable
 private fun TvPlaylistsEmpty(
+    onCreatePlaylist: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     TvEmptyState(
         title = stringResource(LR.string.tv_playlists_empty_title),
         subtitle = stringResource(LR.string.tv_playlists_empty_subtitle),
         actionLabel = stringResource(LR.string.tv_playlists_empty_action_title),
-        onAction = {},
+        onAction = onCreatePlaylist,
         modifier = modifier,
     )
 }
@@ -243,6 +257,7 @@ private fun TvPlaylistsGridPreview() {
                     refreshArtworkUuids = {},
                     refreshEpisodeCount = {},
                     findPodcastTint = { null },
+                    onCreatePlaylist = {},
                 )
             }
         }
@@ -262,6 +277,7 @@ private fun TvPlaylistsEmptyPreview() {
                     refreshArtworkUuids = {},
                     refreshEpisodeCount = {},
                     findPodcastTint = { null },
+                    onCreatePlaylist = {},
                 )
             }
         }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsScreen.kt
@@ -41,8 +41,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.tv.material3.Button
 import androidx.tv.material3.MaterialTheme
-import androidx.tv.material3.OutlinedButton
 import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.component.TvEmptyState
 import au.com.shiftyjelly.pocketcasts.component.TvPlaylistCard
@@ -55,6 +55,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImage
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.Playlist
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistPreview
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.SmartPlaylistPreview
+import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
 import au.com.shiftyjelly.pocketcasts.theme.TvColors
 import au.com.shiftyjelly.pocketcasts.theme.TvTextStyles
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvTextStyles.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvTextStyles.kt
@@ -79,6 +79,21 @@ object TvTextStyles {
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 
+    val ModalTitle = TextStyle(
+        fontSize = 24.sp,
+        fontWeight = FontWeight.SemiBold,
+        lineHeight = 28.sp,
+        textAlign = TextAlign.Center,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    val ModalBody = TextStyle(
+        fontSize = 16.sp,
+        lineHeight = 20.sp,
+        textAlign = TextAlign.Center,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
     val ModalEmail = TextStyle(
         fontSize = 25.sp,
         fontWeight = FontWeight(510),


### PR DESCRIPTION
## Description
Implements the **Create playlist** action on the TV Playlists tab's empty state, mirroring the tvOS `DownloadAppModal`: since playlists can't be created on the TV, the button opens a modal with a QR code pointing to `pocketcasts.com/downloads` so the user can grab the phone app.

- `TvDownloadAppModal` reuses the glassy `TvModal` (widened via a new `width` parameter) with the tvOS copy, a QR code rendered through the existing `qr` module, the plain-text URL, and a focused **Done** button.
- The empty state's "Create a playlist" button now opens the modal; Done and back both dismiss it.

Figma: Ftk3KwnfqaK4g57yCN63p0-fi-3246_3451

Fixes PCDROID-694 https://linear.app/a8c/issue/PCDROID-694/create-playlists-modal

## Testing Instructions
1. Run the `tv` app with signed out state
2. Focus **Create a playlist** and press select.
3. ✅ Verify the modal matches the design (title, subtitle, QR, URL, Done) and that the QR resolves to `https://www.pocketcasts.com/downloads`.
4. Verify **Done** and the back button both dismiss the modal, returning focus to the empty state.

## Screenshots or Screencast
| Empty playlist screen | Create playlist modal | 
| --- | --- |
| <img width="1920" height="1080" alt="Screenshot_20260728_163622" src="https://github.com/user-attachments/assets/444226bc-aeab-4478-9fc5-83a8ea6eb83f" /> | <img width="1920" height="1080" alt="Screenshot_20260728_162905" src="https://github.com/user-attachments/assets/d73acc76-f5fc-459f-969b-4c305654ee9e" /> |

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

#### I have tested any UI changes...
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack