### PR TITLE
Refine fingerprinting mechanism (cherry-pick to 8.17)

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/nowplaying/EpisodeTitles.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/nowplaying/EpisodeTitles.kt
@@ -126,7 +126,7 @@ private fun Content(
         ) {
             if (state.isChaptersPresent) {
                 ChapterPreviousButton(
-                    enabled = !state.isFirstChapter && !isResolvingPrevious,
+                    enabled = !state.isFirstChapter,
                     alpha = if (state.isFirstChapter) 0.5f else 1f,
                     isResolving = isResolvingPrevious,
                     iconTint = playerColors.contrast01,
@@ -206,7 +206,7 @@ private fun Content(
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
                     ChapterNextButtonWithChapterProgressCircle(
-                        enabled = !state.isLastChapter && !isResolvingNext,
+                        enabled = !state.isLastChapter,
                         alpha = if (state.isLastChapter) 0.5f else 1f,
                         progress = state.chapterProgress,
                         isResolving = isResolvingNext,

--- a/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/TranscriptViewModel.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/TranscriptViewModel.kt
@@ -11,6 +11,7 @@ import au.com.shiftyjelly.pocketcasts.payment.PaymentClient
 import au.com.shiftyjelly.pocketcasts.payment.SubscriptionOffer
 import au.com.shiftyjelly.pocketcasts.payment.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.payment.getOrNull
+import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.ChapterSeekResult
 import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.FingerprintTimingManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
@@ -36,15 +37,18 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.reactive.asFlow
 
@@ -81,6 +85,9 @@ class TranscriptViewModel @AssistedInject constructor(
                     state.copy(isPlusUser = signInState.isSignedInAsPlusOrPatron)
                 }
             }
+        }
+        viewModelScope.launch {
+            playbackManager.userSeeks.collect { activeTapResolve?.cancel() }
         }
         observePlaybackState()
     }
@@ -176,38 +183,79 @@ class TranscriptViewModel @AssistedInject constructor(
         }
     }
 
-    /**
-     * Seeks playback to the tapped transcript [entry]. Returns the playback position (ms) sought
-     * to, or `null` if the entry is untimed, tap-to-seek is unavailable, or no mapping is
-     * available (which tracks a seek failure). The caller uses the returned position to drive the
-     * highlight directly rather than re-deriving it from the (lossy) playback position.
-     */
-    fun seekToTranscriptEntry(entry: TranscriptEntry): Int? {
-        val textEntry = entry as? TranscriptEntry.Text ?: return null
-        if (textEntry.startTimeMs < 0) return null
-        val currentState = _uiState.value
-        if (!currentState.isTapToSeekAvailable) return null
+    sealed interface TapSeekResult {
+        data class Seeked(val positionMs: Int) : TapSeekResult
+        data object Resolving : TapSeekResult
+        data object Unavailable : TapSeekResult
+    }
 
-        val refTimeSec = textEntry.startTimeMs / 1000.0
-        val seekTimeMs = if (currentState.isSyncedActive) {
-            fingerprintTimingManager.playbackTimeMs(forReferenceTime = refTimeSec)
+    /**
+     * Seeks playback to the tapped transcript [entry]. Seeks immediately when the mapping is dense
+     * around the entry; otherwise reports [TapSeekResult.Resolving] and the caller follows up with
+     * [resolveAndSeekToEntry]. The caller uses the returned position to drive the highlight
+     * directly rather than re-deriving it from the (lossy) playback position.
+     */
+    fun seekToTranscriptEntry(entry: TranscriptEntry): TapSeekResult {
+        val textEntry = entry as? TranscriptEntry.Text ?: return TapSeekResult.Unavailable
+        if (textEntry.startTimeMs < 0) return TapSeekResult.Unavailable
+        val currentState = _uiState.value
+        if (!currentState.isTapToSeekAvailable) return TapSeekResult.Unavailable
+
+        val episodeUuid = currentState.transcriptEpisodeUuid ?: return TapSeekResult.Unavailable
+        val densePlayback = if (currentState.isSyncedActive) {
+            fingerprintTimingManager.densePlaybackTime(episodeUuid, textEntry.startTimeMs.milliseconds)
         } else {
             null
         }
-        if (seekTimeMs == null) {
-            track { source, podcastUuid, episodeUuid ->
-                SyncedTranscriptsSeekFailedEvent(
-                    reason = "mapping_unavailable",
-                    syncedState = currentState.syncedState.analyticsName(),
-                    podcastUuid = podcastUuid,
-                    episodeUuid = episodeUuid,
-                    source = source,
-                )
-            }
-            notifyTapToSeekUnavailable(currentState.syncedState)
-            return null
-        }
+        if (densePlayback == null) return TapSeekResult.Resolving
 
+        val seekTimeMs = densePlayback.inWholeMilliseconds.toInt()
+        performTapSeek(seekTimeMs)
+        return TapSeekResult.Seeked(seekTimeMs)
+    }
+
+    private var activeTapResolve: Job? = null
+
+    /**
+     * Bounded on-demand resolve for entries outside the dense mapping, mirroring generated chapter
+     * seeks. Returns the playback position (ms) sought to, or `null` when the resolve failed
+     * (which tracks a seek failure). Last tap wins.
+     */
+    suspend fun resolveAndSeekToEntry(entry: TranscriptEntry): Int? {
+        val textEntry = entry as? TranscriptEntry.Text ?: return null
+        val currentState = _uiState.value
+        val episodeUuid = currentState.transcriptEpisodeUuid ?: return null
+
+        val myJob = currentCoroutineContext().job
+        activeTapResolve?.takeIf { it !== myJob }?.cancel()
+        activeTapResolve = myJob
+        try {
+            val episode = episodeManager.findByUuid(episodeUuid)
+            if (episode == null) {
+                trackSeekFailed("episode_not_found", currentState.syncedState)
+                return null
+            }
+            val result = fingerprintTimingManager.resolvePlaybackTime(episode, textEntry.startTimeMs.milliseconds)
+            return when (result) {
+                is ChapterSeekResult.Resolved -> {
+                    // Resolving can take seconds; drop the seek if the episode changed meanwhile.
+                    if (playbackManager.getCurrentEpisode()?.uuid != episodeUuid) return null
+                    val seekTimeMs = result.playbackTime.inWholeMilliseconds.toInt()
+                    performTapSeek(seekTimeMs)
+                    seekTimeMs
+                }
+
+                is ChapterSeekResult.Unresolved -> {
+                    trackSeekFailed(result.reason, currentState.syncedState)
+                    null
+                }
+            }
+        } finally {
+            if (activeTapResolve === myJob) activeTapResolve = null
+        }
+    }
+
+    private fun performTapSeek(seekTimeMs: Int) {
         val fromPositionSeconds = currentPlaybackPositionMs / 1000L
         playbackManager.seekToTimeMs(seekTimeMs)
         track { source, podcastUuid, episodeUuid ->
@@ -219,7 +267,19 @@ class TranscriptViewModel @AssistedInject constructor(
                 source = source,
             )
         }
-        return seekTimeMs
+    }
+
+    private fun trackSeekFailed(reason: String, syncedState: FingerprintTimingManager.State) {
+        track { source, podcastUuid, episodeUuid ->
+            SyncedTranscriptsSeekFailedEvent(
+                reason = reason,
+                syncedState = syncedState.analyticsName(),
+                podcastUuid = podcastUuid,
+                episodeUuid = episodeUuid,
+                source = source,
+            )
+        }
+        notifyTapToSeekUnavailable(syncedState)
     }
 
     // Prompt to download only when it could help, not if already downloaded or sync is unavailable.

--- a/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptPage.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptPage.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.withFrameNanos
@@ -124,17 +125,42 @@ fun TranscriptPage(
                     .weight(1f)
                     .fillMaxWidth(),
             ) {
+                val tapScope = rememberCoroutineScope()
                 val tapToSeekHandler: ((TranscriptEntry, Int) -> Unit)? =
                     if (FeatureFlag.isEnabled(Feature.SYNCED_TRANSCRIPTS) && uiState.isTapToSeekAvailable && viewModel != null) {
                         { entry, index ->
-                            val seekTarget = viewModel.seekToTranscriptEntry(entry)
-                            if (seekTarget != null) {
+                            val applySeek = { seekTarget: Int ->
                                 // Hold the tapped row lit until fingerprinting catches up to the seek.
                                 highlightState = HighlightState(entryIndex = index)
                                 pendingSeek = PendingTapSeek(positionMs = seekTarget, entryIndex = index)
                                 if (!isPlaying) {
                                     forceScrollIndex = index
                                 }
+                            }
+                            when (val result = viewModel.seekToTranscriptEntry(entry)) {
+                                is TranscriptViewModel.TapSeekResult.Seeked -> applySeek(result.positionMs)
+
+                                TranscriptViewModel.TapSeekResult.Resolving -> {
+                                    // Light the row as immediate feedback while the bounded resolve runs.
+                                    val previousHighlight = highlightState
+                                    highlightState = HighlightState(entryIndex = index)
+                                    tapScope.launch {
+                                        var seekTarget: Int? = null
+                                        try {
+                                            seekTarget = viewModel.resolveAndSeekToEntry(entry)
+                                        } finally {
+                                            // Also restores the highlight when a user seek cancels the resolve.
+                                            val target = seekTarget
+                                            if (target != null) {
+                                                applySeek(target)
+                                            } else if (highlightState.entryIndex == index) {
+                                                highlightState = previousHighlight
+                                            }
+                                        }
+                                    }
+                                }
+
+                                TranscriptViewModel.TapSeekResult.Unavailable -> Unit
                             }
                         }
                     } else {

--- a/modules/features/transcripts/src/test/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/TranscriptViewModelTest.kt
+++ b/modules/features/transcripts/src/test/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/TranscriptViewModelTest.kt
@@ -10,6 +10,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.EpisodeDownloadStatus
 import au.com.shiftyjelly.pocketcasts.models.type.SignInState
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.payment.PaymentClient
+import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.ChapterSeekResult
 import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.FingerprintTimingManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
@@ -26,11 +27,16 @@ import com.automattic.eventhorizon.SyncedTranscriptsSeekFailedEvent
 import com.automattic.eventhorizon.SyncedTranscriptsSeekUsedEvent
 import com.automattic.eventhorizon.TranscriptSourceType
 import java.util.Date
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.rx2.asFlowable
 import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.yield
 import org.junit.Assert.assertEquals
@@ -43,6 +49,8 @@ import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doSuspendableAnswer
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -63,8 +71,10 @@ class TranscriptViewModelTest {
         on { state } doReturn FingerprintTimingManager.State.Idle
         on { stateFlow } doReturn syncedStateFlow
     }
+    private val userSeeksFlow = MutableSharedFlow<Unit>()
     private val playbackManager = mock<PlaybackManager> {
         on { playbackStateFlow } doReturn playbackStateFlow
+        on { userSeeks } doReturn userSeeksFlow
     }
     private val episodeManager = mock<EpisodeManager>()
 
@@ -318,7 +328,7 @@ class TranscriptViewModelTest {
     fun `track synced transcript seek used event`() = runTest {
         setUpTapToSeek()
         whenever(fingerprintTimingManager.state).thenReturn(FingerprintTimingManager.State.Active(coverage = 1))
-        whenever(fingerprintTimingManager.playbackTimeMs(any())).thenReturn(20_000)
+        whenever(fingerprintTimingManager.densePlaybackTime(any(), any())).thenReturn(20.seconds)
         syncedStateFlow.value = FingerprintTimingManager.State.Active(coverage = 1)
 
         awaitTapToSeekAvailable()
@@ -326,7 +336,7 @@ class TranscriptViewModelTest {
 
         val seekTarget = viewModel.seekToTranscriptEntry(TranscriptEntry.Text("Line", startTimeMs = 30_000))
 
-        assertEquals(20_000, seekTarget)
+        assertEquals(TranscriptViewModel.TapSeekResult.Seeked(20_000), seekTarget)
         assertEquals(
             SyncedTranscriptsSeekUsedEvent(
                 fromPositionSeconds = 10L,
@@ -342,22 +352,25 @@ class TranscriptViewModelTest {
     @Test
     fun `track synced transcript seek failed event when preparing`() = runTest {
         setUpTapToSeek()
+        whenever(episodeManager.findByUuid("episode-uuid")).thenReturn(PodcastEpisode(uuid = "episode-uuid", publishedDate = Date(), podcastUuid = "podcast-uuid"))
+        whenever(fingerprintTimingManager.resolvePlaybackTime(any(), any()))
+            .thenReturn(ChapterSeekResult.Unresolved(ChapterSeekResult.REASON_NO_MATCH))
         syncedStateFlow.value = FingerprintTimingManager.State.Preparing
 
         awaitTapToSeekAvailable()
         drainEvents()
 
         viewModel.messages.test {
-            val seekTarget = viewModel.seekToTranscriptEntry(TranscriptEntry.Text("Line", startTimeMs = 30_000))
-
-            assertNull(seekTarget)
+            val entry = TranscriptEntry.Text("Line", startTimeMs = 30_000)
+            assertEquals(TranscriptViewModel.TapSeekResult.Resolving, viewModel.seekToTranscriptEntry(entry))
+            assertNull(viewModel.resolveAndSeekToEntry(entry))
             assertEquals(
                 SyncedTranscriptsSeekFailedEvent(
-                    reason = "mapping_unavailable",
+                    reason = "no_match",
                     syncedState = "preparing",
                     source = TranscriptSourceType.Player,
                     episodeUuid = "episode-uuid",
-                    podcastUuid = AnalyticsTracker.INVALID_OR_NULL_VALUE,
+                    podcastUuid = "podcast-uuid",
                 ),
                 eventSink.pollEvent(),
             )
@@ -367,8 +380,60 @@ class TranscriptViewModelTest {
     }
 
     @Test
+    fun `resolve and seek follows a bounded resolve outside the dense mapping`() = runTest {
+        setUpTapToSeek()
+        whenever(episodeManager.findByUuid("episode-uuid")).thenReturn(PodcastEpisode(uuid = "episode-uuid", publishedDate = Date(), podcastUuid = "podcast-uuid"))
+        whenever(fingerprintTimingManager.resolvePlaybackTime(any(), any()))
+            .thenReturn(ChapterSeekResult.Resolved(playbackTime = 45.seconds, usedPrior = false))
+        syncedStateFlow.value = FingerprintTimingManager.State.Preparing
+
+        awaitTapToSeekAvailable()
+        drainEvents()
+
+        val entry = TranscriptEntry.Text("Line", startTimeMs = 30_000)
+        assertEquals(TranscriptViewModel.TapSeekResult.Resolving, viewModel.seekToTranscriptEntry(entry))
+        assertEquals(45_000, viewModel.resolveAndSeekToEntry(entry))
+
+        verify(playbackManager).seekToTimeMs(eq(45_000), anyOrNull())
+        assertEquals(
+            SyncedTranscriptsSeekUsedEvent(
+                fromPositionSeconds = 10L,
+                toPositionSeconds = 45L,
+                source = TranscriptSourceType.Player,
+                episodeUuid = "episode-uuid",
+                podcastUuid = "podcast-uuid",
+            ),
+            eventSink.pollEvent(),
+        )
+    }
+
+    @Test
+    fun `user seek cancels an active tap resolve`() = runTest {
+        setUpTapToSeek()
+        whenever(episodeManager.findByUuid("episode-uuid")).thenReturn(PodcastEpisode(uuid = "episode-uuid", publishedDate = Date(), podcastUuid = "podcast-uuid"))
+        whenever(fingerprintTimingManager.resolvePlaybackTime(any(), any())).doSuspendableAnswer { awaitCancellation() }
+        syncedStateFlow.value = FingerprintTimingManager.State.Preparing
+
+        awaitTapToSeekAvailable()
+        drainEvents()
+
+        val entry = TranscriptEntry.Text("Line", startTimeMs = 30_000)
+        val resolveJob = launch { viewModel.resolveAndSeekToEntry(entry) }
+        runCurrent()
+
+        userSeeksFlow.emit(Unit)
+        resolveJob.join()
+
+        assertTrue(resolveJob.isCancelled)
+        verify(playbackManager, never()).seekToTimeMs(any(), anyOrNull())
+    }
+
+    @Test
     fun `track synced transcript seek failed event when failed`() = runTest {
         setUpTapToSeek()
+        whenever(episodeManager.findByUuid("episode-uuid")).thenReturn(PodcastEpisode(uuid = "episode-uuid", publishedDate = Date(), podcastUuid = "podcast-uuid"))
+        whenever(fingerprintTimingManager.resolvePlaybackTime(any(), any()))
+            .thenReturn(ChapterSeekResult.Unresolved(ChapterSeekResult.REASON_NO_MATCH))
         syncedStateFlow.value = FingerprintTimingManager.State.Failed(
             RuntimeException("no match"),
             episodeUuid = "episode-uuid",
@@ -378,16 +443,16 @@ class TranscriptViewModelTest {
         drainEvents()
 
         viewModel.messages.test {
-            val seekTarget = viewModel.seekToTranscriptEntry(TranscriptEntry.Text("Line", startTimeMs = 30_000))
-
-            assertNull(seekTarget)
+            val entry = TranscriptEntry.Text("Line", startTimeMs = 30_000)
+            assertEquals(TranscriptViewModel.TapSeekResult.Resolving, viewModel.seekToTranscriptEntry(entry))
+            assertNull(viewModel.resolveAndSeekToEntry(entry))
             assertEquals(
                 SyncedTranscriptsSeekFailedEvent(
-                    reason = "mapping_unavailable",
+                    reason = "no_match",
                     syncedState = "failed",
                     source = TranscriptSourceType.Player,
                     episodeUuid = "episode-uuid",
-                    podcastUuid = AnalyticsTracker.INVALID_OR_NULL_VALUE,
+                    podcastUuid = "podcast-uuid",
                 ),
                 eventSink.pollEvent(),
             )
@@ -398,22 +463,25 @@ class TranscriptViewModelTest {
     @Test
     fun `track synced transcript seek failed event without message when unavailable`() = runTest {
         setUpTapToSeek()
+        whenever(episodeManager.findByUuid("episode-uuid")).thenReturn(PodcastEpisode(uuid = "episode-uuid", publishedDate = Date(), podcastUuid = "podcast-uuid"))
+        whenever(fingerprintTimingManager.resolvePlaybackTime(any(), any()))
+            .thenReturn(ChapterSeekResult.Unresolved(ChapterSeekResult.REASON_NO_REFERENCE))
         syncedStateFlow.value = FingerprintTimingManager.State.Unavailable(episodeUuid = "episode-uuid")
 
         awaitTapToSeekAvailable()
         drainEvents()
 
         viewModel.messages.test {
-            val seekTarget = viewModel.seekToTranscriptEntry(TranscriptEntry.Text("Line", startTimeMs = 30_000))
-
-            assertNull(seekTarget)
+            val entry = TranscriptEntry.Text("Line", startTimeMs = 30_000)
+            assertEquals(TranscriptViewModel.TapSeekResult.Resolving, viewModel.seekToTranscriptEntry(entry))
+            assertNull(viewModel.resolveAndSeekToEntry(entry))
             assertEquals(
                 SyncedTranscriptsSeekFailedEvent(
-                    reason = "mapping_unavailable",
+                    reason = "no_reference",
                     syncedState = "unavailable",
                     source = TranscriptSourceType.Player,
                     episodeUuid = "episode-uuid",
-                    podcastUuid = AnalyticsTracker.INVALID_OR_NULL_VALUE,
+                    podcastUuid = "podcast-uuid",
                 ),
                 eventSink.pollEvent(),
             )
@@ -431,18 +499,20 @@ class TranscriptViewModelTest {
             downloadStatus = EpisodeDownloadStatus.Downloaded,
         )
         whenever(episodeManager.findByUuid("episode-uuid")).thenReturn(episode)
+        whenever(fingerprintTimingManager.resolvePlaybackTime(any(), any()))
+            .thenReturn(ChapterSeekResult.Unresolved(ChapterSeekResult.REASON_NO_MATCH))
         syncedStateFlow.value = FingerprintTimingManager.State.Preparing
 
         awaitTapToSeekAvailable()
         drainEvents()
 
         viewModel.messages.test {
-            val seekTarget = viewModel.seekToTranscriptEntry(TranscriptEntry.Text("Line", startTimeMs = 30_000))
-
-            assertNull(seekTarget)
+            val entry = TranscriptEntry.Text("Line", startTimeMs = 30_000)
+            assertEquals(TranscriptViewModel.TapSeekResult.Resolving, viewModel.seekToTranscriptEntry(entry))
+            assertNull(viewModel.resolveAndSeekToEntry(entry))
             assertEquals(
                 SyncedTranscriptsSeekFailedEvent(
-                    reason = "mapping_unavailable",
+                    reason = "no_match",
                     syncedState = "preparing",
                     source = TranscriptSourceType.Player,
                     episodeUuid = "episode-uuid",
@@ -465,7 +535,7 @@ class TranscriptViewModelTest {
 
         val seekTarget = viewModel.seekToTranscriptEntry(TranscriptEntry.Text("Line", startTimeMs = 30_000))
 
-        assertNull(seekTarget)
+        assertEquals(TranscriptViewModel.TapSeekResult.Unavailable, seekTarget)
         assertTrue(eventSink.isEmpty())
         verify(playbackManager, never()).seekToTimeMs(any(), anyOrNull())
     }
@@ -481,7 +551,7 @@ class TranscriptViewModelTest {
 
         val seekTarget = viewModel.seekToTranscriptEntry(TranscriptEntry.Text("Line", startTimeMs = 30_000))
 
-        assertNull(seekTarget)
+        assertEquals(TranscriptViewModel.TapSeekResult.Unavailable, seekTarget)
         assertTrue(eventSink.isEmpty())
     }
 
@@ -496,7 +566,7 @@ class TranscriptViewModelTest {
 
         val seekTarget = viewModel.seekToTranscriptEntry(TranscriptEntry.Text("Line", startTimeMs = 30_000))
 
-        assertNull(seekTarget)
+        assertEquals(TranscriptViewModel.TapSeekResult.Unavailable, seekTarget)
         assertTrue(eventSink.isEmpty())
     }
 
@@ -508,8 +578,8 @@ class TranscriptViewModelTest {
         awaitTapToSeekAvailable()
         drainEvents()
 
-        assertNull(viewModel.seekToTranscriptEntry(TranscriptEntry.Speaker("Speaker")))
-        assertNull(viewModel.seekToTranscriptEntry(TranscriptEntry.Text("Line", startTimeMs = -1)))
+        assertEquals(TranscriptViewModel.TapSeekResult.Unavailable, viewModel.seekToTranscriptEntry(TranscriptEntry.Speaker("Speaker")))
+        assertEquals(TranscriptViewModel.TapSeekResult.Unavailable, viewModel.seekToTranscriptEntry(TranscriptEntry.Text("Line", startTimeMs = -1)))
         assertTrue(eventSink.isEmpty())
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/ChapterSeekResult.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/ChapterSeekResult.kt
@@ -10,6 +10,7 @@ sealed interface ChapterSeekResult {
         const val REASON_TIMEOUT = "timeout"
         const val REASON_NO_AUDIO_SOURCE = "no_audio_source"
         const val REASON_NO_REFERENCE = "no_reference"
+        const val REASON_REFERENCE_FETCH_FAILED = "reference_fetch_failed"
         const val REASON_AUDIO_UNAVAILABLE = "audio_unavailable"
         const val REASON_NO_MATCH = "no_match"
         const val REASON_METERED_NETWORK = "metered_network"

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintConstants.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintConstants.kt
@@ -73,6 +73,18 @@ object FingerprintConstants {
     /** Minimum committed anchors for an on-demand resolve to be trusted. */
     const val ON_DEMAND_MIN_ANCHORS = 2
 
-    /** Hard timeout for an on-demand chapter resolve. */
+    /** Timeout for the reference fetch of an on-demand resolve; short because reference files are small. */
+    const val ON_DEMAND_FETCH_TIMEOUT_MS = 3_000L
+
+    /** Timeout for the decode of an on-demand resolve. */
     const val ON_DEMAND_TIMEOUT_MS = 5_000L
+
+    /** Committed reference time must pass the target by this much before a resolve stops decoding early. */
+    const val ON_DEMAND_EARLY_EXIT_MARGIN_SECONDS = 5.0
+
+    /** How often a yielded continuous decode re-checks for on-demand resolves in flight. */
+    const val RESOLVE_YIELD_POLL_MS = 250L
+
+    /** Release a parked throttled decode after playback has been idle this long. */
+    const val PARKED_DECODE_RELEASE_MS = 120_000L
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintReferenceRetriever.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintReferenceRetriever.kt
@@ -11,11 +11,12 @@ import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.coroutines.coroutineContext
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.sync.Mutex
@@ -30,14 +31,23 @@ class FingerprintReferenceRetriever @Inject constructor(
     @NoCache private val okHttpClient: OkHttpClient,
     @ApplicationContext private val context: Context,
 ) {
-    private val inFlightRequests = mutableMapOf<String, Deferred<ByteArray?>>()
+    sealed interface FetchResult {
+        class Success(val data: ByteArray) : FetchResult
+        data object NotFound : FetchResult
+        data object Error : FetchResult
+    }
+
+    private val fetchScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val inFlightRequests = mutableMapOf<String, Deferred<FetchResult>>()
     private val requestMutex = Mutex()
 
+    // The shared fetch runs in the retriever's own scope, so cancelling one awaiting caller
+    // cannot cancel the request out from under another.
     suspend fun fetchReferenceData(
         baseUrl: String,
         podcastUuid: String,
         episodeUuid: String,
-    ): ByteArray? = coroutineScope {
+    ): FetchResult {
         val key = "$podcastUuid/$episodeUuid"
 
         val deferred = requestMutex.withLock {
@@ -45,7 +55,7 @@ class FingerprintReferenceRetriever @Inject constructor(
             if (existing != null && existing.isActive) {
                 existing
             } else {
-                async {
+                fetchScope.async {
                     try {
                         performFetch(baseUrl, podcastUuid, episodeUuid)
                     } finally {
@@ -54,14 +64,14 @@ class FingerprintReferenceRetriever @Inject constructor(
                 }.also { inFlightRequests[key] = it }
             }
         }
-        deferred.await()
+        return deferred.await()
     }
 
     private suspend fun performFetch(
         baseUrl: String,
         podcastUuid: String,
         episodeUuid: String,
-    ): ByteArray? = withContext(Dispatchers.IO) {
+    ): FetchResult = withContext(Dispatchers.IO) {
         val url = "${baseUrl}$podcastUuid/$episodeUuid-fingerprints.json.gz"
 
         for (attempt in 0 until MAX_RETRIES) {
@@ -79,7 +89,7 @@ class FingerprintReferenceRetriever @Inject constructor(
 
                     if (statusCode == 404 || statusCode == 403) {
                         Timber.d("FingerprintReferenceRetriever: no reference for $episodeUuid ($statusCode)")
-                        return@withContext null
+                        return@withContext FetchResult.NotFound
                     }
 
                     if (statusCode != 200) {
@@ -88,25 +98,25 @@ class FingerprintReferenceRetriever @Inject constructor(
                             continue
                         }
                         Timber.w("FingerprintReferenceRetriever: unexpected status $statusCode for $episodeUuid")
-                        return@withContext null
+                        return@withContext FetchResult.Error
                     }
 
                     val body = response.body.bytes()
                     val jsonData = decompressGzipIfNeeded(body)
 
                     Timber.d("FingerprintReferenceRetriever: reference fetched for $episodeUuid (${jsonData.size} bytes)")
-                    return@withContext jsonData
+                    return@withContext FetchResult.Success(jsonData)
                 }
             } catch (e: CancellationException) {
                 throw e
             } catch (e: IOException) {
                 Timber.w("FingerprintReferenceRetriever: fetch failed for $episodeUuid, attempt ${attempt + 1}/$MAX_RETRIES — ${e.message}")
-                if (attempt == MAX_RETRIES - 1) return@withContext null
+                if (attempt == MAX_RETRIES - 1) return@withContext FetchResult.Error
             }
         }
 
         Timber.w("FingerprintReferenceRetriever: exhausted retries for $episodeUuid")
-        null
+        FetchResult.Error
     }
 
     suspend fun saveReferenceData(data: ByteArray, audioFilePath: String) = withContext(Dispatchers.IO) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
@@ -29,8 +29,10 @@ import com.automattic.eventhorizon.SyncedTranscriptsUnavailableEvent
 import dagger.Lazy
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.File
+import java.io.IOException
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
+import java.util.concurrent.atomic.AtomicInteger
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.math.abs
@@ -51,6 +53,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -120,6 +123,7 @@ class FingerprintTimingManager @Inject constructor(
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     private val decodeDispatcher = Dispatchers.IO.limitedParallelism(1)
     private val mutex = Mutex()
+    private val activeResolves = AtomicInteger(0)
 
     // Mapping state: writers mutate the accumulator under mutex, then atomically publish via @Volatile.
     // Readers access the snapshot without locking, safe for use from the UI thread.
@@ -170,14 +174,19 @@ class FingerprintTimingManager @Inject constructor(
     private var currentDurationSec: Double = 0.0
     private var currentReferenceData: ByteArray? = null
     private var currentReferenceFilePath: String? = null
-    private var currentReferenceDuration: Double = 0.0
+    private var currentReference: ReferenceFingerprint? = null
     private var currentMatcher: CheckpointMatcher? = null
     private var hasReachedActive = false
     private var hasTrackedFailure = false
 
     // Analytics context for the current preparation.
     private var preparationStartMs: Long = 0
+
+    @Volatile
     private var currentIsStreaming: Boolean = false
+
+    @Volatile
+    private var lastProgressAtMs = 0L
 
     // When true, decode the whole stream from the start ignoring the playhead lookahead throttle,
     // so the full reference<->playback map is available for chapter alignment.
@@ -197,6 +206,9 @@ class FingerprintTimingManager @Inject constructor(
                 if (state.isPlaying && !uuid.isNullOrEmpty() && uuid != lastEpisodeUuid) {
                     lastEpisodeUuid = uuid
                     prepareForCurrentEpisode(PrepareTrigger.PLAYBACK)
+                } else if (lastEpisodeUuid != null && (state.isEmpty || state.isStopped)) {
+                    lastEpisodeUuid = null
+                    stop()
                 }
             }
         }
@@ -221,8 +233,10 @@ class FingerprintTimingManager @Inject constructor(
         scope.launch {
             val gen: Long
             mutex.withLock {
-                // Already prepared for this episode — reuse existing state.
-                if (currentEpisodeUuid == episodeUuid && state !is State.Idle) {
+                // Already prepared for this episode — reuse existing state. A failed preparation may
+                // retry when the user opens the transcript, since the failure could be transient.
+                val retryableFailure = trigger == PrepareTrigger.TRANSCRIPT_VIEW && state is State.Failed
+                if (currentEpisodeUuid == episodeUuid && state !is State.Idle && !retryableFailure) {
                     if (trigger == PrepareTrigger.TRANSCRIPT_VIEW) {
                         currentTrigger = trigger
                     }
@@ -244,9 +258,28 @@ class FingerprintTimingManager @Inject constructor(
         progressObserverJob = scope.launch {
             playbackManager.playbackStateFlow.collect { state ->
                 if (state.episodeUuid == episodeUuid && state.isPlaying) {
+                    maybeAdoptDownloadedCopy(episodeUuid)
                     onPlaybackProgress(state.positionMs, state.episodeUuid)
                 }
             }
+        }
+    }
+
+    /** A finished download supersedes streaming: local decode is cheaper and unlocks the eager pass. */
+    private fun maybeAdoptDownloadedCopy(episodeUuid: String) {
+        if (!currentIsStreaming) return
+        val episode = playbackManager.getCurrentEpisode() ?: return
+        if (episode.uuid != episodeUuid || !episode.isDownloaded) return
+        scope.launch {
+            val trigger = currentTrigger
+            mutex.withLock {
+                if (currentEpisodeUuid != episodeUuid || !currentIsStreaming) return@launch
+                generation++
+                resetState()
+                _stateFlow.value = State.Idle
+            }
+            Timber.d("FingerprintTimingManager: episode finished downloading — switching to local file")
+            prepareForCurrentEpisode(trigger)
         }
     }
 
@@ -282,22 +315,7 @@ class FingerprintTimingManager @Inject constructor(
      */
     fun densePlaybackTime(episodeUuid: String, referenceTime: Duration): Duration? {
         if (activeEpisodeUuid != episodeUuid) return null
-        val entries = snapshotReferenceToPlayback
-        val referenceTimeSec = referenceTime.toDouble(DurationUnit.SECONDS)
-        var lo = 0
-        var hi = entries.size
-        while (lo < hi) {
-            val mid = (lo + hi) / 2
-            if (entries[mid].referenceTime <= referenceTimeSec) lo = mid + 1 else hi = mid
-        }
-        if (hi - 1 < 0 || hi >= entries.size) return null
-        if (entries[hi].referenceTime - entries[hi - 1].referenceTime > FingerprintConstants.HIGHLIGHT_MAX_GAP_SECONDS) return null
-        val playback = interpolate(
-            time = referenceTimeSec,
-            entries = entries,
-            keySelector = { it.referenceTime },
-            valueSelector = { it.playbackTime },
-        ) ?: return null
+        val playback = densePlaybackSec(referenceTime.toDouble(DurationUnit.SECONDS), snapshotReferenceToPlayback) ?: return null
         return playback.seconds
     }
 
@@ -306,20 +324,19 @@ class FingerprintTimingManager @Inject constructor(
      * Decodes only a small search window around the expected location, matches into a scratch
      * accumulator, and never touches the continuous mapping or the public state.
      */
-    suspend fun resolveChapterPlaybackTime(episode: BaseEpisode, referenceTime: Duration): ChapterSeekResult {
+    suspend fun resolvePlaybackTime(episode: BaseEpisode, referenceTime: Duration): ChapterSeekResult {
         val audioSource = episode.downloadedFilePath
             ?: episode.downloadUrl
             ?: return ChapterSeekResult.Unresolved(ChapterSeekResult.REASON_NO_AUDIO_SOURCE)
-        return withContext(Dispatchers.Default) {
-            withTimeoutOrNull(FingerprintConstants.ON_DEMAND_TIMEOUT_MS) {
-                performResolve(
-                    episodeUuid = episode.uuid,
-                    podcastUuid = episode.podcastOrSubstituteUuid,
-                    audioSource = audioSource,
-                    isDownloaded = episode.isDownloaded,
-                    referenceTimeSec = referenceTime.toDouble(DurationUnit.SECONDS),
-                )
-            } ?: ChapterSeekResult.Unresolved(ChapterSeekResult.REASON_TIMEOUT)
+        // Resolves block on codec dequeues and network reads, so keep them off the Default pool.
+        return withContext(Dispatchers.IO) {
+            performResolve(
+                episodeUuid = episode.uuid,
+                podcastUuid = episode.podcastOrSubstituteUuid,
+                audioSource = audioSource,
+                isDownloaded = episode.isDownloaded,
+                referenceTimeSec = referenceTime.toDouble(DurationUnit.SECONDS),
+            )
         }
     }
 
@@ -340,10 +357,12 @@ class FingerprintTimingManager @Inject constructor(
             return ChapterSeekResult.Unresolved(ChapterSeekResult.REASON_METERED_NETWORK)
         }
         var estimatedPlayback: Double? = null
-        var warmReferenceData: ByteArray? = null
+        var warmReference: ReferenceFingerprint? = null
+        var sharedCacheKey: String? = null
         mutex.withLock {
             if (currentEpisodeUuid == episodeUuid) {
-                warmReferenceData = currentReferenceData
+                warmReference = currentReference
+                sharedCacheKey = currentSharedCacheKey
                 estimatedPlayback = interpolate(
                     time = referenceTimeSec,
                     entries = snapshotReferenceToPlayback,
@@ -354,36 +373,58 @@ class FingerprintTimingManager @Inject constructor(
         }
         val usedPrior = estimatedPlayback != null
 
-        val referenceData = warmReferenceData
-            ?: loadOrFetchReferenceData(podcastUuid, episodeUuid, audioSource, isDownloaded)
-            ?: return ChapterSeekResult.Unresolved(ChapterSeekResult.REASON_NO_REFERENCE)
+        // The fetch and the decode get separate budgets, so a slow reference download can't eat the decode time.
+        // Only a definitive 404 reports the reference as missing; transient fetch failures stay retryable.
+        val reference = warmReference ?: run {
+            val fetched = withTimeoutOrNull(FingerprintConstants.ON_DEMAND_FETCH_TIMEOUT_MS) {
+                loadOrFetchReferenceData(podcastUuid, episodeUuid, audioSource, isDownloaded)
+            } ?: return ChapterSeekResult.Unresolved(ChapterSeekResult.REASON_TIMEOUT)
+            val referenceData = when (fetched) {
+                is FingerprintReferenceRetriever.FetchResult.Success -> fetched.data
 
-        val reference = ReferenceFingerprint.decode(referenceData)
-            ?: return ChapterSeekResult.Unresolved(ChapterSeekResult.REASON_NO_REFERENCE)
+                is FingerprintReferenceRetriever.FetchResult.NotFound ->
+                    return ChapterSeekResult.Unresolved(ChapterSeekResult.REASON_NO_REFERENCE)
+
+                is FingerprintReferenceRetriever.FetchResult.Error ->
+                    return ChapterSeekResult.Unresolved(ChapterSeekResult.REASON_REFERENCE_FETCH_FAILED)
+            }
+            ReferenceFingerprint.decode(referenceData)
+                ?: return ChapterSeekResult.Unresolved(ChapterSeekResult.REASON_NO_REFERENCE)
+        }
         val matcher = buildMatcher(reference)
             ?: return ChapterSeekResult.Unresolved(ChapterSeekResult.REASON_NO_REFERENCE)
 
         val window = searchWindow(referenceTimeSec, estimatedPlayback)
         val acc = MappingAccumulator()
-        try {
+        activeResolves.incrementAndGet()
+        val timedOut = try {
             matcher.use {
-                streamFingerprintBounded(
-                    audioFilePath = audioSource,
-                    matcher = it,
-                    startingAt = alignToWindowGrid(window.startSec),
-                    endingAt = window.endSec,
-                    acc = acc,
-                )
+                withTimeoutOrNull(FingerprintConstants.ON_DEMAND_TIMEOUT_MS) {
+                    streamFingerprintBounded(
+                        audioFilePath = audioSource,
+                        matcher = it,
+                        startingAt = alignToWindowGrid(window.startSec),
+                        endingAt = window.endSec,
+                        targetReferenceSec = referenceTimeSec,
+                        acc = acc,
+                        cacheKey = sharedCacheKey,
+                    )
+                } == null
             }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
             Timber.w(e, "FingerprintTimingManager: on-demand resolve failed for $episodeUuid")
             return ChapterSeekResult.Unresolved(ChapterSeekResult.REASON_AUDIO_UNAVAILABLE)
+        } finally {
+            activeResolves.decrementAndGet()
         }
 
+        // A timed-out decode may still have committed usable anchors; interpolate from what we have.
         if (acc.playbackToReference.size < FingerprintConstants.ON_DEMAND_MIN_ANCHORS) {
-            return ChapterSeekResult.Unresolved(ChapterSeekResult.REASON_NO_MATCH)
+            return ChapterSeekResult.Unresolved(
+                if (timedOut) ChapterSeekResult.REASON_TIMEOUT else ChapterSeekResult.REASON_NO_MATCH,
+            )
         }
         val playback = interpolate(
             time = referenceTimeSec,
@@ -392,6 +433,8 @@ class FingerprintTimingManager @Inject constructor(
             valueSelector = { it.playbackTime },
         ) ?: return ChapterSeekResult.Unresolved(ChapterSeekResult.REASON_NO_MATCH)
 
+        mergeResolvedAnchors(episodeUuid, acc.playbackToReference)
+
         // The ad offset is non-negative, so the true position is never before the reference time.
         return ChapterSeekResult.Resolved(
             playbackTime = max(referenceTimeSec, playback).seconds,
@@ -399,25 +442,50 @@ class FingerprintTimingManager @Inject constructor(
         )
     }
 
+    /** Resolved anchors passed the same drift filter, so folding them in only densifies the map. */
+    private suspend fun mergeResolvedAnchors(episodeUuid: String, anchors: List<TimeMappingEntry>) {
+        val tolerance = FingerprintConstants.WINDOW_INTERVAL_MS / 2000.0
+        mutex.withLock {
+            if (currentEpisodeUuid != episodeUuid) return
+            var inserted = 0
+            for (anchor in anchors) {
+                if (!mapping.hasAnchorNear(anchor.playbackTime, tolerance)) {
+                    mapping.insert(anchor)
+                    inserted++
+                }
+            }
+            if (inserted > 0) {
+                publishSnapshot()
+                Timber.d("FingerprintTimingManager: merged $inserted resolved anchors into the mapping")
+            }
+        }
+    }
+
     private suspend fun loadOrFetchReferenceData(
         podcastUuid: String,
         episodeUuid: String,
         audioSource: String,
         isDownloaded: Boolean,
-    ): ByteArray? {
+    ): FingerprintReferenceRetriever.FetchResult {
         if (isDownloaded) {
-            referenceRetriever.loadReferenceData(audioSource)?.let { return it }
+            referenceRetriever.loadReferenceData(audioSource)?.let { return FingerprintReferenceRetriever.FetchResult.Success(it) }
+            referenceRetriever.loadCachedReference(episodeUuid)?.let {
+                referenceRetriever.saveReferenceData(it, audioSource)
+                return FingerprintReferenceRetriever.FetchResult.Success(it)
+            }
         } else {
-            referenceRetriever.loadCachedReference(episodeUuid)?.let { return it }
+            referenceRetriever.loadCachedReference(episodeUuid)?.let { return FingerprintReferenceRetriever.FetchResult.Success(it) }
         }
         val baseUrl = "${BuildConfig.SERVER_SHOW_NOTES_URLS}/generated_transcripts/"
-        val data = referenceRetriever.fetchReferenceData(baseUrl, podcastUuid, episodeUuid) ?: return null
-        if (isDownloaded) {
-            referenceRetriever.saveReferenceData(data, audioSource)
-        } else {
-            referenceRetriever.saveCachedReference(episodeUuid, data)
+        val fetched = referenceRetriever.fetchReferenceData(baseUrl, podcastUuid, episodeUuid)
+        if (fetched is FingerprintReferenceRetriever.FetchResult.Success) {
+            if (isDownloaded) {
+                referenceRetriever.saveReferenceData(fetched.data, audioSource)
+            } else {
+                referenceRetriever.saveCachedReference(episodeUuid, fetched.data)
+            }
         }
-        return data
+        return fetched
     }
 
     private fun buildMatcher(reference: ReferenceFingerprint): CheckpointMatcher? {
@@ -439,12 +507,15 @@ class FingerprintTimingManager @Inject constructor(
         matcher: CheckpointMatcher,
         startingAt: Double,
         endingAt: Double,
+        targetReferenceSec: Double,
         acc: MappingAccumulator,
+        cacheKey: String?,
     ) {
         // Capture the current generation so the decode aborts if the episode changes mid-resolve.
         val gen = generation
+        val callerJob = currentCoroutineContext().job
         val isRemoteUrl = audioFilePath.startsWith("http://") || audioFilePath.startsWith("https://")
-        openAudioStream(gen, audioFilePath, startingAt).use { stream ->
+        openAudioStream(gen, audioFilePath, startingAt, cacheKey, followPlayerCache = false, isCallerActive = { callerJob.isActive }).use { stream ->
             stream.start()
 
             val streamer = StreamingWindowedFingerprinter(
@@ -463,6 +534,7 @@ class FingerprintTimingManager @Inject constructor(
                     endingAt = endingAt,
                     throttleToPlayhead = false,
                     trackFrontier = false,
+                    stopWhen = { isResolveTargetCovered(acc, targetReferenceSec) },
                 ) { windows ->
                     matchWindows(windows, matcher, startingAt, acc)
                 }
@@ -646,6 +718,7 @@ class FingerprintTimingManager @Inject constructor(
         debugRejectionsSnapshot = emptyList()
         publishSnapshot()
         lastProgressPositionMs = -1
+        lastProgressAtMs = 0L
         lastStreamStartTimeMs = 0L
         activeDecodeStartSec = 0.0
         activeDecodeFrontierSec = 0.0
@@ -655,7 +728,7 @@ class FingerprintTimingManager @Inject constructor(
         currentDurationSec = 0.0
         currentReferenceData = null
         currentReferenceFilePath = null
-        currentReferenceDuration = 0.0
+        currentReference = null
         currentMatcher?.close()
         currentMatcher = null
         activeEpisodeUuid = null
@@ -752,9 +825,11 @@ class FingerprintTimingManager @Inject constructor(
             ),
         )
 
-        // Try loading cached reference from disk
+        // Try loading cached reference from disk. A reference cached while streaming is still valid
+        // after a download; adopt it into the sidecar instead of refetching.
         val cachedData = if (isDownloaded) {
             referenceRetriever.loadReferenceData(audioSource)
+                ?: referenceRetriever.loadCachedReference(episodeUuid)?.also { referenceRetriever.saveReferenceData(it, audioSource) }
         } else {
             referenceRetriever.loadCachedReference(episodeUuid)
         }
@@ -771,13 +846,25 @@ class FingerprintTimingManager @Inject constructor(
         Timber.d("FingerprintTimingManager: fetching reference from server for $episodeUuid")
 
         val baseUrl = "${BuildConfig.SERVER_SHOW_NOTES_URLS}/generated_transcripts/"
-        val referenceData = referenceRetriever.fetchReferenceData(baseUrl, podcastUuid, episodeUuid)
+        val fetchResult = referenceRetriever.fetchReferenceData(baseUrl, podcastUuid, episodeUuid)
         if (gen != generation) return
 
-        if (referenceData == null) {
-            markUnavailable(reason = "no_reference", isStreaming = !isDownloaded, episodeUuid = episodeUuid)
-            Timber.d("FingerprintTimingManager: no reference available for $episodeUuid")
-            return
+        val referenceData = when (fetchResult) {
+            is FingerprintReferenceRetriever.FetchResult.Success -> fetchResult.data
+
+            is FingerprintReferenceRetriever.FetchResult.NotFound -> {
+                markUnavailable(reason = "no_reference", isStreaming = !isDownloaded, episodeUuid = episodeUuid)
+                Timber.d("FingerprintTimingManager: no reference available for $episodeUuid")
+                return
+            }
+
+            // A transient fetch failure marks Failed rather than Unavailable, so reopening the
+            // transcript can retry it.
+            is FingerprintReferenceRetriever.FetchResult.Error -> {
+                markFailed(IOException("reference fetch failed"), stage = "reference_fetch")
+                Timber.d("FingerprintTimingManager: reference fetch failed for $episodeUuid")
+                return
+            }
         }
 
         val reference = ReferenceFingerprint.decode(referenceData)
@@ -827,7 +914,7 @@ class FingerprintTimingManager @Inject constructor(
             }
             currentReferenceData = referenceData
             currentReferenceFilePath = refPath
-            currentReferenceDuration = reference.totalDuration
+            currentReference = reference
             currentMatcher = matcher
             _stateFlow.value = State.Preparing
             if (cached != null) {
@@ -852,6 +939,7 @@ class FingerprintTimingManager @Inject constructor(
     private fun onPlaybackProgress(positionMs: Int, episodeUuid: String?) {
         if (episodeUuid != currentEpisodeUuid) return
 
+        lastProgressAtMs = SystemClock.elapsedRealtime()
         scope.launch {
             mutex.withLock {
                 processProgress(positionMs)
@@ -1014,22 +1102,50 @@ class FingerprintTimingManager @Inject constructor(
         }
     }
 
-    private fun openAudioStream(gen: Long, audioFilePath: String, startingAt: Double): AudioStream {
+    private fun openAudioStream(
+        gen: Long,
+        audioFilePath: String,
+        startingAt: Double,
+        sharedCacheKey: String?,
+        followPlayerCache: Boolean = true,
+        isCallerActive: () -> Boolean = { true },
+    ): AudioStream {
         val isRemoteUrl = audioFilePath.startsWith("http://") || audioFilePath.startsWith("https://")
         if (!isRemoteUrl && !File(audioFilePath).exists()) {
             throw AudioUnavailableException("audio file not found at $audioFilePath")
         }
 
         val factory = dataSourceFactory.get()
-        // Only follow the player's on-disk cache when it actually exists; otherwise read the URL directly.
-        val cacheKey = currentSharedCacheKey?.takeIf { isRemoteUrl && factory.isCacheAvailable }
+        // Only follow the player's on-disk cache when it actually exists; otherwise read the URL
+        // through the app's HTTP stack so requests carry the player's headers and connection pool.
+        val cacheKey = sharedCacheKey?.takeIf { isRemoteUrl && factory.isCacheAvailable }
+        val isActive = { gen == generation && isCallerActive() }
         val extractor = MediaExtractor()
-        val cacheSource = if (cacheKey != null) {
-            CacheBackedMediaDataSource(factory.blockingCacheFactory, audioFilePath.toUri(), cacheKey, isActive = { gen == generation }) { position, length ->
-                factory.cachedLengthAt(cacheKey, position, length)
-            }
-        } else {
-            null
+        val cacheSource = when {
+            cacheKey != null && followPlayerCache -> StreamingMediaDataSource(
+                dataSourceFactory = factory.blockingCacheFactory,
+                uri = audioFilePath.toUri(),
+                cacheKey = cacheKey,
+                isActive = isActive,
+                cachedLengthAt = { position, length -> factory.cachedLengthAt(cacheKey, position, length) },
+            )
+
+            // Bounded resolves target regions the player may not have cached yet; read through
+            // the cache instead of waiting for the player to fill it.
+            cacheKey != null -> StreamingMediaDataSource(
+                dataSourceFactory = factory.cacheFactory,
+                uri = audioFilePath.toUri(),
+                cacheKey = cacheKey,
+                isActive = isActive,
+            )
+
+            isRemoteUrl -> StreamingMediaDataSource(
+                dataSourceFactory = factory.upstreamFactory,
+                uri = audioFilePath.toUri(),
+                isActive = isActive,
+            )
+
+            else -> null
         }
         try {
             if (cacheSource != null) {
@@ -1080,8 +1196,9 @@ class FingerprintTimingManager @Inject constructor(
         startingAt: Double,
     ) {
         val isRemoteUrl = audioFilePath.startsWith("http://") || audioFilePath.startsWith("https://")
+        val callerJob = currentCoroutineContext().job
         val stream = try {
-            openAudioStream(gen, audioFilePath, startingAt)
+            openAudioStream(gen, audioFilePath, startingAt, currentSharedCacheKey, isCallerActive = { callerJob.isActive })
         } catch (e: AudioUnavailableException) {
             Timber.w("FingerprintTimingManager: ${e.message}")
             markUnavailable(reason = "audio_unavailable", isStreaming = isRemoteUrl, episodeUuid = episodeUuid)
@@ -1112,6 +1229,7 @@ class FingerprintTimingManager @Inject constructor(
                     endingAt = null,
                     throttleToPlayhead = !currentEager,
                     trackFrontier = true,
+                    yieldToResolves = true,
                 ) { windows ->
                     mutex.withLock {
                         if (gen != generation) throw CancellationException("Fingerprint stream superseded")
@@ -1142,12 +1260,15 @@ class FingerprintTimingManager @Inject constructor(
         endingAt: Double?,
         throttleToPlayhead: Boolean,
         trackFrontier: Boolean,
+        yieldToResolves: Boolean = false,
+        stopWhen: (() -> Boolean)? = null,
         onWindows: suspend (List<WindowedFingerprint>) -> Unit,
     ) {
         val extractor = stream.extractor
         val codec = stream.codec
         val bufferInfo = MediaCodec.BufferInfo()
         var inputDone = false
+        var stopRequested = false
         val timeoutUs = FingerprintConstants.CODEC_TIMEOUT_US
         var lastNetworkCheckMs = SystemClock.elapsedRealtime()
         // Default to 16-bit (safest assumption). Updated when the codec
@@ -1157,6 +1278,15 @@ class FingerprintTimingManager @Inject constructor(
         while (true) {
             currentCoroutineContext().ensureActive()
             if (gen != generation) throw CancellationException("Fingerprint stream superseded")
+
+            // An on-demand resolve is on a tight user-facing budget; give it the decode headroom.
+            if (yieldToResolves) {
+                while (activeResolves.get() > 0) {
+                    delay(FingerprintConstants.RESOLVE_YIELD_POLL_MS)
+                    currentCoroutineContext().ensureActive()
+                    if (gen != generation) throw CancellationException("Fingerprint stream superseded")
+                }
+            }
 
             val now = SystemClock.elapsedRealtime()
             if (isRemoteUrl && now - lastNetworkCheckMs >= FingerprintConstants.METERED_RECHECK_INTERVAL_MS) {
@@ -1208,6 +1338,9 @@ class FingerprintTimingManager @Inject constructor(
                             val windows = streamer.pushSamplesF32(samples, stream.channelCount.toUShort())
                             if (windows.isNotEmpty()) {
                                 onWindows(windows)
+                                if (stopWhen?.invoke() == true) {
+                                    stopRequested = true
+                                }
                             }
                         }
 
@@ -1221,16 +1354,30 @@ class FingerprintTimingManager @Inject constructor(
                             val lastKnownPositionMs = lastProgressPositionMs
                             val playheadSec = if (lastKnownPositionMs >= 0) lastKnownPositionMs / 1000.0 else startOffset
                             if (decodedSeconds - playheadSec > FingerprintConstants.LOOKAHEAD_SECONDS) {
+                                // Playback has been paused for a while; release the codec and network
+                                // stream. The progress observer restarts the decode on resume.
+                                val progressAt = lastProgressAtMs
+                                if (progressAt > 0 && SystemClock.elapsedRealtime() - progressAt > FingerprintConstants.PARKED_DECODE_RELEASE_MS) {
+                                    Timber.d("FingerprintTimingManager: playback idle — releasing parked decode")
+                                    break
+                                }
                                 delay((FingerprintConstants.OUTSIDE_LOOKAHEAD_SLEEP_SECONDS * 1000).toLong())
                             }
                         }
                     }
                     codec.releaseOutputBuffer(outputIndex, false)
-                    if (isEos) break
+                    if (isEos || stopRequested) break
                     if (endingAt != null && startOffset + streamer.durationMs().toDouble() / 1000.0 >= endingAt) break
                 }
             }
         }
+    }
+
+    // The uniffi binding wants List<Float>; a FloatArray view keeps samples unboxed until the
+    // FFI boundary instead of materialising an ArrayList of boxed floats per decoded buffer.
+    private class FloatArrayList(private val values: FloatArray) : AbstractList<Float>() {
+        override val size get() = values.size
+        override fun get(index: Int): Float = values[index]
     }
 
     private fun extractFloatSamples(
@@ -1251,17 +1398,19 @@ class FingerprintTimingManager @Inject constructor(
                 if (floatCount == 0) return emptyList()
                 val result = FloatArray(floatCount)
                 floatBuffer.get(result)
-                result.toList()
+                FloatArrayList(result)
             } else {
                 // 16-bit PCM: convert to normalized float [-1.0, 1.0]
                 val shortBuffer = buffer.asShortBuffer()
                 val shortCount = shortBuffer.remaining()
                 if (shortCount == 0) return emptyList()
+                val shorts = ShortArray(shortCount)
+                shortBuffer.get(shorts)
                 val result = FloatArray(shortCount)
                 for (i in 0 until shortCount) {
-                    result[i] = shortBuffer.get() / 32768f
+                    result[i] = shorts[i] / 32768f
                 }
-                result.toList()
+                FloatArrayList(result)
             }
         } finally {
             buffer.order(byteOrder)
@@ -1275,14 +1424,17 @@ class FingerprintTimingManager @Inject constructor(
     ) {
         val isDebug = debugTrackingEnabled || FeatureFlag.isEnabled(Feature.SYNCED_TRANSCRIPT_DEBUG)
 
+        val sizeBefore = mapping.playbackToReference.size
         matchWindows(windows, matcher, startOffset, mapping) { rejected ->
             if (isDebug) recordDebugRejection(rejected.playbackTime, rejected.score)
         }
 
-        publishSnapshot()
         val coverage = mapping.playbackToReference.size
-        if (coverage >= FingerprintConstants.MINIMUM_COVERAGE_FOR_ACTIVE) {
-            markActive(coverage)
+        if (coverage != sizeBefore) {
+            publishSnapshot()
+            if (coverage >= FingerprintConstants.MINIMUM_COVERAGE_FOR_ACTIVE) {
+                markActive(coverage)
+            }
         }
         if (isDebug) {
             debugRejectionsSnapshot = debugRejections.toList()
@@ -1331,7 +1483,7 @@ class FingerprintTimingManager @Inject constructor(
         if (audioPath.startsWith("http://") || audioPath.startsWith("https://")) return
         val refPath = currentReferenceFilePath ?: return
         val refData = currentReferenceData ?: return
-        val refDuration = currentReferenceDuration
+        val refDuration = currentReference?.totalDuration ?: return
 
         val entries = snapshotPlaybackToReference
         FingerprintMappingCache.save(entries, audioPath, refPath, refData, refDuration)
@@ -1547,6 +1699,38 @@ class FingerprintTimingManager @Inject constructor(
             val startSec = max(referenceTimeSec, estimatedPlaybackSec - FingerprintConstants.ON_DEMAND_BACKWARD_MAX_SECONDS)
             val endSec = max(estimatedPlaybackSec, startSec) + FingerprintConstants.ON_DEMAND_FORWARD_BUDGET_SECONDS
             return SearchWindow(startSec, endSec)
+        }
+
+        /** True once a bounded resolve has committed anchors past the target, so further decoding adds nothing. */
+        internal fun isResolveTargetCovered(acc: MappingAccumulator, targetReferenceSec: Double): Boolean {
+            if (acc.playbackToReference.size < FingerprintConstants.ON_DEMAND_MIN_ANCHORS) return false
+            val lastReference = acc.referenceToPlayback.last().referenceTime
+            return lastReference >= targetReferenceSec + FingerprintConstants.ON_DEMAND_EARLY_EXIT_MARGIN_SECONDS
+        }
+
+        /**
+         * Interpolated playback time when the mapping is dense around [referenceTimeSec], in both
+         * timelines: anchors bracketing an ad boundary sit close in reference time but far apart in
+         * playback time, and interpolating across the boundary would land inside the ad.
+         */
+        internal fun densePlaybackSec(referenceTimeSec: Double, entries: List<TimeMappingEntry>): Double? {
+            var lo = 0
+            var hi = entries.size
+            while (lo < hi) {
+                val mid = (lo + hi) / 2
+                if (entries[mid].referenceTime <= referenceTimeSec) lo = mid + 1 else hi = mid
+            }
+            if (hi - 1 < 0 || hi >= entries.size) return null
+            val prev = entries[hi - 1]
+            val next = entries[hi]
+            if (next.referenceTime - prev.referenceTime > FingerprintConstants.HIGHLIGHT_MAX_GAP_SECONDS) return null
+            if (next.playbackTime - prev.playbackTime > FingerprintConstants.HIGHLIGHT_MAX_GAP_SECONDS) return null
+            return interpolate(
+                time = referenceTimeSec,
+                entries = entries,
+                keySelector = { it.referenceTime },
+                valueSelector = { it.playbackTime },
+            )
         }
 
         /** True when [playbackTime] is bracketed by two anchors ≤ [FingerprintConstants.HIGHLIGHT_MAX_GAP_SECONDS] apart. */

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/GeneratedChapterSeeker.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/GeneratedChapterSeeker.kt
@@ -39,11 +39,15 @@ class GeneratedChapterSeeker @Inject constructor(
     data class ResolvingChapter(val episodeUuid: String, val chapterIndex: Int)
 
     private val mutex = Mutex()
+
+    @Volatile
     private var activeCaller: Job? = null
 
-    // Session cache of resolved chapter starts for the most recent episode. Deterministic failures
-    // are remembered too: a missing reference blocks the episode, a no-match blocks its chapter.
-    private var cacheEpisodeUuid: String? = null
+    // Session cache of resolved chapter starts, dropped when the episode or its audio source
+    // changes: a mid-play download can carry differently stitched ads than the stream did.
+    // Deterministic failures are remembered too: a missing reference blocks the episode,
+    // a no-match blocks its chapter.
+    private var cacheSourceKey: String? = null
     private val resolvedCache = mutableMapOf<Int, Duration>()
     private val failedChapters = mutableSetOf<Int>()
     private var referenceUnavailable = false
@@ -58,13 +62,23 @@ class GeneratedChapterSeeker @Inject constructor(
         resolving?.takeIf { it.episodeUuid == uuid }?.chapterIndex
     }
 
-    suspend fun resolveSeekTime(episode: BaseEpisode, chapter: Chapter): Duration? {
+    /** Called when the user seeks by other means, so a stale chapter resolve can't yank playback later. */
+    fun cancelActiveResolve() {
+        activeCaller?.cancel()
+    }
+
+    // Never land before the chapter's own displayed start: the skip buttons picked the chapter from
+    // that boundary, and a resolve landing short of it would make the next button loop in place.
+    suspend fun resolveSeekTime(episode: BaseEpisode, chapter: Chapter): Duration? = resolveSeekTimeUnclamped(episode, chapter)?.coerceAtLeast(chapter.startTime)
+
+    private suspend fun resolveSeekTimeUnclamped(episode: BaseEpisode, chapter: Chapter): Duration? {
         if (!isEnabled(chapter)) return null
         val referenceTime = chapter.referenceStartTime ?: return null
 
+        val sourceKey = "${episode.uuid}|${episode.downloadedFilePath ?: episode.downloadUrl}"
         mutex.withLock {
-            if (cacheEpisodeUuid != episode.uuid) {
-                cacheEpisodeUuid = episode.uuid
+            if (cacheSourceKey != sourceKey) {
+                cacheSourceKey = sourceKey
                 resolvedCache.clear()
                 failedChapters.clear()
                 referenceUnavailable = false
@@ -87,11 +101,11 @@ class GeneratedChapterSeeker @Inject constructor(
             _resolvingChapter.value = resolving
         }
         try {
-            return when (val result = manager.resolveChapterPlaybackTime(episode, referenceTime)) {
+            return when (val result = manager.resolvePlaybackTime(episode, referenceTime)) {
                 is ChapterSeekResult.Resolved -> {
                     val playbackTime = ceil(result.playbackTime.toDouble(DurationUnit.SECONDS)).seconds
                     mutex.withLock {
-                        if (cacheEpisodeUuid == episode.uuid) resolvedCache[chapter.index] = playbackTime
+                        if (cacheSourceKey == sourceKey) resolvedCache[chapter.index] = playbackTime
                     }
                     Timber.d("GeneratedChapterSeeker: resolved chapter ${chapter.index} to $playbackTime (usedPrior=${result.usedPrior})")
                     playbackTime
@@ -99,7 +113,7 @@ class GeneratedChapterSeeker @Inject constructor(
 
                 is ChapterSeekResult.Unresolved -> {
                     mutex.withLock {
-                        if (cacheEpisodeUuid == episode.uuid) {
+                        if (cacheSourceKey == sourceKey) {
                             when (result.reason) {
                                 ChapterSeekResult.REASON_NO_REFERENCE -> referenceUnavailable = true
                                 ChapterSeekResult.REASON_NO_MATCH -> failedChapters += chapter.index

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/MappingAccumulator.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/MappingAccumulator.kt
@@ -22,6 +22,14 @@ internal class MappingAccumulator {
         referenceToPlayback.add(refIdx, entry)
     }
 
+    fun hasAnchorNear(playbackTime: Double, toleranceSec: Double): Boolean {
+        val idx = playbackToReference.sortedInsertionIndex { it.playbackTime < playbackTime }
+        val prev = playbackToReference.getOrNull(idx - 1)
+        val next = playbackToReference.getOrNull(idx)
+        return (prev != null && playbackTime - prev.playbackTime <= toleranceSec) ||
+            (next != null && next.playbackTime - playbackTime <= toleranceSec)
+    }
+
     fun replaceAll(entries: List<TimeMappingEntry>) {
         playbackToReference.clear()
         playbackToReference += entries.sortedBy { it.playbackTime }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/ReferenceFingerprint.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/ReferenceFingerprint.kt
@@ -34,7 +34,12 @@ data class ReferenceFingerprint(
 
     val checkpointDurationSeconds: Float get() = checkpointDuration.toFloat()
 
-    fun libraryCheckpoints(): List<LibraryCheckpoint> {
+    @Json(ignore = true)
+    internal val decodedCheckpoints by lazy { decodeCheckpoints() }
+
+    fun libraryCheckpoints(): List<LibraryCheckpoint> = decodedCheckpoints
+
+    private fun decodeCheckpoints(): List<LibraryCheckpoint> {
         var accumulated = 0
         return checkpoints.mapNotNull { checkpoint ->
             if (checkpoint.size < 2) return@mapNotNull null

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/StreamingMediaDataSource.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/StreamingMediaDataSource.kt
@@ -8,13 +8,18 @@ import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DataSource
 import androidx.media3.datasource.DataSpec
 
+/**
+ * Adapts a Media3 [DataSource] to [MediaDataSource] so MediaExtractor reads go through the app's
+ * HTTP stack. When [cachedLengthAt] is provided, reads follow the player's cache writes instead of
+ * racing them over the network.
+ */
 @OptIn(UnstableApi::class)
-internal class CacheBackedMediaDataSource(
+internal class StreamingMediaDataSource(
     private val dataSourceFactory: DataSource.Factory,
     private val uri: Uri,
-    private val cacheKey: String,
+    private val cacheKey: String? = null,
     private val isActive: () -> Boolean = { true },
-    private val cachedLengthAt: (position: Long, length: Long) -> Long,
+    private val cachedLengthAt: ((position: Long, length: Long) -> Long)? = null,
 ) : MediaDataSource() {
     private var dataSource: DataSource? = null
     private var position = -1L
@@ -29,11 +34,14 @@ internal class CacheBackedMediaDataSource(
 
     override fun readAt(position: Long, buffer: ByteArray, offset: Int, size: Int): Int {
         if (size == 0) return 0
-        var waited = 0L
-        while (cachedLengthAt(position, size.toLong()) <= 0L && waited < FOLLOW_TIMEOUT_MS && isActive()) {
-            Thread.sleep(POLL_MS)
-            waited += POLL_MS
+        if (cachedLengthAt != null) {
+            var waited = 0L
+            while (cachedLengthAt.invoke(position, size.toLong()) <= 0L && waited < FOLLOW_TIMEOUT_MS && isActive()) {
+                Thread.sleep(POLL_MS)
+                waited += POLL_MS
+            }
         }
+        if (!isActive()) return -1
         if (position != this.position || dataSource == null) {
             openAt(position)
         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ExoPlayerDataSourceFactory.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ExoPlayerDataSourceFactory.kt
@@ -7,6 +7,7 @@ import androidx.media3.common.MediaItem.ClippingConfiguration
 import androidx.media3.common.MimeTypes
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.database.StandaloneDatabaseProvider
+import androidx.media3.datasource.DataSource
 import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.datasource.cache.CacheDataSource
 import androidx.media3.datasource.cache.LeastRecentlyUsedCacheEvictor
@@ -67,6 +68,8 @@ class ExoPlayerDataSourceFactory @Inject constructor(
         .let { if (cache != null) it.setCache(cache) else it }
 
     val isCacheAvailable get() = cache != null
+
+    val upstreamFactory: DataSource.Factory get() = defaultFactory
 
     fun cachedLengthAt(cacheKey: String, position: Long, length: Long): Long = cache?.getCachedLength(cacheKey, position, length) ?: -1L
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -125,8 +125,11 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.launchIn
@@ -1080,6 +1083,7 @@ open class PlaybackManager @Inject constructor(
     }
 
     suspend fun seekToTimeMsSuspend(positionMs: Int, seekComplete: (() -> Unit)? = null) {
+        cancelPendingChapterSeek()
         seekToTimeMsInternal(positionMs)
         seekComplete?.invoke()
     }
@@ -1091,6 +1095,7 @@ open class PlaybackManager @Inject constructor(
         }
         launch {
             if (getCurrentEpisode()?.uuid == episodeUuid) {
+                cancelPendingChapterSeek()
                 seekToTimeMsInternal(positionMs)
                 seekComplete?.invoke()
             }
@@ -1153,6 +1158,7 @@ open class PlaybackManager @Inject constructor(
     ) {
         LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Skip forward tapped")
 
+        cancelPendingChapterSeek()
         val episode = getCurrentEpisode() ?: return
         val jumpAmountMs = jumpAmountSeconds * 1000
 
@@ -1187,6 +1193,7 @@ open class PlaybackManager @Inject constructor(
     suspend fun skipBackwardSuspend(sourceView: SourceView = SourceView.UNKNOWN, jumpAmountSeconds: Int = settings.skipBackInSecs.value) {
         LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Skip backward tapped")
 
+        cancelPendingChapterSeek()
         val episode = getCurrentEpisode() ?: return
 
         val jumpAmountMs = jumpAmountSeconds * 1000
@@ -1207,8 +1214,9 @@ open class PlaybackManager @Inject constructor(
     fun skipToNextSelectedOrLastChapter() {
         launch {
             val episode = getCurrentEpisode() ?: return@launch
-            val currentTimeMs = getCurrentTimeMs(episode = episode)
-            playbackStateRelay.blockingFirst().chapters.getNextSelectedChapter(currentTimeMs.milliseconds)?.let { chapter ->
+            // Base the jump on an in-flight chapter resolve so rapid taps advance instead of re-targeting it.
+            val baseTime = pendingChapterSeek?.startTime ?: getCurrentTimeMs(episode = episode).milliseconds
+            playbackStateRelay.blockingFirst().chapters.getNextSelectedChapter(baseTime)?.let { chapter ->
                 seekToChapterStart(episode, chapter)
                 trackPlaybackEvent(SourceView.PLAYER) { source, contentType ->
                     PlaybackChapterSkippedEvent(
@@ -1224,8 +1232,8 @@ open class PlaybackManager @Inject constructor(
     fun skipToPreviousSelectedOrLastChapter() {
         launch {
             val episode = getCurrentEpisode() ?: return@launch
-            val currentTimeMs = getCurrentTimeMs(episode)
-            playbackStateRelay.blockingFirst().chapters.getPreviousSelectedChapter(currentTimeMs.milliseconds)?.let { chapter ->
+            val baseTime = pendingChapterSeek?.startTime ?: getCurrentTimeMs(episode).milliseconds
+            playbackStateRelay.blockingFirst().chapters.getPreviousSelectedChapter(baseTime)?.let { chapter ->
                 seekToChapterStart(episode, chapter)
                 trackPlaybackEvent(SourceView.PLAYER) { source, contentType ->
                     PlaybackChapterSkippedEvent(
@@ -1274,15 +1282,35 @@ open class PlaybackManager @Inject constructor(
         }
     }
 
+    @Volatile
+    private var pendingChapterSeek: Chapter? = null
+
+    private val _userSeeks = MutableSharedFlow<Unit>(extraBufferCapacity = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+
+    /** Emits on every user-initiated seek or skip, so pending resolve-driven seeks can stand down. */
+    val userSeeks = _userSeeks.asSharedFlow()
+
     /**
      * Generated chapter timestamps live on the reference timeline; resolve the real stream position
      * through the fingerprint map before seeking. Falls back to the chapter's own start time.
      */
     private suspend fun seekToChapterStart(episode: BaseEpisode?, chapter: Chapter) {
-        val resolved = episode?.let { generatedChapterSeeker.get().resolveSeekTime(it, chapter) }
-        // Resolving can take seconds; drop the seek if the episode changed meanwhile.
-        if (episode != null && getCurrentEpisode()?.uuid != episode.uuid) return
-        seekToTimeMsInternal(resolved ?: chapter.startTime)
+        pendingChapterSeek = chapter
+        try {
+            val resolved = episode?.let { generatedChapterSeeker.get().resolveSeekTime(it, chapter) }
+            // Resolving can take seconds; drop the seek if the episode changed meanwhile.
+            if (episode != null && getCurrentEpisode()?.uuid != episode.uuid) return
+            seekToTimeMsInternal(resolved ?: chapter.startTime)
+        } finally {
+            // A superseding tap has already installed its own chapter; only the owner clears it.
+            if (pendingChapterSeek === chapter) pendingChapterSeek = null
+        }
+    }
+
+    private fun cancelPendingChapterSeek() {
+        pendingChapterSeek = null
+        generatedChapterSeeker.get().cancelActiveResolve()
+        _userSeeks.tryEmit(Unit)
     }
 
     fun clearUpNextAsync() {

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintReferenceRetrieverTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintReferenceRetrieverTest.kt
@@ -4,8 +4,12 @@ import android.content.Context
 import java.io.File
 import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
 import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -37,6 +41,42 @@ class FingerprintReferenceRetrieverTest {
     @Test
     fun `loadCachedReference returns null when missing`() = runTest {
         assertNull(retriever.loadCachedReference("episode-1"))
+    }
+
+    @Test
+    fun `fetchReferenceData returns Success for a 200 response`() = runTest {
+        MockWebServer().use { server ->
+            server.enqueue(MockResponse().setBody("{}"))
+            server.start()
+
+            val result = retriever.fetchReferenceData(server.url("/").toString(), "podcast", "episode")
+
+            assertArrayEquals("{}".toByteArray(), (result as FingerprintReferenceRetriever.FetchResult.Success).data)
+        }
+    }
+
+    @Test
+    fun `fetchReferenceData returns NotFound for a 404 response`() = runTest {
+        MockWebServer().use { server ->
+            server.enqueue(MockResponse().setResponseCode(404))
+            server.start()
+
+            val result = retriever.fetchReferenceData(server.url("/").toString(), "podcast", "episode")
+
+            assertEquals(FingerprintReferenceRetriever.FetchResult.NotFound, result)
+        }
+    }
+
+    @Test
+    fun `fetchReferenceData returns Error for an unexpected status`() = runTest {
+        MockWebServer().use { server ->
+            server.enqueue(MockResponse().setResponseCode(400))
+            server.start()
+
+            val result = retriever.fetchReferenceData(server.url("/").toString(), "podcast", "episode")
+
+            assertTrue(result is FingerprintReferenceRetriever.FetchResult.Error)
+        }
     }
 
     @Test

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManagerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManagerTest.kt
@@ -659,4 +659,65 @@ class FingerprintTimingManagerTest {
         assertEquals(600.0, window.startSec, 0.001)
         assertEquals(600.0 + FingerprintConstants.ON_DEMAND_FORWARD_BUDGET_SECONDS, window.endSec, 0.001)
     }
+
+    @Test
+    fun `isResolveTargetCovered requires minimum anchors`() {
+        val acc = MappingAccumulator()
+        acc.insert(TimeMappingEntry(playbackTime = 650.0, referenceTime = 620.0))
+        assertFalse(FingerprintTimingManager.isResolveTargetCovered(acc, targetReferenceSec = 600.0))
+    }
+
+    @Test
+    fun `isResolveTargetCovered requires reference past target with margin`() {
+        val acc = MappingAccumulator()
+        acc.insert(TimeMappingEntry(playbackTime = 620.0, referenceTime = 590.0))
+        acc.insert(TimeMappingEntry(playbackTime = 632.0, referenceTime = 602.0))
+        assertFalse(FingerprintTimingManager.isResolveTargetCovered(acc, targetReferenceSec = 600.0))
+    }
+
+    @Test
+    fun `isResolveTargetCovered stops once anchors bracket the target`() {
+        val acc = MappingAccumulator()
+        acc.insert(TimeMappingEntry(playbackTime = 620.0, referenceTime = 590.0))
+        acc.insert(TimeMappingEntry(playbackTime = 636.0, referenceTime = 606.0))
+        assertTrue(FingerprintTimingManager.isResolveTargetCovered(acc, targetReferenceSec = 600.0))
+    }
+
+    @Test
+    fun `densePlaybackSec interpolates between close anchors`() {
+        val entries = listOf(
+            TimeMappingEntry(playbackTime = 130.0, referenceTime = 100.0),
+            TimeMappingEntry(playbackTime = 134.0, referenceTime = 104.0),
+        )
+        val result = FingerprintTimingManager.densePlaybackSec(referenceTimeSec = 102.0, entries = entries)
+        assertEquals(132.0, result!!, 0.001)
+    }
+
+    @Test
+    fun `densePlaybackSec returns null outside the mapped range`() {
+        val entries = listOf(
+            TimeMappingEntry(playbackTime = 130.0, referenceTime = 100.0),
+            TimeMappingEntry(playbackTime = 134.0, referenceTime = 104.0),
+        )
+        assertNull(FingerprintTimingManager.densePlaybackSec(referenceTimeSec = 99.0, entries = entries))
+        assertNull(FingerprintTimingManager.densePlaybackSec(referenceTimeSec = 105.0, entries = entries))
+    }
+
+    @Test
+    fun `densePlaybackSec returns null when reference gap is too wide`() {
+        val entries = listOf(
+            TimeMappingEntry(playbackTime = 130.0, referenceTime = 100.0),
+            TimeMappingEntry(playbackTime = 150.0, referenceTime = 120.0),
+        )
+        assertNull(FingerprintTimingManager.densePlaybackSec(referenceTimeSec = 110.0, entries = entries))
+    }
+
+    @Test
+    fun `densePlaybackSec returns null when playback gap spans an ad boundary`() {
+        val entries = listOf(
+            TimeMappingEntry(playbackTime = 130.0, referenceTime = 100.0),
+            TimeMappingEntry(playbackTime = 190.0, referenceTime = 104.0),
+        )
+        assertNull(FingerprintTimingManager.densePlaybackSec(referenceTimeSec = 102.0, entries = entries))
+    }
 }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/GeneratedChapterSeekerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/GeneratedChapterSeekerTest.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -69,7 +70,7 @@ class GeneratedChapterSeekerTest {
         val chapter = generatedChapter.copy(origin = ChapterOrigin.ShowNotes)
 
         assertNull(seeker().resolveSeekTime(episode, chapter))
-        verifyBlocking(timingManager, never()) { resolveChapterPlaybackTime(any(), any()) }
+        verifyBlocking(timingManager, never()) { resolvePlaybackTime(any(), any()) }
     }
 
     @Test
@@ -77,13 +78,13 @@ class GeneratedChapterSeekerTest {
         FeatureFlag.setEnabled(Feature.SYNCED_TRANSCRIPTS, false)
 
         assertNull(seeker().resolveSeekTime(episode, generatedChapter))
-        verifyBlocking(timingManager, never()) { resolveChapterPlaybackTime(any(), any()) }
+        verifyBlocking(timingManager, never()) { resolvePlaybackTime(any(), any()) }
     }
 
     @Test
     fun `returns null on non-phone platforms`() = runTest {
         assertNull(seeker(AppPlatform.Automotive).resolveSeekTime(episode, generatedChapter))
-        verifyBlocking(timingManager, never()) { resolveChapterPlaybackTime(any(), any()) }
+        verifyBlocking(timingManager, never()) { resolvePlaybackTime(any(), any()) }
     }
 
     @Test
@@ -91,7 +92,7 @@ class GeneratedChapterSeekerTest {
         val chapter = generatedChapter.copy(referenceStartTime = null)
 
         assertNull(seeker().resolveSeekTime(episode, chapter))
-        verifyBlocking(timingManager, never()) { resolveChapterPlaybackTime(any(), any()) }
+        verifyBlocking(timingManager, never()) { resolvePlaybackTime(any(), any()) }
     }
 
     @Test
@@ -101,52 +102,84 @@ class GeneratedChapterSeekerTest {
         }
 
         assertEquals(131.5.seconds, seeker().resolveSeekTime(episode, generatedChapter))
-        verifyBlocking(timingManager, never()) { resolveChapterPlaybackTime(any(), any()) }
+        verifyBlocking(timingManager, never()) { resolvePlaybackTime(any(), any()) }
     }
 
     @Test
     fun `resolves and caches the rounded-up playback time`() = runTest {
         timingManager = mock {
-            on { resolveChapterPlaybackTime(any(), eq(100.seconds)) } doReturn
+            on { resolvePlaybackTime(any(), eq(100.seconds)) } doReturn
                 ChapterSeekResult.Resolved(playbackTime = 130.2.seconds, usedPrior = false)
         }
         val seeker = seeker()
 
         assertEquals(131.seconds, seeker.resolveSeekTime(episode, generatedChapter))
         assertEquals(131.seconds, seeker.resolveSeekTime(episode, generatedChapter))
-        verifyBlocking(timingManager, times(1)) { resolveChapterPlaybackTime(any(), any()) }
+        verifyBlocking(timingManager, times(1)) { resolvePlaybackTime(any(), any()) }
+    }
+
+    @Test
+    fun `clamps a resolve landing short of the chapter start`() = runTest {
+        timingManager = mock {
+            on { resolvePlaybackTime(any(), eq(100.seconds)) } doReturn
+                ChapterSeekResult.Resolved(playbackTime = 120.2.seconds, usedPrior = false)
+        }
+
+        assertEquals(130.seconds, seeker().resolveSeekTime(episode, generatedChapter))
+    }
+
+    @Test
+    fun `clamps a dense mapping time short of the chapter start`() = runTest {
+        timingManager = mock {
+            on { densePlaybackTime(eq("episode-uuid"), eq(100.seconds)) } doReturn 129.5.seconds
+        }
+
+        assertEquals(130.seconds, seeker().resolveSeekTime(episode, generatedChapter))
     }
 
     @Test
     fun `retries when unresolved for a transient reason`() = runTest {
         timingManager = mock {
-            on { resolveChapterPlaybackTime(any(), any()) } doReturn
+            on { resolvePlaybackTime(any(), any()) } doReturn
                 ChapterSeekResult.Unresolved(ChapterSeekResult.REASON_TIMEOUT)
         }
         val seeker = seeker()
 
         assertNull(seeker.resolveSeekTime(episode, generatedChapter))
         assertNull(seeker.resolveSeekTime(episode, generatedChapter))
-        verifyBlocking(timingManager, times(2)) { resolveChapterPlaybackTime(any(), any()) }
+        verifyBlocking(timingManager, times(2)) { resolvePlaybackTime(any(), any()) }
+    }
+
+    @Test
+    fun `retries when the reference fetch failed transiently`() = runTest {
+        timingManager = mock {
+            on { resolvePlaybackTime(any(), any()) } doReturn
+                ChapterSeekResult.Unresolved(ChapterSeekResult.REASON_REFERENCE_FETCH_FAILED)
+        }
+        val seeker = seeker()
+
+        assertNull(seeker.resolveSeekTime(episode, generatedChapter))
+        assertNull(seeker.resolveSeekTime(episode, generatedChapter))
+        verifyBlocking(timingManager, times(2)) { resolvePlaybackTime(any(), any()) }
     }
 
     @Test
     fun `does not retry a chapter that failed with no match`() = runTest {
         timingManager = mock {
-            on { resolveChapterPlaybackTime(any(), any()) } doReturn
+            on { resolvePlaybackTime(any(), any()) } doReturn
                 ChapterSeekResult.Unresolved(ChapterSeekResult.REASON_NO_MATCH)
         }
         val seeker = seeker()
 
         assertNull(seeker.resolveSeekTime(episode, generatedChapter))
         assertNull(seeker.resolveSeekTime(episode, generatedChapter))
-        verifyBlocking(timingManager, times(1)) { resolveChapterPlaybackTime(any(), any()) }
+        verifyBlocking(timingManager, times(1)) { resolvePlaybackTime(any(), any()) }
     }
 
     @Test
     fun `no match failure does not block other chapters`() = runTest {
         timingManager = mock {
-            on { resolveChapterPlaybackTime(any(), any()) } doReturn
+            on { resolvePlaybackTime(any(), any()) } doReturn
                 ChapterSeekResult.Unresolved(ChapterSeekResult.REASON_NO_MATCH)
         }
         val seeker = seeker()
@@ -154,13 +187,13 @@ class GeneratedChapterSeekerTest {
 
         assertNull(seeker.resolveSeekTime(episode, generatedChapter))
         assertNull(seeker.resolveSeekTime(episode, otherChapter))
-        verifyBlocking(timingManager, times(2)) { resolveChapterPlaybackTime(any(), any()) }
+        verifyBlocking(timingManager, times(2)) { resolvePlaybackTime(any(), any()) }
     }
 
     @Test
     fun `missing reference blocks further resolves for the episode`() = runTest {
         timingManager = mock {
-            on { resolveChapterPlaybackTime(any(), any()) } doReturn
+            on { resolvePlaybackTime(any(), any()) } doReturn
                 ChapterSeekResult.Unresolved(ChapterSeekResult.REASON_NO_REFERENCE)
         }
         val seeker = seeker()
@@ -168,27 +201,27 @@ class GeneratedChapterSeekerTest {
 
         assertNull(seeker.resolveSeekTime(episode, generatedChapter))
         assertNull(seeker.resolveSeekTime(episode, otherChapter))
-        verifyBlocking(timingManager, times(1)) { resolveChapterPlaybackTime(any(), any()) }
+        verifyBlocking(timingManager, times(1)) { resolvePlaybackTime(any(), any()) }
     }
 
     @Test
     fun `dense mapping still serves a chapter that previously failed`() = runTest {
         timingManager = mock {
             on { densePlaybackTime(any(), any()) } doReturnConsecutively listOf(null, 131.5.seconds)
-            on { resolveChapterPlaybackTime(any(), any()) } doReturn
+            on { resolvePlaybackTime(any(), any()) } doReturn
                 ChapterSeekResult.Unresolved(ChapterSeekResult.REASON_NO_MATCH)
         }
         val seeker = seeker()
 
         assertNull(seeker.resolveSeekTime(episode, generatedChapter))
         assertEquals(131.5.seconds, seeker.resolveSeekTime(episode, generatedChapter))
-        verifyBlocking(timingManager, times(1)) { resolveChapterPlaybackTime(any(), any()) }
+        verifyBlocking(timingManager, times(1)) { resolvePlaybackTime(any(), any()) }
     }
 
     @Test
     fun `negative results are dropped when the episode changes`() = runTest {
         timingManager = mock {
-            on { resolveChapterPlaybackTime(any(), any()) } doReturn
+            on { resolvePlaybackTime(any(), any()) } doReturn
                 ChapterSeekResult.Unresolved(ChapterSeekResult.REASON_NO_REFERENCE)
         }
         val seeker = seeker()
@@ -196,13 +229,13 @@ class GeneratedChapterSeekerTest {
 
         assertNull(seeker.resolveSeekTime(episode, generatedChapter))
         assertNull(seeker.resolveSeekTime(otherEpisode, generatedChapter))
-        verifyBlocking(timingManager, times(2)) { resolveChapterPlaybackTime(any(), any()) }
+        verifyBlocking(timingManager, times(2)) { resolvePlaybackTime(any(), any()) }
     }
 
     @Test
     fun `cache is dropped when the episode changes`() = runTest {
         timingManager = mock {
-            on { resolveChapterPlaybackTime(any(), any()) } doReturn
+            on { resolvePlaybackTime(any(), any()) } doReturn
                 ChapterSeekResult.Resolved(playbackTime = 130.0.seconds, usedPrior = true)
         }
         val seeker = seeker()
@@ -212,13 +245,28 @@ class GeneratedChapterSeekerTest {
         seeker.resolveSeekTime(otherEpisode, generatedChapter)
         seeker.resolveSeekTime(episode, generatedChapter)
 
-        verifyBlocking(timingManager, times(3)) { resolveChapterPlaybackTime(any(), any()) }
+        verifyBlocking(timingManager, times(3)) { resolvePlaybackTime(any(), any()) }
+    }
+
+    @Test
+    fun `cache is dropped when the audio source changes`() = runTest {
+        timingManager = mock {
+            on { resolvePlaybackTime(any(), any()) } doReturn
+                ChapterSeekResult.Resolved(playbackTime = 130.0.seconds, usedPrior = true)
+        }
+        val seeker = seeker()
+        val downloadedEpisode = episode.copy(downloadedFilePath = "/audio.mp3")
+
+        seeker.resolveSeekTime(episode, generatedChapter)
+        seeker.resolveSeekTime(downloadedEpisode, generatedChapter)
+
+        verifyBlocking(timingManager, times(2)) { resolvePlaybackTime(any(), any()) }
     }
 
     @Test
     fun `clears resolving state after a resolve`() = runTest {
         timingManager = mock {
-            on { resolveChapterPlaybackTime(any(), any()) } doReturn
+            on { resolvePlaybackTime(any(), any()) } doReturn
                 ChapterSeekResult.Resolved(playbackTime = 130.0.seconds, usedPrior = false)
         }
         val seeker = seeker()
@@ -233,7 +281,7 @@ class GeneratedChapterSeekerTest {
     @Test
     fun `superseded tap does not clear the new tap's resolving state`() = runTest {
         timingManager = mock {
-            on { resolveChapterPlaybackTime(any(), any()) } doSuspendableAnswer { awaitCancellation() }
+            on { resolvePlaybackTime(any(), any()) } doSuspendableAnswer { awaitCancellation() }
         }
         val seeker = seeker()
         launch { seeker.resolveSeekTime(episode, generatedChapter) }
@@ -250,9 +298,32 @@ class GeneratedChapterSeekerTest {
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
+    fun `cancelActiveResolve cancels the in-flight caller and clears its state`() = runTest {
+        timingManager = mock {
+            on { resolvePlaybackTime(any(), any()) } doSuspendableAnswer { awaitCancellation() }
+        }
+        val seeker = seeker()
+        val job = launch { seeker.resolveSeekTime(episode, generatedChapter) }
+        runCurrent()
+        assertEquals(GeneratedChapterSeeker.ResolvingChapter("episode-uuid", 2), seeker.resolvingChapter.value)
+
+        seeker.cancelActiveResolve()
+        job.join()
+
+        assertTrue(job.isCancelled)
+        assertNull(seeker.resolvingChapter.value)
+    }
+
+    @Test
+    fun `cancelActiveResolve without an in-flight caller is a no-op`() {
+        seeker().cancelActiveResolve()
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
     fun `resolving chapter index follows the current episode`() = runTest {
         timingManager = mock {
-            on { resolveChapterPlaybackTime(any(), any()) } doSuspendableAnswer { awaitCancellation() }
+            on { resolvePlaybackTime(any(), any()) } doSuspendableAnswer { awaitCancellation() }
         }
         val seeker = seeker()
         val job = launch { seeker.resolveSeekTime(episode, generatedChapter) }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/MappingAccumulatorTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/MappingAccumulatorTest.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.repositories.fingerprint
 
 import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.FingerprintTimingManager.TimeMappingEntry
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -39,6 +40,23 @@ class MappingAccumulatorTest {
         assertEquals(3, main.playbackToReference.size)
         assertEquals(bootstrap, main.playbackToReference)
         assertEquals(bootstrap.last(), main.lastTrusted)
+    }
+
+    @Test
+    fun `hasAnchorNear finds neighbours within tolerance on both sides`() {
+        val acc = MappingAccumulator()
+        acc.insert(TimeMappingEntry(playbackTime = 10.0, referenceTime = 5.0))
+
+        assertTrue(acc.hasAnchorNear(10.0, toleranceSec = 0.5))
+        assertTrue(acc.hasAnchorNear(10.4, toleranceSec = 0.5))
+        assertTrue(acc.hasAnchorNear(9.6, toleranceSec = 0.5))
+        assertFalse(acc.hasAnchorNear(11.0, toleranceSec = 0.5))
+        assertFalse(acc.hasAnchorNear(8.9, toleranceSec = 0.5))
+    }
+
+    @Test
+    fun `hasAnchorNear is false on empty accumulator`() {
+        assertFalse(MappingAccumulator().hasAnchorNear(10.0, toleranceSec = 0.5))
     }
 
     @Test

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/StreamingMediaDataSourceTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/StreamingMediaDataSourceTest.kt
@@ -1,0 +1,123 @@
+package au.com.shiftyjelly.pocketcasts.repositories.fingerprint
+
+import android.net.Uri
+import androidx.media3.common.C
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.DataSpec
+import androidx.media3.datasource.TransferListener
+import java.util.concurrent.atomic.AtomicInteger
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@UnstableApi
+@RunWith(RobolectricTestRunner::class)
+class StreamingMediaDataSourceTest {
+
+    private val uri = Uri.parse("https://example.com/audio.mp3")
+    private val data = ByteArray(200) { it.toByte() }
+    private val factory = FakeDataSourceFactory(data)
+    private val buffer = ByteArray(64)
+
+    @Test
+    fun `getSize returns the length reported when opening at zero`() {
+        val source = StreamingMediaDataSource(factory, uri)
+
+        assertEquals(200L, source.size)
+    }
+
+    @Test
+    fun `sequential reads reuse the open source`() {
+        val source = StreamingMediaDataSource(factory, uri)
+
+        assertEquals(10, source.readAt(0, buffer, 0, 10))
+        assertEquals(10, source.readAt(10, buffer, 0, 10))
+
+        assertEquals(1, factory.createdSources.size)
+        assertEquals(10.toByte(), buffer[0])
+    }
+
+    @Test
+    fun `readAt reopens when the requested position does not follow the last read`() {
+        val source = StreamingMediaDataSource(factory, uri)
+
+        assertEquals(10, source.readAt(0, buffer, 0, 10))
+        assertEquals(10, source.readAt(50, buffer, 0, 10))
+
+        assertEquals(2, factory.createdSources.size)
+        assertEquals(50L, factory.createdSources[1].openedAt)
+        assertEquals(50.toByte(), buffer[0])
+    }
+
+    @Test
+    fun `readAt returns end of stream when reading past the end`() {
+        val source = StreamingMediaDataSource(factory, uri)
+
+        assertEquals(-1, source.readAt(200, buffer, 0, 10))
+    }
+
+    @Test
+    fun `follow loop waits until the cache covers the read then reads`() {
+        val calls = AtomicInteger()
+        val source = StreamingMediaDataSource(
+            dataSourceFactory = factory,
+            uri = uri,
+            cachedLengthAt = { _, _ -> if (calls.incrementAndGet() < 3) 0L else 100L },
+        )
+
+        assertEquals(10, source.readAt(0, buffer, 0, 10))
+        assertTrue(calls.get() >= 3)
+    }
+
+    @Test
+    fun `readAt returns end of stream when the caller is no longer active`() {
+        val source = StreamingMediaDataSource(factory, uri, isActive = { false })
+
+        assertEquals(-1, source.readAt(0, buffer, 0, 10))
+        assertTrue(factory.createdSources.isEmpty())
+    }
+
+    @Test
+    fun `readAt returns end of stream when the caller becomes inactive between reads`() {
+        var active = true
+        val source = StreamingMediaDataSource(factory, uri, isActive = { active })
+
+        assertEquals(10, source.readAt(0, buffer, 0, 10))
+        active = false
+        assertEquals(-1, source.readAt(10, buffer, 0, 10))
+    }
+
+    private class FakeDataSourceFactory(private val data: ByteArray) : DataSource.Factory {
+        val createdSources = mutableListOf<FakeDataSource>()
+
+        override fun createDataSource(): DataSource = FakeDataSource(data).also { createdSources += it }
+    }
+
+    private class FakeDataSource(private val data: ByteArray) : DataSource {
+        var openedAt = -1L
+        private var readPosition = 0
+
+        override fun addTransferListener(transferListener: TransferListener) = Unit
+
+        override fun open(dataSpec: DataSpec): Long {
+            openedAt = dataSpec.position
+            readPosition = dataSpec.position.toInt()
+            return data.size - dataSpec.position
+        }
+
+        override fun read(buffer: ByteArray, offset: Int, length: Int): Int {
+            if (readPosition >= data.size) return C.RESULT_END_OF_INPUT
+            val toRead = minOf(length, data.size - readPosition)
+            System.arraycopy(data, readPosition, buffer, offset, toRead)
+            readPosition += toRead
+            return toRead
+        }
+
+        override fun getUri(): Uri? = null
+
+        override fun close() = Unit
+    }
+}


### PR DESCRIPTION
## Description

Cherry-pick of #5614 into `release/8.17`.

> **This change was already reviewed and merged on `main`.** This PR exists to land it in the upcoming release. CI and a quick review should still run to confirm the cherry-pick applies cleanly and introduces no issues on the release branch, since `release/8.17` may have diverged from `main`.

Stacked on #5660 (cherry-pick of #5613) — merge that first; this PR retargets `release/8.17` automatically when it lands.

- Original PR: https://github.com/Automattic/pocket-casts-android/pull/5614
- Cherry-picked commit: `decd9eec4d`

## Testing Instructions

See the original PR (https://github.com/Automattic/pocket-casts-android/pull/5614) for full testing steps. In addition, verify the change behaves as described on top of `release/8.17`.