### PR TITLE
Fix "Show video" shelf action to respect audio-only setting

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ShelfSharedViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ShelfSharedViewModel.kt
@@ -95,8 +95,9 @@ class ShelfSharedViewModel @Inject constructor(
         playbackManager.streamVideoState,
         playbackManager.streamHlsAvailable,
         playbackManager.videoRenderingEnabled,
-    ) { streamVideoState, hlsAvailable, renderingEnabled ->
-        VideoState(streamVideoState, hlsAvailable, renderingEnabled)
+        settings.audioOnly.flow,
+    ) { streamVideoState, hlsAvailable, renderingEnabled, audioOnly ->
+        VideoState(streamVideoState, hlsAvailable, renderingEnabled, audioOnly)
     }
 
     val uiState = combine(
@@ -121,7 +122,8 @@ class ShelfSharedViewModel @Inject constructor(
     ): UiState {
         val episode = (shelfUpNext as? UpNextQueue.State.Loaded)?.episode
         val streamHasVideo = videoState.streamVideoState == StreamVideoState.HasVideo || videoState.streamVideoState == StreamVideoState.Unknown
-        val canToggleVideo = FeatureFlag.isEnabled(Feature.HLS_STREAMING) &&
+        val canToggleVideo = !videoState.audioOnly &&
+            FeatureFlag.isEnabled(Feature.HLS_STREAMING) &&
             episode is PodcastEpisode &&
             (streamHasVideo || videoState.hlsAvailable)
         return uiState.value.copy(
@@ -136,6 +138,7 @@ class ShelfSharedViewModel @Inject constructor(
         val streamVideoState: StreamVideoState,
         val hlsAvailable: Boolean,
         val renderingEnabled: Boolean,
+        val audioOnly: Boolean,
     )
 
     fun onEffectsClick(source: ShelfItemSource) {

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ShelfSharedViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ShelfSharedViewModelTest.kt
@@ -345,6 +345,26 @@ class ShelfSharedViewModelTest {
     }
 
     @Test
+    fun `given audio only enabled, then stream selector is hidden`() = runTest {
+        val episode = PodcastEpisode("uuid", publishedDate = Date())
+        initViewModel(
+            currentEpisode = episode,
+            hlsAvailable = true,
+            streamVideoState = StreamVideoState.AudioOnly,
+            audioOnly = true,
+        )
+
+        shelfSharedViewModel.uiState.test {
+            var state = awaitItem()
+            while (state.episode == null) {
+                state = awaitItem()
+            }
+            assertFalse(state.shelfItems.contains(ShelfItem.StreamSelector))
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `given no hls stream and no video, then stream selector is hidden`() = runTest {
         val episode = PodcastEpisode("uuid", publishedDate = Date())
         initViewModel(
@@ -402,6 +422,7 @@ class ShelfSharedViewModelTest {
         currentEpisode: PodcastEpisode? = null,
         hlsAvailable: Boolean = false,
         streamVideoState: StreamVideoState = StreamVideoState.NotVideo,
+        audioOnly: Boolean = false,
     ) {
         FeatureFlag.setEnabled(Feature.HLS_STREAMING, true)
 
@@ -433,6 +454,10 @@ class ShelfSharedViewModelTest {
         whenever(playbackManager.streamVideoState).thenReturn(MutableStateFlow(streamVideoState))
         whenever(playbackManager.streamHlsAvailable).thenReturn(MutableStateFlow(hlsAvailable))
         whenever(playbackManager.videoRenderingEnabled).thenReturn(MutableStateFlow(true))
+
+        val audioOnlySetting = mock<UserSetting<Boolean>>()
+        whenever(audioOnlySetting.flow).thenReturn(MutableStateFlow(audioOnly))
+        whenever(settings.audioOnly).thenReturn(audioOnlySetting)
 
         shelfSharedViewModel = ShelfSharedViewModel(
             eventHorizon = EventHorizon(TestEventSink()),

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -430,6 +430,8 @@ open class PlaybackManager @Inject constructor(
     }
 
     fun toggleVideoRendering(streamWarningConfirmed: Boolean = false) {
+        // Audio only forces audio, so toggling would only desync the rendering flag.
+        if (settings.audioOnly.value) return
         val episode = getCurrentEpisode()
         when {
             videoToggleRequiresStreamSwitch() -> {


### PR DESCRIPTION
## Description
During my latest beta test pass I noticed that the expanded shelf still offers the "Show video" option when the "Audio only" setting is ON. This was a regression that I fixed and I'm planning to include it in the final 8.17 release.

## Testing Instructions
1. Start playing a HLS episode with Audio only OFF
2. ✅  Verify video is playing
3. Open shelf on fullscreen player
4. ✅  Verify Hide video option available
5. Tap it and notice video rendering if now off
6. Expand shelf again
7. ✅ Verify Show video option available
8. Tap it and notice video is back
9. Now open Settings > General and toggle Audio only ON
10. Open fullscreen player again
11. ✅ Verify we're back to audio-only
12. Open shelf
13. ✅ Verify "Hide video" option is gone

## Screenshots or Screencast 
https://github.com/user-attachments/assets/cea29281-7284-4298-8677-e8e7aa9ee184

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
