### PR TITLE
[TV] Add a playlist details screen to the TV app

### DIFF
--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -263,6 +263,7 @@
     <string name="tv_playlist_play_all">Play all episodes</string>
     <string name="tv_playlist_empty_title">No episodes</string>
     <string name="tv_playlist_empty_subtitle">Either it’s time to celebrate completing this list or edit your rules in the mobile app to get some more.</string>
+    <string name="tv_playlist_empty_subtitle_manual">Add episodes to this playlist from the mobile app and they’ll show up here.</string>
     <string name="unavailable">Unavailable</string>
     <string name="browse_podcasts">Browse podcasts</string>
     <string name="pocket_casts_plus_badge">Pocket Casts Plus badge</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -260,6 +260,9 @@
     <string name="tv_playlists_empty_action_title">Create a playlist</string>
     <string name="tv_playlists_download_title">Create playlists on your phone</string>
     <string name="tv_playlists_download_subtitle">They’ll be waiting here when you’re done. Scan to get the app</string>
+    <string name="tv_playlist_play_all">Play all episodes</string>
+    <string name="tv_playlist_empty_title">No episodes</string>
+    <string name="tv_playlist_empty_subtitle">Either it’s time to celebrate completing this list or edit your rules in the mobile app to get some more.</string>
     <string name="unavailable">Unavailable</string>
     <string name="browse_podcasts">Browse podcasts</string>
     <string name="pocket_casts_plus_badge">Pocket Casts Plus badge</string>
@@ -1018,6 +1021,7 @@
     <string name="playlist_select_episodes">Select episodes</string>
     <string name="playlist_setting_auto_download_description">Enable to auto download episodes in this playlist.</string>
     <string name="playlist_sort_by">Sort by</string>
+    <string name="playlist">Playlist</string>
     <string name="playlists">Playlists</string>
     <string name="playlists_empty_state_body">Playlists let you organize episodes manually or automatically with smart rules.</string>
     <string name="playlists_empty_state_title">Organize episodes your way</string>

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvArtworkImage.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvArtworkImage.kt
@@ -1,0 +1,25 @@
+package au.com.shiftyjelly.pocketcasts.component
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.ColorPainter
+import androidx.compose.ui.layout.ContentScale
+import coil3.compose.AsyncImage
+
+@Composable
+fun TvArtworkImage(
+    model: Any?,
+    modifier: Modifier = Modifier,
+) {
+    val placeholder = remember { ColorPainter(Color.Black.copy(alpha = 0.2f)) }
+    AsyncImage(
+        model = model,
+        placeholder = placeholder,
+        error = placeholder,
+        contentDescription = null,
+        contentScale = ContentScale.Crop,
+        modifier = modifier,
+    )
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeRow.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeRow.kt
@@ -1,0 +1,202 @@
+package au.com.shiftyjelly.pocketcasts.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.tv.material3.CardDefaults
+import androidx.tv.material3.Icon
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.localization.helper.RelativeDateFormatter
+import au.com.shiftyjelly.pocketcasts.localization.helper.TimeHelper
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImage
+import au.com.shiftyjelly.pocketcasts.theme.TvColors
+import au.com.shiftyjelly.pocketcasts.theme.TvTextStyles
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import java.util.Date
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+
+@Composable
+fun TvEpisodeRow(
+    episode: PodcastEpisode,
+    onClick: () -> Unit,
+    dateFormatter: RelativeDateFormatter,
+    modifier: Modifier = Modifier,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isFocused by interactionSource.collectIsFocusedAsState()
+    val titleColor = if (isFocused) TvColors.Dark else Color.White
+    val captionColor = if (isFocused) TvColors.TextSecondaryActive else TvColors.TextSecondary
+
+    TvTile(
+        onClick = onClick,
+        scale = CardDefaults.scale(focusedScale = 1.02f),
+        shape = CardDefaults.shape(RoundedCornerShape(8.dp)),
+        colors = CardDefaults.colors(
+            containerColor = TvColors.DarkGray,
+            focusedContainerColor = TvColors.LightGray,
+        ),
+        interactionSource = interactionSource,
+        modifier = modifier.alpha(if (episode.isArchived && !isFocused) 0.3f else 1f),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp),
+        ) {
+            EpisodeArtwork(podcastUuid = episode.podcastUuid)
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                ) {
+                    if (episode.isVideo) {
+                        Icon(
+                            painter = painterResource(IR.drawable.ic_video_small_fill),
+                            contentDescription = null,
+                            tint = captionColor,
+                            modifier = Modifier.size(14.dp),
+                        )
+                    }
+                    Text(
+                        text = episode.rememberPublishedDateText(dateFormatter),
+                        style = TvTextStyles.PlaylistCardCaption,
+                        color = captionColor,
+                    )
+                }
+                Text(
+                    text = episode.title,
+                    style = TvTextStyles.EpisodeRowTitle,
+                    color = titleColor,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Text(
+                        text = episode.rememberPlaybackTimeText(),
+                        style = TvTextStyles.PlaylistCardCaption,
+                        color = captionColor,
+                    )
+                    if (episode.isInProgress && episode.duration > 0.0) {
+                        EpisodeProgressBar(
+                            progress = (episode.playedUpTo / episode.duration).toFloat().coerceIn(0f, 1f),
+                            color = captionColor,
+                        )
+                    } else if (episode.isFinished) {
+                        Icon(
+                            painter = painterResource(IR.drawable.ic_check),
+                            contentDescription = null,
+                            tint = captionColor,
+                            modifier = Modifier.size(14.dp),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun EpisodeArtwork(
+    podcastUuid: String,
+    modifier: Modifier = Modifier,
+) {
+    TvArtworkImage(
+        model = PodcastImage.getMediumArtworkUrl(podcastUuid),
+        modifier = modifier
+            .size(82.dp)
+            .clip(RoundedCornerShape(4.dp)),
+    )
+}
+
+@Composable
+private fun EpisodeProgressBar(
+    progress: Float,
+    color: Color,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .width(120.dp)
+            .height(4.dp)
+            .clip(CircleShape)
+            .background(color.copy(alpha = 0.3f)),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxHeight()
+                .fillMaxWidth(progress)
+                .background(color),
+        )
+    }
+}
+
+@Composable
+private fun PodcastEpisode.rememberPublishedDateText(dateFormatter: RelativeDateFormatter): String {
+    return remember(publishedDate, dateFormatter) { dateFormatter.format(publishedDate) }
+}
+
+@Composable
+private fun PodcastEpisode.rememberPlaybackTimeText(): String {
+    val context = LocalContext.current
+    return remember(playedUpToMs, durationMs, isInProgress) {
+        if (isInProgress) {
+            TimeHelper.getTimeLeft(playedUpToMs, durationMs.toLong(), inProgress = true, context).text
+        } else {
+            TimeHelper.getTimeDurationShortString(durationMs.toLong(), context)
+        }
+    }
+}
+
+@Preview(device = Devices.TV_1080p)
+@Composable
+private fun TvEpisodeRowPreview() {
+    AppTheme(themeType = Theme.ThemeType.EXTRA_DARK) {
+        MaterialTheme {
+            TvEpisodeRow(
+                episode = PodcastEpisode(
+                    uuid = "episode-uuid",
+                    title = "A very long episode title that spans over multiple lines to test the ellipsis",
+                    duration = 6000.0,
+                    playedUpTo = 1200.0,
+                    publishedDate = Date(0),
+                ),
+                onClick = {},
+                dateFormatter = RelativeDateFormatter(LocalContext.current),
+            )
+        }
+    }
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPlaylistCard.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPlaylistCard.kt
@@ -29,8 +29,6 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.graphics.painter.ColorPainter
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
@@ -45,7 +43,6 @@ import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.theme.TvColors
 import au.com.shiftyjelly.pocketcasts.theme.TvTextStyles
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
-import coil3.compose.AsyncImage
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
@@ -206,13 +203,8 @@ private fun PlaylistCover(
     val offsetX = (if (isBackCover) 0.7f else -16f) + restingOffset
     val offsetY = (if (isBackCover) 66.7f else 44.7f) + restingOffset
 
-    val coverPlaceholder = remember { ColorPainter(Color.Black.copy(alpha = 0.2f)) }
-    AsyncImage(
+    TvArtworkImage(
         model = artworkUrl,
-        placeholder = coverPlaceholder,
-        error = coverPlaceholder,
-        contentDescription = null,
-        contentScale = ContentScale.Crop,
         modifier = Modifier
             .offset(x = offsetX.dp, y = offsetY.dp)
             .size(104.dp)

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsScreen.kt
@@ -205,7 +205,7 @@ private fun TvPlaylistsGrid(
                 .focusGroup()
                 .focusProperties {
                     onEnter = {
-                        focusRequesters.getOrNull(lastFocusedIndex)?.requestFocus()
+                        runCatching { focusRequesters.getOrNull(lastFocusedIndex)?.requestFocus() }
                     }
                 },
         ) {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -75,37 +76,42 @@ fun TvPlaylistsScreen(
     var isDownloadModalVisible by rememberSaveable { mutableStateOf(false) }
     var openedPlaylist by rememberSaveable(stateSaver = OpenedPlaylistSaver) { mutableStateOf<OpenedPlaylist?>(null) }
 
+    val stateHolder = rememberSaveableStateHolder()
     val playlist = openedPlaylist
     if (playlist != null) {
         BackHandler {
             openedPlaylist = null
         }
-        TvPlaylistDetailsScreen(
-            playlistUuid = playlist.uuid,
-            playlistType = playlist.type,
-            onClose = { openedPlaylist = null },
-            modifier = modifier,
-        )
-    } else {
-        TvPlaylistsContent(
-            uiState = uiState,
-            getArtworkUuidsFlow = viewModel::getArtworkUuidsFlow,
-            getEpisodeCountFlow = viewModel::getEpisodeCountFlow,
-            refreshArtworkUuids = viewModel::refreshArtworkUuids,
-            refreshEpisodeCount = viewModel::refreshEpisodeCount,
-            findPodcastTint = viewModel::findPodcastTint,
-            onCreatePlaylist = { isDownloadModalVisible = true },
-            onOpenPlaylist = { preview ->
-                isDownloadModalVisible = false
-                openedPlaylist = OpenedPlaylist(preview.uuid, preview.type)
-            },
-            modifier = modifier,
-        )
-
-        if (isDownloadModalVisible) {
-            TvDownloadAppModal(
-                onDismissRequest = { isDownloadModalVisible = false },
+        stateHolder.SaveableStateProvider("details-${playlist.uuid}") {
+            TvPlaylistDetailsScreen(
+                playlistUuid = playlist.uuid,
+                playlistType = playlist.type,
+                onClose = { openedPlaylist = null },
+                modifier = modifier,
             )
+        }
+    } else {
+        stateHolder.SaveableStateProvider("grid") {
+            TvPlaylistsContent(
+                uiState = uiState,
+                getArtworkUuidsFlow = viewModel::getArtworkUuidsFlow,
+                getEpisodeCountFlow = viewModel::getEpisodeCountFlow,
+                refreshArtworkUuids = viewModel::refreshArtworkUuids,
+                refreshEpisodeCount = viewModel::refreshEpisodeCount,
+                findPodcastTint = viewModel::findPodcastTint,
+                onCreatePlaylist = { isDownloadModalVisible = true },
+                onOpenPlaylist = { preview ->
+                    isDownloadModalVisible = false
+                    openedPlaylist = OpenedPlaylist(preview.uuid, preview.type)
+                },
+                modifier = modifier,
+            )
+
+            if (isDownloadModalVisible) {
+                TvDownloadAppModal(
+                    onDismissRequest = { isDownloadModalVisible = false },
+                )
+            }
         }
     }
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsScreen.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.playlists
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
@@ -25,6 +26,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -51,6 +53,7 @@ import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.loading.LoadingView
 import au.com.shiftyjelly.pocketcasts.models.to.PlaylistIcon
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules
+import au.com.shiftyjelly.pocketcasts.playlists.details.TvPlaylistDetailsScreen
 import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImage
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.Playlist
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistPreview
@@ -70,24 +73,53 @@ fun TvPlaylistsScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     var isDownloadModalVisible by rememberSaveable { mutableStateOf(false) }
+    var openedPlaylist by rememberSaveable(stateSaver = OpenedPlaylistSaver) { mutableStateOf<OpenedPlaylist?>(null) }
 
-    TvPlaylistsContent(
-        uiState = uiState,
-        getArtworkUuidsFlow = viewModel::getArtworkUuidsFlow,
-        getEpisodeCountFlow = viewModel::getEpisodeCountFlow,
-        refreshArtworkUuids = viewModel::refreshArtworkUuids,
-        refreshEpisodeCount = viewModel::refreshEpisodeCount,
-        findPodcastTint = viewModel::findPodcastTint,
-        onCreatePlaylist = { isDownloadModalVisible = true },
-        modifier = modifier,
-    )
-
-    if (isDownloadModalVisible) {
-        TvDownloadAppModal(
-            onDismissRequest = { isDownloadModalVisible = false },
+    val playlist = openedPlaylist
+    if (playlist != null) {
+        BackHandler {
+            openedPlaylist = null
+        }
+        TvPlaylistDetailsScreen(
+            playlistUuid = playlist.uuid,
+            playlistType = playlist.type,
+            onClose = { openedPlaylist = null },
+            modifier = modifier,
         )
+    } else {
+        TvPlaylistsContent(
+            uiState = uiState,
+            getArtworkUuidsFlow = viewModel::getArtworkUuidsFlow,
+            getEpisodeCountFlow = viewModel::getEpisodeCountFlow,
+            refreshArtworkUuids = viewModel::refreshArtworkUuids,
+            refreshEpisodeCount = viewModel::refreshEpisodeCount,
+            findPodcastTint = viewModel::findPodcastTint,
+            onCreatePlaylist = { isDownloadModalVisible = true },
+            onOpenPlaylist = { preview ->
+                isDownloadModalVisible = false
+                openedPlaylist = OpenedPlaylist(preview.uuid, preview.type)
+            },
+            modifier = modifier,
+        )
+
+        if (isDownloadModalVisible) {
+            TvDownloadAppModal(
+                onDismissRequest = { isDownloadModalVisible = false },
+            )
+        }
     }
 }
+
+private data class OpenedPlaylist(val uuid: String, val type: Playlist.Type)
+
+private val OpenedPlaylistSaver = listSaver<OpenedPlaylist?, String>(
+    save = { playlist -> playlist?.let { listOf(it.uuid, it.type.key) }.orEmpty() },
+    restore = { saved ->
+        saved.takeIf { it.size == 2 }?.let { (uuid, typeKey) ->
+            Playlist.Type.fromValue(typeKey)?.let { type -> OpenedPlaylist(uuid, type) }
+        }
+    },
+)
 
 @Composable
 private fun TvPlaylistsContent(
@@ -98,6 +130,7 @@ private fun TvPlaylistsContent(
     refreshEpisodeCount: suspend (String) -> Unit,
     findPodcastTint: suspend (String) -> Int?,
     onCreatePlaylist: () -> Unit,
+    onOpenPlaylist: (PlaylistPreview) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     AnimatedContent(
@@ -128,6 +161,7 @@ private fun TvPlaylistsContent(
                     refreshArtworkUuids = refreshArtworkUuids,
                     refreshEpisodeCount = refreshEpisodeCount,
                     findPodcastTint = findPodcastTint,
+                    onOpenPlaylist = onOpenPlaylist,
                     modifier = Modifier.fillMaxSize(),
                 )
             }
@@ -143,6 +177,7 @@ private fun TvPlaylistsGrid(
     refreshArtworkUuids: suspend (String) -> Unit,
     refreshEpisodeCount: suspend (String) -> Unit,
     findPodcastTint: suspend (String) -> Int?,
+    onOpenPlaylist: (PlaylistPreview) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier.padding(horizontal = 32.dp)) {
@@ -179,6 +214,7 @@ private fun TvPlaylistsGrid(
                     refreshArtworkUuids = refreshArtworkUuids,
                     refreshEpisodeCount = refreshEpisodeCount,
                     findPodcastTint = findPodcastTint,
+                    onOpenPlaylist = onOpenPlaylist,
                     modifier = Modifier
                         .focusRequester(focusRequesters[index])
                         .onFocusChanged { focusState ->
@@ -200,6 +236,7 @@ private fun TvPlaylistGridItem(
     refreshArtworkUuids: suspend (String) -> Unit,
     refreshEpisodeCount: suspend (String) -> Unit,
     findPodcastTint: suspend (String) -> Int?,
+    onOpenPlaylist: (PlaylistPreview) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val artworkUuids by remember(playlist.uuid) { getArtworkUuidsFlow(playlist.uuid) }.collectAsState()
@@ -224,7 +261,7 @@ private fun TvPlaylistGridItem(
         episodeCount = episodeCount,
         artworkUrls = artworkUuids.orEmpty().map(PodcastImage::getMediumArtworkUrl),
         cardColor = TvPlaylistCardColors.cardColor(podcastTint, seed = playlist.uuid),
-        onClick = {},
+        onClick = { onOpenPlaylist(playlist) },
         modifier = modifier,
     )
 }
@@ -259,6 +296,7 @@ private fun TvPlaylistsGridPreview() {
                     refreshEpisodeCount = {},
                     findPodcastTint = { null },
                     onCreatePlaylist = {},
+                    onOpenPlaylist = {},
                 )
             }
         }
@@ -279,6 +317,7 @@ private fun TvPlaylistsEmptyPreview() {
                     refreshEpisodeCount = {},
                     findPodcastTint = { null },
                     onCreatePlaylist = {},
+                    onOpenPlaylist = {},
                 )
             }
         }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshotFlow
+import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -52,6 +53,7 @@ import au.com.shiftyjelly.pocketcasts.theme.TvTextStyles
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import java.util.Date
 import kotlinx.coroutines.flow.first
+import timber.log.Timber
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
@@ -132,9 +134,14 @@ private fun EpisodeList(
     val dateFormatter = remember(context) { RelativeDateFormatter(context) }
     val firstEpisodeFocusRequester = remember { FocusRequester() }
     val listState = rememberLazyListState()
+    val initialFocusIndex = remember {
+        Snapshot.withoutReadObservation { listState.firstVisibleItemIndex }
+            .coerceIn(0, episodes.lastIndex)
+    }
     LaunchedEffect(Unit) {
-        snapshotFlow { listState.layoutInfo.visibleItemsInfo.isNotEmpty() }.first { it }
+        snapshotFlow { listState.layoutInfo.visibleItemsInfo.any { it.index == initialFocusIndex } }.first { it }
         runCatching { firstEpisodeFocusRequester.requestFocus() }
+            .onFailure { Timber.e(it, "Failed to focus the first visible playlist episode") }
     }
     LazyColumn(
         state = listState,
@@ -152,7 +159,7 @@ private fun EpisodeList(
                 modifier = Modifier
                     .fillMaxWidth()
                     .focusProperties { left = playAllFocusRequester }
-                    .then(if (index == 0) Modifier.focusRequester(firstEpisodeFocusRequester) else Modifier),
+                    .then(if (index == initialFocusIndex) Modifier.focusRequester(firstEpisodeFocusRequester) else Modifier),
             )
         }
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
@@ -11,11 +11,13 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -41,12 +43,15 @@ import au.com.shiftyjelly.pocketcasts.compose.loading.LoadingView
 import au.com.shiftyjelly.pocketcasts.localization.helper.RelativeDateFormatter
 import au.com.shiftyjelly.pocketcasts.localization.helper.TimeHelper
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.to.PlaylistEpisode
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.ManualPlaylist
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.Playlist
 import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
 import au.com.shiftyjelly.pocketcasts.theme.TvColors
 import au.com.shiftyjelly.pocketcasts.theme.TvTextStyles
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import java.util.Date
+import kotlinx.coroutines.flow.first
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
@@ -99,8 +104,11 @@ private fun TvPlaylistDetailsContent(
                         playAllFocusRequester = playAllFocusRequester,
                         modifier = Modifier.width(ArtworkSize),
                     )
-                    if (uiState.totalEpisodeCount == 0) {
-                        NoEpisodes(modifier = Modifier.weight(1f).fillMaxHeight())
+                    if (uiState.episodes.isEmpty()) {
+                        NoEpisodes(
+                            playlistType = uiState.playlist.type,
+                            modifier = Modifier.weight(1f).fillMaxHeight(),
+                        )
                     } else {
                         EpisodeList(
                             episodes = uiState.episodes,
@@ -122,28 +130,39 @@ private fun EpisodeList(
 ) {
     val context = LocalContext.current
     val dateFormatter = remember(context) { RelativeDateFormatter(context) }
+    val firstEpisodeFocusRequester = remember { FocusRequester() }
+    val listState = rememberLazyListState()
+    LaunchedEffect(Unit) {
+        snapshotFlow { listState.layoutInfo.visibleItemsInfo.isNotEmpty() }.first { it }
+        runCatching { firstEpisodeFocusRequester.requestFocus() }
+    }
     LazyColumn(
+        state = listState,
         verticalArrangement = Arrangement.spacedBy(12.dp),
         modifier = modifier,
     ) {
-        items(
+        itemsIndexed(
             items = episodes,
-            key = { episode -> episode.uuid },
-        ) { episode ->
+            key = { _, episode -> episode.uuid },
+        ) { index, episode ->
             TvEpisodeRow(
                 episode = episode,
                 onClick = {},
                 dateFormatter = dateFormatter,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .focusProperties { left = playAllFocusRequester },
+                    .focusProperties { left = playAllFocusRequester }
+                    .then(if (index == 0) Modifier.focusRequester(firstEpisodeFocusRequester) else Modifier),
             )
         }
     }
 }
 
 @Composable
-private fun NoEpisodes(modifier: Modifier = Modifier) {
+private fun NoEpisodes(
+    playlistType: Playlist.Type,
+    modifier: Modifier = Modifier,
+) {
     Box(
         contentAlignment = Alignment.Center,
         modifier = modifier,
@@ -159,7 +178,10 @@ private fun NoEpisodes(modifier: Modifier = Modifier) {
                 textAlign = TextAlign.Center,
             )
             Text(
-                text = stringResource(LR.string.tv_playlist_empty_subtitle),
+                text = when (playlistType) {
+                    Playlist.Type.Manual -> stringResource(LR.string.tv_playlist_empty_subtitle_manual)
+                    Playlist.Type.Smart -> stringResource(LR.string.tv_playlist_empty_subtitle)
+                },
                 style = MaterialTheme.typography.bodyLarge,
                 color = TvColors.TextSecondary,
                 textAlign = TextAlign.Center,
@@ -223,7 +245,7 @@ private fun episodeSummaryText(episodes: List<PodcastEpisode>): String {
     return if (episodes.isEmpty()) {
         countText
     } else {
-        val totalDurationMs = episodes.sumOf { episode -> episode.duration * 1000 }.toLong()
+        val totalDurationMs = episodes.sumOf { episode -> episode.durationMs.toLong() }
         "$countText · ${TimeHelper.getTimeDurationShortString(totalDurationMs, LocalContext.current)}"
     }
 }
@@ -245,6 +267,35 @@ private fun TvPlaylistDetailsPreview() {
                         metadata = Playlist.Metadata.ForPreview,
                     ),
                     episodes = emptyList(),
+                ),
+            )
+        }
+    }
+}
+
+@Preview(device = Devices.TV_1080p)
+@Composable
+private fun TvPlaylistDetailsLoadedPreview() {
+    AppTheme(themeType = Theme.ThemeType.EXTRA_DARK) {
+        MaterialTheme {
+            val episodes = List(5) { index ->
+                PodcastEpisode(
+                    uuid = "episode-$index",
+                    title = "Episode $index",
+                    duration = 1800.0,
+                    publishedDate = Date(0),
+                )
+            }
+            TvPlaylistDetailsContent(
+                uiState = TvPlaylistDetailsUiState.Loaded(
+                    playlist = ManualPlaylist(
+                        uuid = "playlist-uuid",
+                        title = "New Releases",
+                        episodes = episodes.map(PlaylistEpisode::Available),
+                        settings = Playlist.Settings.ForPreview,
+                        metadata = Playlist.Metadata.ForPreview,
+                    ),
+                    episodes = episodes,
                 ),
             )
         }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
@@ -1,0 +1,252 @@
+package au.com.shiftyjelly.pocketcasts.playlists.details
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.tv.material3.Button
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.component.TvEpisodeRow
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.compose.components.PlaylistArtwork
+import au.com.shiftyjelly.pocketcasts.compose.loading.LoadingView
+import au.com.shiftyjelly.pocketcasts.localization.helper.RelativeDateFormatter
+import au.com.shiftyjelly.pocketcasts.localization.helper.TimeHelper
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.ManualPlaylist
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.Playlist
+import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
+import au.com.shiftyjelly.pocketcasts.theme.TvColors
+import au.com.shiftyjelly.pocketcasts.theme.TvTextStyles
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+fun TvPlaylistDetailsScreen(
+    playlistUuid: String,
+    playlistType: Playlist.Type,
+    onClose: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: TvPlaylistDetailsViewModel = hiltViewModel<TvPlaylistDetailsViewModel, TvPlaylistDetailsViewModel.Factory>(
+        key = playlistUuid,
+        creationCallback = { factory -> factory.create(playlistUuid, playlistType) },
+    ),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    LaunchedEffect(uiState, onClose) {
+        if (uiState is TvPlaylistDetailsUiState.NotFound) {
+            onClose()
+        }
+    }
+
+    TvPlaylistDetailsContent(
+        uiState = uiState,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun TvPlaylistDetailsContent(
+    uiState: TvPlaylistDetailsUiState,
+    modifier: Modifier = Modifier,
+) {
+    Box(modifier = modifier.fillMaxSize()) {
+        when (uiState) {
+            is TvPlaylistDetailsUiState.Loading, TvPlaylistDetailsUiState.NotFound -> {
+                LoadingView(color = Color.White, modifier = Modifier.fillMaxSize())
+            }
+
+            is TvPlaylistDetailsUiState.Loaded -> {
+                val playAllFocusRequester = remember { FocusRequester() }
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(80.dp),
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(start = 32.dp, top = 16.dp, end = 32.dp),
+                ) {
+                    PlaylistInfo(
+                        playlist = uiState.playlist,
+                        episodes = uiState.episodes,
+                        playAllFocusRequester = playAllFocusRequester,
+                        modifier = Modifier.width(ArtworkSize),
+                    )
+                    if (uiState.totalEpisodeCount == 0) {
+                        NoEpisodes(modifier = Modifier.weight(1f).fillMaxHeight())
+                    } else {
+                        EpisodeList(
+                            episodes = uiState.episodes,
+                            playAllFocusRequester = playAllFocusRequester,
+                            modifier = Modifier.weight(1f),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun EpisodeList(
+    episodes: List<PodcastEpisode>,
+    playAllFocusRequester: FocusRequester,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val dateFormatter = remember(context) { RelativeDateFormatter(context) }
+    LazyColumn(
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+        modifier = modifier,
+    ) {
+        items(
+            items = episodes,
+            key = { episode -> episode.uuid },
+        ) { episode ->
+            TvEpisodeRow(
+                episode = episode,
+                onClick = {},
+                dateFormatter = dateFormatter,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .focusProperties { left = playAllFocusRequester },
+            )
+        }
+    }
+}
+
+@Composable
+private fun NoEpisodes(modifier: Modifier = Modifier) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = modifier,
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = stringResource(LR.string.tv_playlist_empty_title),
+                style = TvTextStyles.ScreenTitle,
+                color = Color.White,
+                textAlign = TextAlign.Center,
+            )
+            Text(
+                text = stringResource(LR.string.tv_playlist_empty_subtitle),
+                style = MaterialTheme.typography.bodyLarge,
+                color = TvColors.TextSecondary,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.widthIn(max = 400.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun PlaylistInfo(
+    playlist: Playlist,
+    episodes: List<PodcastEpisode>,
+    playAllFocusRequester: FocusRequester,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(28.dp),
+        modifier = modifier,
+    ) {
+        PlaylistArtwork(
+            podcastUuids = playlist.metadata.artworkUuids,
+            artworkSize = ArtworkSize,
+            cornerSize = 8.dp,
+        )
+        Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            Text(
+                text = when (playlist.type) {
+                    Playlist.Type.Manual -> stringResource(LR.string.playlist)
+                    Playlist.Type.Smart -> stringResource(LR.string.smart_playlist)
+                },
+                style = TvTextStyles.PlaylistCardCaption,
+                color = TvColors.TextSecondary,
+            )
+            Text(
+                text = playlist.title,
+                style = TvTextStyles.ScreenTitle,
+                color = Color.White,
+            )
+            Text(
+                text = episodeSummaryText(episodes),
+                style = TvTextStyles.PlaylistCardCaption,
+                color = TvColors.TextSecondary,
+            )
+        }
+        if (episodes.isNotEmpty()) {
+            Button(
+                onClick = {},
+                colors = TvButtonDefaults.filledButtonColors(),
+                modifier = Modifier.focusRequester(playAllFocusRequester),
+            ) {
+                Text(stringResource(LR.string.tv_playlist_play_all))
+            }
+        }
+    }
+}
+
+@Composable
+private fun episodeSummaryText(episodes: List<PodcastEpisode>): String {
+    val countText = pluralStringResource(LR.plurals.episode_count, episodes.size, episodes.size)
+    return if (episodes.isEmpty()) {
+        countText
+    } else {
+        val totalDurationMs = episodes.sumOf { episode -> episode.duration * 1000 }.toLong()
+        "$countText · ${TimeHelper.getTimeDurationShortString(totalDurationMs, LocalContext.current)}"
+    }
+}
+
+private val ArtworkSize = 200.dp
+
+@Preview(device = Devices.TV_1080p)
+@Composable
+private fun TvPlaylistDetailsPreview() {
+    AppTheme(themeType = Theme.ThemeType.EXTRA_DARK) {
+        MaterialTheme {
+            TvPlaylistDetailsContent(
+                uiState = TvPlaylistDetailsUiState.Loaded(
+                    playlist = ManualPlaylist(
+                        uuid = "playlist-uuid",
+                        title = "New Releases",
+                        episodes = emptyList(),
+                        settings = Playlist.Settings.ForPreview,
+                        metadata = Playlist.Metadata.ForPreview,
+                    ),
+                    episodes = emptyList(),
+                ),
+            )
+        }
+    }
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModel.kt
@@ -1,0 +1,68 @@
+package au.com.shiftyjelly.pocketcasts.playlists.details
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.to.toPodcastEpisodes
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.Playlist
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.WhileSubscribed
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+
+@HiltViewModel(assistedFactory = TvPlaylistDetailsViewModel.Factory::class)
+class TvPlaylistDetailsViewModel @AssistedInject constructor(
+    @Assisted private val playlistUuid: String,
+    @Assisted private val playlistType: Playlist.Type,
+    private val playlistManager: PlaylistManager,
+) : ViewModel() {
+
+    private val playlistFlow: Flow<Playlist?> = when (playlistType) {
+        Playlist.Type.Manual -> playlistManager.manualPlaylistFlow(playlistUuid)
+        Playlist.Type.Smart -> playlistManager.smartPlaylistFlow(playlistUuid)
+    }
+
+    val uiState: StateFlow<TvPlaylistDetailsUiState> = playlistFlow
+        .map { playlist ->
+            if (playlist == null) {
+                TvPlaylistDetailsUiState.NotFound
+            } else {
+                TvPlaylistDetailsUiState.Loaded(
+                    playlist = playlist,
+                    episodes = playlist.episodes.toPodcastEpisodes(),
+                )
+            }
+        }
+        .stateIn(
+            viewModelScope,
+            SharingStarted.WhileSubscribed(stopTimeout = 300.milliseconds, replayExpiration = Duration.ZERO),
+            TvPlaylistDetailsUiState.Loading,
+        )
+
+    @AssistedFactory
+    interface Factory {
+        fun create(playlistUuid: String, playlistType: Playlist.Type): TvPlaylistDetailsViewModel
+    }
+}
+
+sealed interface TvPlaylistDetailsUiState {
+    data object Loading : TvPlaylistDetailsUiState
+
+    data object NotFound : TvPlaylistDetailsUiState
+
+    data class Loaded(
+        val playlist: Playlist,
+        val episodes: List<PodcastEpisode>,
+    ) : TvPlaylistDetailsUiState {
+        val totalEpisodeCount get() = playlist.episodes.size
+    }
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModel.kt
@@ -62,7 +62,5 @@ sealed interface TvPlaylistDetailsUiState {
     data class Loaded(
         val playlist: Playlist,
         val episodes: List<PodcastEpisode>,
-    ) : TvPlaylistDetailsUiState {
-        val totalEpisodeCount get() = playlist.episodes.size
-    }
+    ) : TvPlaylistDetailsUiState
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvTextStyles.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvTextStyles.kt
@@ -45,6 +45,13 @@ object TvTextStyles {
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 
+    val EpisodeRowTitle = TextStyle(
+        fontSize = 19.sp,
+        fontWeight = FontWeight.Medium,
+        lineHeight = 24.sp,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
     val FeaturedTileSponsoredLabel = TextStyle(
         fontSize = 14.sp,
         platformStyle = PlatformTextStyle(includeFontPadding = false),

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModelTest.kt
@@ -43,7 +43,6 @@ class TvPlaylistDetailsViewModelTest {
 
             val state = awaitItem() as TvPlaylistDetailsUiState.Loaded
             assertEquals(listOf(episode), state.episodes)
-            assertEquals(1, state.totalEpisodeCount)
         }
     }
 

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModelTest.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.playlists.details
 
 import app.cash.turbine.test
+import au.com.shiftyjelly.pocketcasts.models.entity.ManualPlaylistEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.PlaylistEpisode
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.ManualPlaylist
@@ -43,6 +44,30 @@ class TvPlaylistDetailsViewModelTest {
 
             val state = awaitItem() as TvPlaylistDetailsUiState.Loaded
             assertEquals(listOf(episode), state.episodes)
+        }
+    }
+
+    @Test
+    fun `only available episodes are surfaced`() = runTest {
+        val available = episode(uuid = "available")
+        val unavailable = PlaylistEpisode.Unavailable(ManualPlaylistEpisode.test(episodeUuid = "unavailable"))
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            assertEquals(TvPlaylistDetailsUiState.Loading, awaitItem())
+
+            playlists.emit(
+                ManualPlaylist(
+                    uuid = "playlist-uuid",
+                    title = "Playlist",
+                    episodes = listOf(PlaylistEpisode.Available(available), unavailable),
+                    settings = Playlist.Settings.ForPreview,
+                    metadata = Playlist.Metadata.ForPreview,
+                ),
+            )
+
+            val state = awaitItem() as TvPlaylistDetailsUiState.Loaded
+            assertEquals(listOf(available), state.episodes)
         }
     }
 

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModelTest.kt
@@ -1,0 +1,83 @@
+package au.com.shiftyjelly.pocketcasts.playlists.details
+
+import app.cash.turbine.test
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.to.PlaylistEpisode
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.ManualPlaylist
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.Playlist
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
+import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import java.util.Date
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TvPlaylistDetailsViewModelTest {
+
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
+
+    private val playlists = MutableSharedFlow<ManualPlaylist?>(replay = 1)
+    private val playlistManager = mock<PlaylistManager> {
+        on { manualPlaylistFlow(any(), anyOrNull()) } doReturn playlists
+    }
+
+    private val episode = episode(uuid = "episode-1")
+
+    @Test
+    fun `playlist episodes load`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            assertEquals(TvPlaylistDetailsUiState.Loading, awaitItem())
+
+            playlists.emit(playlist(episode))
+
+            val state = awaitItem() as TvPlaylistDetailsUiState.Loaded
+            assertEquals(listOf(episode), state.episodes)
+            assertEquals(1, state.totalEpisodeCount)
+        }
+    }
+
+    @Test
+    fun `deleted playlist resolves to the not found state`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            assertEquals(TvPlaylistDetailsUiState.Loading, awaitItem())
+
+            playlists.emit(playlist(episode))
+            assertEquals(listOf(episode), (awaitItem() as TvPlaylistDetailsUiState.Loaded).episodes)
+
+            playlists.emit(null)
+            assertEquals(TvPlaylistDetailsUiState.NotFound, awaitItem())
+        }
+    }
+
+    private fun createViewModel() = TvPlaylistDetailsViewModel(
+        playlistUuid = "playlist-uuid",
+        playlistType = Playlist.Type.Manual,
+        playlistManager = playlistManager,
+    )
+
+    private fun playlist(vararg episodes: PodcastEpisode) = ManualPlaylist(
+        uuid = "playlist-uuid",
+        title = "Playlist",
+        episodes = episodes.map(PlaylistEpisode::Available),
+        settings = Playlist.Settings.ForPreview,
+        metadata = Playlist.Metadata.ForPreview,
+    )
+
+    private fun episode(uuid: String) = PodcastEpisode(
+        uuid = uuid,
+        publishedDate = Date(0),
+    )
+}


### PR DESCRIPTION
## Description

Adds the playlist details screen to the TV app, mirroring the Apple TV implementation: opening a playlist from the Playlists tab shows a left info pane (artwork collage, playlist type, title, "N episodes · total duration", and a `Play all episodes` button) next to the scrolling episode list. The screen renders inside the app scaffold so the top tab bar stays visible, and back returns to the grid.

- New reusable `TvEpisodeRow` (artwork, relative date, video indicator, 2-line title, duration/time-left with a progress bar for in-progress and a checkmark for played, archived rows dimmed) and `TvArtworkImage` components; the header collage reuses the shared `PlaylistArtwork` composable.
- `TvPlaylistDetailsViewModel` observes `PlaylistManager.manualPlaylistFlow`/`smartPlaylistFlow` (assisted-inject with uuid + type, keyed per playlist, replay cache dropped when the screen closes) and resolves to a `NotFound` state that auto-closes the screen when the playlist is deleted while open.
- In-tab navigation with saveable state and `BackHandler`; pressing LEFT from any episode row focuses `Play all episodes`.
- `Play all episodes` and episode row clicks are intentionally no-ops — playback wiring comes in follow-up PRs, as do sorting and the archived filter (next two PRs of this stack).

Fixes PCDROID-693 https://linear.app/a8c/issue/PCDROID-693/playlist-details.
Designs: Ftk3KwnfqaK4g57yCN63p0-fi-3258_12136.

Stacked on #5658 (`feat/tv-create-playlist`) — merge bottom-up.

## Testing Instructions

1. Install the TV app (`./gradlew :tv:installDebug`) on an Android TV device or emulator, signed in with playlists synced.
2. Open the Playlists tab and select a playlist.
3. ✅ Verify the header shows the artwork collage, playlist type, title, and "N episodes · duration".
4. Move through the episode list with the d-pad and check date, title, duration, and played/progress indicators.
5. ✅ Press LEFT from an episode row — focus should jump to `Play all episodes`.
6. Press back to return to the grid. Optionally delete the open playlist from a phone and verify the TV screen closes after sync.

## Screenshots or Screencast
<img width="1920" height="1080" alt="pr1-details" src="https://github.com/user-attachments/assets/a0539277-a411-4124-af4f-83d641f37c09" />



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md _(TV app is unreleased — skipped)_
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes _(ViewModel unit tests added)_
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics. _(analytics deliberately excluded — follow-up)_
