### PR TITLE
Tap into ExoPlayer's cache instead of a standalone MediaSource for fingerprinting (cherry-pick to 8.17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 *   Updates
     *   Respect Audio only toggle when playing progressive mp4 episodes
         ([#5627](https://github.com/Automattic/pocket-casts-android/pull/5627))
+    *   Tap into ExoPlayer's cache instead of a standalone MediaSource for fingerprinting
+        ([#5618](https://github.com/Automattic/pocket-casts-android/pull/5618))
 *   Bug Fixes
     *   Fix episodes being cached over mobile data when Warn before using data is enabled
         ([#5567](https://github.com/Automattic/pocket-casts-android/pull/5567))

--- a/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptCueHelper.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptCueHelper.kt
@@ -146,6 +146,8 @@ internal object TranscriptCueHelper {
 
     fun isSeekSettled(posMs: Int, seekTargetMs: Int): Boolean = abs(posMs - seekTargetMs) <= SEEK_SETTLE_TOLERANCE_MS
 
+    fun isHeldTapStale(posMs: Int, seekTargetMs: Int?): Boolean = seekTargetMs != null && !isSeekSettled(posMs, seekTargetMs)
+
     fun hasReachedTappedRow(outcome: HighlightOutcome, tappedIndex: Int): Boolean = outcome is HighlightOutcome.Show && outcome.entryIndex >= tappedIndex
 
     fun findWordIndex(

--- a/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptPage.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptPage.kt
@@ -142,8 +142,10 @@ fun TranscriptPage(
 
                                 TranscriptViewModel.TapSeekResult.Resolving -> {
                                     // Light the row as immediate feedback while the bounded resolve runs.
+                                    // The null-target hold keeps the frame loop from overwriting it.
                                     val previousHighlight = highlightState
                                     highlightState = HighlightState(entryIndex = index)
+                                    pendingSeek = PendingTapSeek(positionMs = null, entryIndex = index)
                                     tapScope.launch {
                                         var seekTarget: Int? = null
                                         try {
@@ -153,8 +155,11 @@ fun TranscriptPage(
                                             val target = seekTarget
                                             if (target != null) {
                                                 applySeek(target)
-                                            } else if (highlightState.entryIndex == index) {
-                                                highlightState = previousHighlight
+                                            } else {
+                                                pendingSeek = pendingSeek?.takeUnless { it.positionMs == null && it.entryIndex == index }
+                                                if (highlightState.entryIndex == index) {
+                                                    highlightState = previousHighlight
+                                                }
                                             }
                                         }
                                     }
@@ -366,13 +371,19 @@ private fun HighlightEffect(
 
     val cueIndexHolder = remember(transcript.entries) { intArrayOf(0) }
 
+    // A new transcript makes any held tap stale; branch flaps below must not drop it.
+    LaunchedEffect(transcript.entries) {
+        latestOnConsumePendingSeek()
+    }
+
     if (isPlaying && isSyncedActive) {
         LaunchedEffect(transcript.entries) {
             cueIndexHolder[0] = 0
-            latestOnConsumePendingSeek()
             var wasHighlighting = false
             var settledForSeek: Int? = null
-            latestOnHighlightChanged(HighlightState())
+            if (latestPendingSeek == null) {
+                latestOnHighlightChanged(HighlightState())
+            }
             val episode = playbackManager.getCurrentEpisode()
             while (true) {
                 withFrameNanos { }
@@ -385,13 +396,15 @@ private fun HighlightEffect(
 
                 val pending = latestPendingSeek
                 if (pending != null) {
-                    // Hold the tapped row until the seek settles and resolution reaches it.
-                    if (settledForSeek != pending.positionMs &&
-                        TranscriptCueHelper.isSeekSettled(posMs, pending.positionMs)
+                    // Hold the tapped row until the target is known, the seek settles, and
+                    // resolution reaches it.
+                    val targetMs = pending.positionMs
+                    if (targetMs != null && settledForSeek != targetMs &&
+                        TranscriptCueHelper.isSeekSettled(posMs, targetMs)
                     ) {
-                        settledForSeek = pending.positionMs
+                        settledForSeek = targetMs
                     }
-                    val settled = settledForSeek == pending.positionMs
+                    val settled = targetMs != null && settledForSeek == targetMs
                     val reachedRow = TranscriptCueHelper.hasReachedTappedRow(outcome, pending.entryIndex)
                     if (settled && reachedRow) {
                         latestOnConsumePendingSeek()
@@ -421,13 +434,17 @@ private fun HighlightEffect(
             }
         }
     } else if (isSyncedActive) {
-        // Paused but synced: no frame loop, so recompute once per position change.
+        // Paused but synced: no frame loop, so recompute once per position change. A held tap
+        // stays lit while the position sits at its target; seeking elsewhere releases it.
         LaunchedEffect(transcript.entries, playbackState?.positionMs) {
             val posMs = playbackState?.positionMs ?: return@LaunchedEffect
-            if (posMs == latestPendingSeek?.positionMs) {
-                return@LaunchedEffect
+            val pending = latestPendingSeek
+            if (pending != null) {
+                if (!TranscriptCueHelper.isHeldTapStale(posMs, pending.positionMs)) {
+                    return@LaunchedEffect
+                }
+                latestOnConsumePendingSeek()
             }
-            latestOnConsumePendingSeek()
             when (val outcome = resolveHighlight(transcript.entries, posMs, fingerprintTimingManager, cueIndexHolder[0])) {
                 is HighlightOutcome.Show -> {
                     cueIndexHolder[0] = outcome.entryIndex
@@ -553,7 +570,8 @@ internal data class HighlightState(
 )
 
 internal data class PendingTapSeek(
-    val positionMs: Int,
+    // Null while the bounded resolve is still computing the target position.
+    val positionMs: Int?,
     val entryIndex: Int,
 )
 

--- a/modules/features/transcripts/src/test/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptCueHelperTest.kt
+++ b/modules/features/transcripts/src/test/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptCueHelperTest.kt
@@ -378,6 +378,24 @@ class TranscriptCueHelperTest {
         assertFalse(TranscriptCueHelper.isSeekSettled(posMs = 60_000, seekTargetMs = 30_000))
     }
 
+    // --- isHeldTapStale ---
+
+    @Test
+    fun `isHeldTapStale is false while the position sits at the seek target`() {
+        assertFalse(TranscriptCueHelper.isHeldTapStale(posMs = 30_500, seekTargetMs = 30_000))
+    }
+
+    @Test
+    fun `isHeldTapStale is false while the target is still resolving`() {
+        assertFalse(TranscriptCueHelper.isHeldTapStale(posMs = 90_000, seekTargetMs = null))
+    }
+
+    @Test
+    fun `isHeldTapStale is true once the position moves away from the seek target`() {
+        assertTrue(TranscriptCueHelper.isHeldTapStale(posMs = 90_000, seekTargetMs = 30_000))
+        assertTrue(TranscriptCueHelper.isHeldTapStale(posMs = 5_000, seekTargetMs = 30_000))
+    }
+
     // --- hasReachedTappedRow ---
 
     @Test

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintConstants.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintConstants.kt
@@ -1,21 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.repositories.fingerprint
 
 object FingerprintConstants {
-    /** If consecutive playback-progress updates differ by more than this, treat it as a seek/skip. */
-    const val RESTART_DELTA_SECONDS = 10.0
-
-    /** Slack window around the already-mapped range before playback is considered "outside". */
-    const val PLAYBACK_RANGE_MARGIN_SECONDS = 30.0
-
-    /** Minimum time between stream restarts while playback sits outside the mapped range. */
-    const val STREAM_BOOTSTRAP_COOLDOWN_MS = 5_000L
-
-    /** Position must be stable for this long before a seek restarts the stream; coalesces rapid multi-tap skips. */
-    const val RESTART_DEBOUNCE_MS = 1_500L
-
-    /** How often a running remote decode re-checks that the network still permits streaming. */
-    const val METERED_RECHECK_INTERVAL_MS = 5_000L
-
     /** Minimum match score to accept a fingerprint match result. */
     const val MATCH_SCORE_THRESHOLD = 0.5f
 
@@ -40,17 +25,35 @@ object FingerprintConstants {
     /** Minimum score gap between top-1 and top-2 matcher candidates. */
     const val DRIFT_SCORE_DOMINANCE_GAP = 0.05f
 
-    /** Distance ahead of current playback within which fingerprinting runs at full speed. */
-    const val LOOKAHEAD_SECONDS = 60.0
-
-    /** Sleep between chunks when fingerprinting ahead of the lookahead window. */
-    const val OUTSIDE_LOOKAHEAD_SLEEP_SECONDS = 0.5
+    /** Position drift between consecutive tap chunks beyond which the window stream restarts. */
+    const val TAP_CONTINUITY_TOLERANCE_SECONDS = 0.25
 
     /** Minimum fraction of reference timeline a cached mapping must cover. */
     const val FULL_COVERAGE_THRESHOLD = 0.95
 
     /** Max gap between bracketing anchors to consider playback on matched content. */
     const val HIGHLIGHT_MAX_GAP_SECONDS = 8.0
+
+    /**
+     * Grace past the newest anchor before the live edge counts as unmatched. The tap-built map lags
+     * the playhead by a full window plus stride and sink-buffer variance, so this must exceed
+     * [WINDOW_DURATION_MS] + [WINDOW_INTERVAL_MS] with headroom for the odd missed match.
+     */
+    const val TAP_TRAILING_GRACE_SECONDS = 12.0
+
+    /**
+     * Drop the trailing grace once completed tap windows reach this far past the newest anchor
+     * without matching — the live edge is provably unmatched (an ad), not merely pending. Wide
+     * enough that a couple of isolated missed matches never trip it.
+     */
+    const val TAP_UNMATCHED_EDGE_SECONDS = 3.0
+
+    /**
+     * Audio decoded in one shot when a tap stream starts in unmapped territory. The tap only sees
+     * audio in realtime, so its first window lands [WINDOW_DURATION_MS] after a seek; a faster-than-
+     * realtime decode of this span puts anchors at the new playhead within ~a second instead.
+     */
+    const val TAP_CATCH_UP_SECONDS = 12.0
 
     /** Persistent cache schema version. Bump when on-disk shape changes. */
     const val MAPPING_CACHE_SCHEMA_VERSION = 4
@@ -76,15 +79,12 @@ object FingerprintConstants {
     /** Timeout for the reference fetch of an on-demand resolve; short because reference files are small. */
     const val ON_DEMAND_FETCH_TIMEOUT_MS = 3_000L
 
-    /** Timeout for the decode of an on-demand resolve. */
-    const val ON_DEMAND_TIMEOUT_MS = 5_000L
+    /** Budget for the decode of an on-demand resolve; opening a remote source alone can take seconds. */
+    const val ON_DEMAND_DECODE_TIMEOUT_MS = 8_000L
 
     /** Committed reference time must pass the target by this much before a resolve stops decoding early. */
     const val ON_DEMAND_EARLY_EXIT_MARGIN_SECONDS = 5.0
 
     /** How often a yielded continuous decode re-checks for on-demand resolves in flight. */
     const val RESOLVE_YIELD_POLL_MS = 250L
-
-    /** Release a parked throttled decode after playback has been idle this long. */
-    const val PARKED_DECODE_RELEASE_MS = 120_000L
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintPcmTap.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintPcmTap.kt
@@ -1,0 +1,90 @@
+package au.com.shiftyjelly.pocketcasts.repositories.fingerprint
+
+import androidx.annotation.OptIn
+import androidx.media3.common.C
+import androidx.media3.common.audio.AudioProcessor
+import androidx.media3.common.util.UnstableApi
+import java.nio.ByteBuffer
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.math.abs
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+
+/**
+ * Publishes the PCM the player is already decoding, stamped with its media-time position, so
+ * fingerprinting can reuse it instead of downloading and decoding the episode a second time.
+ * Producer callbacks are all invoked from the playback thread.
+ */
+@OptIn(UnstableApi::class)
+@Singleton
+class FingerprintPcmTap @Inject constructor() {
+
+    class PcmChunk(
+        val data: ByteArray,
+        val encoding: Int,
+        val sampleRate: Int,
+        val channelCount: Int,
+        val positionSec: Double,
+    )
+
+    private val chunkFlow = MutableSharedFlow<PcmChunk>(
+        extraBufferCapacity = CHUNK_BUFFER_CAPACITY,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+    val chunks: SharedFlow<PcmChunk> = chunkFlow.asSharedFlow()
+
+    private var pendingAnchorUs = C.TIME_UNSET
+    private var anchorUs = C.TIME_UNSET
+    private var framesSinceAnchor = 0L
+
+    fun onSinkBuffer(presentationTimeUs: Long) {
+        pendingAnchorUs = presentationTimeUs
+    }
+
+    fun onSinkFlush() {
+        pendingAnchorUs = C.TIME_UNSET
+        anchorUs = C.TIME_UNSET
+        framesSinceAnchor = 0
+    }
+
+    fun onPcm(buffer: ByteBuffer, format: AudioProcessor.AudioFormat) {
+        val frames = buffer.remaining() / format.bytesPerFrame
+        if (frames == 0) return
+        val pending = pendingAnchorUs
+        pendingAnchorUs = C.TIME_UNSET
+        if (anchorUs == C.TIME_UNSET) {
+            if (pending == C.TIME_UNSET) return
+            anchorUs = pending
+            framesSinceAnchor = 0
+        } else if (pending != C.TIME_UNSET) {
+            if (abs(pending - positionUs(format.sampleRate)) > REANCHOR_TOLERANCE_US) {
+                anchorUs = pending
+                framesSinceAnchor = 0
+            }
+        }
+        val positionSec = positionUs(format.sampleRate) / 1_000_000.0
+        framesSinceAnchor += frames
+        if (chunkFlow.subscriptionCount.value == 0) return
+        val data = ByteArray(buffer.remaining())
+        buffer.duplicate().get(data)
+        chunkFlow.tryEmit(
+            PcmChunk(
+                data = data,
+                encoding = format.encoding,
+                sampleRate = format.sampleRate,
+                channelCount = format.channelCount,
+                positionSec = positionSec,
+            ),
+        )
+    }
+
+    private fun positionUs(sampleRate: Int): Long = anchorUs + framesSinceAnchor * 1_000_000 / sampleRate
+
+    companion object {
+        private const val CHUNK_BUFFER_CAPACITY = 64
+        private const val REANCHOR_TOLERANCE_US = 200_000L
+    }
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTapAudioProcessor.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTapAudioProcessor.kt
@@ -1,0 +1,26 @@
+package au.com.shiftyjelly.pocketcasts.repositories.fingerprint
+
+import androidx.annotation.OptIn
+import androidx.media3.common.audio.AudioProcessor
+import androidx.media3.common.audio.BaseAudioProcessor
+import androidx.media3.common.util.UnstableApi
+import java.nio.ByteBuffer
+
+/** Passthrough processor that copies the player's decoded PCM into [FingerprintPcmTap]. */
+@OptIn(UnstableApi::class)
+class FingerprintTapAudioProcessor(
+    private val tap: FingerprintPcmTap,
+    private val isEnabled: () -> Boolean,
+) : BaseAudioProcessor() {
+
+    override fun onConfigure(inputAudioFormat: AudioProcessor.AudioFormat): AudioProcessor.AudioFormat {
+        return if (isEnabled()) inputAudioFormat else AudioProcessor.AudioFormat.NOT_SET
+    }
+
+    override fun queueInput(inputBuffer: ByteBuffer) {
+        val remaining = inputBuffer.remaining()
+        if (remaining == 0) return
+        tap.onPcm(inputBuffer.asReadOnlyBuffer(), inputAudioFormat)
+        replaceOutputBuffer(remaining).put(inputBuffer).flip()
+    }
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
@@ -4,11 +4,10 @@ import android.content.Context
 import android.media.MediaCodec
 import android.media.MediaExtractor
 import android.media.MediaFormat
-import android.net.ConnectivityManager
-import android.net.NetworkCapabilities
 import android.os.SystemClock
 import androidx.annotation.VisibleForTesting
 import androidx.core.net.toUri
+import androidx.media3.common.C
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -38,6 +37,7 @@ import javax.inject.Singleton
 import kotlin.math.abs
 import kotlin.math.floor
 import kotlin.math.max
+import kotlin.math.min
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.DurationUnit
@@ -52,7 +52,6 @@ import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
@@ -73,6 +72,7 @@ class FingerprintTimingManager @Inject constructor(
     private val chapterManager: Lazy<ChapterManager>,
     private val settings: Settings,
     private val dataSourceFactory: Lazy<ExoPlayerDataSourceFactory>,
+    private val pcmTap: FingerprintPcmTap,
 ) {
 
     /** Who asked for preparation; decides whether streaming over a metered network is acceptable. */
@@ -142,21 +142,16 @@ class FingerprintTimingManager @Inject constructor(
     var debugRejectionsSnapshot: List<DebugRejection> = emptyList()
         private set
 
-    @Volatile
-    private var lastProgressPositionMs = -1
     private var generationJob: Job? = null
-    private var progressObserverJob: Job? = null
-    private var pendingRestartJob: Job? = null
-    private var lastStreamStartTimeMs = 0L
+    private var downloadObserverJob: Job? = null
+
+    // Playback time of the newest window the tap has completed (matched or not) in the current
+    // stream; NaN until the first window. Lets the grace gates tell "pending" from "unmatched".
+    @Volatile
+    private var tapFrontierSec = Double.NaN
 
     @Volatile
-    private var activeDecodeStartSec = 0.0
-
-    @Volatile
-    private var activeDecodeFrontierSec = 0.0
-
-    @Volatile
-    private var unmeteredRetryCallback: ConnectivityManager.NetworkCallback? = null
+    private var catchUpJob: Job? = null
 
     @Volatile
     private var generation = 0L
@@ -185,10 +180,7 @@ class FingerprintTimingManager @Inject constructor(
     @Volatile
     private var currentIsStreaming: Boolean = false
 
-    @Volatile
-    private var lastProgressAtMs = 0L
-
-    // When true, decode the whole stream from the start ignoring the playhead lookahead throttle,
+    // When true, decode the whole file locally from the start instead of following the PCM tap,
     // so the full reference<->playback map is available for chapter alignment.
     @Volatile
     private var currentEager: Boolean = false
@@ -242,24 +234,25 @@ class FingerprintTimingManager @Inject constructor(
                     }
                     return@launch
                 }
+                // The tap builds the map progressively; keep whatever the last episode accumulated.
+                persistMappingCacheIfFull()
                 resetState()
                 generation++
                 gen = generation
             }
             // Abort if a newer stop()/prepare() has started since we acquired the lock.
             if (gen != generation) return@launch
-            startPlaybackProgressObserver(episodeUuid)
+            startDownloadCompletionObserver(episodeUuid)
             prepareForEpisode(gen, episodeUuid, podcastUuid, audioSource, sharedCacheKey, episode.isDownloaded, episode.duration, trigger)
         }
     }
 
-    private fun startPlaybackProgressObserver(episodeUuid: String) {
-        progressObserverJob?.cancel()
-        progressObserverJob = scope.launch {
+    private fun startDownloadCompletionObserver(episodeUuid: String) {
+        downloadObserverJob?.cancel()
+        downloadObserverJob = scope.launch {
             playbackManager.playbackStateFlow.collect { state ->
                 if (state.episodeUuid == episodeUuid && state.isPlaying) {
                     maybeAdoptDownloadedCopy(episodeUuid)
-                    onPlaybackProgress(state.positionMs, state.episodeUuid)
                 }
             }
         }
@@ -287,6 +280,7 @@ class FingerprintTimingManager @Inject constructor(
         scope.launch {
             mutex.withLock {
                 generation++
+                persistMappingCacheIfFull()
                 resetState()
                 _stateFlow.value = State.Idle
             }
@@ -311,13 +305,22 @@ class FingerprintTimingManager @Inject constructor(
 
     /**
      * Playback time for [referenceTime] when the active mapping is dense around it, so a full
-     * on-demand resolve is unnecessary. Null when the mapping is missing, sparse, or another episode's.
+     * on-demand resolve is unnecessary. Null when the mapping is missing, sparse, or another
+     * episode's. Allows the same trailing grace past the last anchor as [isWithinMatchedContent],
+     * since the tap-built map lags the playhead by a window length.
      */
     fun densePlaybackTime(episodeUuid: String, referenceTime: Duration): Duration? {
         if (activeEpisodeUuid != episodeUuid) return null
-        val playback = densePlaybackSec(referenceTime.toDouble(DurationUnit.SECONDS), snapshotReferenceToPlayback) ?: return null
+        val playback = densePlaybackSec(
+            referenceTimeSec = referenceTime.toDouble(DurationUnit.SECONDS),
+            entries = snapshotReferenceToPlayback,
+            allowTrailingGrace = !isLiveEdgeUnmatched(snapshotPlaybackToReference),
+        ) ?: return null
         return playback.seconds
     }
+
+    /** True when completed tap windows have passed the newest anchor without matching, so the live edge is an ad. */
+    private fun isLiveEdgeUnmatched(entries: List<TimeMappingEntry>): Boolean = isLiveEdgeUnmatched(tapFrontierSec, entries.lastOrNull()?.playbackTime)
 
     /**
      * One-shot bounded resolve of a generated chapter's reference time to the playback timeline.
@@ -399,7 +402,7 @@ class FingerprintTimingManager @Inject constructor(
         activeResolves.incrementAndGet()
         val timedOut = try {
             matcher.use {
-                withTimeoutOrNull(FingerprintConstants.ON_DEMAND_TIMEOUT_MS) {
+                withTimeoutOrNull(FingerprintConstants.ON_DEMAND_DECODE_TIMEOUT_MS) {
                     streamFingerprintBounded(
                         audioFilePath = audioSource,
                         matcher = it,
@@ -435,9 +438,20 @@ class FingerprintTimingManager @Inject constructor(
 
         mergeResolvedAnchors(episodeUuid, acc.playbackToReference)
 
-        // The ad offset is non-negative, so the true position is never before the reference time.
+        Timber.d(
+            "FingerprintTimingManager: resolve ref=%.1f window=[%.1f,%.1f] anchors=%d playback=%.1f usedPrior=%b",
+            referenceTimeSec,
+            window.startSec,
+            window.endSec,
+            acc.referenceToPlayback.size,
+            playback,
+            usedPrior,
+        )
+
+        // The offset can be negative when the reference audio carries ads this copy doesn't,
+        // so the resolved position must not be clamped to the reference time.
         return ChapterSeekResult.Resolved(
-            playbackTime = max(referenceTimeSec, playback).seconds,
+            playbackTime = max(0.0, playback).seconds,
             usedPrior = usedPrior,
         )
     }
@@ -456,6 +470,10 @@ class FingerprintTimingManager @Inject constructor(
             }
             if (inserted > 0) {
                 publishSnapshot()
+                val coverage = mapping.playbackToReference.size
+                if (coverage >= FingerprintConstants.MINIMUM_COVERAGE_FOR_ACTIVE) {
+                    markActive(coverage)
+                }
                 Timber.d("FingerprintTimingManager: merged $inserted resolved anchors into the mapping")
             }
         }
@@ -510,12 +528,13 @@ class FingerprintTimingManager @Inject constructor(
         targetReferenceSec: Double,
         acc: MappingAccumulator,
         cacheKey: String?,
+        followPlayerCache: Boolean = false,
     ) {
         // Capture the current generation so the decode aborts if the episode changes mid-resolve.
         val gen = generation
         val callerJob = currentCoroutineContext().job
         val isRemoteUrl = audioFilePath.startsWith("http://") || audioFilePath.startsWith("https://")
-        openAudioStream(gen, audioFilePath, startingAt, cacheKey, followPlayerCache = false, isCallerActive = { callerJob.isActive }).use { stream ->
+        openAudioStream(gen, audioFilePath, startingAt, cacheKey, followPlayerCache = followPlayerCache, isCallerActive = { callerJob.isActive }).use { stream ->
             stream.start()
 
             val streamer = StreamingWindowedFingerprinter(
@@ -528,65 +547,20 @@ class FingerprintTimingManager @Inject constructor(
                 decodeAndFingerprint(
                     stream = stream,
                     gen = gen,
-                    isRemoteUrl = isRemoteUrl,
                     streamer = streamer,
-                    startOffset = startingAt,
+                    startOffset = stream.startSec,
                     endingAt = endingAt,
-                    throttleToPlayhead = false,
-                    trackFrontier = false,
                     stopWhen = { isResolveTargetCovered(acc, targetReferenceSec) },
                 ) { windows ->
-                    matchWindows(windows, matcher, startingAt, acc)
+                    matchWindows(windows, matcher, stream.startSec, acc)
                 }
                 val tail = streamer.flush()
                 if (tail.isNotEmpty()) {
-                    matchWindows(tail, matcher, startingAt, acc)
+                    matchWindows(tail, matcher, stream.startSec, acc)
                 }
             } finally {
                 streamer.close()
             }
-        }
-    }
-
-    /** Must be called under [mutex]. */
-    private fun registerUnmeteredRetry(episodeUuid: String) {
-        if (unmeteredRetryCallback != null) return
-        val callback = object : ConnectivityManager.NetworkCallback() {
-            override fun onCapabilitiesChanged(network: android.net.Network, networkCapabilities: NetworkCapabilities) {
-                if (!networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED)) return
-                if (!Network.isUnmeteredConnection(context)) return
-                if (playbackManager.getCurrentEpisode()?.uuid != episodeUuid) return
-                val self = this
-                scope.launch {
-                    val shouldRetry = mutex.withLock {
-                        if (unmeteredRetryCallback !== self) return@withLock false
-                        unregisterUnmeteredRetry()
-                        true
-                    }
-                    if (shouldRetry) {
-                        Timber.d("FingerprintTimingManager: unmetered network available — retrying preparation")
-                        prepareForCurrentEpisode(PrepareTrigger.PLAYBACK)
-                    }
-                }
-            }
-        }
-        unmeteredRetryCallback = callback
-        runCatching {
-            val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
-            connectivityManager.registerDefaultNetworkCallback(callback)
-        }.onFailure {
-            unmeteredRetryCallback = null
-            Timber.w(it, "FingerprintTimingManager: failed to register network callback")
-        }
-    }
-
-    /** Must be called under [mutex]. */
-    private fun unregisterUnmeteredRetry() {
-        val callback = unmeteredRetryCallback ?: return
-        unmeteredRetryCallback = null
-        runCatching {
-            val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
-            connectivityManager.unregisterNetworkCallback(callback)
         }
     }
 
@@ -664,7 +638,7 @@ class FingerprintTimingManager @Inject constructor(
     fun matchedReferenceTime(forPlaybackTimeMs: Int): Double? {
         val playbackTimeSec = forPlaybackTimeMs / 1000.0
         val entries = snapshotPlaybackToReference
-        if (!isWithinMatchedContent(playbackTimeSec, entries)) {
+        if (!isWithinMatchedContent(playbackTimeSec, entries, allowTrailingGrace = !isLiveEdgeUnmatched(entries))) {
             if (lastMatchedContentResult) {
                 lastMatchedContentResult = false
                 logMatchedContentTransition(playbackTimeSec, entries, matched = false)
@@ -708,20 +682,15 @@ class FingerprintTimingManager @Inject constructor(
     private fun resetState() {
         generationJob?.cancel()
         generationJob = null
-        progressObserverJob?.cancel()
-        progressObserverJob = null
-        pendingRestartJob?.cancel()
-        pendingRestartJob = null
-        unregisterUnmeteredRetry()
+        downloadObserverJob?.cancel()
+        downloadObserverJob = null
         mapping.reset()
         debugRejections.clear()
         debugRejectionsSnapshot = emptyList()
         publishSnapshot()
-        lastProgressPositionMs = -1
-        lastProgressAtMs = 0L
-        lastStreamStartTimeMs = 0L
-        activeDecodeStartSec = 0.0
-        activeDecodeFrontierSec = 0.0
+        tapFrontierSec = Double.NaN
+        catchUpJob?.cancel()
+        catchUpJob = null
         currentEpisodeUuid = null
         currentAudioFilePath = null
         currentSharedCacheKey = null
@@ -741,9 +710,9 @@ class FingerprintTimingManager @Inject constructor(
     }
 
     /**
-     * Eager full-stream mapping only makes sense on mobile, for episodes with generated chapters,
-     * and only for local downloads. Streaming episodes fall back to the throttled follow-the-playhead
-     * pass plus the bounded on-demand resolver, so we never pull a whole file over the network to map it.
+     * Eager full-file mapping only makes sense on mobile, for episodes with generated chapters,
+     * and only for local downloads. Everything else builds the map from the player's PCM tap
+     * plus the bounded on-demand resolver, so nothing is ever downloaded twice.
      */
     private suspend fun shouldRunEagerPass(episodeUuid: String, isDownloaded: Boolean): Boolean {
         if (Util.getAppPlatform(context) != AppPlatform.Phone) return false
@@ -788,19 +757,10 @@ class FingerprintTimingManager @Inject constructor(
             return
         }
 
-        val blocked = shouldBlockRemoteFingerprinting(
-            isDownloaded = isDownloaded,
-            trigger = trigger,
-            warnOnMeteredNetwork = settings.warnOnMeteredNetwork.value,
-            isUnmetered = { Network.isUnmeteredConnection(context) },
-        )
-        if (blocked) {
-            mutex.withLock {
-                if (gen != generation) return
-                markUnavailable(reason = "metered_network", isStreaming = true, episodeUuid = episodeUuid)
-                registerUnmeteredRetry(episodeUuid)
-            }
-            Timber.d("FingerprintTimingManager: skipping remote fingerprinting on metered network")
+        if (playbackManager.isPlaybackRemote()) {
+            // The player decodes remotely, so there is no local PCM to fingerprint.
+            markUnavailable(reason = "remote_playback", isStreaming = !isDownloaded, episodeUuid = episodeUuid)
+            Timber.d("FingerprintTimingManager: remote playback")
             return
         }
 
@@ -927,151 +887,206 @@ class FingerprintTimingManager @Inject constructor(
             }
         }
 
-        // Start streaming fingerprint generation. An eager pass maps the whole timeline from the start;
-        // otherwise we follow the playhead.
-        val startPosition = if (currentEager) 0.0 else playbackManager.playbackStateFlow.first().positionMs / 1000.0
+        // A downloaded episode with generated chapters gets a full local decode so the whole map is
+        // available for chapter alignment; everything else builds the map from the player's PCM tap.
         mutex.withLock {
             if (gen != generation) return
-            startStream(audioFilePath, matcher, episodeUuid, startPosition = startPosition)
-        }
-    }
-
-    private fun onPlaybackProgress(positionMs: Int, episodeUuid: String?) {
-        if (episodeUuid != currentEpisodeUuid) return
-
-        lastProgressAtMs = SystemClock.elapsedRealtime()
-        scope.launch {
-            mutex.withLock {
-                processProgress(positionMs)
-            }
-        }
-    }
-
-    private fun processProgress(positionMs: Int) {
-        val positionSec = positionMs / 1000.0
-        val mappedRunEndSec = mappedRunEnd(positionSec, mapping.playbackToReference)
-        val decision = decideOnProgress(
-            positionSec = positionSec,
-            lastPositionSec = if (lastProgressPositionMs >= 0) lastProgressPositionMs / 1000.0 else null,
-            isEager = currentEager,
-            mappedRunEndSec = mappedRunEndSec,
-            hasAnyMapping = mapping.playbackToReference.isNotEmpty(),
-            isDecodeActive = generationJob?.isActive == true,
-            isCoveredByActiveDecode = isCoveredByActiveDecode(positionSec),
-            isRunEndCoveredByActiveDecode = mappedRunEndSec != null && isCoveredByActiveDecode(mappedRunEndSec),
-            isRunEndNearEpisodeEnd = mappedRunEndSec != null &&
-                mappedRunEndSec >= currentDurationSec - FingerprintConstants.PLAYBACK_RANGE_MARGIN_SECONDS,
-            hasPendingRestart = pendingRestartJob?.isActive == true,
-            hasStreamStarted = lastStreamStartTimeMs != 0L,
-            msSinceStreamStart = SystemClock.elapsedRealtime() - lastStreamStartTimeMs,
-            isStreaming = currentIsStreaming,
-        )
-        lastProgressPositionMs = positionMs
-        when (decision) {
-            ProgressDecision.None -> Unit
-
-            ProgressDecision.CancelDecode -> {
-                Timber.d("FingerprintTimingManager: playback within mapped range — cancelling decode")
-                generationJob?.cancel()
-                generationJob = null
-            }
-
-            ProgressDecision.ScheduleDebouncedRestart -> {
-                Timber.d("FingerprintTimingManager: playback jumped — scheduling restart")
-                schedulePendingRestart()
-            }
-
-            ProgressDecision.RestartOutsideRange -> {
-                Timber.d("FingerprintTimingManager: playback outside mapped range — restarting")
-                restartFromPlayhead()
-            }
-
-            is ProgressDecision.RestartFromRunEnd -> {
-                Timber.d("FingerprintTimingManager: mapping about to run out — resuming decode from run end")
-                restartFromRunEnd(decision.runEndSec)
+            if (currentEager) {
+                startEagerLocalDecode(gen, audioFilePath, matcher, episodeUuid)
+            } else {
+                startTapCollection(gen, matcher)
             }
         }
     }
 
     /** Must be called under [mutex]. */
-    private fun schedulePendingRestart() {
-        pendingRestartJob?.cancel()
-        val gen = generation
-        pendingRestartJob = scope.launch {
-            delay(FingerprintConstants.RESTART_DEBOUNCE_MS)
-            playbackManager.playbackStateFlow.first { it.isPlaying }
-            mutex.withLock {
-                if (gen != generation) return@withLock
-                val settledSec = lastProgressPositionMs / 1000.0
-                if (mappedRunEnd(settledSec, mapping.playbackToReference) != null || isCoveredByActiveDecode(settledSec)) return@withLock
-                Timber.d("FingerprintTimingManager: playback jumped — restarting")
-                restartFromPlayhead()
-            }
-        }
-    }
-
-    private fun canStreamOnCurrentNetwork(): Boolean = !currentIsStreaming ||
-        !shouldBlockRemoteFingerprinting(
-            isDownloaded = false,
-            trigger = currentTrigger,
-            warnOnMeteredNetwork = settings.warnOnMeteredNetwork.value,
-            isUnmetered = { Network.isUnmeteredConnection(context) },
-        )
-
-    /** Must be called under [mutex]. */
-    private fun restartFromPlayhead() {
-        if (!canStreamOnCurrentNetwork()) {
-            Timber.d("FingerprintTimingManager: skipping stream restart on metered network")
-            return
-        }
-        val matcher = currentMatcher ?: return
-        val audioPath = currentAudioFilePath ?: return
-        val uuid = currentEpisodeUuid ?: return
-        mapping.resetFilter()
-        startStream(audioPath, matcher, uuid, startPosition = lastProgressPositionMs / 1000.0)
-    }
-
-    /** Must be called under [mutex]. Continues an existing run, so the drift filter's trusted anchor is kept. */
-    private fun restartFromRunEnd(runEndSec: Double) {
-        if (!canStreamOnCurrentNetwork()) {
-            Timber.d("FingerprintTimingManager: skipping stream restart on metered network")
-            return
-        }
-        val matcher = currentMatcher ?: return
-        val audioPath = currentAudioFilePath ?: return
-        val uuid = currentEpisodeUuid ?: return
-        startStream(audioPath, matcher, uuid, startPosition = runEndSec)
-    }
-
-    private fun isCoveredByActiveDecode(positionSec: Double): Boolean {
-        if (generationJob?.isActive != true) return false
-        return positionSec >= activeDecodeStartSec &&
-            positionSec <= activeDecodeFrontierSec + FingerprintConstants.PLAYBACK_RANGE_MARGIN_SECONDS
-    }
-
-    /** Must be called under [mutex]. */
-    private fun startStream(audioFilePath: String, matcher: CheckpointMatcher, episodeUuid: String, startPosition: Double) {
+    private fun startEagerLocalDecode(gen: Long, audioFilePath: String, matcher: CheckpointMatcher, episodeUuid: String) {
         generationJob?.cancel()
-        lastStreamStartTimeMs = SystemClock.elapsedRealtime()
-        val aligned = alignToWindowGrid(startPosition)
-        activeDecodeStartSec = aligned
-        activeDecodeFrontierSec = aligned
-        // Superseded decode jobs re-check this token before touching shared state.
-        val gen = generation
         generationJob = scope.launch(decodeDispatcher) {
             try {
-                streamFingerprint(gen, audioFilePath, matcher, episodeUuid, startingAt = aligned)
+                streamFingerprint(gen, audioFilePath, matcher, episodeUuid, startingAt = 0.0)
                 if (gen == generation) {
                     persistMappingCacheIfFull()
                 }
             } catch (_: CancellationException) {
-                Timber.d("FingerprintTimingManager: streaming fingerprint cancelled")
+                Timber.d("FingerprintTimingManager: eager fingerprint decode cancelled")
             } catch (e: Exception) {
-                Timber.w(e, "FingerprintTimingManager: streaming fingerprint failed")
+                Timber.w(e, "FingerprintTimingManager: eager fingerprint decode failed")
                 if (gen == generation && state !is State.Active) {
                     markFailed(e, stage = "fingerprint_stream")
                 }
             }
+        }
+    }
+
+    /** Must be called under [mutex]. */
+    private fun startTapCollection(gen: Long, matcher: CheckpointMatcher) {
+        generationJob?.cancel()
+        generationJob = scope.launch(decodeDispatcher) {
+            var streamer: StreamingWindowedFingerprinter? = null
+            var streamStartSec = 0.0
+            var expectedNextSec = 0.0
+            var sampleRate = 0
+            var channelCount = 0
+            try {
+                pcmTap.chunks.collect { chunk ->
+                    if (gen != generation) throw CancellationException("Fingerprint tap superseded")
+                    val frames = chunkFrames(chunk)
+                    if (frames == 0) return@collect
+                    val isContinuous = streamer != null &&
+                        chunk.sampleRate == sampleRate &&
+                        chunk.channelCount == channelCount &&
+                        abs(chunk.positionSec - expectedNextSec) <= FingerprintConstants.TAP_CONTINUITY_TOLERANCE_SECONDS
+                    if (!isContinuous) {
+                        streamer?.let { finishTapStreamer(gen, it, matcher, streamStartSec) }
+                        Timber.d("FingerprintTimingManager: tap stream started at %.1fs", chunk.positionSec)
+                        streamer = StreamingWindowedFingerprinter(
+                            chunk.sampleRate.toUInt(),
+                            chunk.channelCount.toUShort(),
+                            FingerprintConstants.WINDOW_DURATION_MS.toUInt(),
+                            FingerprintConstants.WINDOW_INTERVAL_MS.toUInt(),
+                        )
+                        streamStartSec = chunk.positionSec
+                        sampleRate = chunk.sampleRate
+                        channelCount = chunk.channelCount
+                        tapFrontierSec = Double.NaN
+                        maybeStartCatchUpResolve(gen, chunk.positionSec)
+                    }
+                    val windows = streamer.pushSamplesF32(chunkToFloatSamples(chunk), chunk.channelCount.toUShort())
+                    if (windows.isNotEmpty()) {
+                        tapFrontierSec = streamStartSec + windows.last().timestampMs.toDouble() / 1000.0
+                        mutex.withLock {
+                            if (gen != generation) throw CancellationException("Fingerprint tap superseded")
+                            processMatches(windows, matcher, streamStartSec)
+                        }
+                    }
+                    expectedNextSec = chunk.positionSec + frames.toDouble() / chunk.sampleRate
+                }
+            } catch (_: CancellationException) {
+                Timber.d("FingerprintTimingManager: tap collection cancelled")
+            } catch (e: Exception) {
+                Timber.w(e, "FingerprintTimingManager: tap collection failed")
+                if (gen == generation && state !is State.Active) {
+                    markFailed(e, stage = "pcm_tap")
+                }
+            } finally {
+                streamer?.close()
+            }
+        }
+    }
+
+    /**
+     * One-shot faster-than-realtime decode of the first [FingerprintConstants.TAP_CATCH_UP_SECONDS]
+     * after a tap stream (re)start, so anchors reach the new playhead ~a second after a seek instead
+     * of a full window later. Reads through the player cache, which is buffering this exact region.
+     */
+    private fun maybeStartCatchUpResolve(gen: Long, startSec: Double) {
+        if (currentEager) return
+        if (isWithinMatchedContent(startSec, snapshotPlaybackToReference)) return
+        catchUpJob?.cancel()
+        catchUpJob = scope.launch(Dispatchers.IO) {
+            try {
+                var reference: ReferenceFingerprint? = null
+                var audioSource: String? = null
+                var episodeUuid: String? = null
+                var cacheKey: String? = null
+                var isStreaming = false
+                mutex.withLock {
+                    if (gen != generation) return@launch
+                    reference = currentReference
+                    audioSource = currentAudioFilePath
+                    episodeUuid = currentEpisodeUuid
+                    cacheKey = currentSharedCacheKey
+                    isStreaming = currentIsStreaming
+                }
+                val ref = reference ?: return@launch
+                val audio = audioSource ?: return@launch
+                val uuid = episodeUuid ?: return@launch
+                val blocked = shouldBlockOnDemandResolve(
+                    isDownloaded = !isStreaming,
+                    warnOnMeteredNetwork = settings.warnOnMeteredNetwork.value,
+                    isUnmetered = { Network.isUnmeteredConnection(context) },
+                )
+                if (blocked) return@launch
+                val matcher = buildMatcher(ref) ?: return@launch
+                val acc = MappingAccumulator()
+                activeResolves.incrementAndGet()
+                try {
+                    matcher.use {
+                        withTimeoutOrNull(FingerprintConstants.ON_DEMAND_DECODE_TIMEOUT_MS) {
+                            streamFingerprintBounded(
+                                audioFilePath = audio,
+                                matcher = it,
+                                startingAt = alignToWindowGrid(startSec),
+                                endingAt = startSec + FingerprintConstants.TAP_CATCH_UP_SECONDS,
+                                targetReferenceSec = Double.MAX_VALUE,
+                                acc = acc,
+                                cacheKey = cacheKey,
+                                // The player is buffering this exact region; follow its cache
+                                // instead of racing it with a duplicate fetch.
+                                followPlayerCache = true,
+                            )
+                        }
+                    }
+                } finally {
+                    activeResolves.decrementAndGet()
+                }
+                if (acc.playbackToReference.isNotEmpty()) {
+                    mergeResolvedAnchors(uuid, acc.playbackToReference)
+                    Timber.d(
+                        "FingerprintTimingManager: catch-up mapped %d anchors at %.1fs",
+                        acc.playbackToReference.size,
+                        startSec,
+                    )
+                }
+            } catch (_: CancellationException) {
+            } catch (e: Exception) {
+                Timber.d(e, "FingerprintTimingManager: catch-up decode failed")
+            }
+        }
+    }
+
+    private suspend fun finishTapStreamer(
+        gen: Long,
+        streamer: StreamingWindowedFingerprinter,
+        matcher: CheckpointMatcher,
+        streamStartSec: Double,
+    ) {
+        try {
+            val tail = streamer.flush()
+            if (tail.isNotEmpty()) {
+                mutex.withLock {
+                    if (gen != generation) throw CancellationException("Fingerprint tap superseded")
+                    processMatches(tail, matcher, streamStartSec)
+                }
+            }
+        } finally {
+            streamer.close()
+        }
+    }
+
+    private fun chunkFrames(chunk: FingerprintPcmTap.PcmChunk): Int {
+        val bytesPerSample = if (chunk.encoding == C.ENCODING_PCM_FLOAT) 4 else 2
+        val bytesPerFrame = bytesPerSample * chunk.channelCount
+        return if (bytesPerFrame > 0) chunk.data.size / bytesPerFrame else 0
+    }
+
+    private fun chunkToFloatSamples(chunk: FingerprintPcmTap.PcmChunk): List<Float> {
+        val buffer = ByteBuffer.wrap(chunk.data).order(ByteOrder.nativeOrder())
+        return if (chunk.encoding == C.ENCODING_PCM_FLOAT) {
+            val floatBuffer = buffer.asFloatBuffer()
+            val result = FloatArray(floatBuffer.remaining())
+            floatBuffer.get(result)
+            FloatArrayList(result)
+        } else {
+            val shortBuffer = buffer.asShortBuffer()
+            val shorts = ShortArray(shortBuffer.remaining())
+            shortBuffer.get(shorts)
+            val result = FloatArray(shorts.size)
+            for (i in shorts.indices) {
+                result[i] = shorts[i] / 32768f
+            }
+            FloatArrayList(result)
         }
     }
 
@@ -1084,6 +1099,7 @@ class FingerprintTimingManager @Inject constructor(
         val format: MediaFormat,
         val sampleRate: Int,
         val channelCount: Int,
+        val startSec: Double,
         private val cacheSource: AutoCloseable? = null,
     ) : AutoCloseable {
         fun start() {
@@ -1174,8 +1190,18 @@ class FingerprintTimingManager @Inject constructor(
         val channelCount = format.getInteger(MediaFormat.KEY_CHANNEL_COUNT)
         val mime = format.getString(MediaFormat.KEY_MIME) ?: "audio/mpeg"
 
+        var startSec = startingAt
         if (startingAt > 0) {
             extractor.seekTo((startingAt * 1_000_000).toLong(), MediaExtractor.SEEK_TO_CLOSEST_SYNC)
+            val landedUs = extractor.sampleTime
+            if (landedUs >= 0) {
+                startSec = landedUs / 1_000_000.0
+            }
+            Timber.d(
+                "FingerprintTimingManager: extractor seek requested=%.2fs landed=%.2fs",
+                startingAt,
+                startSec,
+            )
         }
 
         val codec = try {
@@ -1185,7 +1211,7 @@ class FingerprintTimingManager @Inject constructor(
             cacheSource?.close()
             throw AudioOpenException(e)
         }
-        return AudioStream(extractor, codec, format, sampleRate, channelCount, cacheSource)
+        return AudioStream(extractor, codec, format, sampleRate, channelCount, startSec, cacheSource)
     }
 
     private suspend fun streamFingerprint(
@@ -1223,17 +1249,14 @@ class FingerprintTimingManager @Inject constructor(
                 decodeAndFingerprint(
                     stream = stream,
                     gen = gen,
-                    isRemoteUrl = isRemoteUrl,
                     streamer = streamer,
-                    startOffset = startingAt,
+                    startOffset = stream.startSec,
                     endingAt = null,
-                    throttleToPlayhead = !currentEager,
-                    trackFrontier = true,
                     yieldToResolves = true,
                 ) { windows ->
                     mutex.withLock {
                         if (gen != generation) throw CancellationException("Fingerprint stream superseded")
-                        processMatches(windows, matcher, startingAt)
+                        processMatches(windows, matcher, stream.startSec)
                     }
                 }
 
@@ -1242,7 +1265,7 @@ class FingerprintTimingManager @Inject constructor(
                 if (tail.isNotEmpty()) {
                     mutex.withLock {
                         if (gen != generation) throw CancellationException("Fingerprint stream superseded")
-                        processMatches(tail, matcher, startingAt)
+                        processMatches(tail, matcher, stream.startSec)
                     }
                 }
             } finally {
@@ -1254,12 +1277,9 @@ class FingerprintTimingManager @Inject constructor(
     private suspend fun decodeAndFingerprint(
         stream: AudioStream,
         gen: Long,
-        isRemoteUrl: Boolean,
         streamer: StreamingWindowedFingerprinter,
         startOffset: Double,
         endingAt: Double?,
-        throttleToPlayhead: Boolean,
-        trackFrontier: Boolean,
         yieldToResolves: Boolean = false,
         stopWhen: (() -> Boolean)? = null,
         onWindows: suspend (List<WindowedFingerprint>) -> Unit,
@@ -1270,7 +1290,6 @@ class FingerprintTimingManager @Inject constructor(
         var inputDone = false
         var stopRequested = false
         val timeoutUs = FingerprintConstants.CODEC_TIMEOUT_US
-        var lastNetworkCheckMs = SystemClock.elapsedRealtime()
         // Default to 16-bit (safest assumption). Updated when the codec
         // reports its actual format via INFO_OUTPUT_FORMAT_CHANGED.
         var isOutputFloat = false
@@ -1285,16 +1304,6 @@ class FingerprintTimingManager @Inject constructor(
                     delay(FingerprintConstants.RESOLVE_YIELD_POLL_MS)
                     currentCoroutineContext().ensureActive()
                     if (gen != generation) throw CancellationException("Fingerprint stream superseded")
-                }
-            }
-
-            val now = SystemClock.elapsedRealtime()
-            if (isRemoteUrl && now - lastNetworkCheckMs >= FingerprintConstants.METERED_RECHECK_INTERVAL_MS) {
-                lastNetworkCheckMs = now
-                val allowed = mutex.withLock { gen != generation || canStreamOnCurrentNetwork() }
-                if (!allowed) {
-                    Timber.d("FingerprintTimingManager: network no longer permits streaming — stopping fingerprint stream")
-                    throw CancellationException("Fingerprint stream stopped on metered network")
                 }
             }
 
@@ -1341,27 +1350,6 @@ class FingerprintTimingManager @Inject constructor(
                                 if (stopWhen?.invoke() == true) {
                                     stopRequested = true
                                 }
-                            }
-                        }
-
-                        val decodedSeconds = startOffset + streamer.durationMs().toDouble() / 1000.0
-                        if (trackFrontier && gen == generation) {
-                            activeDecodeFrontierSec = decodedSeconds
-                        }
-
-                        // Eager passes decode as fast as possible; throttled passes stay near the playhead.
-                        if (throttleToPlayhead) {
-                            val lastKnownPositionMs = lastProgressPositionMs
-                            val playheadSec = if (lastKnownPositionMs >= 0) lastKnownPositionMs / 1000.0 else startOffset
-                            if (decodedSeconds - playheadSec > FingerprintConstants.LOOKAHEAD_SECONDS) {
-                                // Playback has been paused for a while; release the codec and network
-                                // stream. The progress observer restarts the decode on resume.
-                                val progressAt = lastProgressAtMs
-                                if (progressAt > 0 && SystemClock.elapsedRealtime() - progressAt > FingerprintConstants.PARKED_DECODE_RELEASE_MS) {
-                                    Timber.d("FingerprintTimingManager: playback idle — releasing parked decode")
-                                    break
-                                }
-                                delay((FingerprintConstants.OUTSIDE_LOOKAHEAD_SLEEP_SECONDS * 1000).toLong())
                             }
                         }
                     }
@@ -1536,14 +1524,6 @@ class FingerprintTimingManager @Inject constructor(
         debugRejectionsSnapshot = debugRejections.toList()
     }
 
-    internal sealed interface ProgressDecision {
-        data object None : ProgressDecision
-        data object CancelDecode : ProgressDecision
-        data object ScheduleDebouncedRestart : ProgressDecision
-        data object RestartOutsideRange : ProgressDecision
-        data class RestartFromRunEnd(val runEndSec: Double) : ProgressDecision
-    }
-
     companion object {
         /** Core eager-pass gate (assumes the platform check already passed). */
         internal fun computeEager(
@@ -1557,92 +1537,6 @@ class FingerprintTimingManager @Inject constructor(
             warnOnMeteredNetwork: Boolean,
             isUnmetered: () -> Boolean,
         ): Boolean = !isDownloaded && warnOnMeteredNetwork && !isUnmetered()
-
-        /** [isUnmetered] is a supplier so the network lookup is skipped for downloaded episodes. */
-        internal fun shouldBlockRemoteFingerprinting(
-            isDownloaded: Boolean,
-            trigger: PrepareTrigger,
-            warnOnMeteredNetwork: Boolean,
-            isUnmetered: () -> Boolean,
-        ): Boolean {
-            if (isDownloaded) return false
-            if (isUnmetered()) return false
-            return trigger != PrepareTrigger.TRANSCRIPT_VIEW || warnOnMeteredNetwork
-        }
-
-        /** Decides how a playback-progress tick affects the fingerprint stream. */
-        internal fun decideOnProgress(
-            positionSec: Double,
-            lastPositionSec: Double?,
-            isEager: Boolean,
-            mappedRunEndSec: Double?,
-            hasAnyMapping: Boolean,
-            isDecodeActive: Boolean,
-            isCoveredByActiveDecode: Boolean,
-            isRunEndCoveredByActiveDecode: Boolean,
-            isRunEndNearEpisodeEnd: Boolean,
-            hasPendingRestart: Boolean,
-            hasStreamStarted: Boolean,
-            msSinceStreamStart: Long,
-            isStreaming: Boolean,
-        ): ProgressDecision {
-            if (isEager) return ProgressDecision.None
-            val isJump = lastPositionSec != null && abs(positionSec - lastPositionSec) > FingerprintConstants.RESTART_DELTA_SECONDS
-            if (isJump) {
-                if (mappedRunEndSec != null) {
-                    val mappedFarAhead = mappedRunEndSec >= positionSec + FingerprintConstants.LOOKAHEAD_SECONDS
-                    return if (isStreaming && isDecodeActive && mappedFarAhead) ProgressDecision.CancelDecode else ProgressDecision.None
-                }
-                if (isCoveredByActiveDecode) return ProgressDecision.None
-                return ProgressDecision.ScheduleDebouncedRestart
-            }
-            if (hasPendingRestart) return ProgressDecision.None
-            if (mappedRunEndSec != null) {
-                val approachingRunEnd = mappedRunEndSec - positionSec < FingerprintConstants.LOOKAHEAD_SECONDS
-                if (approachingRunEnd && !isRunEndCoveredByActiveDecode && !isRunEndNearEpisodeEnd &&
-                    msSinceStreamStart >= FingerprintConstants.STREAM_BOOTSTRAP_COOLDOWN_MS
-                ) {
-                    return ProgressDecision.RestartFromRunEnd(mappedRunEndSec)
-                }
-                return ProgressDecision.None
-            }
-            val canRecoverWithoutMapping = !isDecodeActive && hasStreamStarted
-            if (!isCoveredByActiveDecode && (hasAnyMapping || canRecoverWithoutMapping) &&
-                msSinceStreamStart >= FingerprintConstants.STREAM_BOOTSTRAP_COOLDOWN_MS
-            ) {
-                return ProgressDecision.RestartOutsideRange
-            }
-            return ProgressDecision.None
-        }
-
-        /**
-         * End of the contiguous mapped run containing [positionSec], or null when outside a run.
-         * Asymmetric: no slack past a mid-list run end, the margin's grace past the final anchor.
-         */
-        internal fun mappedRunEnd(positionSec: Double, entries: List<TimeMappingEntry>): Double? {
-            if (entries.isEmpty()) return null
-            val margin = FingerprintConstants.PLAYBACK_RANGE_MARGIN_SECONDS
-            var lo = 0
-            var hi = entries.size
-            while (lo < hi) {
-                val mid = (lo + hi) / 2
-                if (entries[mid].playbackTime <= positionSec) lo = mid + 1 else hi = mid
-            }
-            val prev = entries.getOrNull(lo - 1)
-            val next = entries.getOrNull(lo)
-            val inRun = when {
-                prev != null && next != null -> next.playbackTime - prev.playbackTime <= margin
-                prev != null -> positionSec - prev.playbackTime <= margin
-                else -> next != null && next.playbackTime - positionSec <= margin
-            }
-            if (!inRun) return null
-            if (next == null) return prev!!.playbackTime
-            var i = lo
-            while (i + 1 < entries.size && entries[i + 1].playbackTime - entries[i].playbackTime <= margin) {
-                i++
-            }
-            return entries[i].playbackTime
-        }
 
         fun interpolate(
             time: Double,
@@ -1685,9 +1579,10 @@ class FingerprintTimingManager @Inject constructor(
         }
 
         /**
-         * Audio region to decode for an on-demand resolve. Ad offsets are non-negative and
-         * non-decreasing, so the true position is at or after the reference time; cold resolves
-         * only search forward, warm ones bracket the mapping-derived estimate.
+         * Audio region to decode for an on-demand resolve. The offset can run negative when the
+         * reference audio carries ads this copy doesn't, so warm windows start at the estimate when
+         * it sits before the reference time; cold resolves search forward and rely on slope-1
+         * extrapolation for negative offsets.
          */
         internal fun searchWindow(referenceTimeSec: Double, estimatedPlaybackSec: Double?): SearchWindow {
             if (estimatedPlaybackSec == null) {
@@ -1696,7 +1591,8 @@ class FingerprintTimingManager @Inject constructor(
                     endSec = referenceTimeSec + FingerprintConstants.ON_DEMAND_COLD_BUDGET_SECONDS,
                 )
             }
-            val startSec = max(referenceTimeSec, estimatedPlaybackSec - FingerprintConstants.ON_DEMAND_BACKWARD_MAX_SECONDS)
+            val backstop = min(referenceTimeSec, estimatedPlaybackSec)
+            val startSec = max(0.0, max(backstop, estimatedPlaybackSec - FingerprintConstants.ON_DEMAND_BACKWARD_MAX_SECONDS))
             val endSec = max(estimatedPlaybackSec, startSec) + FingerprintConstants.ON_DEMAND_FORWARD_BUDGET_SECONDS
             return SearchWindow(startSec, endSec)
         }
@@ -1711,20 +1607,28 @@ class FingerprintTimingManager @Inject constructor(
         /**
          * Interpolated playback time when the mapping is dense around [referenceTimeSec], in both
          * timelines: anchors bracketing an ad boundary sit close in reference time but far apart in
-         * playback time, and interpolating across the boundary would land inside the ad.
+         * playback time, and interpolating across the boundary would land inside the ad. Past the
+         * last anchor a trailing grace of [FingerprintConstants.TAP_TRAILING_GRACE_SECONDS] is
+         * allowed, since the tap-built map always lags the playhead by a window length.
          */
-        internal fun densePlaybackSec(referenceTimeSec: Double, entries: List<TimeMappingEntry>): Double? {
+        internal fun densePlaybackSec(referenceTimeSec: Double, entries: List<TimeMappingEntry>, allowTrailingGrace: Boolean = true): Double? {
+            if (entries.isEmpty()) return null
             var lo = 0
             var hi = entries.size
             while (lo < hi) {
                 val mid = (lo + hi) / 2
                 if (entries[mid].referenceTime <= referenceTimeSec) lo = mid + 1 else hi = mid
             }
-            if (hi - 1 < 0 || hi >= entries.size) return null
-            val prev = entries[hi - 1]
-            val next = entries[hi]
-            if (next.referenceTime - prev.referenceTime > FingerprintConstants.HIGHLIGHT_MAX_GAP_SECONDS) return null
-            if (next.playbackTime - prev.playbackTime > FingerprintConstants.HIGHLIGHT_MAX_GAP_SECONDS) return null
+            if (hi == 0) return null
+            if (hi >= entries.size) {
+                if (!allowTrailingGrace) return null
+                if (referenceTimeSec - entries[entries.size - 1].referenceTime > FingerprintConstants.TAP_TRAILING_GRACE_SECONDS) return null
+            } else {
+                val prev = entries[hi - 1]
+                val next = entries[hi]
+                if (next.referenceTime - prev.referenceTime > FingerprintConstants.HIGHLIGHT_MAX_GAP_SECONDS) return null
+                if (next.playbackTime - prev.playbackTime > FingerprintConstants.HIGHLIGHT_MAX_GAP_SECONDS) return null
+            }
             return interpolate(
                 time = referenceTimeSec,
                 entries = entries,
@@ -1733,8 +1637,13 @@ class FingerprintTimingManager @Inject constructor(
             )
         }
 
-        /** True when [playbackTime] is bracketed by two anchors ≤ [FingerprintConstants.HIGHLIGHT_MAX_GAP_SECONDS] apart. */
-        fun isWithinMatchedContent(playbackTime: Double, entries: List<TimeMappingEntry>): Boolean {
+        /**
+         * True when [playbackTime] is bracketed by two anchors ≤ [FingerprintConstants.HIGHLIGHT_MAX_GAP_SECONDS]
+         * apart, or trails the newest anchor within [FingerprintConstants.TAP_TRAILING_GRACE_SECONDS] — the
+         * tap-built map always lags the playhead by a window length.
+         */
+        fun isWithinMatchedContent(playbackTime: Double, entries: List<TimeMappingEntry>, allowTrailingGrace: Boolean = true): Boolean {
+            if (entries.isEmpty()) return false
             var lo = 0
             var hi = entries.size
             while (lo < hi) {
@@ -1745,8 +1654,18 @@ class FingerprintTimingManager @Inject constructor(
                     hi = mid
                 }
             }
-            if (hi - 1 < 0 || hi >= entries.size) return false
+            if (hi >= entries.size) {
+                return allowTrailingGrace &&
+                    playbackTime - entries[entries.size - 1].playbackTime <= FingerprintConstants.TAP_TRAILING_GRACE_SECONDS
+            }
+            if (hi == 0) return false
             return (entries[hi].playbackTime - entries[hi - 1].playbackTime) <= FingerprintConstants.HIGHLIGHT_MAX_GAP_SECONDS
+        }
+
+        /** True once the tap's completed-window frontier has outrun the newest anchor by more than the odd missed match. */
+        internal fun isLiveEdgeUnmatched(frontierSec: Double, lastAnchorPlaybackSec: Double?): Boolean {
+            if (frontierSec.isNaN() || lastAnchorPlaybackSec == null) return false
+            return frontierSec - lastAnchorPlaybackSec > FingerprintConstants.TAP_UNMATCHED_EDGE_SECONDS
         }
 
         fun alignToWindowGrid(time: Double): Double {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/GeneratedChapterSeeker.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/GeneratedChapterSeeker.kt
@@ -67,14 +67,14 @@ class GeneratedChapterSeeker @Inject constructor(
         activeCaller?.cancel()
     }
 
-    // Never land before the chapter's own displayed start: the skip buttons picked the chapter from
-    // that boundary, and a resolve landing short of it would make the next button loop in place.
-    suspend fun resolveSeekTime(episode: BaseEpisode, chapter: Chapter): Duration? = resolveSeekTimeUnclamped(episode, chapter)?.coerceAtLeast(chapter.startTime)
-
-    private suspend fun resolveSeekTimeUnclamped(episode: BaseEpisode, chapter: Chapter): Duration? {
+    suspend fun resolveSeekTime(episode: BaseEpisode, chapter: Chapter): Duration? {
         if (!isEnabled(chapter)) return null
         val referenceTime = chapter.referenceStartTime ?: return null
 
+        // Cached and dense times can predate a boundary re-alignment, and landing short of the
+        // displayed start the skip buttons picked the chapter from would loop the next button in
+        // place, so clamp them. A fresh resolve stays unclamped: it may legitimately land before
+        // the displayed start (negative ad offset) and re-aligns the boundary via its own anchors.
         val sourceKey = "${episode.uuid}|${episode.downloadedFilePath ?: episode.downloadUrl}"
         mutex.withLock {
             if (cacheSourceKey != sourceKey) {
@@ -84,10 +84,10 @@ class GeneratedChapterSeeker @Inject constructor(
                 referenceUnavailable = false
             }
             resolvedCache[chapter.index]
-        }?.let { return it }
+        }?.let { return it.coerceAtLeast(chapter.startTime) }
 
         val manager = fingerprintTimingManager.get()
-        manager.densePlaybackTime(episode.uuid, referenceTime)?.let { return it }
+        manager.densePlaybackTime(episode.uuid, referenceTime)?.let { return it.coerceAtLeast(chapter.startTime) }
 
         // A remembered failure repeats deterministically, so fall back without re-resolving.
         if (mutex.withLock { referenceUnavailable || chapter.index in failedChapters }) return null

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/FingerprintTapAudioSink.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/FingerprintTapAudioSink.kt
@@ -1,0 +1,39 @@
+package au.com.shiftyjelly.pocketcasts.repositories.playback
+
+import androidx.annotation.OptIn
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.audio.AudioSink
+import androidx.media3.exoplayer.audio.ForwardingAudioSink
+import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.FingerprintPcmTap
+import java.nio.ByteBuffer
+
+/** Reports each buffer's media timestamp to [FingerprintPcmTap] before the processor chain consumes it. */
+@OptIn(UnstableApi::class)
+internal class FingerprintTapAudioSink(
+    sink: AudioSink,
+    private val tap: FingerprintPcmTap,
+) : ForwardingAudioSink(sink) {
+
+    // Buffer timestamps arrive in renderer time; the renderer reports this offset back to media time.
+    private var outputStreamOffsetUs = 0L
+
+    override fun setOutputStreamOffsetUs(outputStreamOffsetUs: Long) {
+        this.outputStreamOffsetUs = outputStreamOffsetUs
+        super.setOutputStreamOffsetUs(outputStreamOffsetUs)
+    }
+
+    override fun handleBuffer(buffer: ByteBuffer, presentationTimeUs: Long, encodedAccessUnitCount: Int): Boolean {
+        tap.onSinkBuffer(presentationTimeUs - outputStreamOffsetUs)
+        return super.handleBuffer(buffer, presentationTimeUs, encodedAccessUnitCount)
+    }
+
+    override fun flush() {
+        tap.onSinkFlush()
+        super.flush()
+    }
+
+    override fun reset() {
+        tap.onSinkFlush()
+        super.reset()
+    }
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayerFactoryImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayerFactoryImpl.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.repositories.playback
 
 import android.content.Context
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.FingerprintPcmTap
 import au.com.shiftyjelly.pocketcasts.repositories.stats.PlaybackStatsCollector
 import au.com.shiftyjelly.pocketcasts.repositories.user.StatsManager
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -12,6 +13,7 @@ class PlayerFactoryImpl @Inject constructor(
     private val statsManager: StatsManager,
     private val playbackStatsCollector: PlaybackStatsCollector,
     private val dataSourceFactory: ExoPlayerDataSourceFactory,
+    private val fingerprintPcmTap: FingerprintPcmTap,
     @ApplicationContext private val context: Context,
 ) : PlayerFactory {
 
@@ -29,6 +31,7 @@ class PlayerFactoryImpl @Inject constructor(
             playbackStatsCollector = playbackStatsCollector,
             context = context,
             dataSourceFactory = dataSourceFactory,
+            fingerprintPcmTap = fingerprintPcmTap,
             onPlayerEvent = onPlayerEvent,
         )
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ShiftyAudioProcessorChain.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ShiftyAudioProcessorChain.kt
@@ -12,7 +12,10 @@ import kotlin.time.Duration.Companion.microseconds
 import timber.log.Timber
 
 @OptIn(UnstableApi::class)
-class ShiftyAudioProcessorChain(private val customAudio: ShiftyCustomAudio) : AudioProcessorChain {
+class ShiftyAudioProcessorChain(
+    private val customAudio: ShiftyCustomAudio,
+    fingerprintTapProcessor: AudioProcessor? = null,
+) : AudioProcessorChain {
     private val lowProcessor = ShiftyTrimSilenceProcessor(
         416000.microseconds,
         291000.microseconds,
@@ -34,7 +37,10 @@ class ShiftyAudioProcessorChain(private val customAudio: ShiftyCustomAudio) : Au
     )
     private val sonicAudioProcessor = SonicAudioProcessor()
 
-    private val audioProcessors = arrayOf(lowProcessor, mediumProcessor, highProcessor, sonicAudioProcessor)
+    private val trimProcessors = arrayOf(lowProcessor, mediumProcessor, highProcessor)
+    private val audioProcessors = listOfNotNull(fingerprintTapProcessor).toTypedArray() +
+        trimProcessors +
+        arrayOf<AudioProcessor>(sonicAudioProcessor)
     private var trimMode = TrimMode.OFF
     override fun getAudioProcessors(): Array<AudioProcessor> {
         return audioProcessors
@@ -53,8 +59,7 @@ class ShiftyAudioProcessorChain(private val customAudio: ShiftyCustomAudio) : Au
             (audioProcessor as? ShiftyTrimSilenceProcessor)?.enabled = false
         }
         if (trimMode != TrimMode.OFF) {
-            val index = trimMode.ordinal - 1
-            (audioProcessors[index] as ShiftyTrimSilenceProcessor).enabled = true
+            trimProcessors[trimMode.ordinal - 1].enabled = true
         }
         return trimMode != TrimMode.OFF
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ShiftyRenderersFactory.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ShiftyRenderersFactory.kt
@@ -12,6 +12,8 @@ import androidx.media3.exoplayer.audio.AudioSink
 import androidx.media3.exoplayer.audio.DefaultAudioSink
 import androidx.media3.exoplayer.mediacodec.MediaCodecSelector
 import au.com.shiftyjelly.pocketcasts.models.type.TrimMode
+import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.FingerprintPcmTap
+import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.FingerprintTapAudioProcessor
 import au.com.shiftyjelly.pocketcasts.repositories.user.StatsManager
 
 /**
@@ -23,6 +25,8 @@ class ShiftyRenderersFactory(
     context: Context,
     statsManager: StatsManager,
     private var boostVolume: Boolean,
+    private val fingerprintPcmTap: FingerprintPcmTap? = null,
+    private val fingerprintTapEnabled: () -> Boolean = { false },
 ) : DefaultRenderersFactory(context),
     AnalyticsListener {
     private var playbackSpeed = 0f
@@ -47,12 +51,14 @@ class ShiftyRenderersFactory(
     }
 
     override fun buildAudioSink(context: Context, enableFloatOutput: Boolean, enableAudioOutputPlaybackParameters: Boolean): AudioSink {
-        processorChain = ShiftyAudioProcessorChain(customAudio)
-        return DefaultAudioSink.Builder(context)
+        val tapProcessor = fingerprintPcmTap?.let { FingerprintTapAudioProcessor(it, fingerprintTapEnabled) }
+        processorChain = ShiftyAudioProcessorChain(customAudio, tapProcessor)
+        val sink = DefaultAudioSink.Builder(context)
             .setAudioProcessorChain(processorChain!!)
             .setEnableFloatOutput(enableFloatOutput)
             .setEnableAudioOutputPlaybackParameters(enableAudioOutputPlaybackParameters)
             .build()
+        return if (fingerprintPcmTap != null) FingerprintTapAudioSink(sink, fingerprintPcmTap) else sink
     }
 
     override fun buildAudioRenderers(

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -22,9 +22,13 @@ import androidx.media3.ui.WearUnsuitableOutputPlaybackSuppressionResolverListene
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.PlaybackEffects
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.FingerprintPcmTap
 import au.com.shiftyjelly.pocketcasts.repositories.stats.PlaybackStatsCollector
 import au.com.shiftyjelly.pocketcasts.repositories.user.StatsManager
+import au.com.shiftyjelly.pocketcasts.utils.AppPlatform
 import au.com.shiftyjelly.pocketcasts.utils.Util
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.Dispatchers
@@ -37,6 +41,7 @@ class SimplePlayer(
     private val playbackStatsCollector: PlaybackStatsCollector,
     private val context: Context,
     private val dataSourceFactory: ExoPlayerDataSourceFactory,
+    private val fingerprintPcmTap: FingerprintPcmTap? = null,
     override val onPlayerEvent: (au.com.shiftyjelly.pocketcasts.repositories.playback.Player, PlayerEvent) -> Unit,
 ) : LocalPlayer(onPlayerEvent) {
     private val reducedBufferManufacturers = listOf("mercedes-benz")
@@ -336,11 +341,15 @@ class SimplePlayer(
 
     private fun createRenderersFactory(): ShiftyRenderersFactory {
         val playbackEffects: PlaybackEffects? = this.playbackEffects
-        return if (playbackEffects == null) {
-            ShiftyRenderersFactory(context = context, statsManager = statsManager, boostVolume = false)
-        } else {
-            ShiftyRenderersFactory(context = context, statsManager = statsManager, boostVolume = playbackEffects.isVolumeBoosted)
-        }
+        return ShiftyRenderersFactory(
+            context = context,
+            statsManager = statsManager,
+            boostVolume = playbackEffects?.isVolumeBoosted ?: false,
+            fingerprintPcmTap = fingerprintPcmTap,
+            fingerprintTapEnabled = {
+                FeatureFlag.isEnabled(Feature.SYNCED_TRANSCRIPTS) && Util.getAppPlatform(context) == AppPlatform.Phone
+            },
+        )
     }
 
     fun setDisplay(surfaceView: SurfaceView?): Boolean {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/TranscriptWindowExtractor.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/TranscriptWindowExtractor.kt
@@ -79,7 +79,9 @@ class TranscriptWindowExtractor @Inject constructor(
 
     companion object {
         private const val MIN_WORDS = 10
-        private val COVERAGE_TIMEOUT = 5.seconds
+
+        // The tap-built map lags the playhead by a full fingerprint window, so cover that plus slack.
+        private val COVERAGE_TIMEOUT = 12.seconds
 
         internal fun parseVttWindow(content: String, timeSecs: Int, windowSecs: Int): String? {
             val entries = WebVttParser().parse(Buffer().writeUtf8(content)).getOrNull() ?: return null

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/DriftFilterTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/DriftFilterTest.kt
@@ -35,6 +35,7 @@ class DriftFilterTest {
             chapterManager = Lazy { mock(ChapterManager::class.java) },
             settings = mock(Settings::class.java),
             dataSourceFactory = Lazy { mock(ExoPlayerDataSourceFactory::class.java) },
+            pcmTap = FingerprintPcmTap(),
         )
         manager.debugTrackingEnabled = true
     }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintPcmTapTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintPcmTapTest.kt
@@ -1,0 +1,130 @@
+package au.com.shiftyjelly.pocketcasts.repositories.fingerprint
+
+import androidx.media3.common.C
+import androidx.media3.common.audio.AudioProcessor
+import app.cash.turbine.test
+import java.nio.ByteBuffer
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class FingerprintPcmTapTest {
+
+    private val tap = FingerprintPcmTap()
+    private val format = AudioProcessor.AudioFormat(SAMPLE_RATE, 1, C.ENCODING_PCM_16BIT)
+
+    private fun pcmBuffer(frames: Int) = ByteBuffer.allocate(frames * format.bytesPerFrame)
+
+    @Test
+    fun `emits nothing until the sink provides an anchor`() = runTest {
+        tap.chunks.test {
+            tap.onPcm(pcmBuffer(frames = 100), format)
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `stamps the first chunk with the sink's media time`() = runTest {
+        tap.chunks.test {
+            tap.onSinkBuffer(10_000_000L)
+            tap.onPcm(pcmBuffer(frames = 100), format)
+            assertEquals(10.0, awaitItem().positionSec, 1e-6)
+        }
+    }
+
+    @Test
+    fun `extrapolates positions from frame counts between sink buffers`() = runTest {
+        tap.chunks.test {
+            tap.onSinkBuffer(10_000_000L)
+            tap.onPcm(pcmBuffer(frames = 100), format)
+            awaitItem()
+            tap.onPcm(pcmBuffer(frames = 50), format)
+            assertEquals(10.1, awaitItem().positionSec, 1e-6)
+            tap.onPcm(pcmBuffer(frames = 50), format)
+            assertEquals(10.15, awaitItem().positionSec, 1e-6)
+        }
+    }
+
+    @Test
+    fun `keeps the anchor when sink times drift within tolerance`() = runTest {
+        tap.chunks.test {
+            tap.onSinkBuffer(10_000_000L)
+            tap.onPcm(pcmBuffer(frames = 100), format)
+            awaitItem()
+            tap.onSinkBuffer(10_050_000L)
+            tap.onPcm(pcmBuffer(frames = 100), format)
+            assertEquals(10.1, awaitItem().positionSec, 1e-6)
+        }
+    }
+
+    @Test
+    fun `re-anchors when the sink time jumps past tolerance`() = runTest {
+        tap.chunks.test {
+            tap.onSinkBuffer(10_000_000L)
+            tap.onPcm(pcmBuffer(frames = 100), format)
+            awaitItem()
+            tap.onSinkBuffer(60_000_000L)
+            tap.onPcm(pcmBuffer(frames = 100), format)
+            assertEquals(60.0, awaitItem().positionSec, 1e-6)
+        }
+    }
+
+    @Test
+    fun `a consumed sink time cannot re-anchor later buffers`() = runTest {
+        tap.chunks.test {
+            tap.onSinkBuffer(10_000_000L)
+            tap.onPcm(pcmBuffer(frames = 100), format)
+            awaitItem()
+            tap.onPcm(pcmBuffer(frames = 300), format)
+            assertEquals(10.1, awaitItem().positionSec, 1e-6)
+            tap.onPcm(pcmBuffer(frames = 100), format)
+            assertEquals(10.4, awaitItem().positionSec, 1e-6)
+        }
+    }
+
+    @Test
+    fun `sink flush clears the anchor until a new buffer arrives`() = runTest {
+        tap.chunks.test {
+            tap.onSinkBuffer(10_000_000L)
+            tap.onPcm(pcmBuffer(frames = 100), format)
+            awaitItem()
+            tap.onSinkFlush()
+            tap.onPcm(pcmBuffer(frames = 100), format)
+            expectNoEvents()
+            tap.onSinkBuffer(5_000_000L)
+            tap.onPcm(pcmBuffer(frames = 100), format)
+            assertEquals(5.0, awaitItem().positionSec, 1e-6)
+        }
+    }
+
+    @Test
+    fun `tracks position while unsubscribed without emitting`() = runTest {
+        tap.onSinkBuffer(0L)
+        tap.onPcm(pcmBuffer(frames = 200), format)
+        tap.chunks.test {
+            tap.onPcm(pcmBuffer(frames = 100), format)
+            assertEquals(0.2, awaitItem().positionSec, 1e-6)
+        }
+    }
+
+    @Test
+    fun `copies the pcm payload and format into the chunk`() = runTest {
+        tap.chunks.test {
+            tap.onSinkBuffer(1_000_000L)
+            val bytes = ByteArray(10) { it.toByte() }
+            val buffer = ByteBuffer.wrap(bytes)
+            tap.onPcm(buffer, format)
+            val chunk = awaitItem()
+            assertArrayEquals(bytes, chunk.data)
+            assertEquals(C.ENCODING_PCM_16BIT, chunk.encoding)
+            assertEquals(SAMPLE_RATE, chunk.sampleRate)
+            assertEquals(1, chunk.channelCount)
+            assertEquals(0, buffer.position())
+        }
+    }
+
+    companion object {
+        private const val SAMPLE_RATE = 1000
+    }
+}

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTapAudioProcessorTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTapAudioProcessorTest.kt
@@ -1,0 +1,76 @@
+package au.com.shiftyjelly.pocketcasts.repositories.fingerprint
+
+import androidx.media3.common.C
+import androidx.media3.common.audio.AudioProcessor
+import java.nio.ByteBuffer
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+
+class FingerprintTapAudioProcessorTest {
+
+    private val tap = mock<FingerprintPcmTap>()
+    private val format = AudioProcessor.AudioFormat(44100, 2, C.ENCODING_PCM_16BIT)
+
+    private fun processor(isEnabled: Boolean) = FingerprintTapAudioProcessor(tap, isEnabled = { isEnabled }).apply {
+        configure(format)
+        flush(AudioProcessor.StreamMetadata.DEFAULT)
+    }
+
+    @Test
+    fun `stays inactive when disabled`() {
+        val processor = FingerprintTapAudioProcessor(tap, isEnabled = { false })
+        assertSame(AudioProcessor.AudioFormat.NOT_SET, processor.configure(format))
+        assertFalse(processor.isActive)
+    }
+
+    @Test
+    fun `keeps the input format when enabled`() {
+        val processor = FingerprintTapAudioProcessor(tap, isEnabled = { true })
+        assertSame(format, processor.configure(format))
+        assertTrue(processor.isActive)
+    }
+
+    @Test
+    fun `passes input through unchanged`() {
+        val processor = processor(isEnabled = true)
+        val bytes = ByteArray(16) { it.toByte() }
+        val input = ByteBuffer.wrap(bytes.copyOf())
+        processor.queueInput(input)
+        assertEquals(0, input.remaining())
+        val output = processor.output
+        val copied = ByteArray(output.remaining())
+        output.get(copied)
+        assertArrayEquals(bytes, copied)
+    }
+
+    @Test
+    fun `copies the pcm into the tap as a read-only view`() {
+        val processor = processor(isEnabled = true)
+        val bytes = ByteArray(16) { it.toByte() }
+        processor.queueInput(ByteBuffer.wrap(bytes.copyOf()))
+        val captor = argumentCaptor<ByteBuffer>()
+        verify(tap).onPcm(captor.capture(), eq(format))
+        val seen = captor.firstValue
+        assertTrue(seen.isReadOnly)
+        val copied = ByteArray(seen.remaining())
+        seen.get(copied)
+        assertArrayEquals(bytes, copied)
+    }
+
+    @Test
+    fun `ignores empty input`() {
+        val processor = processor(isEnabled = true)
+        processor.queueInput(ByteBuffer.allocate(0))
+        verifyNoInteractions(tap)
+        assertEquals(0, processor.output.remaining())
+    }
+}

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManagerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManagerTest.kt
@@ -1,7 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.repositories.fingerprint
 
-import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.FingerprintTimingManager.PrepareTrigger
-import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.FingerprintTimingManager.ProgressDecision
 import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.FingerprintTimingManager.TimeMappingEntry
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -119,8 +117,8 @@ class FingerprintTimingManagerTest {
 
     @Test
     fun `computeEager skips streaming episode`() {
-        // Streaming episodes never eager-decode the whole file; they use the throttled pass plus
-        // the bounded on-demand resolver, regardless of network, to avoid pulling the whole file.
+        // Streaming episodes never eager-decode the whole file; the PCM tap plus the bounded
+        // on-demand resolver cover them without pulling the whole file.
         val eager = FingerprintTimingManager.computeEager(
             hasGeneratedChapters = true,
             isDownloaded = false,
@@ -135,87 +133,6 @@ class FingerprintTimingManagerTest {
             isDownloaded = true,
         )
         assertFalse(eager)
-    }
-
-    @Test
-    fun `shouldBlockRemoteFingerprinting never blocks downloaded episodes`() {
-        val blocked = FingerprintTimingManager.shouldBlockRemoteFingerprinting(
-            isDownloaded = true,
-            trigger = PrepareTrigger.PLAYBACK,
-            warnOnMeteredNetwork = true,
-            isUnmetered = { false },
-        )
-        assertFalse(blocked)
-    }
-
-    @Test
-    fun `shouldBlockRemoteFingerprinting does not query network for downloaded episodes`() {
-        var queriedNetwork = false
-        FingerprintTimingManager.shouldBlockRemoteFingerprinting(
-            isDownloaded = true,
-            trigger = PrepareTrigger.PLAYBACK,
-            warnOnMeteredNetwork = false,
-            isUnmetered = {
-                queriedNetwork = true
-                true
-            },
-        )
-        assertFalse(queriedNetwork)
-    }
-
-    @Test
-    fun `shouldBlockRemoteFingerprinting never blocks on unmetered network`() {
-        val blocked = FingerprintTimingManager.shouldBlockRemoteFingerprinting(
-            isDownloaded = false,
-            trigger = PrepareTrigger.PLAYBACK,
-            warnOnMeteredNetwork = true,
-            isUnmetered = { true },
-        )
-        assertFalse(blocked)
-    }
-
-    @Test
-    fun `shouldBlockRemoteFingerprinting blocks playback trigger on metered network`() {
-        val blocked = FingerprintTimingManager.shouldBlockRemoteFingerprinting(
-            isDownloaded = false,
-            trigger = PrepareTrigger.PLAYBACK,
-            warnOnMeteredNetwork = false,
-            isUnmetered = { false },
-        )
-        assertTrue(blocked)
-    }
-
-    @Test
-    fun `shouldBlockRemoteFingerprinting blocks bookmark trigger on metered network`() {
-        val blocked = FingerprintTimingManager.shouldBlockRemoteFingerprinting(
-            isDownloaded = false,
-            trigger = PrepareTrigger.BOOKMARK,
-            warnOnMeteredNetwork = false,
-            isUnmetered = { false },
-        )
-        assertTrue(blocked)
-    }
-
-    @Test
-    fun `shouldBlockRemoteFingerprinting allows transcript view on metered network`() {
-        val blocked = FingerprintTimingManager.shouldBlockRemoteFingerprinting(
-            isDownloaded = false,
-            trigger = PrepareTrigger.TRANSCRIPT_VIEW,
-            warnOnMeteredNetwork = false,
-            isUnmetered = { false },
-        )
-        assertFalse(blocked)
-    }
-
-    @Test
-    fun `shouldBlockRemoteFingerprinting blocks transcript view when user warns on data use`() {
-        val blocked = FingerprintTimingManager.shouldBlockRemoteFingerprinting(
-            isDownloaded = false,
-            trigger = PrepareTrigger.TRANSCRIPT_VIEW,
-            warnOnMeteredNetwork = true,
-            isUnmetered = { false },
-        )
-        assertTrue(blocked)
     }
 
     @Test
@@ -259,362 +176,6 @@ class FingerprintTimingManagerTest {
     }
 
     @Test
-    fun `decideOnProgress ignores ticks in eager mode`() {
-        val decision = decideOnProgress(positionSec = 100.0, lastPositionSec = 10.0, isEager = true)
-        assertEquals(ProgressDecision.None, decision)
-    }
-
-    @Test
-    fun `decideOnProgress small delta does nothing`() {
-        val decision = decideOnProgress(positionSec = 15.0, lastPositionSec = 10.0)
-        assertEquals(ProgressDecision.None, decision)
-    }
-
-    @Test
-    fun `decideOnProgress first tick is never a jump`() {
-        val decision = decideOnProgress(positionSec = 500.0, lastPositionSec = null)
-        assertEquals(ProgressDecision.None, decision)
-    }
-
-    @Test
-    fun `decideOnProgress jump within mapped run does not restart`() {
-        val decision = decideOnProgress(positionSec = 100.0, lastPositionSec = 10.0, mappedRunEndSec = 120.0)
-        assertEquals(ProgressDecision.None, decision)
-    }
-
-    @Test
-    fun `decideOnProgress jump within run cancels decode when streaming and mapped far ahead`() {
-        val decision = decideOnProgress(
-            positionSec = 100.0,
-            lastPositionSec = 10.0,
-            mappedRunEndSec = 200.0,
-            isDecodeActive = true,
-            isStreaming = true,
-        )
-        assertEquals(ProgressDecision.CancelDecode, decision)
-    }
-
-    @Test
-    fun `decideOnProgress jump within run keeps decode for local files`() {
-        val decision = decideOnProgress(
-            positionSec = 100.0,
-            lastPositionSec = 10.0,
-            mappedRunEndSec = 200.0,
-            isDecodeActive = true,
-            isStreaming = false,
-        )
-        assertEquals(ProgressDecision.None, decision)
-    }
-
-    @Test
-    fun `decideOnProgress jump within run without active decode does not cancel`() {
-        val decision = decideOnProgress(
-            positionSec = 100.0,
-            lastPositionSec = 10.0,
-            mappedRunEndSec = 200.0,
-            isDecodeActive = false,
-            isStreaming = true,
-        )
-        assertEquals(ProgressDecision.None, decision)
-    }
-
-    @Test
-    fun `decideOnProgress jump within run keeps decode when the run end is not far ahead`() {
-        val decision = decideOnProgress(
-            positionSec = 100.0,
-            lastPositionSec = 10.0,
-            mappedRunEndSec = 130.0,
-            isDecodeActive = true,
-            isStreaming = true,
-        )
-        assertEquals(ProgressDecision.None, decision)
-    }
-
-    @Test
-    fun `decideOnProgress jump outside mapped range schedules debounced restart`() {
-        val decision = decideOnProgress(positionSec = 100.0, lastPositionSec = 10.0)
-        assertEquals(ProgressDecision.ScheduleDebouncedRestart, decision)
-    }
-
-    @Test
-    fun `decideOnProgress jump into mapping gap schedules debounced restart`() {
-        val decision = decideOnProgress(
-            positionSec = 300.0,
-            lastPositionSec = 50.0,
-            mappedRunEndSec = null,
-            hasAnyMapping = true,
-        )
-        assertEquals(ProgressDecision.ScheduleDebouncedRestart, decision)
-    }
-
-    @Test
-    fun `decideOnProgress jump covered by active decode does not restart`() {
-        val decision = decideOnProgress(
-            positionSec = 300.0,
-            lastPositionSec = 50.0,
-            hasAnyMapping = true,
-            isDecodeActive = true,
-            isCoveredByActiveDecode = true,
-        )
-        assertEquals(ProgressDecision.None, decision)
-    }
-
-    @Test
-    fun `decideOnProgress pending restart suppresses outside range restart`() {
-        val decision = decideOnProgress(
-            positionSec = 100.0,
-            lastPositionSec = 99.0,
-            hasAnyMapping = true,
-            hasPendingRestart = true,
-        )
-        assertEquals(ProgressDecision.None, decision)
-    }
-
-    @Test
-    fun `decideOnProgress outside mapped range respects bootstrap cooldown`() {
-        val decision = decideOnProgress(
-            positionSec = 100.0,
-            lastPositionSec = 99.0,
-            hasAnyMapping = true,
-            msSinceStreamStart = FingerprintConstants.STREAM_BOOTSTRAP_COOLDOWN_MS - 1,
-        )
-        assertEquals(ProgressDecision.None, decision)
-    }
-
-    @Test
-    fun `decideOnProgress outside mapped range restarts after cooldown`() {
-        val decision = decideOnProgress(
-            positionSec = 100.0,
-            lastPositionSec = 99.0,
-            hasAnyMapping = true,
-            msSinceStreamStart = FingerprintConstants.STREAM_BOOTSTRAP_COOLDOWN_MS,
-        )
-        assertEquals(ProgressDecision.RestartOutsideRange, decision)
-    }
-
-    @Test
-    fun `decideOnProgress outside range covered by active decode does not restart`() {
-        val decision = decideOnProgress(
-            positionSec = 100.0,
-            lastPositionSec = 99.0,
-            hasAnyMapping = true,
-            isDecodeActive = true,
-            isCoveredByActiveDecode = true,
-            msSinceStreamStart = FingerprintConstants.STREAM_BOOTSTRAP_COOLDOWN_MS,
-        )
-        assertEquals(ProgressDecision.None, decision)
-    }
-
-    @Test
-    fun `decideOnProgress outside range with decode elsewhere still restarts`() {
-        val decision = decideOnProgress(
-            positionSec = 100.0,
-            lastPositionSec = 99.0,
-            hasAnyMapping = true,
-            isDecodeActive = true,
-            isCoveredByActiveDecode = false,
-            msSinceStreamStart = FingerprintConstants.STREAM_BOOTSTRAP_COOLDOWN_MS,
-        )
-        assertEquals(ProgressDecision.RestartOutsideRange, decision)
-    }
-
-    @Test
-    fun `decideOnProgress resumes from run end when the mapping is about to run out`() {
-        val decision = decideOnProgress(
-            positionSec = 100.0,
-            lastPositionSec = 99.0,
-            mappedRunEndSec = 130.0,
-        )
-        assertEquals(ProgressDecision.RestartFromRunEnd(130.0), decision)
-    }
-
-    @Test
-    fun `decideOnProgress does not resume while the run end is far ahead`() {
-        val decision = decideOnProgress(
-            positionSec = 100.0,
-            lastPositionSec = 99.0,
-            mappedRunEndSec = 100.0 + FingerprintConstants.LOOKAHEAD_SECONDS,
-        )
-        assertEquals(ProgressDecision.None, decision)
-    }
-
-    @Test
-    fun `decideOnProgress does not resume when a decode already covers the run end`() {
-        val decision = decideOnProgress(
-            positionSec = 100.0,
-            lastPositionSec = 99.0,
-            mappedRunEndSec = 130.0,
-            isDecodeActive = true,
-            isRunEndCoveredByActiveDecode = true,
-        )
-        assertEquals(ProgressDecision.None, decision)
-    }
-
-    @Test
-    fun `decideOnProgress does not resume when the run end is near the episode end`() {
-        val decision = decideOnProgress(
-            positionSec = 100.0,
-            lastPositionSec = 99.0,
-            mappedRunEndSec = 130.0,
-            isRunEndNearEpisodeEnd = true,
-        )
-        assertEquals(ProgressDecision.None, decision)
-    }
-
-    @Test
-    fun `decideOnProgress run end resume respects bootstrap cooldown`() {
-        val decision = decideOnProgress(
-            positionSec = 100.0,
-            lastPositionSec = 99.0,
-            mappedRunEndSec = 130.0,
-            msSinceStreamStart = FingerprintConstants.STREAM_BOOTSTRAP_COOLDOWN_MS - 1,
-        )
-        assertEquals(ProgressDecision.None, decision)
-    }
-
-    @Test
-    fun `decideOnProgress relocates a decode replaying mapped audio to the run end`() {
-        val decision = decideOnProgress(
-            positionSec = 100.0,
-            lastPositionSec = 99.0,
-            mappedRunEndSec = 130.0,
-            isDecodeActive = true,
-            isRunEndCoveredByActiveDecode = false,
-            isStreaming = true,
-        )
-        assertEquals(ProgressDecision.RestartFromRunEnd(130.0), decision)
-    }
-
-    @Test
-    fun `decideOnProgress empty mapping does not restart before the stream ever ran`() {
-        val decision = decideOnProgress(
-            positionSec = 100.0,
-            lastPositionSec = 99.0,
-        )
-        assertEquals(ProgressDecision.None, decision)
-    }
-
-    @Test
-    fun `decideOnProgress empty mapping does not restart while the decode is running`() {
-        val decision = decideOnProgress(
-            positionSec = 100.0,
-            lastPositionSec = 99.0,
-            isDecodeActive = true,
-            isCoveredByActiveDecode = true,
-        )
-        assertEquals(ProgressDecision.None, decision)
-    }
-
-    @Test
-    fun `decideOnProgress empty mapping restarts after the stream died without producing one`() {
-        val decision = decideOnProgress(
-            positionSec = 100.0,
-            lastPositionSec = 99.0,
-            hasStreamStarted = true,
-        )
-        assertEquals(ProgressDecision.RestartOutsideRange, decision)
-    }
-
-    @Test
-    fun `mappedRunEnd empty mapping returns null`() {
-        assertNull(FingerprintTimingManager.mappedRunEnd(50.0, emptyList()))
-    }
-
-    @Test
-    fun `mappedRunEnd inside contiguous run returns run end`() {
-        assertEquals(100.0, FingerprintTimingManager.mappedRunEnd(35.0, entriesAt(0.0, 100.0, step = 10.0))!!, 0.0)
-    }
-
-    @Test
-    fun `mappedRunEnd on exact anchor returns run end`() {
-        assertEquals(100.0, FingerprintTimingManager.mappedRunEnd(40.0, entriesAt(0.0, 100.0, step = 10.0))!!, 0.0)
-    }
-
-    @Test
-    fun `mappedRunEnd in gap between islands returns null`() {
-        val entries = entriesAt(0.0, 100.0, step = 10.0) + entriesAt(500.0, 600.0, step = 10.0)
-        assertNull(FingerprintTimingManager.mappedRunEnd(300.0, entries))
-    }
-
-    @Test
-    fun `mappedRunEnd exactly on a mid-list island end gets no slack`() {
-        val entries = entriesAt(0.0, 100.0, step = 10.0) + entriesAt(500.0, 600.0, step = 10.0)
-        assertNull(FingerprintTimingManager.mappedRunEnd(100.0, entries))
-    }
-
-    @Test
-    fun `mappedRunEnd just past island end with far next island returns null`() {
-        val entries = entriesAt(0.0, 100.0, step = 10.0) + entriesAt(500.0, 600.0, step = 10.0)
-        assertNull(FingerprintTimingManager.mappedRunEnd(110.0, entries))
-    }
-
-    @Test
-    fun `mappedRunEnd inside first island stops at gap`() {
-        val entries = entriesAt(0.0, 100.0, step = 10.0) + entriesAt(500.0, 600.0, step = 10.0)
-        assertEquals(100.0, FingerprintTimingManager.mappedRunEnd(50.0, entries)!!, 0.0)
-    }
-
-    @Test
-    fun `mappedRunEnd within margin after last entry returns last entry`() {
-        assertEquals(100.0, FingerprintTimingManager.mappedRunEnd(120.0, entriesAt(0.0, 100.0, step = 10.0))!!, 0.0)
-    }
-
-    @Test
-    fun `mappedRunEnd beyond margin after last entry returns null`() {
-        assertNull(FingerprintTimingManager.mappedRunEnd(131.0, entriesAt(0.0, 100.0, step = 10.0)))
-    }
-
-    @Test
-    fun `mappedRunEnd within margin before first entry returns run end`() {
-        assertEquals(200.0, FingerprintTimingManager.mappedRunEnd(80.0, entriesAt(100.0, 200.0, step = 10.0))!!, 0.0)
-    }
-
-    @Test
-    fun `mappedRunEnd beyond margin before first entry returns null`() {
-        assertNull(FingerprintTimingManager.mappedRunEnd(60.0, entriesAt(100.0, 200.0, step = 10.0)))
-    }
-
-    private fun entriesAt(from: Double, to: Double, step: Double): List<TimeMappingEntry> {
-        val entries = mutableListOf<TimeMappingEntry>()
-        var time = from
-        while (time <= to) {
-            entries.add(TimeMappingEntry(playbackTime = time, referenceTime = time))
-            time += step
-        }
-        return entries
-    }
-
-    private fun decideOnProgress(
-        positionSec: Double,
-        lastPositionSec: Double?,
-        isEager: Boolean = false,
-        mappedRunEndSec: Double? = null,
-        hasAnyMapping: Boolean = mappedRunEndSec != null,
-        isDecodeActive: Boolean = false,
-        isCoveredByActiveDecode: Boolean = false,
-        isRunEndCoveredByActiveDecode: Boolean = false,
-        isRunEndNearEpisodeEnd: Boolean = false,
-        hasPendingRestart: Boolean = false,
-        hasStreamStarted: Boolean = hasAnyMapping || isDecodeActive,
-        msSinceStreamStart: Long = FingerprintConstants.STREAM_BOOTSTRAP_COOLDOWN_MS,
-        isStreaming: Boolean = false,
-    ): ProgressDecision = FingerprintTimingManager.decideOnProgress(
-        positionSec = positionSec,
-        lastPositionSec = lastPositionSec,
-        isEager = isEager,
-        mappedRunEndSec = mappedRunEndSec,
-        hasAnyMapping = hasAnyMapping,
-        isDecodeActive = isDecodeActive,
-        isCoveredByActiveDecode = isCoveredByActiveDecode,
-        isRunEndCoveredByActiveDecode = isRunEndCoveredByActiveDecode,
-        isRunEndNearEpisodeEnd = isRunEndNearEpisodeEnd,
-        hasPendingRestart = hasPendingRestart,
-        hasStreamStarted = hasStreamStarted,
-        msSinceStreamStart = msSinceStreamStart,
-        isStreaming = isStreaming,
-    )
-
-    @Test
     fun `alignToWindowGrid aligns to stride boundary`() {
         val aligned = FingerprintTimingManager.alignToWindowGrid(5.7)
         assertEquals(5.0, aligned, 0.001)
@@ -647,17 +208,30 @@ class FingerprintTimingManagerTest {
     }
 
     @Test
-    fun `searchWindow warm never starts below reference time`() {
+    fun `searchWindow warm starts at reference time when the estimate is just ahead`() {
         val window = FingerprintTimingManager.searchWindow(referenceTimeSec = 600.0, estimatedPlaybackSec = 650.0)
         assertEquals(600.0, window.startSec, 0.001)
         assertEquals(650.0 + FingerprintConstants.ON_DEMAND_FORWARD_BUDGET_SECONDS, window.endSec, 0.001)
     }
 
     @Test
-    fun `searchWindow warm keeps forward budget when estimate is below reference time`() {
+    fun `searchWindow warm starts at the estimate when the offset is negative`() {
+        val window = FingerprintTimingManager.searchWindow(referenceTimeSec = 600.0, estimatedPlaybackSec = 570.0)
+        assertEquals(570.0, window.startSec, 0.001)
+        assertEquals(570.0 + FingerprintConstants.ON_DEMAND_FORWARD_BUDGET_SECONDS, window.endSec, 0.001)
+    }
+
+    @Test
+    fun `searchWindow warm keeps the backward bound below a far-back estimate`() {
         val window = FingerprintTimingManager.searchWindow(referenceTimeSec = 600.0, estimatedPlaybackSec = 300.0)
-        assertEquals(600.0, window.startSec, 0.001)
-        assertEquals(600.0 + FingerprintConstants.ON_DEMAND_FORWARD_BUDGET_SECONDS, window.endSec, 0.001)
+        assertEquals(300.0, window.startSec, 0.001)
+        assertEquals(300.0 + FingerprintConstants.ON_DEMAND_FORWARD_BUDGET_SECONDS, window.endSec, 0.001)
+    }
+
+    @Test
+    fun `searchWindow warm never starts below zero`() {
+        val window = FingerprintTimingManager.searchWindow(referenceTimeSec = 10.0, estimatedPlaybackSec = -20.0)
+        assertEquals(0.0, window.startSec, 0.001)
     }
 
     @Test
@@ -700,7 +274,36 @@ class FingerprintTimingManagerTest {
             TimeMappingEntry(playbackTime = 134.0, referenceTime = 104.0),
         )
         assertNull(FingerprintTimingManager.densePlaybackSec(referenceTimeSec = 99.0, entries = entries))
-        assertNull(FingerprintTimingManager.densePlaybackSec(referenceTimeSec = 105.0, entries = entries))
+        assertNull(FingerprintTimingManager.densePlaybackSec(referenceTimeSec = 104.0 + FingerprintConstants.TAP_TRAILING_GRACE_SECONDS + 1.0, entries = entries))
+    }
+
+    @Test
+    fun `densePlaybackSec extrapolates within the trailing grace past the last anchor`() {
+        val entries = listOf(
+            TimeMappingEntry(playbackTime = 130.0, referenceTime = 100.0),
+            TimeMappingEntry(playbackTime = 134.0, referenceTime = 104.0),
+        )
+        val result = FingerprintTimingManager.densePlaybackSec(referenceTimeSec = 110.0, entries = entries)
+        assertEquals(140.0, result!!, 0.001)
+    }
+
+    @Test
+    fun `densePlaybackSec drops the trailing grace when the live edge is unmatched`() {
+        val entries = listOf(
+            TimeMappingEntry(playbackTime = 130.0, referenceTime = 100.0),
+            TimeMappingEntry(playbackTime = 134.0, referenceTime = 104.0),
+        )
+        assertNull(FingerprintTimingManager.densePlaybackSec(referenceTimeSec = 110.0, entries = entries, allowTrailingGrace = false))
+        val bracketed = FingerprintTimingManager.densePlaybackSec(referenceTimeSec = 102.0, entries = entries, allowTrailingGrace = false)
+        assertEquals(132.0, bracketed!!, 0.001)
+    }
+
+    @Test
+    fun `isLiveEdgeUnmatched tolerates isolated missed matches`() {
+        assertFalse(FingerprintTimingManager.isLiveEdgeUnmatched(frontierSec = 102.0, lastAnchorPlaybackSec = 100.0))
+        assertTrue(FingerprintTimingManager.isLiveEdgeUnmatched(frontierSec = 103.5, lastAnchorPlaybackSec = 100.0))
+        assertFalse(FingerprintTimingManager.isLiveEdgeUnmatched(frontierSec = Double.NaN, lastAnchorPlaybackSec = 100.0))
+        assertFalse(FingerprintTimingManager.isLiveEdgeUnmatched(frontierSec = 103.5, lastAnchorPlaybackSec = null))
     }
 
     @Test

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/GeneratedChapterSeekerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/GeneratedChapterSeekerTest.kt
@@ -119,13 +119,26 @@ class GeneratedChapterSeekerTest {
     }
 
     @Test
-    fun `clamps a resolve landing short of the chapter start`() = runTest {
+    fun `does not clamp a fresh resolve landing short of the chapter start`() = runTest {
         timingManager = mock {
             on { resolvePlaybackTime(any(), eq(100.seconds)) } doReturn
                 ChapterSeekResult.Resolved(playbackTime = 120.2.seconds, usedPrior = false)
         }
 
-        assertEquals(130.seconds, seeker().resolveSeekTime(episode, generatedChapter))
+        assertEquals(121.seconds, seeker().resolveSeekTime(episode, generatedChapter))
+    }
+
+    @Test
+    fun `clamps a cached resolve landing short of the chapter start`() = runTest {
+        timingManager = mock {
+            on { resolvePlaybackTime(any(), eq(100.seconds)) } doReturn
+                ChapterSeekResult.Resolved(playbackTime = 120.2.seconds, usedPrior = false)
+        }
+        val seeker = seeker()
+
+        assertEquals(121.seconds, seeker.resolveSeekTime(episode, generatedChapter))
+        assertEquals(130.seconds, seeker.resolveSeekTime(episode, generatedChapter))
+        verifyBlocking(timingManager, times(1)) { resolvePlaybackTime(any(), any()) }
     }
 
     @Test

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/MatchedContentGateTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/MatchedContentGateTest.kt
@@ -34,9 +34,27 @@ class MatchedContentGateTest {
     }
 
     @Test
-    fun `not matched past last anchor`() {
+    fun `matched within trailing grace past last anchor`() {
         val entries = listOf(entry(18.0), entry(20.0))
-        assertFalse(FingerprintTimingManager.isWithinMatchedContent(25.0, entries))
+        assertTrue(FingerprintTimingManager.isWithinMatchedContent(31.0, entries))
+    }
+
+    @Test
+    fun `not matched beyond trailing grace past last anchor`() {
+        val entries = listOf(entry(18.0), entry(20.0))
+        assertFalse(FingerprintTimingManager.isWithinMatchedContent(32.1, entries))
+    }
+
+    @Test
+    fun `not matched within trailing grace when the live edge is unmatched`() {
+        val entries = listOf(entry(18.0), entry(20.0))
+        assertFalse(FingerprintTimingManager.isWithinMatchedContent(31.0, entries, allowTrailingGrace = false))
+    }
+
+    @Test
+    fun `interior anchors still match when the trailing grace is dropped`() {
+        val entries = listOf(entry(18.0), entry(20.0))
+        assertTrue(FingerprintTimingManager.isWithinMatchedContent(19.0, entries, allowTrailingGrace = false))
     }
 
     @Test
@@ -75,9 +93,10 @@ class MatchedContentGateTest {
     }
 
     @Test
-    fun `single anchor is not matched without bracketing pair`() {
+    fun `single anchor matches within the trailing grace`() {
         val entries = listOf(entry(20.0))
-        assertFalse(FingerprintTimingManager.isWithinMatchedContent(20.0, entries))
+        assertTrue(FingerprintTimingManager.isWithinMatchedContent(20.0, entries))
+        assertFalse(FingerprintTimingManager.isWithinMatchedContent(32.1, entries))
     }
 
     @Test

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/FingerprintTapAudioSinkTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/FingerprintTapAudioSinkTest.kt
@@ -1,0 +1,65 @@
+package au.com.shiftyjelly.pocketcasts.repositories.playback
+
+import androidx.media3.exoplayer.audio.AudioSink
+import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.FingerprintPcmTap
+import java.nio.ByteBuffer
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class FingerprintTapAudioSinkTest {
+
+    private val delegate = mock<AudioSink>()
+    private val tap = mock<FingerprintPcmTap>()
+    private val sink = FingerprintTapAudioSink(delegate, tap)
+    private val buffer = ByteBuffer.allocate(4)
+
+    @Test
+    fun `reports the raw presentation time before any stream offset`() {
+        sink.handleBuffer(buffer, 5_000_000L, 1)
+        verify(tap).onSinkBuffer(5_000_000L)
+    }
+
+    @Test
+    fun `converts renderer time to media time using the stream offset`() {
+        sink.setOutputStreamOffsetUs(2_000_000L)
+        sink.handleBuffer(buffer, 5_000_000L, 1)
+        verify(tap).onSinkBuffer(3_000_000L)
+    }
+
+    @Test
+    fun `applies offset updates to subsequent buffers`() {
+        sink.setOutputStreamOffsetUs(2_000_000L)
+        sink.handleBuffer(buffer, 5_000_000L, 1)
+        sink.setOutputStreamOffsetUs(10_000_000L)
+        sink.handleBuffer(buffer, 12_000_000L, 1)
+        verify(tap).onSinkBuffer(3_000_000L)
+        verify(tap).onSinkBuffer(2_000_000L)
+    }
+
+    @Test
+    fun `forwards buffers and offsets to the wrapped sink`() {
+        whenever(delegate.handleBuffer(any(), any(), any())).thenReturn(true)
+        sink.setOutputStreamOffsetUs(2_000_000L)
+        assertTrue(sink.handleBuffer(buffer, 5_000_000L, 1))
+        verify(delegate).setOutputStreamOffsetUs(2_000_000L)
+        verify(delegate).handleBuffer(buffer, 5_000_000L, 1)
+    }
+
+    @Test
+    fun `flush clears the tap anchor`() {
+        sink.flush()
+        verify(tap).onSinkFlush()
+        verify(delegate).flush()
+    }
+
+    @Test
+    fun `reset clears the tap anchor`() {
+        sink.reset()
+        verify(tap).onSinkFlush()
+        verify(delegate).reset()
+    }
+}


### PR DESCRIPTION
## Description

Cherry-pick of #5618 into `release/8.17`.

> **This change was already reviewed and merged on `main`.** This PR exists to land it in the upcoming release. CI and a quick review should still run to confirm the cherry-pick applies cleanly and introduces no issues on the release branch, since `release/8.17` may have diverged from `main`.

Stacked on #5661 (cherry-pick of #5614) — merge the stack bottom-up: #5660 → #5661 → this. The changelog entry was moved from the 8.18 section (where it landed on `main`) to 8.17, since this release now ships it.

- Original PR: https://github.com/Automattic/pocket-casts-android/pull/5618
- Cherry-picked commit: `7d79463e1f`

## Testing Instructions

See the original PR (https://github.com/Automattic/pocket-casts-android/pull/5618) for full testing steps. In addition, verify the change behaves as described on top of `release/8.17`.