### PR TITLE
Cherry-pick HLS video toggle (#5620) and progressive audio-only (#5627) to 8.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 8.18
 -----
-
+*   New Features
+    *   Add option to switch to the HLS video stream when playing a downloaded episode
+        ([#5620](https://github.com/Automattic/pocket-casts-android/pull/5620))
 
 8.17
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,6 @@
 8.18
 -----
-*   New Features
-    *   Add option to switch to the HLS video stream when playing a downloaded episode
-        ([#5620](https://github.com/Automattic/pocket-casts-android/pull/5620))
-*   Updates
-    *   Respect Audio only toggle when playing progressive mp4 episodes
-        ([#5627](https://github.com/Automattic/pocket-casts-android/pull/5627))
+
 
 8.17
 -----
@@ -18,6 +13,11 @@
         ([#5536](https://github.com/Automattic/pocket-casts-android/pull/5536))
     *   HLS support
         ([#5602](https://github.com/Automattic/pocket-casts-android/pull/5602))
+    *   Add option to switch to the HLS video stream when playing a downloaded episode
+        ([#5620](https://github.com/Automattic/pocket-casts-android/pull/5620))
+*   Updates
+    *   Respect Audio only toggle when playing progressive mp4 episodes
+        ([#5627](https://github.com/Automattic/pocket-casts-android/pull/5627))
 *   Bug Fixes
     *   Fix episodes being cached over mobile data when Warn before using data is enabled
         ([#5567](https://github.com/Automattic/pocket-casts-android/pull/5567))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 *   New Features
     *   Add option to switch to the HLS video stream when playing a downloaded episode
         ([#5620](https://github.com/Automattic/pocket-casts-android/pull/5620))
+*   Updates
+    *   Respect Audio only toggle when playing progressive mp4 episodes
+        ([#5627](https://github.com/Automattic/pocket-casts-android/pull/5627))
 
 8.17
 -----

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -404,6 +404,11 @@ class PlayerHeaderFragment :
                             }
                         }
 
+                        NavigationState.ShowStreamingWarningDialog -> {
+                            warningsHelper.streamingWarningDialog(onConfirm = { shelfSharedViewModel.onVideoToggleConfirmed() })
+                                .show(parentFragmentManager, "stream warning")
+                        }
+
                         NavigationState.ShowAddBookmark -> {
                             val bookmarkArguments = viewModel.createBookmarkArguments()
                             if (bookmarkArguments != null) {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ShelfSharedViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ShelfSharedViewModel.kt
@@ -91,14 +91,21 @@ class ShelfSharedViewModel @Inject constructor(
     private val _snackbarMessages = MutableSharedFlow<SnackbarMessage>()
     val snackbarMessages = _snackbarMessages.asSharedFlow()
 
+    private val videoStateFlow = combine(
+        playbackManager.streamVideoState,
+        playbackManager.streamHlsAvailable,
+        playbackManager.videoRenderingEnabled,
+    ) { streamVideoState, hlsAvailable, renderingEnabled ->
+        VideoState(streamVideoState, hlsAvailable, renderingEnabled)
+    }
+
     val uiState = combine(
         settings.shelfItems.flow,
         shelfUpNextObservable.asFlow(),
         shelfUpNextObservable.asFlow()
             .mapNotNull { state -> (state as? UpNextQueue.State.Loaded)?.episode?.uuid }
             .flatMapLatest { episodeUuid -> transcriptManager.observeIsTranscriptAvailable(episodeUuid) },
-        playbackManager.streamVideoState,
-        playbackManager.videoRenderingEnabled,
+        videoStateFlow,
         ::createUiState,
     ).stateIn(
         viewModelScope,
@@ -110,19 +117,26 @@ class ShelfSharedViewModel @Inject constructor(
         shelfItems: List<ShelfItem>,
         shelfUpNext: UpNextQueue.State,
         isTranscriptAvailable: Boolean,
-        streamVideoState: StreamVideoState,
-        videoRenderingEnabled: Boolean,
+        videoState: VideoState,
     ): UiState {
         val episode = (shelfUpNext as? UpNextQueue.State.Loaded)?.episode
-        val streamHasVideo = streamVideoState == StreamVideoState.HasVideo || streamVideoState == StreamVideoState.Unknown
-        val canToggleVideo = FeatureFlag.isEnabled(Feature.HLS_STREAMING) && episode is PodcastEpisode && streamHasVideo
+        val streamHasVideo = videoState.streamVideoState == StreamVideoState.HasVideo || videoState.streamVideoState == StreamVideoState.Unknown
+        val canToggleVideo = FeatureFlag.isEnabled(Feature.HLS_STREAMING) &&
+            episode is PodcastEpisode &&
+            (streamHasVideo || videoState.hlsAvailable)
         return uiState.value.copy(
             shelfItems = shelfItems.filter { it.showIf(episode) && (it != ShelfItem.StreamSelector || canToggleVideo) },
             episode = episode,
             isTranscriptAvailable = isTranscriptAvailable,
-            isVideoRenderingEnabled = videoRenderingEnabled,
+            isVideoRenderingEnabled = videoState.renderingEnabled && streamHasVideo,
         )
     }
+
+    private data class VideoState(
+        val streamVideoState: StreamVideoState,
+        val hlsAvailable: Boolean,
+        val renderingEnabled: Boolean,
+    )
 
     fun onEffectsClick(source: ShelfItemSource) {
         trackShelfAction(ShelfItem.Effects, source)
@@ -132,7 +146,17 @@ class ShelfSharedViewModel @Inject constructor(
     }
 
     fun onVideoToggleClick(source: ShelfItemSource) {
-        playbackManager.toggleVideoRendering()
+        if (playbackManager.videoToggleRequiresStreamSwitch() && playbackManager.shouldWarnAboutPlayback()) {
+            viewModelScope.launch {
+                _navigationState.emit(NavigationState.ShowStreamingWarningDialog)
+            }
+        } else {
+            playbackManager.toggleVideoRendering()
+        }
+    }
+
+    fun onVideoToggleConfirmed() {
+        playbackManager.toggleVideoRendering(streamWarningConfirmed = true)
     }
 
     fun onSleepClick(source: ShelfItemSource) {
@@ -381,6 +405,7 @@ class ShelfSharedViewModel @Inject constructor(
         ) : NavigationState
 
         data object ShowMoreActions : NavigationState
+        data object ShowStreamingWarningDialog : NavigationState
         data object ShowAddBookmark : NavigationState
         data class StartUpsellFlow(val source: OnboardingUpgradeSource) : NavigationState
         data class AddEpisodeToPlaylist(val episodeUuid: String, val podcastUuid: String) : NavigationState

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ShelfSharedViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ShelfSharedViewModelTest.kt
@@ -27,8 +27,12 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
+import au.com.shiftyjelly.pocketcasts.repositories.transcript.TranscriptManager
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
+import au.com.shiftyjelly.pocketcasts.sharedtest.InMemoryFeatureFlagRule
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import com.automattic.eventhorizon.EventHorizon
 import io.reactivex.Observable
 import java.time.Instant
@@ -48,6 +52,7 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -59,6 +64,9 @@ class ShelfSharedViewModelTest {
 
     @get:Rule
     val coroutineRule = MainCoroutineRule()
+
+    @get:Rule
+    val featureFlagRule = InMemoryFeatureFlagRule()
 
     @Mock
     private lateinit var applicationScope: CoroutineScope
@@ -83,6 +91,9 @@ class ShelfSharedViewModelTest {
 
     @Mock
     private lateinit var userEpisodeManager: UserEpisodeManager
+
+    @Mock
+    private lateinit var transcriptManager: TranscriptManager
 
     private lateinit var shelfSharedViewModel: ShelfSharedViewModel
 
@@ -311,19 +322,105 @@ class ShelfSharedViewModelTest {
 
         shelfSharedViewModel.onVideoToggleClick(ShelfItemSource.Shelf)
 
-        verify(playbackManager).toggleVideoRendering()
+        verify(playbackManager).toggleVideoRendering(streamWarningConfirmed = false)
+    }
+
+    @Test
+    fun `given hls stream available and no video, then stream selector is shown`() = runTest {
+        val episode = PodcastEpisode("uuid", publishedDate = Date())
+        initViewModel(
+            currentEpisode = episode,
+            hlsAvailable = true,
+            streamVideoState = StreamVideoState.NotVideo,
+        )
+
+        shelfSharedViewModel.uiState.test {
+            var state = awaitItem()
+            while (state.episode == null) {
+                state = awaitItem()
+            }
+            assertTrue(state.shelfItems.contains(ShelfItem.StreamSelector))
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `given no hls stream and no video, then stream selector is hidden`() = runTest {
+        val episode = PodcastEpisode("uuid", publishedDate = Date())
+        initViewModel(
+            currentEpisode = episode,
+            hlsAvailable = false,
+            streamVideoState = StreamVideoState.NotVideo,
+        )
+
+        shelfSharedViewModel.uiState.test {
+            var state = awaitItem()
+            while (state.episode == null) {
+                state = awaitItem()
+            }
+            assertFalse(state.shelfItems.contains(ShelfItem.StreamSelector))
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `given stream switch required and warning needed, when video toggle clicked, then streaming warning dialog is shown`() = runTest {
+        initViewModel()
+        whenever(playbackManager.videoToggleRequiresStreamSwitch()).thenReturn(true)
+        whenever(playbackManager.shouldWarnAboutPlayback()).thenReturn(true)
+
+        shelfSharedViewModel.navigationState.test {
+            shelfSharedViewModel.onVideoToggleClick(ShelfItemSource.Shelf)
+            assertEquals(NavigationState.ShowStreamingWarningDialog, awaitItem())
+        }
+
+        verify(playbackManager, never()).toggleVideoRendering(streamWarningConfirmed = false)
+    }
+
+    @Test
+    fun `given stream switch required without warning, when video toggle clicked, then video rendering is toggled`() = runTest {
+        initViewModel()
+        whenever(playbackManager.videoToggleRequiresStreamSwitch()).thenReturn(true)
+        whenever(playbackManager.shouldWarnAboutPlayback()).thenReturn(false)
+
+        shelfSharedViewModel.onVideoToggleClick(ShelfItemSource.Shelf)
+
+        verify(playbackManager).toggleVideoRendering(streamWarningConfirmed = false)
+    }
+
+    @Test
+    fun `when video toggle confirmed, then video rendering is toggled with stream warning confirmed`() = runTest {
+        initViewModel()
+
+        shelfSharedViewModel.onVideoToggleConfirmed()
+
+        verify(playbackManager).toggleVideoRendering(streamWarningConfirmed = true)
     }
 
     private fun initViewModel(
         subscription: Subscription? = plusSubscription,
+        currentEpisode: PodcastEpisode? = null,
+        hlsAvailable: Boolean = false,
+        streamVideoState: StreamVideoState = StreamVideoState.NotVideo,
     ) {
+        FeatureFlag.setEnabled(Feature.HLS_STREAMING, true)
+
         whenever(playbackManager.upNextQueue).thenReturn(upNextQueue)
+        val upNextState = if (currentEpisode != null) {
+            UpNextQueue.State.Loaded(currentEpisode, null, listOf(currentEpisode))
+        } else {
+            UpNextQueue.State.Empty
+        }
         whenever(
             upNextQueue.getChangesObservableWithLiveCurrentEpisode(
                 episodeManager,
                 podcastManager,
             ),
-        ).thenReturn(Observable.just(UpNextQueue.State.Empty))
+        ).thenReturn(Observable.just(upNextState))
+
+        if (currentEpisode != null) {
+            whenever(transcriptManager.observeIsTranscriptAvailable(currentEpisode.uuid)).thenReturn(flowOf(false))
+        }
 
         val userSetting = mock<UserSetting<List<ShelfItem>>>()
         whenever(userSetting.flow).thenReturn(MutableStateFlow(ShelfItem.entries))
@@ -333,7 +430,8 @@ class ShelfSharedViewModelTest {
         whenever(userSubscriptionSetting.value).thenReturn(subscription)
         whenever(settings.cachedSubscription).thenReturn(userSubscriptionSetting)
 
-        whenever(playbackManager.streamVideoState).thenReturn(MutableStateFlow(StreamVideoState.NotVideo))
+        whenever(playbackManager.streamVideoState).thenReturn(MutableStateFlow(streamVideoState))
+        whenever(playbackManager.streamHlsAvailable).thenReturn(MutableStateFlow(hlsAvailable))
         whenever(playbackManager.videoRenderingEnabled).thenReturn(MutableStateFlow(true))
 
         shelfSharedViewModel = ShelfSharedViewModel(
@@ -345,7 +443,7 @@ class ShelfSharedViewModelTest {
             podcastManager = podcastManager,
             settings = settings,
             userEpisodeManager = userEpisodeManager,
-            transcriptManager = mock(),
+            transcriptManager = transcriptManager,
             downloadQueue = mock(),
         )
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CastPlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CastPlayer.kt
@@ -237,7 +237,7 @@ class CastPlayer(
         this.podcast = podcast
     }
 
-    override fun setEpisode(episode: BaseEpisode) {
+    override fun setEpisode(episode: BaseEpisode, preferStream: Boolean) {
         this.episodeLocation = EpisodeLocation.Stream(episode, episode.streamUrl, episode.isStreamUrlHls)
         localEpisodeUuid = episode.uuid
         buildCustomData()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/LocalPlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/LocalPlayer.kt
@@ -189,8 +189,8 @@ abstract class LocalPlayer(override val onPlayerEvent: (Player, PlayerEvent) -> 
         }
     }
 
-    override fun setEpisode(episode: BaseEpisode) {
-        episodeLocation = EpisodeLocation.create(episode)
+    override fun setEpisode(episode: BaseEpisode, preferStream: Boolean) {
+        episodeLocation = EpisodeLocation.create(episode, preferStream)
     }
 
     override suspend fun setPlaybackEffects(playbackEffects: PlaybackEffects) {}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -484,7 +484,9 @@ open class PlaybackManager @Inject constructor(
     }
 
     private fun audioOnlyModeOrNull(): Boolean? {
-        if (getCurrentEpisode()?.isStreamUrlHls != true || player?.isStreaming != true) return null
+        val episode = getCurrentEpisode() ?: return null
+        val playingHlsStream = episode.isStreamUrlHls && player?.isStreaming == true
+        if (!playingHlsStream && !episode.isVideo) return null
         return settings.audioOnly.value || !_videoRenderingEnabled.value
     }
 
@@ -2108,12 +2110,12 @@ open class PlaybackManager @Inject constructor(
 
         val playingStream = !episode.isDownloaded || (videoStreamPreferred && episode.isStreamUrlHls && !castManager.isConnected())
 
-        // HLS may carry video, so start it Unknown until the tracks resolve it, unless audio only forces no video. Non-HLS keeps its own flag.
-        _streamVideoState.value = when {
-            !playingStream || !episode.isStreamUrlHls -> StreamVideoState.NotVideo
-            settings.audioOnly.value -> StreamVideoState.AudioOnly
-            else -> StreamVideoState.Unknown
-        }
+        // Audio only forces video content to audio. Otherwise HLS starts Unknown until the tracks resolve it; non-HLS keeps its own flag.
+        _streamVideoState.value = StreamVideoState.initialFor(
+            episode,
+            audioOnly = settings.audioOnly.value,
+            playingHlsStream = playingStream && episode.isStreamUrlHls,
+        )
         _videoRenderingEnabled.value = true
 
         lastPlaybackSource = sourceView

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -110,6 +110,7 @@ import java.io.FileInputStream
 import java.io.FileNotFoundException
 import java.util.Date
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -270,7 +271,12 @@ open class PlaybackManager @Inject constructor(
     private val _videoRenderingEnabled = MutableStateFlow(true)
     val videoRenderingEnabled = _videoRenderingEnabled.asStateFlow()
 
-    private var currentStreamHlsAvailable = false
+    private val _streamHlsAvailable = MutableStateFlow(false)
+    val streamHlsAvailable = _streamHlsAvailable.asStateFlow()
+
+    private var videoStreamPreferred = false
+    private var videoStreamPreferredEpisodeUuid: String? = null
+    private val isVideoToggleReloading = AtomicBoolean(false)
 
     private var lastPlaybackSource: SourceView? = null
 
@@ -339,6 +345,15 @@ open class PlaybackManager @Inject constructor(
                 player?.updateAudioOnly()
             }
         }
+
+        launch {
+            upNextQueue.changesObservable.asFlow()
+                .map { state -> (state as? UpNextQueue.State.Loaded)?.episode?.uuid }
+                .distinctUntilChanged()
+                .collect { uuid ->
+                    _streamHlsAvailable.value = uuid != null && alternateEnclosureManager.findForEpisode(uuid).firstHlsStreamUrl() != null
+                }
+        }
     }
 
     fun getCurrentEpisode(): BaseEpisode? {
@@ -391,7 +406,7 @@ open class PlaybackManager @Inject constructor(
         episode.overrideStreamContentType = null
         // Stream the first HLS alternate enclosure when streaming is on, or when the episode is HLS-only.
         val hlsUrl = alternateEnclosureManager.findForEpisode(episode.uuid).firstHlsStreamUrl()
-        currentStreamHlsAvailable = hlsUrl != null
+        _streamHlsAvailable.value = hlsUrl != null
         val hlsStreamingEnabled = FeatureFlag.isEnabled(Feature.HLS_STREAMING)
         if (hlsUrl != null && (hlsStreamingEnabled || episode.downloadUrl.isNullOrBlank())) {
             episode.overrideStreamUrl = hlsUrl
@@ -399,16 +414,72 @@ open class PlaybackManager @Inject constructor(
         }
     }
 
-    fun toggleVideoRendering() {
-        _videoRenderingEnabled.value = !_videoRenderingEnabled.value
-        getCurrentEpisode()?.let { episode ->
+    fun videoToggleRequiresStreamSwitch(): Boolean {
+        val episode = getCurrentEpisode() ?: return false
+        return episode.isDownloaded &&
+            _streamHlsAvailable.value &&
+            !videoStreamPreferred &&
+            player?.isRemote != true &&
+            FeatureFlag.isEnabled(Feature.HLS_STREAMING)
+    }
+
+    fun toggleVideoRendering(streamWarningConfirmed: Boolean = false) {
+        val episode = getCurrentEpisode()
+        when {
+            videoToggleRequiresStreamSwitch() -> {
+                if (!isVideoToggleReloading.compareAndSet(false, true)) return
+                videoStreamPreferred = true
+                videoStreamPreferredEpisodeUuid = episode?.uuid
+                trackVideoToggled(episode, PlaybackContentType.Video)
+                reloadForVideoToggle(episode, streamWarningConfirmed)
+            }
+
+            videoStreamPreferred && episode?.isDownloaded == true && player?.isRemote != true -> {
+                if (!isVideoToggleReloading.compareAndSet(false, true)) return
+                videoStreamPreferred = false
+                videoStreamPreferredEpisodeUuid = null
+                trackVideoToggled(episode, PlaybackContentType.Audio)
+                reloadForVideoToggle(episode, streamWarningConfirmed)
+            }
+
+            else -> {
+                _videoRenderingEnabled.value = !_videoRenderingEnabled.value
+                trackVideoToggled(episode, if (_videoRenderingEnabled.value) PlaybackContentType.Video else PlaybackContentType.Audio)
+            }
+        }
+    }
+
+    private fun trackVideoToggled(episode: BaseEpisode?, switchedTo: PlaybackContentType) {
+        episode?.let {
             eventHorizon.track(
                 PlaybackHlsToggledEvent(
-                    switchedTo = if (_videoRenderingEnabled.value) PlaybackContentType.Video else PlaybackContentType.Audio,
-                    episodeUuid = episode.uuid,
-                    podcastUuid = episode.podcastOrSubstituteUuid,
+                    switchedTo = switchedTo,
+                    episodeUuid = it.uuid,
+                    podcastUuid = it.podcastOrSubstituteUuid,
                 ),
             )
+        }
+    }
+
+    private fun reloadForVideoToggle(episode: BaseEpisode?, streamWarningConfirmed: Boolean) {
+        if (episode == null) {
+            isVideoToggleReloading.set(false)
+            return
+        }
+        launch(Dispatchers.Default) {
+            try {
+                player?.let { player ->
+                    val currentTimeSecs = player.getCurrentPositionMs().toDouble() / 1000.0
+                    episodeManager.updatePlayedUpToBlocking(episode, currentTimeSecs, true)
+                }
+                loadCurrentEpisode(
+                    play = isPlaying(),
+                    forceStream = streamWarningConfirmed,
+                    showedStreamWarning = streamWarningConfirmed,
+                )
+            } finally {
+                isVideoToggleReloading.set(false)
+            }
         }
     }
 
@@ -523,7 +594,9 @@ open class PlaybackManager @Inject constructor(
         pauseSuspend(sourceView = SourceView.METERED_NETWORK_CHANGE)
     }
 
-    fun shouldWarnAboutPlayback(episodeUUID: String? = upNextQueue.currentEpisode?.uuid): Boolean {
+    fun shouldWarnAboutPlayback(): Boolean = shouldWarnAboutPlayback(upNextQueue.currentEpisode?.uuid)
+
+    fun shouldWarnAboutPlayback(episodeUUID: String?): Boolean {
         return !Util.isCarUiMode(application) &&
             settings.warnOnMeteredNetwork.value &&
             !Network.isUnmeteredConnection(application) &&
@@ -1596,7 +1669,7 @@ open class PlaybackManager @Inject constructor(
                 PlayerEpisodeCompletedEvent(
                     podcastUuid = episode.podcastOrSubstituteUuid,
                     episodeUuid = episode.uuid,
-                    hlsAvailable = currentStreamHlsAvailable,
+                    hlsAvailable = _streamHlsAvailable.value,
                     audioOnlyMode = audioOnlyModeOrNull(),
                 ),
             )
@@ -1929,17 +2002,18 @@ open class PlaybackManager @Inject constructor(
     /**
      * Does the media player need to be recreated.
      */
-    private fun isPlayerResetNeeded(episode: BaseEpisode, sameEpisode: Boolean, chromeCastConnected: Boolean): Boolean {
+    private fun isPlayerResetNeeded(episode: BaseEpisode, sameEpisode: Boolean, chromeCastConnected: Boolean, playingStream: Boolean): Boolean {
         // reset the player if local and changing episode
         val playbackOnDevice = !chromeCastConnected
         return if (!sameEpisode) {
             playbackOnDevice
         } else {
-            episode.isDownloaded &&
-                playbackOnDevice &&
-                episode.downloadedFilePath != null &&
+            playbackOnDevice &&
                 player != null &&
-                episode.downloadedFilePath != player?.filePath
+                (
+                    player?.isStreaming != playingStream ||
+                        (episode.isDownloaded && episode.downloadedFilePath != null && episode.downloadedFilePath != player?.filePath)
+                    )
         }
     }
 
@@ -2027,9 +2101,16 @@ open class PlaybackManager @Inject constructor(
         // Resolve the HLS alternate enclosure so streamUrl reflects the stream that will play.
         applyStreamOverride(episode)
 
+        if (videoStreamPreferred && episode.uuid != videoStreamPreferredEpisodeUuid) {
+            videoStreamPreferred = false
+            videoStreamPreferredEpisodeUuid = null
+        }
+
+        val playingStream = !episode.isDownloaded || (videoStreamPreferred && episode.isStreamUrlHls && !castManager.isConnected())
+
         // HLS may carry video, so start it Unknown until the tracks resolve it, unless audio only forces no video. Non-HLS keeps its own flag.
         _streamVideoState.value = when {
-            !episode.isStreamUrlHls -> StreamVideoState.NotVideo
+            !playingStream || !episode.isStreamUrlHls -> StreamVideoState.NotVideo
             settings.audioOnly.value -> StreamVideoState.AudioOnly
             else -> StreamVideoState.Unknown
         }
@@ -2039,12 +2120,12 @@ open class PlaybackManager @Inject constructor(
 
         eventHorizon.track(
             PlaybackSourceResolvedEvent(
-                playbackProtocol = if (episode.isStreamUrlHls) PlaybackProtocolType.Hls else PlaybackProtocolType.Progressive,
+                playbackProtocol = if (playingStream && episode.isStreamUrlHls) PlaybackProtocolType.Hls else PlaybackProtocolType.Progressive,
                 isFallback = false,
                 contentType = playbackContentTypeFor(episode),
                 episodeUuid = episode.uuid,
                 podcastUuid = episode.podcastOrSubstituteUuid,
-                hlsEngine = if (episode.isStreamUrlHls) HLS_ENGINE_EXOPLAYER else null,
+                hlsEngine = if (playingStream && episode.isStreamUrlHls) HLS_ENGINE_EXOPLAYER else null,
             ),
         )
 
@@ -2054,7 +2135,7 @@ open class PlaybackManager @Inject constructor(
         }
 
         episodeSubscription?.dispose()
-        if (!episode.isDownloaded) {
+        if (playingStream) {
             if (!Util.isCarUiMode(application) &&
                 !Util.isWearOs(application) &&
                 // The watch handles these warnings before this is called
@@ -2078,7 +2159,7 @@ open class PlaybackManager @Inject constructor(
                 withContext(Dispatchers.Main) {
                     playbackStateRelay.accept(playbackState)
                 }
-            } else {
+            } else if (!episode.isDownloaded) {
                 val episodeObservable = when (episode) {
                     is PodcastEpisode -> {
                         episodeManager.findByUuidFlow(episode.uuid)
@@ -2094,7 +2175,8 @@ open class PlaybackManager @Inject constructor(
                     .takeUntil { it.isDownloaded }
                     .subscribeBy(
                         onNext = {
-                            if (player?.isStreaming == true && it.isDownloaded && player?.isRemote == false) {
+                            val watchingVideo = _streamVideoState.value == StreamVideoState.HasVideo && _videoRenderingEnabled.value
+                            if (player?.isStreaming == true && it.isDownloaded && player?.isRemote == false && !watchingVideo) {
                                 LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Episode was streaming but was now downloaded, switching to downloaded file")
 
                                 launch(Dispatchers.Default) {
@@ -2135,7 +2217,7 @@ open class PlaybackManager @Inject constructor(
         // We want to make sure we get the current position at the last possible moment before changing/resetting the player
         val currentPositionMs = if (
             isPlayerSwitchRequired() ||
-            isPlayerResetNeeded(episode, sameEpisode, castManager.isConnected())
+            isPlayerResetNeeded(episode, sameEpisode, castManager.isConnected(), playingStream)
         ) {
             // Don't create a player if we aren't playing because it will start to buffer
             if (play) {
@@ -2165,7 +2247,7 @@ open class PlaybackManager @Inject constructor(
         }
 
         player?.setPodcast(podcast)
-        player?.setEpisode(episode)
+        player?.setEpisode(episode, videoStreamPreferred)
 
         val playbackEffects = if (podcast != null && podcast.overrideGlobalEffects) {
             podcast.playbackEffects
@@ -2380,7 +2462,7 @@ open class PlaybackManager @Inject constructor(
             PlaybackPlayEvent(
                 source = source.analyticsValue,
                 contentType = contentType,
-                hlsAvailable = currentStreamHlsAvailable,
+                hlsAvailable = _streamHlsAvailable.value,
                 audioOnlyMode = audioOnlyModeOrNull(),
             )
         }
@@ -2509,7 +2591,7 @@ open class PlaybackManager @Inject constructor(
                         PlayerEpisodeCompletedEvent(
                             podcastUuid = episode.podcastOrSubstituteUuid,
                             episodeUuid = episode.uuid,
-                            hlsAvailable = currentStreamHlsAvailable,
+                            hlsAvailable = _streamHlsAvailable.value,
                             audioOnlyMode = audioOnlyModeOrNull(),
                         ),
                     )

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Player.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Player.kt
@@ -20,7 +20,7 @@ sealed interface EpisodeLocation {
     ) : EpisodeLocation
 
     companion object {
-        fun create(episode: BaseEpisode) = if (episode.isDownloaded) {
+        fun create(episode: BaseEpisode, preferStream: Boolean = false) = if (episode.isDownloaded && !(preferStream && episode.isStreamUrlHls)) {
             EpisodeLocation.Downloaded(episode, episode.downloadedFilePath)
         } else {
             EpisodeLocation.Stream(episode, episode.streamUrl, episode.isStreamUrlHls)
@@ -71,5 +71,5 @@ interface Player {
     fun supportsVideo(): Boolean
     fun setVolume(volume: Float)
     fun setPodcast(podcast: Podcast?)
-    fun setEpisode(episode: BaseEpisode)
+    fun setEpisode(episode: BaseEpisode, preferStream: Boolean = false)
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Player.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Player.kt
@@ -40,6 +40,15 @@ enum class StreamVideoState {
     Unknown,
     HasVideo,
     AudioOnly,
+    ;
+
+    companion object {
+        fun initialFor(episode: BaseEpisode, audioOnly: Boolean, playingHlsStream: Boolean) = when {
+            audioOnly && (episode.isVideo || playingHlsStream) -> AudioOnly
+            playingHlsStream -> Unknown
+            else -> NotVideo
+        }
+    }
 }
 
 interface Player {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -311,9 +311,8 @@ class SimplePlayer(
     @OptIn(UnstableApi::class)
     private fun applyAudioOnly() {
         val trackSelector = trackSelector ?: return
-        val disableVideo = settings.audioOnly.value && episodeLocation.isHlsStream
         trackSelector.parameters = trackSelector.buildUponParameters()
-            .setTrackTypeDisabled(C.TRACK_TYPE_VIDEO, disableVideo)
+            .setTrackTypeDisabled(C.TRACK_TYPE_VIDEO, settings.audioOnly.value)
             .build()
     }
 

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/EpisodeLocationTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/EpisodeLocationTest.kt
@@ -47,6 +47,48 @@ class EpisodeLocationTest {
         assertTrue(location.isHlsStream)
     }
 
+    @Test
+    fun `downloaded episode prefers hls override stream`() {
+        val episode = createEpisode(
+            downloadStatus = EpisodeDownloadStatus.Downloaded,
+            downloadedFilePath = "/path/episode.mp3",
+        ).apply {
+            overrideStreamUrl = "https://example.com/episode.m3u8"
+            overrideStreamContentType = "application/x-mpegURL"
+        }
+
+        val location = EpisodeLocation.create(episode, preferStream = true)
+
+        assertTrue(location is EpisodeLocation.Stream)
+        assertEquals("https://example.com/episode.m3u8", location.uri)
+        assertTrue(location.isHlsStream)
+    }
+
+    @Test
+    fun `downloaded episode without hls stays downloaded when preferring stream`() {
+        val episode = createEpisode(
+            downloadStatus = EpisodeDownloadStatus.Downloaded,
+            downloadedFilePath = "/path/episode.mp3",
+        )
+
+        val location = EpisodeLocation.create(episode, preferStream = true)
+
+        assertTrue(location is EpisodeLocation.Downloaded)
+        assertEquals("/path/episode.mp3", location.uri)
+        assertFalse(location.isHlsStream)
+    }
+
+    @Test
+    fun `not downloaded episode streams when preferring stream`() {
+        val episode = createEpisode()
+
+        val location = EpisodeLocation.create(episode, preferStream = true)
+
+        assertTrue(location is EpisodeLocation.Stream)
+        assertEquals("https://example.com/episode.mp3", location.uri)
+        assertFalse(location.isHlsStream)
+    }
+
     private fun createEpisode(
         downloadStatus: EpisodeDownloadStatus = EpisodeDownloadStatus.DownloadNotRequested,
         downloadedFilePath: String? = null,

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/StreamVideoStateTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/StreamVideoStateTest.kt
@@ -1,0 +1,77 @@
+package au.com.shiftyjelly.pocketcasts.repositories.playback
+
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import java.util.Date
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class StreamVideoStateTest {
+
+    @Test
+    fun `audio episode starts not video`() {
+        val episode = createEpisode(fileType = "audio/mpeg")
+
+        assertEquals(StreamVideoState.NotVideo, StreamVideoState.initialFor(episode, audioOnly = false, playingHlsStream = false))
+    }
+
+    @Test
+    fun `audio episode ignores audio only`() {
+        val episode = createEpisode(fileType = "audio/mpeg")
+
+        assertEquals(StreamVideoState.NotVideo, StreamVideoState.initialFor(episode, audioOnly = true, playingHlsStream = false))
+    }
+
+    @Test
+    fun `video episode starts not video so its own flag decides`() {
+        val episode = createEpisode(fileType = "video/mp4")
+
+        assertEquals(StreamVideoState.NotVideo, StreamVideoState.initialFor(episode, audioOnly = false, playingHlsStream = false))
+    }
+
+    @Test
+    fun `audio only forces a video episode to audio`() {
+        val episode = createEpisode(fileType = "video/mp4")
+
+        assertEquals(StreamVideoState.AudioOnly, StreamVideoState.initialFor(episode, audioOnly = true, playingHlsStream = false))
+    }
+
+    @Test
+    fun `hls stream starts unknown`() {
+        val episode = createHlsEpisode()
+
+        assertEquals(StreamVideoState.Unknown, StreamVideoState.initialFor(episode, audioOnly = false, playingHlsStream = true))
+    }
+
+    @Test
+    fun `audio only forces an hls stream to audio`() {
+        val episode = createHlsEpisode()
+
+        assertEquals(StreamVideoState.AudioOnly, StreamVideoState.initialFor(episode, audioOnly = true, playingHlsStream = true))
+    }
+
+    @Test
+    fun `downloaded hls episode playing its local file starts not video`() {
+        val episode = createHlsEpisode()
+
+        assertEquals(StreamVideoState.NotVideo, StreamVideoState.initialFor(episode, audioOnly = false, playingHlsStream = false))
+    }
+
+    @Test
+    fun `downloaded hls episode playing its local audio file ignores audio only`() {
+        val episode = createHlsEpisode()
+
+        assertEquals(StreamVideoState.NotVideo, StreamVideoState.initialFor(episode, audioOnly = true, playingHlsStream = false))
+    }
+
+    private fun createEpisode(fileType: String) = PodcastEpisode(
+        uuid = "episode-uuid",
+        publishedDate = Date(),
+        downloadUrl = "https://example.com/episode.mp3",
+        fileType = fileType,
+    )
+
+    private fun createHlsEpisode() = createEpisode(fileType = "audio/mpeg").apply {
+        overrideStreamUrl = "https://example.com/episode.m3u8"
+        overrideStreamContentType = "application/x-mpegURL"
+    }
+}


### PR DESCRIPTION
## Description

Cherry-pick of #5620 and #5627 into `release/8.17`.

> **These changes were already reviewed and merged on `main`.** This PR exists to land them in the upcoming release. CI and a quick review should still run to confirm the cherry-picks apply cleanly and introduce no issues on the release branch, since `release/8.17` may have diverged from `main`.

- Original PRs: https://github.com/Automattic/pocket-casts-android/pull/5620, https://github.com/Automattic/pocket-casts-android/pull/5627
- Cherry-picked commits: `572f044195` (#5620), `0e4c198b05` (#5627)

The two are bundled because #5627 builds directly on #5620's `StreamVideoState.initialFor` / stream-preference changes in `PlaybackManager` and cannot be cherry-picked independently.

Conflict resolutions (verified: the touched playback files are byte-identical to `main` after applying both commits, so the eventual backmerge stays clean):
- `PlaybackManager.kt` (`audioOnlyModeOrNull`): kept the #5644 version already on the release branch via #5649, matching `main`'s final state.
- `CHANGELOG.md`: both entries moved into the `8.17` section since that is the release they now ship in (on `main` they sit under `8.18`; the backmerge should keep them under `8.17`). The #5628 entry that rode along in the conflict hunk was dropped since #5628 is not part of this cherry-pick.

## Testing Instructions

See the original PRs (https://github.com/Automattic/pocket-casts-android/pull/5620, https://github.com/Automattic/pocket-casts-android/pull/5627) for full testing steps. In addition, verify the changes behave as described on top of `release/8.17`. `StreamVideoStateTest` and `spotlessCheck` pass locally on this branch.
