### PR TITLE
[TV] Wipe all local data when signing out

### DIFF
--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -258,6 +258,8 @@
     <string name="tv_playlists_empty_title">Your playlists live here</string>
     <string name="tv_playlists_empty_subtitle">Build one manually or let Smart Rules do the sorting for you.</string>
     <string name="tv_playlists_empty_action_title">Create a playlist</string>
+    <string name="tv_playlists_download_title">Create playlists on your phone</string>
+    <string name="tv_playlists_download_subtitle">They’ll be waiting here when you’re done. Scan to get the app</string>
     <string name="unavailable">Unavailable</string>
     <string name="browse_podcasts">Browse podcasts</string>
     <string name="pocket_casts_plus_badge">Pocket Casts Plus badge</string>

--- a/modules/services/preferences/build.gradle.kts
+++ b/modules/services/preferences/build.gradle.kts
@@ -42,4 +42,6 @@ dependencies {
 
     testImplementation(libs.coroutines.test)
     testImplementation(libs.junit)
+    testImplementation(libs.mockito.kotlin)
+    testImplementation(libs.robolectric)
 }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/AccountConstants.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/AccountConstants.kt
@@ -11,6 +11,9 @@ object AccountConstants {
     const val SIGN_IN_TYPE_KEY = "sign_in"
     const val LOGIN_IDENTITY = "login_identity"
 
+    // Legacy key value
+    const val ANON_ID_KEY = "nosara_tracks_anon_id"
+
     sealed class SignInType(val value: String) {
         object Password : SignInType("Password")
         object Tokens : SignInType("Tokens")

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -371,6 +371,8 @@ interface Settings {
 
     fun clearPlusPreferences()
 
+    fun clearUserPreferences()
+
     fun setDismissLowStorageModalTime(lastUpdateTime: Long)
     fun shouldShowLowStorageModalAfterSnooze(): Boolean
 

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -591,7 +591,13 @@ class SettingsImpl @Inject constructor(
     override fun clearUserPreferences() {
         val preservedKeys = listOf(collectAnalytics, sendCrashReports, linkCrashReportsToUser)
             .flatMap { setting -> listOf(setting.sharedPrefKey, "${setting.sharedPrefKey}ModifiedAt") }
-            .toSet() + PROCESSED_SIGNOUT_KEY
+            .toSet() + setOf(
+            PROCESSED_SIGNOUT_KEY,
+            AccountConstants.ANON_ID_KEY,
+            Settings.PREFERENCE_STORAGE_CHOICE,
+            Settings.PREFERENCE_STORAGE_CHOICE_NAME,
+            Settings.PREFERENCE_STORAGE_CUSTOM_FOLDER,
+        )
         val preferenceStores = listOf(sharedPreferences, privatePreferences)
         preferenceStores.forEach { preferences ->
             preferences.edit(commit = true) {

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -592,7 +592,7 @@ class SettingsImpl @Inject constructor(
     override fun clearUserPreferences() {
         val preservedKeys = listOf(collectAnalytics, sendCrashReports, linkCrashReportsToUser)
             .flatMap { setting -> listOf(setting.sharedPrefKey, "${setting.sharedPrefKey}ModifiedAt") }
-            .toSet()
+            .toSet() + PROCESSED_SIGNOUT_KEY
         listOf(sharedPreferences, privatePreferences).forEach { preferences ->
             val editor = preferences.edit()
             preferences.all.keys

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -588,6 +588,21 @@ class SettingsImpl @Inject constructor(
         setCancelledAcknowledged(false)
     }
 
+    @SuppressLint("ApplySharedPref")
+    override fun clearUserPreferences() {
+        val preservedKeys = listOf(collectAnalytics, sendCrashReports, linkCrashReportsToUser)
+            .flatMap { setting -> listOf(setting.sharedPrefKey, "${setting.sharedPrefKey}ModifiedAt") }
+            .toSet()
+        listOf(sharedPreferences, privatePreferences).forEach { preferences ->
+            val editor = preferences.edit()
+            preferences.all.keys
+                .filterNot { key -> key in preservedKeys }
+                .forEach { key -> editor.remove(key) }
+            editor.commit()
+            UserSetting.refreshAll(preferences)
+        }
+    }
+
     private fun getDefaultCountryCode(): String {
         val languageCode = languageCode
         if (languageCode != null) {

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -89,6 +89,7 @@ class SettingsImpl @Inject constructor(
         private const val END_OF_YEAR_SHOW_MODAL_2025_KEY = "EndOfYearModalShowModal2025Key"
         private const val DONE_INITIAL_ONBOARDING_KEY = "CompletedOnboardingKey"
         private const val PROCESSED_SIGNOUT_KEY = "ProcessedSignout"
+        private const val MIGRATED_VERSION_CODE_KEY = "MIGRATED_VERSION_CODE"
         private const val NEEDS_LOGIN_PROMPT_AFTER_RESTORE_KEY = "NeedsLoginPromptAfterRestore"
     }
 
@@ -593,6 +594,7 @@ class SettingsImpl @Inject constructor(
             .flatMap { setting -> listOf(setting.sharedPrefKey, "${setting.sharedPrefKey}ModifiedAt") }
             .toSet() + setOf(
             PROCESSED_SIGNOUT_KEY,
+            MIGRATED_VERSION_CODE_KEY,
             AccountConstants.ANON_ID_KEY,
             Settings.PREFERENCE_STORAGE_CHOICE,
             Settings.PREFERENCE_STORAGE_CHOICE_NAME,
@@ -607,6 +609,7 @@ class SettingsImpl @Inject constructor(
             }
         }
         preferenceStores.forEach { preferences -> UserSetting.refreshAll(preferences) }
+        refreshStateFlow.value = RefreshState.Never
     }
 
     private fun getDefaultCountryCode(): String {
@@ -792,11 +795,11 @@ class SettingsImpl @Inject constructor(
     )
 
     override fun getMigratedVersionCode(): Int {
-        return getInt("MIGRATED_VERSION_CODE", 0)
+        return getInt(MIGRATED_VERSION_CODE_KEY, 0)
     }
 
     override fun setMigratedVersionCode(versionCode: Int) {
-        setInt("MIGRATED_VERSION_CODE", versionCode)
+        setInt(MIGRATED_VERSION_CODE_KEY, versionCode)
     }
 
     override val podcastBadgeType = UserSetting.PrefFromInt<BadgeType>(

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -592,14 +592,15 @@ class SettingsImpl @Inject constructor(
         val preservedKeys = listOf(collectAnalytics, sendCrashReports, linkCrashReportsToUser)
             .flatMap { setting -> listOf(setting.sharedPrefKey, "${setting.sharedPrefKey}ModifiedAt") }
             .toSet() + PROCESSED_SIGNOUT_KEY
-        listOf(sharedPreferences, privatePreferences).forEach { preferences ->
+        val preferenceStores = listOf(sharedPreferences, privatePreferences)
+        preferenceStores.forEach { preferences ->
             preferences.edit(commit = true) {
                 preferences.all.keys
                     .filterNot { key -> key in preservedKeys }
                     .forEach { key -> remove(key) }
             }
-            UserSetting.refreshAll(preferences)
         }
+        preferenceStores.forEach { preferences -> UserSetting.refreshAll(preferences) }
     }
 
     private fun getDefaultCountryCode(): String {

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -588,17 +588,16 @@ class SettingsImpl @Inject constructor(
         setCancelledAcknowledged(false)
     }
 
-    @SuppressLint("ApplySharedPref")
     override fun clearUserPreferences() {
         val preservedKeys = listOf(collectAnalytics, sendCrashReports, linkCrashReportsToUser)
             .flatMap { setting -> listOf(setting.sharedPrefKey, "${setting.sharedPrefKey}ModifiedAt") }
             .toSet() + PROCESSED_SIGNOUT_KEY
         listOf(sharedPreferences, privatePreferences).forEach { preferences ->
-            val editor = preferences.edit()
-            preferences.all.keys
-                .filterNot { key -> key in preservedKeys }
-                .forEach { key -> editor.remove(key) }
-            editor.commit()
+            preferences.edit(commit = true) {
+                preferences.all.keys
+                    .filterNot { key -> key in preservedKeys }
+                    .forEach { key -> remove(key) }
+            }
             UserSetting.refreshAll(preferences)
         }
     }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/UserSetting.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/UserSetting.kt
@@ -58,15 +58,12 @@ abstract class UserSetting<T>(
     // These are lazy because (1) the class needs to initialize before calling get() and
     // (2) we don't want to get the current value from SharedPreferences for every
     // setting immediately on app startup.
-    private var isFlowInitialized = false
-    protected val _flow by lazy {
-        isFlowInitialized = true
-        MutableStateFlow(get())
-    }
+    private val flowDelegate = lazy { MutableStateFlow(get()) }
+    protected val _flow by flowDelegate
     override val flow: StateFlow<T> by lazy { _flow }
 
     fun refresh() {
-        if (isFlowInitialized) {
+        if (flowDelegate.isInitialized()) {
             _flow.value = get()
         }
     }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/UserSetting.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/UserSetting.kt
@@ -3,8 +3,10 @@ package au.com.shiftyjelly.pocketcasts.preferences
 import android.annotation.SuppressLint
 import android.content.SharedPreferences
 import au.com.shiftyjelly.pocketcasts.coroutines.flow.mapState
+import java.lang.ref.WeakReference
 import java.time.Clock
 import java.time.Instant
+import java.util.concurrent.CopyOnWriteArrayList
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -35,6 +37,10 @@ abstract class UserSetting<T>(
     protected val sharedPrefs: SharedPreferences,
 ) : ReadWriteSetting<T> {
 
+    init {
+        allSettings.add(WeakReference(this))
+    }
+
     private val modifiedAtKey = "${sharedPrefKey}ModifiedAt"
 
     private fun getModifiedAtServerString(): String? = sharedPrefs.getString(modifiedAtKey, null)
@@ -52,8 +58,18 @@ abstract class UserSetting<T>(
     // These are lazy because (1) the class needs to initialize before calling get() and
     // (2) we don't want to get the current value from SharedPreferences for every
     // setting immediately on app startup.
-    protected val _flow by lazy { MutableStateFlow(get()) }
+    private var isFlowInitialized = false
+    protected val _flow by lazy {
+        isFlowInitialized = true
+        MutableStateFlow(get())
+    }
     override val flow: StateFlow<T> by lazy { _flow }
+
+    fun refresh() {
+        if (isFlowInitialized) {
+            _flow.value = get()
+        }
+    }
 
     // External callers should use [value] to get the current value if they can't
     // listen to the flow for changes.
@@ -347,5 +363,17 @@ abstract class UserSetting<T>(
         // This means that if a user syncs settings that were set before we started tracking timestamps
         // they would not update on a new device because we update settings only if the local timestamp is before remote timestamp.
         val DefaultFallbackTimestamp: Instant = Instant.EPOCH.plusSeconds(1)
+
+        private val allSettings = CopyOnWriteArrayList<WeakReference<UserSetting<*>>>()
+
+        fun refreshAll(sharedPrefs: SharedPreferences) {
+            allSettings.removeAll { reference -> reference.get() == null }
+            allSettings.forEach { reference ->
+                val setting = reference.get()
+                if (setting?.sharedPrefs === sharedPrefs) {
+                    setting.refresh()
+                }
+            }
+        }
     }
 }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/UserSetting.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/UserSetting.kt
@@ -37,10 +37,6 @@ abstract class UserSetting<T>(
     protected val sharedPrefs: SharedPreferences,
 ) : ReadWriteSetting<T> {
 
-    init {
-        allSettings.add(WeakReference(this))
-    }
-
     private val modifiedAtKey = "${sharedPrefKey}ModifiedAt"
 
     private fun getModifiedAtServerString(): String? = sharedPrefs.getString(modifiedAtKey, null)
@@ -58,7 +54,10 @@ abstract class UserSetting<T>(
     // These are lazy because (1) the class needs to initialize before calling get() and
     // (2) we don't want to get the current value from SharedPreferences for every
     // setting immediately on app startup.
-    private val flowDelegate = lazy { MutableStateFlow(get()) }
+    private val flowDelegate = lazy {
+        allSettings.add(WeakReference(this))
+        MutableStateFlow(get())
+    }
     protected val _flow by flowDelegate
     override val flow: StateFlow<T> by lazy { _flow }
 

--- a/modules/services/preferences/src/test/kotlin/au/com/shiftyjelly/pocketcasts/preferences/FakeSharedPreferences.kt
+++ b/modules/services/preferences/src/test/kotlin/au/com/shiftyjelly/pocketcasts/preferences/FakeSharedPreferences.kt
@@ -1,0 +1,73 @@
+package au.com.shiftyjelly.pocketcasts.preferences
+
+import android.content.SharedPreferences
+
+class FakeSharedPreferences : SharedPreferences {
+    private val values = mutableMapOf<String, Any?>()
+
+    override fun getAll(): MutableMap<String, *> = values.toMutableMap()
+
+    override fun getString(key: String, defValue: String?) = values[key] as? String ?: defValue
+
+    @Suppress("UNCHECKED_CAST")
+    override fun getStringSet(key: String, defValues: MutableSet<String>?) = (values[key] as? Set<String>)?.toMutableSet() ?: defValues
+
+    override fun getInt(key: String, defValue: Int) = values[key] as? Int ?: defValue
+
+    override fun getLong(key: String, defValue: Long) = values[key] as? Long ?: defValue
+
+    override fun getFloat(key: String, defValue: Float) = values[key] as? Float ?: defValue
+
+    override fun getBoolean(key: String, defValue: Boolean) = values[key] as? Boolean ?: defValue
+
+    override fun contains(key: String) = key in values
+
+    override fun edit(): SharedPreferences.Editor = Editor()
+
+    override fun registerOnSharedPreferenceChangeListener(listener: SharedPreferences.OnSharedPreferenceChangeListener) = Unit
+
+    override fun unregisterOnSharedPreferenceChangeListener(listener: SharedPreferences.OnSharedPreferenceChangeListener) = Unit
+
+    private inner class Editor : SharedPreferences.Editor {
+        private val pending = mutableMapOf<String, Any?>()
+        private val removals = mutableSetOf<String>()
+        private var clearAll = false
+
+        override fun putString(key: String, value: String?) = apply { pending[key] = value }
+
+        override fun putStringSet(key: String, values: MutableSet<String>?) = apply { pending[key] = values }
+
+        override fun putInt(key: String, value: Int) = apply { pending[key] = value }
+
+        override fun putLong(key: String, value: Long) = apply { pending[key] = value }
+
+        override fun putFloat(key: String, value: Float) = apply { pending[key] = value }
+
+        override fun putBoolean(key: String, value: Boolean) = apply { pending[key] = value }
+
+        override fun remove(key: String) = apply { removals += key }
+
+        override fun clear() = apply { clearAll = true }
+
+        override fun commit(): Boolean {
+            applyChanges()
+            return true
+        }
+
+        override fun apply() = applyChanges()
+
+        private fun applyChanges() {
+            if (clearAll) {
+                values.clear()
+            }
+            removals.forEach(values::remove)
+            pending.forEach { (key, value) ->
+                if (value == null) {
+                    values.remove(key)
+                } else {
+                    values[key] = value
+                }
+            }
+        }
+    }
+}

--- a/modules/services/preferences/src/test/kotlin/au/com/shiftyjelly/pocketcasts/preferences/FakeSharedPreferences.kt
+++ b/modules/services/preferences/src/test/kotlin/au/com/shiftyjelly/pocketcasts/preferences/FakeSharedPreferences.kt
@@ -10,7 +10,9 @@ class FakeSharedPreferences : SharedPreferences {
     override fun getString(key: String, defValue: String?) = values[key] as? String ?: defValue
 
     @Suppress("UNCHECKED_CAST")
-    override fun getStringSet(key: String, defValues: MutableSet<String>?) = (values[key] as? Set<String>)?.toMutableSet() ?: defValues
+    override fun getStringSet(key: String, defValues: MutableSet<String>?): MutableSet<String>? {
+        return (values[key] as? Set<String>)?.toMutableSet() ?: defValues
+    }
 
     override fun getInt(key: String, defValue: Int) = values[key] as? Int ?: defValue
 
@@ -24,9 +26,13 @@ class FakeSharedPreferences : SharedPreferences {
 
     override fun edit(): SharedPreferences.Editor = Editor()
 
-    override fun registerOnSharedPreferenceChangeListener(listener: SharedPreferences.OnSharedPreferenceChangeListener) = Unit
+    override fun registerOnSharedPreferenceChangeListener(
+        listener: SharedPreferences.OnSharedPreferenceChangeListener,
+    ) = Unit
 
-    override fun unregisterOnSharedPreferenceChangeListener(listener: SharedPreferences.OnSharedPreferenceChangeListener) = Unit
+    override fun unregisterOnSharedPreferenceChangeListener(
+        listener: SharedPreferences.OnSharedPreferenceChangeListener,
+    ) = Unit
 
     private inner class Editor : SharedPreferences.Editor {
         private val pending = mutableMapOf<String, Any?>()

--- a/modules/services/preferences/src/test/kotlin/au/com/shiftyjelly/pocketcasts/preferences/SettingsImplTest.kt
+++ b/modules/services/preferences/src/test/kotlin/au/com/shiftyjelly/pocketcasts/preferences/SettingsImplTest.kt
@@ -76,6 +76,21 @@ class SettingsImplTest {
     }
 
     @Test
+    fun `clearUserPreferences keeps the device level keys`() {
+        publicPrefs.edit().putString(AccountConstants.ANON_ID_KEY, "anon").commit()
+        publicPrefs.edit().putString(Settings.PREFERENCE_STORAGE_CHOICE, "choice").commit()
+        publicPrefs.edit().putString(Settings.PREFERENCE_STORAGE_CHOICE_NAME, "name").commit()
+        publicPrefs.edit().putString(Settings.PREFERENCE_STORAGE_CUSTOM_FOLDER, "folder").commit()
+
+        settings.clearUserPreferences()
+
+        assertTrue(publicPrefs.contains(AccountConstants.ANON_ID_KEY))
+        assertTrue(publicPrefs.contains(Settings.PREFERENCE_STORAGE_CHOICE))
+        assertTrue(publicPrefs.contains(Settings.PREFERENCE_STORAGE_CHOICE_NAME))
+        assertTrue(publicPrefs.contains(Settings.PREFERENCE_STORAGE_CUSTOM_FOLDER))
+    }
+
+    @Test
     fun `clearUserPreferences keeps the processed sign out flag`() {
         settings.setFullySignedOut(false)
 

--- a/modules/services/preferences/src/test/kotlin/au/com/shiftyjelly/pocketcasts/preferences/SettingsImplTest.kt
+++ b/modules/services/preferences/src/test/kotlin/au/com/shiftyjelly/pocketcasts/preferences/SettingsImplTest.kt
@@ -1,0 +1,87 @@
+package au.com.shiftyjelly.pocketcasts.preferences
+
+import com.google.firebase.remoteconfig.FirebaseRemoteConfig
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+import com.squareup.moshi.Moshi
+import java.time.Instant
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import android.provider.Settings as AndroidSettings
+
+@Config(manifest = Config.NONE, sdk = [35])
+@RunWith(RobolectricTestRunner::class)
+class SettingsImplTest {
+    private val publicPrefs = FakeSharedPreferences()
+    private val privatePrefs = FakeSharedPreferences()
+
+    init {
+        AndroidSettings.Secure.putString(
+            RuntimeEnvironment.getApplication().contentResolver,
+            AndroidSettings.Secure.ANDROID_ID,
+            "8bytesid",
+        )
+    }
+
+    private val settings = SettingsImpl(
+        sharedPreferences = publicPrefs,
+        privatePreferences = privatePrefs,
+        context = RuntimeEnvironment.getApplication(),
+        firebaseRemoteConfig = mock<FirebaseRemoteConfig>(),
+        moshi = Moshi.Builder()
+            .add(
+                Instant::class.java,
+                object : JsonAdapter<Instant>() {
+                    override fun fromJson(reader: JsonReader): Instant = Instant.parse(reader.nextString())
+                    override fun toJson(writer: JsonWriter, value: Instant?) {
+                        writer.value(value?.toString())
+                    }
+                },
+            )
+            .build(),
+    )
+
+    @Test
+    fun `clearUserPreferences removes user keys from both preferences`() {
+        settings.hideNotificationOnPause.set(true, updateModifiedAt = true)
+        publicPrefs.edit().putString("SomeOtherKey", "value").commit()
+        privatePrefs.edit().putString("SomePrivateKey", "value").commit()
+
+        settings.clearUserPreferences()
+
+        assertFalse(publicPrefs.contains("hideNotificationOnPause"))
+        assertFalse(publicPrefs.contains("hideNotificationOnPauseModifiedAt"))
+        assertFalse(publicPrefs.contains("SomeOtherKey"))
+        assertFalse(privatePrefs.contains("SomePrivateKey"))
+    }
+
+    @Test
+    fun `clearUserPreferences keeps the analytics consent preferences`() {
+        settings.collectAnalytics.set(false, updateModifiedAt = false)
+        settings.sendCrashReports.set(false, updateModifiedAt = false)
+        settings.linkCrashReportsToUser.set(true, updateModifiedAt = false)
+
+        settings.clearUserPreferences()
+
+        assertFalse(settings.collectAnalytics.value)
+        assertFalse(settings.sendCrashReports.value)
+        assertTrue(settings.linkCrashReportsToUser.value)
+    }
+
+    @Test
+    fun `clearUserPreferences refreshes the in-memory setting values`() {
+        settings.hideNotificationOnPause.set(true, updateModifiedAt = false)
+        assertTrue(settings.hideNotificationOnPause.flow.value)
+
+        settings.clearUserPreferences()
+
+        assertFalse(settings.hideNotificationOnPause.flow.value)
+    }
+}

--- a/modules/services/preferences/src/test/kotlin/au/com/shiftyjelly/pocketcasts/preferences/SettingsImplTest.kt
+++ b/modules/services/preferences/src/test/kotlin/au/com/shiftyjelly/pocketcasts/preferences/SettingsImplTest.kt
@@ -1,11 +1,13 @@
 package au.com.shiftyjelly.pocketcasts.preferences
 
+import au.com.shiftyjelly.pocketcasts.models.to.RefreshState
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.JsonReader
 import com.squareup.moshi.JsonWriter
 import com.squareup.moshi.Moshi
 import java.time.Instant
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -81,6 +83,7 @@ class SettingsImplTest {
         publicPrefs.edit().putString(Settings.PREFERENCE_STORAGE_CHOICE, "choice").commit()
         publicPrefs.edit().putString(Settings.PREFERENCE_STORAGE_CHOICE_NAME, "name").commit()
         publicPrefs.edit().putString(Settings.PREFERENCE_STORAGE_CUSTOM_FOLDER, "folder").commit()
+        settings.setMigratedVersionCode(42)
 
         settings.clearUserPreferences()
 
@@ -88,6 +91,17 @@ class SettingsImplTest {
         assertTrue(publicPrefs.contains(Settings.PREFERENCE_STORAGE_CHOICE))
         assertTrue(publicPrefs.contains(Settings.PREFERENCE_STORAGE_CHOICE_NAME))
         assertTrue(publicPrefs.contains(Settings.PREFERENCE_STORAGE_CUSTOM_FOLDER))
+        assertEquals(42, settings.getMigratedVersionCode())
+    }
+
+    @Test
+    fun `clearUserPreferences resets the in-memory refresh state`() {
+        settings.setRefreshState(RefreshState.Failed("boom"))
+        assertTrue(settings.refreshStateFlow.value is RefreshState.Failed)
+
+        settings.clearUserPreferences()
+
+        assertTrue(settings.refreshStateFlow.value is RefreshState.Never)
     }
 
     @Test

--- a/modules/services/preferences/src/test/kotlin/au/com/shiftyjelly/pocketcasts/preferences/SettingsImplTest.kt
+++ b/modules/services/preferences/src/test/kotlin/au/com/shiftyjelly/pocketcasts/preferences/SettingsImplTest.kt
@@ -76,6 +76,15 @@ class SettingsImplTest {
     }
 
     @Test
+    fun `clearUserPreferences keeps the processed sign out flag`() {
+        settings.setFullySignedOut(false)
+
+        settings.clearUserPreferences()
+
+        assertFalse(settings.getFullySignedOut())
+    }
+
+    @Test
     fun `clearUserPreferences refreshes the in-memory setting values`() {
         settings.hideNotificationOnPause.set(true, updateModifiedAt = false)
         assertTrue(settings.hideNotificationOnPause.flow.value)

--- a/modules/services/preferences/src/test/kotlin/au/com/shiftyjelly/pocketcasts/preferences/UserSettingTest.kt
+++ b/modules/services/preferences/src/test/kotlin/au/com/shiftyjelly/pocketcasts/preferences/UserSettingTest.kt
@@ -1,0 +1,47 @@
+package au.com.shiftyjelly.pocketcasts.preferences
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UserSettingTest {
+
+    @Test
+    fun `refresh emits the persisted value when the flow is initialized`() {
+        val sharedPrefs = FakeSharedPreferences()
+        val setting = UserSetting.BoolPref("key", defaultValue = false, sharedPrefs = sharedPrefs)
+        setting.set(true, updateModifiedAt = false)
+        assertTrue(setting.flow.value)
+
+        sharedPrefs.edit().clear().commit()
+        setting.refresh()
+
+        assertFalse(setting.flow.value)
+    }
+
+    @Test
+    fun `refresh before the flow is initialized does not crash`() {
+        val setting = UserSetting.BoolPref("key", defaultValue = false, sharedPrefs = FakeSharedPreferences())
+
+        setting.refresh()
+
+        assertFalse(setting.flow.value)
+    }
+
+    @Test
+    fun `refreshAll refreshes only settings backed by the given preferences`() {
+        val prefsA = FakeSharedPreferences()
+        val prefsB = FakeSharedPreferences()
+        val settingA = UserSetting.BoolPref("key", defaultValue = false, sharedPrefs = prefsA)
+        val settingB = UserSetting.BoolPref("key", defaultValue = false, sharedPrefs = prefsB)
+        settingA.set(true, updateModifiedAt = false)
+        settingB.set(true, updateModifiedAt = false)
+
+        prefsA.edit().clear().commit()
+        prefsB.edit().clear().commit()
+        UserSetting.refreshAll(prefsA)
+
+        assertFalse(settingA.flow.value)
+        assertTrue(settingB.flow.value)
+    }
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/AccountManagerStatusInfo.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/AccountManagerStatusInfo.kt
@@ -53,7 +53,6 @@ class AccountManagerStatusInfo @Inject constructor(
     }
 
     internal companion object {
-        // Legacy key value
-        const val ANON_ID_KEY = "nosara_tracks_anon_id"
+        const val ANON_ID_KEY = AccountConstants.ANON_ID_KEY
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
@@ -40,6 +40,7 @@ import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
@@ -52,8 +53,8 @@ import timber.log.Timber
 interface UserManager {
     fun beginMonitoringAccountManager(playbackManager: PlaybackManager)
     fun getSignInState(): Flowable<SignInState>
-    fun signOut(playbackManager: PlaybackManager, wasInitiatedByUser: Boolean)
-    fun signOutAndClearData(playbackManager: PlaybackManager, upNextQueue: UpNextQueue, folderManager: FolderManager, searchHistoryManager: SearchHistoryManager, episodeManager: EpisodeManager, wasInitiatedByUser: Boolean)
+    fun signOut(playbackManager: PlaybackManager, wasInitiatedByUser: Boolean): Job?
+    fun signOutAndClearData(playbackManager: PlaybackManager, upNextQueue: UpNextQueue, folderManager: FolderManager, searchHistoryManager: SearchHistoryManager, episodeManager: EpisodeManager, wasInitiatedByUser: Boolean): Job?
 }
 
 class UserManagerImpl @Inject constructor(
@@ -155,10 +156,11 @@ class UserManagerImpl @Inject constructor(
         return settings.cachedSubscription.value
     }
 
-    override fun signOut(playbackManager: PlaybackManager, wasInitiatedByUser: Boolean) {
+    override fun signOut(playbackManager: PlaybackManager, wasInitiatedByUser: Boolean): Job? {
+        var signOutJob: Job? = null
         if (wasInitiatedByUser || !settings.getFullySignedOut()) {
             LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Signing out")
-            applicationScope.launch {
+            signOutJob = applicationScope.launch {
                 syncManager.signOut {
                     settings.clearPlusPreferences()
 
@@ -185,6 +187,7 @@ class UserManagerImpl @Inject constructor(
             }
         }
         settings.setFullySignedOut(true)
+        return signOutJob
     }
 
     override fun signOutAndClearData(
@@ -194,9 +197,9 @@ class UserManagerImpl @Inject constructor(
         searchHistoryManager: SearchHistoryManager,
         episodeManager: EpisodeManager,
         wasInitiatedByUser: Boolean,
-    ) {
+    ): Job? {
         // Sign out first to make sure no data changes get synced
-        signOut(playbackManager = playbackManager, wasInitiatedByUser = wasInitiatedByUser)
+        val signOutJob = signOut(playbackManager = playbackManager, wasInitiatedByUser = wasInitiatedByUser)
 
         // Need to stop playback before we start clearing data
         playbackManager.removeEpisode(
@@ -222,5 +225,6 @@ class UserManagerImpl @Inject constructor(
             }
             episodeManager.deleteAll(SourceView.UNKNOWN)
         }
+        return signOutJob
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
@@ -53,7 +53,11 @@ import timber.log.Timber
 interface UserManager {
     fun beginMonitoringAccountManager(playbackManager: PlaybackManager)
     fun getSignInState(): Flowable<SignInState>
+
+    /** Returns the job for the async credential sign out, or null when the sign out is skipped. */
     fun signOut(playbackManager: PlaybackManager, wasInitiatedByUser: Boolean): Job?
+
+    /** Returns the [signOut] job; the data is already cleared when this call returns. */
     fun signOutAndClearData(playbackManager: PlaybackManager, upNextQueue: UpNextQueue, folderManager: FolderManager, searchHistoryManager: SearchHistoryManager, episodeManager: EpisodeManager, wasInitiatedByUser: Boolean): Job?
 }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/auth/TvSignOutManager.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/auth/TvSignOutManager.kt
@@ -14,9 +14,11 @@ import au.com.shiftyjelly.pocketcasts.ui.images.CoilManager
 import au.com.shiftyjelly.pocketcasts.utils.FileUtil
 import dagger.Lazy
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 
 class TvSignOutManager @Inject constructor(
     private val userManager: UserManager,
@@ -33,7 +35,7 @@ class TvSignOutManager @Inject constructor(
 ) {
     fun signOutAndWipeData() {
         applicationScope.launch(ioDispatcher) {
-            userManager.signOutAndClearData(
+            val signOutJob = userManager.signOutAndClearData(
                 playbackManager = playbackManager.get(),
                 upNextQueue = upNextQueue.get(),
                 folderManager = folderManager.get(),
@@ -41,6 +43,7 @@ class TvSignOutManager @Inject constructor(
                 episodeManager = episodeManager.get(),
                 wasInitiatedByUser = true,
             )
+            withTimeoutOrNull(SIGN_OUT_TIMEOUT) { signOutJob?.join() }
             deleteDownloadedFiles()
             coilManager.clearAll()
             settings.clearUserPreferences()
@@ -55,5 +58,9 @@ class TvSignOutManager @Inject constructor(
             fileStorage.getOrCreateEpisodesTempDir(),
         )
         dirs.forEach { dir -> FileUtil.deleteDirContents(dir.absolutePath) }
+    }
+
+    private companion object {
+        val SIGN_OUT_TIMEOUT = 10.seconds
     }
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/auth/TvSignOutManager.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/auth/TvSignOutManager.kt
@@ -10,7 +10,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.FolderManager
 import au.com.shiftyjelly.pocketcasts.repositories.searchhistory.SearchHistoryManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
-import au.com.shiftyjelly.pocketcasts.ui.images.CoilManager
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import dagger.Lazy
 import javax.inject.Inject
@@ -29,7 +28,6 @@ class TvSignOutManager @Inject constructor(
     private val searchHistoryManager: Lazy<SearchHistoryManager>,
     private val episodeManager: Lazy<EpisodeManager>,
     private val fileStorage: FileStorage,
-    private val coilManager: CoilManager,
     private val settings: Settings,
     @ApplicationScope private val applicationScope: CoroutineScope,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
@@ -50,7 +48,6 @@ class TvSignOutManager @Inject constructor(
                 LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, "TV sign out did not finish before the wipe timeout")
             }
             runWipeStep("delete downloaded files") { deleteDownloadedFiles() }
-            runWipeStep("clear image caches") { coilManager.clearAll() }
             runWipeStep("clear user preferences") { settings.clearUserPreferences() }
         }
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/auth/TvSignOutManager.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/auth/TvSignOutManager.kt
@@ -11,7 +11,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.FolderManager
 import au.com.shiftyjelly.pocketcasts.repositories.searchhistory.SearchHistoryManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.ui.images.CoilManager
-import au.com.shiftyjelly.pocketcasts.utils.FileUtil
 import dagger.Lazy
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.seconds
@@ -55,9 +54,16 @@ class TvSignOutManager @Inject constructor(
             fileStorage.getOrCreateEpisodesDir(),
             fileStorage.getOrCreateCloudDir(),
             fileStorage.getOrCreateNetworkImagesDir(),
+            fileStorage.getOrCreateEpisodesOldTempDir(),
             fileStorage.getOrCreateEpisodesTempDir(),
         )
-        dirs.forEach { dir -> FileUtil.deleteDirContents(dir.absolutePath) }
+        dirs.forEach { dir ->
+            dir.listFiles()?.forEach { file ->
+                if (!file.name.equals(".nomedia", ignoreCase = true)) {
+                    file.deleteRecursively()
+                }
+            }
+        }
     }
 
     private companion object {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/auth/TvSignOutManager.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/auth/TvSignOutManager.kt
@@ -53,17 +53,19 @@ class TvSignOutManager @Inject constructor(
     }
 
     private fun deleteDownloadedFiles() {
-        val dirs = listOfNotNull(
-            fileStorage.getOrCreateEpisodesDir(),
-            fileStorage.getOrCreateCloudDir(),
-            fileStorage.getOrCreateNetworkImagesDir(),
-            fileStorage.getOrCreateEpisodesOldTempDir(),
-            fileStorage.getOrCreateEpisodesTempDir(),
+        val dirProviders = listOf(
+            "episodes" to fileStorage::getOrCreateEpisodesDir,
+            "cloud" to fileStorage::getOrCreateCloudDir,
+            "network images" to fileStorage::getOrCreateNetworkImagesDir,
+            "old temp episodes" to fileStorage::getOrCreateEpisodesOldTempDir,
+            "temp episodes" to fileStorage::getOrCreateEpisodesTempDir,
         )
-        dirs.forEach { dir ->
-            dir.listFiles()?.forEach { file ->
-                if (!file.name.equals(".nomedia", ignoreCase = true)) {
-                    file.deleteRecursively()
+        dirProviders.forEach { (name, provider) ->
+            runWipeStep("delete $name directory") {
+                provider()?.listFiles()?.forEach { file ->
+                    if (!file.name.equals(".nomedia", ignoreCase = true)) {
+                        file.deleteRecursively()
+                    }
                 }
             }
         }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/auth/TvSignOutManager.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/auth/TvSignOutManager.kt
@@ -11,9 +11,11 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.FolderManager
 import au.com.shiftyjelly.pocketcasts.repositories.searchhistory.SearchHistoryManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.ui.images.CoilManager
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import dagger.Lazy
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -34,18 +36,22 @@ class TvSignOutManager @Inject constructor(
 ) {
     fun signOutAndWipeData() {
         applicationScope.launch(ioDispatcher) {
-            val signOutJob = userManager.signOutAndClearData(
-                playbackManager = playbackManager.get(),
-                upNextQueue = upNextQueue.get(),
-                folderManager = folderManager.get(),
-                searchHistoryManager = searchHistoryManager.get(),
-                episodeManager = episodeManager.get(),
-                wasInitiatedByUser = true,
-            )
-            withTimeoutOrNull(SIGN_OUT_TIMEOUT) { signOutJob?.join() }
-            deleteDownloadedFiles()
-            coilManager.clearAll()
-            settings.clearUserPreferences()
+            val signOutJob = runWipeStep("sign out and clear data") {
+                userManager.signOutAndClearData(
+                    playbackManager = playbackManager.get(),
+                    upNextQueue = upNextQueue.get(),
+                    folderManager = folderManager.get(),
+                    searchHistoryManager = searchHistoryManager.get(),
+                    episodeManager = episodeManager.get(),
+                    wasInitiatedByUser = true,
+                )
+            }
+            if (signOutJob != null && withTimeoutOrNull(SIGN_OUT_TIMEOUT) { signOutJob.join() } == null) {
+                LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, "TV sign out did not finish before the wipe timeout")
+            }
+            runWipeStep("delete downloaded files") { deleteDownloadedFiles() }
+            runWipeStep("clear image caches") { coilManager.clearAll() }
+            runWipeStep("clear user preferences") { settings.clearUserPreferences() }
         }
     }
 
@@ -64,6 +70,15 @@ class TvSignOutManager @Inject constructor(
                 }
             }
         }
+    }
+
+    private inline fun <T> runWipeStep(name: String, block: () -> T): T? = try {
+        block()
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, e, "TV sign out step failed: $name")
+        null
     }
 
     private companion object {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/auth/TvSignOutManager.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/auth/TvSignOutManager.kt
@@ -1,0 +1,60 @@
+package au.com.shiftyjelly.pocketcasts.auth
+
+import au.com.shiftyjelly.pocketcasts.coroutines.di.ApplicationScope
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.di.IoDispatcher
+import au.com.shiftyjelly.pocketcasts.repositories.file.FileStorage
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.FolderManager
+import au.com.shiftyjelly.pocketcasts.repositories.searchhistory.SearchHistoryManager
+import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
+import au.com.shiftyjelly.pocketcasts.ui.images.CoilManager
+import au.com.shiftyjelly.pocketcasts.utils.FileUtil
+import dagger.Lazy
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+class TvSignOutManager @Inject constructor(
+    private val userManager: UserManager,
+    private val playbackManager: Lazy<PlaybackManager>,
+    private val upNextQueue: Lazy<UpNextQueue>,
+    private val folderManager: Lazy<FolderManager>,
+    private val searchHistoryManager: Lazy<SearchHistoryManager>,
+    private val episodeManager: Lazy<EpisodeManager>,
+    private val fileStorage: FileStorage,
+    private val coilManager: CoilManager,
+    private val settings: Settings,
+    @ApplicationScope private val applicationScope: CoroutineScope,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+) {
+    fun signOutAndWipeData() {
+        applicationScope.launch(ioDispatcher) {
+            userManager.signOutAndClearData(
+                playbackManager = playbackManager.get(),
+                upNextQueue = upNextQueue.get(),
+                folderManager = folderManager.get(),
+                searchHistoryManager = searchHistoryManager.get(),
+                episodeManager = episodeManager.get(),
+                wasInitiatedByUser = true,
+            )
+            deleteDownloadedFiles()
+            coilManager.clearAll()
+            settings.clearUserPreferences()
+            settings.setFullySignedOut(true)
+        }
+    }
+
+    private fun deleteDownloadedFiles() {
+        val dirs = listOfNotNull(
+            fileStorage.getOrCreateEpisodesDir(),
+            fileStorage.getOrCreateCloudDir(),
+            fileStorage.getOrCreateNetworkImagesDir(),
+            fileStorage.getOrCreateEpisodesTempDir(),
+        )
+        dirs.forEach { dir -> FileUtil.deleteDirContents(dir.absolutePath) }
+    }
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/auth/TvSignOutManager.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/auth/TvSignOutManager.kt
@@ -44,7 +44,6 @@ class TvSignOutManager @Inject constructor(
             deleteDownloadedFiles()
             coilManager.clearAll()
             settings.clearUserPreferences()
-            settings.setFullySignedOut(true)
         }
     }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEmptyState.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEmptyState.kt
@@ -56,7 +56,7 @@ fun TvEmptyState(
                 onClick = onAction,
                 colors = TvButtonDefaults.filledButtonColors(),
             ) {
-                Text(actionLabel)
+                Text(actionLabel, style = TvTextStyles.ModalButtonLabel)
             }
         }
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEmptyState.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEmptyState.kt
@@ -15,10 +15,11 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.tv.material3.Button
 import androidx.tv.material3.MaterialTheme
-import androidx.tv.material3.OutlinedButton
 import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
 import au.com.shiftyjelly.pocketcasts.theme.TvColors
 import au.com.shiftyjelly.pocketcasts.theme.TvTextStyles
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
@@ -51,7 +52,10 @@ fun TvEmptyState(
                 modifier = Modifier.widthIn(max = 400.dp),
             )
             Spacer(modifier = Modifier.height(32.dp))
-            OutlinedButton(onClick = onAction) {
+            Button(
+                onClick = onAction,
+                colors = TvButtonDefaults.filledButtonColors(),
+            ) {
                 Text(actionLabel)
             }
         }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvModal.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
@@ -35,6 +36,7 @@ import java.util.function.Consumer
 fun TvModal(
     onDismissRequest: () -> Unit,
     modifier: Modifier = Modifier,
+    width: Dp = DefaultModalWidth,
     content: @Composable ColumnScope.() -> Unit,
 ) {
     Dialog(
@@ -45,6 +47,7 @@ fun TvModal(
         TvModalWindowEffects(isBlurBehindEnabled = isBlurBehindEnabled)
         TvModalSurface(
             isTranslucent = isBlurBehindEnabled,
+            width = width,
             modifier = modifier,
             content = content,
         )
@@ -55,6 +58,7 @@ fun TvModal(
 internal fun TvModalSurface(
     modifier: Modifier = Modifier,
     isTranslucent: Boolean = false,
+    width: Dp = DefaultModalWidth,
     content: @Composable ColumnScope.() -> Unit,
 ) {
     Column(
@@ -62,7 +66,7 @@ internal fun TvModalSurface(
         verticalArrangement = Arrangement.spacedBy(16.dp),
         content = content,
         modifier = modifier
-            .width(400.dp)
+            .width(width)
             .clip(ModalShape)
             .background(if (isTranslucent) TranslucentContainerColor else OpaqueContainerColor)
             .background(HighlightBrush)
@@ -105,6 +109,7 @@ private fun rememberIsBlurBehindEnabled(): State<Boolean> {
     return isBlurBehindEnabled
 }
 
+private val DefaultModalWidth = 400.dp
 private val ModalShape = RoundedCornerShape(28.dp)
 private val TranslucentContainerColor = TvColors.Dark.copy(alpha = 0.6f)
 private val OpaqueContainerColor = TvColors.Dark.copy(alpha = 0.94f)

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffoldViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffoldViewModel.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.auth.TvSignOutManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
-import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -16,7 +15,6 @@ import kotlinx.coroutines.rx2.asFlow
 
 @HiltViewModel
 class TvScaffoldViewModel @Inject constructor(
-    private val userManager: UserManager,
     private val syncManager: SyncManager,
     private val signOutManager: TvSignOutManager,
 ) : ViewModel() {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffoldViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffoldViewModel.kt
@@ -2,10 +2,9 @@ package au.com.shiftyjelly.pocketcasts.home
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.auth.TvSignOutManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
-import dagger.Lazy
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -19,7 +18,7 @@ import kotlinx.coroutines.rx2.asFlow
 class TvScaffoldViewModel @Inject constructor(
     private val userManager: UserManager,
     private val syncManager: SyncManager,
-    private val playbackManager: Lazy<PlaybackManager>,
+    private val signOutManager: TvSignOutManager,
 ) : ViewModel() {
     private val selectedTabIndex = MutableStateFlow(0)
 
@@ -43,7 +42,7 @@ class TvScaffoldViewModel @Inject constructor(
     }
 
     fun signOut() {
-        userManager.signOut(playbackManager.get(), wasInitiatedByUser = true)
+        signOutManager.signOutAndWipeData()
     }
 
     private fun currentProfileState() = profileState(syncManager.isLoggedIn(), syncManager.getEmail())

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvDownloadAppModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvDownloadAppModal.kt
@@ -1,0 +1,104 @@
+package au.com.shiftyjelly.pocketcasts.playlists
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.tv.material3.Button
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.component.TvModal
+import au.com.shiftyjelly.pocketcasts.component.TvModalSurface
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.qr.rememberQrPainter
+import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
+import au.com.shiftyjelly.pocketcasts.theme.TvColors
+import au.com.shiftyjelly.pocketcasts.theme.TvTextStyles
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+fun TvDownloadAppModal(
+    onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    TvModal(
+        onDismissRequest = onDismissRequest,
+        width = 600.dp,
+        modifier = modifier,
+    ) {
+        TvDownloadAppModalContent(onDone = onDismissRequest)
+    }
+}
+
+@Composable
+private fun ColumnScope.TvDownloadAppModalContent(
+    onDone: () -> Unit,
+) {
+    val focusRequester = remember { FocusRequester() }
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+
+    Text(
+        text = stringResource(LR.string.tv_playlists_download_title),
+        color = Color.White,
+        style = TvTextStyles.ModalTitle,
+    )
+    Text(
+        text = stringResource(LR.string.tv_playlists_download_subtitle),
+        color = TvColors.TextSecondary,
+        style = TvTextStyles.ModalBody,
+    )
+    Image(
+        painter = rememberQrPainter(content = DOWNLOAD_URL, size = QrCodeSize),
+        contentDescription = null,
+        modifier = Modifier
+            .padding(vertical = 16.dp)
+            .background(Color.White, RoundedCornerShape(8.dp))
+            .padding(10.dp)
+            .size(QrCodeSize),
+    )
+    Text(
+        text = DOWNLOAD_URL_LABEL,
+        color = TvColors.TextSecondary,
+        style = TvTextStyles.ModalBody,
+    )
+    Button(
+        onClick = onDone,
+        colors = TvButtonDefaults.filledButtonColors(),
+        modifier = Modifier
+            .padding(top = 16.dp)
+            .focusRequester(focusRequester),
+    ) {
+        Text(stringResource(LR.string.done))
+    }
+}
+
+private const val DOWNLOAD_URL = "https://pocketcasts.com/downloads"
+private val DOWNLOAD_URL_LABEL = DOWNLOAD_URL.removePrefix("https://")
+private val QrCodeSize = 144.dp
+
+@Preview
+@Composable
+private fun TvDownloadAppModalPreview() {
+    AppTheme(themeType = Theme.ThemeType.EXTRA_DARK) {
+        MaterialTheme {
+            TvModalSurface(width = 600.dp) {
+                TvDownloadAppModalContent(onDone = {})
+            }
+        }
+    }
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvDownloadAppModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvDownloadAppModal.kt
@@ -83,7 +83,7 @@ private fun ColumnScope.TvDownloadAppModalContent(
             .padding(top = 16.dp)
             .focusRequester(focusRequester),
     ) {
-        Text(stringResource(LR.string.done))
+        Text(stringResource(LR.string.done), style = TvTextStyles.ModalButtonLabel)
     }
 }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsScreen.kt
@@ -41,8 +41,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.tv.material3.Button
 import androidx.tv.material3.MaterialTheme
-import androidx.tv.material3.OutlinedButton
 import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.component.TvEmptyState
 import au.com.shiftyjelly.pocketcasts.component.TvPlaylistCard
@@ -55,6 +55,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImage
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.Playlist
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistPreview
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.SmartPlaylistPreview
+import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
 import au.com.shiftyjelly.pocketcasts.theme.TvColors
 import au.com.shiftyjelly.pocketcasts.theme.TvTextStyles
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
@@ -68,6 +69,8 @@ fun TvPlaylistsScreen(
     viewModel: TvPlaylistsViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    var isDownloadModalVisible by rememberSaveable { mutableStateOf(false) }
+
     TvPlaylistsContent(
         uiState = uiState,
         getArtworkUuidsFlow = viewModel::getArtworkUuidsFlow,
@@ -75,8 +78,15 @@ fun TvPlaylistsScreen(
         refreshArtworkUuids = viewModel::refreshArtworkUuids,
         refreshEpisodeCount = viewModel::refreshEpisodeCount,
         findPodcastTint = viewModel::findPodcastTint,
+        onCreatePlaylist = { isDownloadModalVisible = true },
         modifier = modifier,
     )
+
+    if (isDownloadModalVisible) {
+        TvDownloadAppModal(
+            onDismissRequest = { isDownloadModalVisible = false },
+        )
+    }
 }
 
 @Composable
@@ -87,6 +97,7 @@ private fun TvPlaylistsContent(
     refreshArtworkUuids: suspend (String) -> Unit,
     refreshEpisodeCount: suspend (String) -> Unit,
     findPodcastTint: suspend (String) -> Int?,
+    onCreatePlaylist: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     AnimatedContent(
@@ -105,7 +116,10 @@ private fun TvPlaylistsContent(
             is TvPlaylistsUiState.Loading -> LoadingView(color = Color.White, modifier = Modifier.fillMaxSize())
 
             is TvPlaylistsUiState.Loaded -> if (state.playlists.isEmpty()) {
-                TvPlaylistsEmpty(modifier = Modifier.fillMaxSize())
+                TvPlaylistsEmpty(
+                    onCreatePlaylist = onCreatePlaylist,
+                    modifier = Modifier.fillMaxSize(),
+                )
             } else {
                 TvPlaylistsGrid(
                     playlists = state.playlists,
@@ -217,13 +231,14 @@ private fun TvPlaylistGridItem(
 
 @Composable
 private fun TvPlaylistsEmpty(
+    onCreatePlaylist: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     TvEmptyState(
         title = stringResource(LR.string.tv_playlists_empty_title),
         subtitle = stringResource(LR.string.tv_playlists_empty_subtitle),
         actionLabel = stringResource(LR.string.tv_playlists_empty_action_title),
-        onAction = {},
+        onAction = onCreatePlaylist,
         modifier = modifier,
     )
 }
@@ -243,6 +258,7 @@ private fun TvPlaylistsGridPreview() {
                     refreshArtworkUuids = {},
                     refreshEpisodeCount = {},
                     findPodcastTint = { null },
+                    onCreatePlaylist = {},
                 )
             }
         }
@@ -262,6 +278,7 @@ private fun TvPlaylistsEmptyPreview() {
                     refreshArtworkUuids = {},
                     refreshEpisodeCount = {},
                     findPodcastTint = { null },
+                    onCreatePlaylist = {},
                 )
             }
         }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvTextStyles.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvTextStyles.kt
@@ -79,6 +79,21 @@ object TvTextStyles {
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 
+    val ModalTitle = TextStyle(
+        fontSize = 24.sp,
+        fontWeight = FontWeight.SemiBold,
+        lineHeight = 28.sp,
+        textAlign = TextAlign.Center,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    val ModalBody = TextStyle(
+        fontSize = 16.sp,
+        lineHeight = 20.sp,
+        textAlign = TextAlign.Center,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
     val ModalEmail = TextStyle(
         fontSize = 25.sp,
         fontWeight = FontWeight(510),

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/TvScaffoldViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/TvScaffoldViewModelTest.kt
@@ -1,15 +1,14 @@
 package au.com.shiftyjelly.pocketcasts
 
 import app.cash.turbine.test
+import au.com.shiftyjelly.pocketcasts.auth.TvSignOutManager
 import au.com.shiftyjelly.pocketcasts.home.TvProfileState
 import au.com.shiftyjelly.pocketcasts.home.TvScaffoldViewModel
 import au.com.shiftyjelly.pocketcasts.home.TvTab
-import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import com.jakewharton.rxrelay2.BehaviorRelay
-import dagger.Lazy
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -37,10 +36,10 @@ class TvScaffoldViewModelTest {
         on { isLoggedInObservable } doReturn isLoggedIn
         on { emailFlow() } doReturn email
     }
-    private val playbackManager = mock<PlaybackManager>()
+    private val signOutManager = mock<TvSignOutManager>()
 
     private val viewModel by lazy {
-        TvScaffoldViewModel(userManager, syncManager, Lazy { playbackManager })
+        TvScaffoldViewModel(userManager, syncManager, signOutManager)
     }
 
     @Test
@@ -130,9 +129,9 @@ class TvScaffoldViewModelTest {
     }
 
     @Test
-    fun `signOut delegates to the user manager`() = runTest {
+    fun `signOut delegates to the sign out manager`() = runTest {
         viewModel.signOut()
 
-        verify(userManager).signOut(playbackManager, wasInitiatedByUser = true)
+        verify(signOutManager).signOutAndWipeData()
     }
 }

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/TvScaffoldViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/TvScaffoldViewModelTest.kt
@@ -6,7 +6,6 @@ import au.com.shiftyjelly.pocketcasts.home.TvProfileState
 import au.com.shiftyjelly.pocketcasts.home.TvScaffoldViewModel
 import au.com.shiftyjelly.pocketcasts.home.TvTab
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
-import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import com.jakewharton.rxrelay2.BehaviorRelay
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -30,7 +29,6 @@ class TvScaffoldViewModelTest {
     private val isLoggedIn = BehaviorRelay.createDefault(false)
     private val email = MutableStateFlow<String?>(null)
 
-    private val userManager = mock<UserManager>()
     private val syncManager = mock<SyncManager> {
         on { isLoggedIn() } doReturn false
         on { isLoggedInObservable } doReturn isLoggedIn
@@ -39,7 +37,7 @@ class TvScaffoldViewModelTest {
     private val signOutManager = mock<TvSignOutManager>()
 
     private val viewModel by lazy {
-        TvScaffoldViewModel(userManager, syncManager, signOutManager)
+        TvScaffoldViewModel(syncManager, signOutManager)
     }
 
     @Test

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/auth/TvSignOutManagerTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/auth/TvSignOutManagerTest.kt
@@ -9,7 +9,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.FolderManager
 import au.com.shiftyjelly.pocketcasts.repositories.searchhistory.SearchHistoryManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
-import au.com.shiftyjelly.pocketcasts.ui.images.CoilManager
 import java.io.File
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
@@ -45,7 +44,6 @@ class TvSignOutManagerTest {
     private val folderManager = mock<FolderManager>()
     private val searchHistoryManager = mock<SearchHistoryManager>()
     private val episodeManager = mock<EpisodeManager>()
-    private val coilManager = mock<CoilManager>()
     private val settings = mock<Settings>()
 
     @Test
@@ -55,7 +53,7 @@ class TvSignOutManagerTest {
         manager.signOutAndWipeData()
         advanceUntilIdle()
 
-        inOrder(userManager, coilManager, settings) {
+        inOrder(userManager, settings) {
             verify(userManager).signOutAndClearData(
                 playbackManager = eq(playbackManager),
                 upNextQueue = eq(upNextQueue),
@@ -64,7 +62,6 @@ class TvSignOutManagerTest {
                 episodeManager = eq(episodeManager),
                 wasInitiatedByUser = eq(true),
             )
-            verify(coilManager).clearAll()
             verify(settings).clearUserPreferences()
         }
     }
@@ -105,13 +102,11 @@ class TvSignOutManagerTest {
         manager.signOutAndWipeData()
         runCurrent()
 
-        verify(coilManager, never()).clearAll()
         verify(settings, never()).clearUserPreferences()
 
         signOutJob.complete()
         runCurrent()
 
-        verify(coilManager).clearAll()
         verify(settings).clearUserPreferences()
     }
 
@@ -133,7 +128,6 @@ class TvSignOutManagerTest {
         searchHistoryManager = { searchHistoryManager },
         episodeManager = { episodeManager },
         fileStorage = fileStorage,
-        coilManager = coilManager,
         settings = settings,
         applicationScope = this,
         ioDispatcher = coroutineRule.testDispatcher,

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/auth/TvSignOutManagerTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/auth/TvSignOutManagerTest.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.auth
 
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.file.FileStorage
+import au.com.shiftyjelly.pocketcasts.repositories.file.StorageException
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
@@ -22,6 +23,7 @@ import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
@@ -89,6 +91,23 @@ class TvSignOutManagerTest {
         assertFalse(groupImage.exists())
         assertTrue(noMediaFile.exists())
         assertTrue(episodesDir.exists())
+    }
+
+    @Test
+    fun `sign out deletes the remaining directories when one lookup fails`() = runTest {
+        val cloudDir = temporaryFolder.newFolder("cloud")
+        val cloudFile = File(cloudDir, "file.mp3").apply { writeText("audio") }
+        val fileStorage = mock<FileStorage> {
+            on { getOrCreateEpisodesDir() } doThrow StorageException("no storage")
+            on { getOrCreateCloudDir() } doReturn cloudDir
+        }
+        val manager = createManager(fileStorage = fileStorage)
+
+        manager.signOutAndWipeData()
+        advanceUntilIdle()
+
+        assertFalse(cloudFile.exists())
+        verify(settings).clearUserPreferences()
     }
 
     @Test

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/auth/TvSignOutManagerTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/auth/TvSignOutManagerTest.kt
@@ -72,12 +72,16 @@ class TvSignOutManagerTest {
     @Test
     fun `sign out deletes the downloaded files`() = runTest {
         val episodesDir = temporaryFolder.newFolder("episodes")
-        val cloudDir = temporaryFolder.newFolder("cloud_files")
+        val imagesDir = temporaryFolder.newFolder("network_images")
         val downloadedEpisode = File(episodesDir, "episode.mp3").apply { writeText("audio") }
-        val cloudFile = File(cloudDir, "file.mp3").apply { writeText("audio") }
+        val noMediaFile = File(episodesDir, ".nomedia").apply { writeText("") }
+        val groupImage = File(imagesDir, "groups/group.webp").apply {
+            parentFile?.mkdirs()
+            writeText("image")
+        }
         val fileStorage = mock<FileStorage> {
             on { getOrCreateEpisodesDir() } doReturn episodesDir
-            on { getOrCreateCloudDir() } doReturn cloudDir
+            on { getOrCreateNetworkImagesDir() } doReturn imagesDir
         }
         val manager = createManager(fileStorage = fileStorage)
 
@@ -85,7 +89,8 @@ class TvSignOutManagerTest {
         advanceUntilIdle()
 
         assertFalse(downloadedEpisode.exists())
-        assertFalse(cloudFile.exists())
+        assertFalse(groupImage.exists())
+        assertTrue(noMediaFile.exists())
         assertTrue(episodesDir.exists())
     }
 

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/auth/TvSignOutManagerTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/auth/TvSignOutManagerTest.kt
@@ -1,0 +1,113 @@
+package au.com.shiftyjelly.pocketcasts.auth
+
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.file.FileStorage
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.FolderManager
+import au.com.shiftyjelly.pocketcasts.repositories.searchhistory.SearchHistoryManager
+import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
+import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import au.com.shiftyjelly.pocketcasts.ui.images.CoilManager
+import java.io.File
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.inOrder
+import org.mockito.kotlin.mock
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TvSignOutManagerTest {
+
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
+
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    private val userManager = mock<UserManager>()
+    private val playbackManager = mock<PlaybackManager>()
+    private val upNextQueue = mock<UpNextQueue>()
+    private val folderManager = mock<FolderManager>()
+    private val searchHistoryManager = mock<SearchHistoryManager>()
+    private val episodeManager = mock<EpisodeManager>()
+    private val coilManager = mock<CoilManager>()
+    private val settings = mock<Settings>()
+
+    @Test
+    fun `sign out clears the account data and caches in order`() = runTest {
+        val manager = createManager(fileStorage = mock<FileStorage>())
+
+        manager.signOutAndWipeData()
+        advanceUntilIdle()
+
+        inOrder(userManager, coilManager, settings) {
+            verify(userManager).signOutAndClearData(
+                playbackManager = eq(playbackManager),
+                upNextQueue = eq(upNextQueue),
+                folderManager = eq(folderManager),
+                searchHistoryManager = eq(searchHistoryManager),
+                episodeManager = eq(episodeManager),
+                wasInitiatedByUser = eq(true),
+            )
+            verify(coilManager).clearAll()
+            verify(settings).clearUserPreferences()
+            verify(settings).setFullySignedOut(true)
+        }
+    }
+
+    @Test
+    fun `sign out deletes the downloaded files`() = runTest {
+        val episodesDir = temporaryFolder.newFolder("episodes")
+        val cloudDir = temporaryFolder.newFolder("cloud_files")
+        val downloadedEpisode = File(episodesDir, "episode.mp3").apply { writeText("audio") }
+        val cloudFile = File(cloudDir, "file.mp3").apply { writeText("audio") }
+        val fileStorage = mock<FileStorage> {
+            on { getOrCreateEpisodesDir() } doReturn episodesDir
+            on { getOrCreateCloudDir() } doReturn cloudDir
+        }
+        val manager = createManager(fileStorage = fileStorage)
+
+        manager.signOutAndWipeData()
+        advanceUntilIdle()
+
+        assertFalse(downloadedEpisode.exists())
+        assertFalse(cloudFile.exists())
+        assertTrue(episodesDir.exists())
+    }
+
+    @Test
+    fun `sign out ignores unavailable storage directories`() = runTest {
+        val manager = createManager(fileStorage = mock<FileStorage>())
+
+        manager.signOutAndWipeData()
+        advanceUntilIdle()
+
+        inOrder(settings) {
+            verify(settings).clearUserPreferences()
+            verify(settings).setFullySignedOut(true)
+        }
+    }
+
+    private fun kotlinx.coroutines.test.TestScope.createManager(fileStorage: FileStorage) = TvSignOutManager(
+        userManager = userManager,
+        playbackManager = { playbackManager },
+        upNextQueue = { upNextQueue },
+        folderManager = { folderManager },
+        searchHistoryManager = { searchHistoryManager },
+        episodeManager = { episodeManager },
+        fileStorage = fileStorage,
+        coilManager = coilManager,
+        settings = settings,
+        applicationScope = this,
+        ioDispatcher = coroutineRule.testDispatcher,
+    )
+}

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/auth/TvSignOutManagerTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/auth/TvSignOutManagerTest.kt
@@ -12,18 +12,23 @@ import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import au.com.shiftyjelly.pocketcasts.ui.images.CoilManager
 import java.io.File
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
+import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class TvSignOutManagerTest {
@@ -82,6 +87,27 @@ class TvSignOutManagerTest {
         assertFalse(downloadedEpisode.exists())
         assertFalse(cloudFile.exists())
         assertTrue(episodesDir.exists())
+    }
+
+    @Test
+    fun `wipe waits for the pending sign out before clearing caches`() = runTest {
+        val signOutJob = Job()
+        whenever(
+            userManager.signOutAndClearData(any(), any(), any(), any(), any(), any()),
+        ).thenReturn(signOutJob)
+        val manager = createManager(fileStorage = mock<FileStorage>())
+
+        manager.signOutAndWipeData()
+        runCurrent()
+
+        verify(coilManager, never()).clearAll()
+        verify(settings, never()).clearUserPreferences()
+
+        signOutJob.complete()
+        runCurrent()
+
+        verify(coilManager).clearAll()
+        verify(settings).clearUserPreferences()
     }
 
     @Test

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/auth/TvSignOutManagerTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/auth/TvSignOutManagerTest.kt
@@ -23,6 +23,7 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class TvSignOutManagerTest {
@@ -60,7 +61,6 @@ class TvSignOutManagerTest {
             )
             verify(coilManager).clearAll()
             verify(settings).clearUserPreferences()
-            verify(settings).setFullySignedOut(true)
         }
     }
 
@@ -91,10 +91,7 @@ class TvSignOutManagerTest {
         manager.signOutAndWipeData()
         advanceUntilIdle()
 
-        inOrder(settings) {
-            verify(settings).clearUserPreferences()
-            verify(settings).setFullySignedOut(true)
-        }
+        verify(settings).clearUserPreferences()
     }
 
     private fun kotlinx.coroutines.test.TestScope.createManager(fileStorage: FileStorage) = TvSignOutManager(


### PR DESCRIPTION
## Description
Apple TV keeps nothing locally once signed out: credentials are cleared first so nothing syncs, playback stops, and the database, downloaded files, and preferences (except device-level keys) are all wiped. The Android TV app previously used the light `UserManager.signOut`, which keeps the whole local library.

This PR mirrors the tvOS behavior:
- New `Settings.clearUserPreferences()` removes every key from the public and private preferences except the analytics-consent keys, the processed-sign-out flag, and the device-level keys (analytics anon id, storage location, migrated version code); the "Global" file holding the device ID is untouched (the analog of tvOS preserving `appId`/`analyticsOptOut`). `UserSetting` gains `refresh()` plus a registry so in-memory setting flows re-read their defaults after the wipe.
- New `TvSignOutManager` runs the full wipe on the application scope: `signOutAndClearData` (its `force = true` playlist re-seed is a no-op on TV thanks to the seeding change), waits for the asynchronous credential sign-out to finish so late preference writes can't survive the wipe (`UserManager.signOut`/`signOutAndClearData` now return their `Job`, ignored by all other callers), recursively deletes the episode/cloud/network-image/temp directories (keeping `.nomedia`), and finally clears user preferences.
- `TvScaffoldViewModel.signOut()` delegates to the new manager.

Phone, automotive, and wear sign-out behavior is unchanged.

## Testing Instructions
1. On TV, sign in with an account that has podcasts and playlists and play an episode.
2. Open the profile modal and log out.
3. The Playlists tab returns to the empty state, Your Podcasts is empty, and Up Next is cleared.
4. Check the app's storage: downloaded files are gone, and the shared preferences contain only the analytics-consent and device-level keys.

## Screenshots or Screencast
Not applicable — no UI changes.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
