### PR TITLE
[TV] Add episode sorting to the TV playlist details screen

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/OptionsFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/OptionsFragment.kt
@@ -28,15 +28,16 @@ import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.viewModels
 import androidx.fragment.compose.content
+import au.com.shiftyjelly.pocketcasts.compose.components.displayLabel
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.models.type.PlaylistEpisodeSortType
 import au.com.shiftyjelly.pocketcasts.playlists.PlaylistViewModel.Companion.DOWNLOAD_ALL_LIMIT
 import au.com.shiftyjelly.pocketcasts.playlists.component.PlaylistOption
 import au.com.shiftyjelly.pocketcasts.playlists.component.PlaylistOptionsColumn
 import au.com.shiftyjelly.pocketcasts.playlists.component.PlaylistSortOptionsColumn
-import au.com.shiftyjelly.pocketcasts.playlists.component.displayLabel
 import au.com.shiftyjelly.pocketcasts.playlists.manual.EditPlaylistFragment
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.Playlist
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.availableSortTypes
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.views.dialog.ConfirmationDialog
 import au.com.shiftyjelly.pocketcasts.views.dialog.ConfirmationDialog.ButtonType
@@ -79,7 +80,7 @@ class OptionsFragment : BaseDialogFragment() {
                     AnimatedContent(targetState = isSelectingSortType) { isSorting ->
                         if (isSorting) {
                             PlaylistSortOptionsColumn(
-                                availableSortTypes = playlist.availableSortOptions,
+                                availableSortTypes = playlist.availableSortTypes,
                                 selectedSortType = playlist.settings.sortType,
                                 onSelectSortType = { type ->
                                     viewModel.updateSortType(type)
@@ -247,11 +248,3 @@ class OptionsFragment : BaseDialogFragment() {
         }
     }
 }
-
-private val smartSortTypes = PlaylistEpisodeSortType.entries - PlaylistEpisodeSortType.DragAndDrop
-
-private val Playlist.availableSortOptions
-    get() = when (type) {
-        Playlist.Type.Manual -> PlaylistEpisodeSortType.entries
-        Playlist.Type.Smart -> smartSortTypes
-    }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/OptionsFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/OptionsFragment.kt
@@ -30,7 +30,6 @@ import androidx.fragment.app.viewModels
 import androidx.fragment.compose.content
 import au.com.shiftyjelly.pocketcasts.compose.components.displayLabel
 import au.com.shiftyjelly.pocketcasts.compose.theme
-import au.com.shiftyjelly.pocketcasts.models.type.PlaylistEpisodeSortType
 import au.com.shiftyjelly.pocketcasts.playlists.PlaylistViewModel.Companion.DOWNLOAD_ALL_LIMIT
 import au.com.shiftyjelly.pocketcasts.playlists.component.PlaylistOption
 import au.com.shiftyjelly.pocketcasts.playlists.component.PlaylistOptionsColumn

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/component/PlaylistSortOptionsColumn.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/component/PlaylistSortOptionsColumn.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -26,22 +25,13 @@ import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.components.TextC50
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
+import au.com.shiftyjelly.pocketcasts.compose.components.displayLabel
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.models.type.PlaylistEpisodeSortType
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
-
-@Composable
-@ReadOnlyComposable
-internal fun PlaylistEpisodeSortType.displayLabel() = when (this) {
-    PlaylistEpisodeSortType.NewestToOldest -> stringResource(LR.string.sort_newest_to_oldest)
-    PlaylistEpisodeSortType.OldestToNewest -> stringResource(LR.string.sort_oldest_to_newest)
-    PlaylistEpisodeSortType.ShortestToLongest -> stringResource(LR.string.episode_sort_short_to_long)
-    PlaylistEpisodeSortType.LongestToShortest -> stringResource(LR.string.episode_sort_long_to_short)
-    PlaylistEpisodeSortType.DragAndDrop -> stringResource(LR.string.episode_sort_custom_order)
-}
 
 @Composable
 internal fun PlaylistSortOptionsColumn(

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PlaylistEpisodeSortTypeLabel.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PlaylistEpisodeSortTypeLabel.kt
@@ -1,0 +1,17 @@
+package au.com.shiftyjelly.pocketcasts.compose.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.res.stringResource
+import au.com.shiftyjelly.pocketcasts.models.type.PlaylistEpisodeSortType
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+@ReadOnlyComposable
+fun PlaylistEpisodeSortType.displayLabel() = when (this) {
+    PlaylistEpisodeSortType.NewestToOldest -> stringResource(LR.string.sort_newest_to_oldest)
+    PlaylistEpisodeSortType.OldestToNewest -> stringResource(LR.string.sort_oldest_to_newest)
+    PlaylistEpisodeSortType.ShortestToLongest -> stringResource(LR.string.episode_sort_short_to_long)
+    PlaylistEpisodeSortType.LongestToShortest -> stringResource(LR.string.episode_sort_long_to_short)
+    PlaylistEpisodeSortType.DragAndDrop -> stringResource(LR.string.episode_sort_custom_order)
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/Playlist.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/Playlist.kt
@@ -78,6 +78,12 @@ sealed interface Playlist {
     }
 }
 
+val Playlist.availableSortTypes: List<PlaylistEpisodeSortType>
+    get() = when (type) {
+        Playlist.Type.Manual -> PlaylistEpisodeSortType.entries
+        Playlist.Type.Smart -> PlaylistEpisodeSortType.entries - PlaylistEpisodeSortType.DragAndDrop
+    }
+
 data class SmartPlaylist(
     override val uuid: String,
     override val title: String,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvDropdownMenu.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvDropdownMenu.kt
@@ -1,0 +1,167 @@
+package au.com.shiftyjelly.pocketcasts.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
+import androidx.tv.material3.Button
+import androidx.tv.material3.ButtonDefaults
+import androidx.tv.material3.Icon
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
+import au.com.shiftyjelly.pocketcasts.theme.TvColors
+import au.com.shiftyjelly.pocketcasts.theme.TvTextStyles
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+
+@Composable
+fun TvDropdownMenu(
+    onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+    title: String? = null,
+    width: Dp = DefaultMenuWidth,
+    alignment: Alignment = Alignment.TopEnd,
+    offset: DpOffset = DpOffset(x = 0.dp, y = 48.dp),
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    val intOffset = with(LocalDensity.current) {
+        IntOffset(x = offset.x.roundToPx(), y = offset.y.roundToPx())
+    }
+    Popup(
+        alignment = alignment,
+        offset = intOffset,
+        onDismissRequest = onDismissRequest,
+        properties = PopupProperties(focusable = true),
+    ) {
+        TvDropdownMenuSurface(
+            title = title,
+            width = width,
+            modifier = modifier,
+            content = content,
+        )
+    }
+}
+
+@Composable
+internal fun TvDropdownMenuSurface(
+    modifier: Modifier = Modifier,
+    title: String? = null,
+    width: Dp = DefaultMenuWidth,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    Column(
+        modifier = modifier
+            .width(width)
+            .clip(MenuShape)
+            .background(TvOverlayContainerColor)
+            .border(1.dp, TvOverlayBorderColor, MenuShape)
+            .padding(12.dp),
+    ) {
+        if (title != null) {
+            Text(
+                text = title,
+                style = TvTextStyles.PlaylistCardCaption,
+                color = TvColors.TextSecondary,
+                modifier = Modifier.padding(start = 16.dp, top = 4.dp, bottom = 8.dp),
+            )
+        }
+        content()
+    }
+}
+
+@Composable
+fun TvDropdownMenuItem(
+    label: String,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val focusModifier = if (isSelected) {
+        val focusRequester = remember { FocusRequester() }
+        LaunchedEffect(Unit) {
+            focusRequester.requestFocus()
+        }
+        Modifier.focusRequester(focusRequester)
+    } else {
+        Modifier
+    }
+    Button(
+        onClick = onClick,
+        colors = ButtonDefaults.colors(
+            containerColor = Color.Transparent,
+            contentColor = Color.White,
+            focusedContainerColor = TvColors.LightGray,
+            focusedContentColor = TvColors.Dark,
+        ),
+        border = TvButtonDefaults.borderlessButtonBorder(),
+        modifier = modifier
+            .fillMaxWidth()
+            .then(focusModifier),
+    ) {
+        Box(modifier = Modifier.size(14.dp)) {
+            if (isSelected) {
+                Icon(
+                    painter = painterResource(IR.drawable.ic_check),
+                    contentDescription = null,
+                    modifier = Modifier.size(14.dp),
+                )
+            }
+        }
+        Text(
+            text = label,
+            modifier = Modifier.padding(start = 10.dp),
+        )
+        Spacer(modifier = Modifier.weight(1f))
+    }
+}
+
+private val DefaultMenuWidth = 240.dp
+private val MenuShape = RoundedCornerShape(20.dp)
+
+@Preview
+@Composable
+private fun TvDropdownMenuPreview() {
+    AppTheme(themeType = Theme.ThemeType.EXTRA_DARK) {
+        MaterialTheme {
+            TvDropdownMenuSurface(title = "Sort by") {
+                TvDropdownMenuItem(
+                    label = "Newest to oldest",
+                    isSelected = true,
+                    onClick = {},
+                )
+                TvDropdownMenuItem(
+                    label = "Oldest to newest",
+                    isSelected = false,
+                    onClick = {},
+                )
+            }
+        }
+    }
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvModal.kt
@@ -68,9 +68,9 @@ internal fun TvModalSurface(
         modifier = modifier
             .width(width)
             .clip(ModalShape)
-            .background(if (isTranslucent) TranslucentContainerColor else OpaqueContainerColor)
+            .background(if (isTranslucent) TranslucentContainerColor else TvOverlayContainerColor)
             .background(HighlightBrush)
-            .border(1.dp, BorderColor, ModalShape)
+            .border(1.dp, TvOverlayBorderColor, ModalShape)
             .padding(horizontal = 53.dp, vertical = 40.dp),
     )
 }
@@ -112,8 +112,8 @@ private fun rememberIsBlurBehindEnabled(): State<Boolean> {
 private val DefaultModalWidth = 400.dp
 private val ModalShape = RoundedCornerShape(28.dp)
 private val TranslucentContainerColor = TvColors.Dark.copy(alpha = 0.6f)
-private val OpaqueContainerColor = TvColors.Dark.copy(alpha = 0.94f)
-private val BorderColor = Color.White.copy(alpha = 0.12f)
+internal val TvOverlayContainerColor = TvColors.Dark.copy(alpha = 0.94f)
+internal val TvOverlayBorderColor = Color.White.copy(alpha = 0.12f)
 private val HighlightBrush = Brush.verticalGradient(
     colors = listOf(
         Color.White.copy(alpha = 0.08f),

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
@@ -4,10 +4,12 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
@@ -16,7 +18,10 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.Alignment
@@ -26,6 +31,7 @@ import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -35,22 +41,31 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.Button
+import androidx.tv.material3.Icon
+import androidx.tv.material3.IconButton
+import androidx.tv.material3.IconButtonDefaults
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.component.TvDropdownMenu
+import au.com.shiftyjelly.pocketcasts.component.TvDropdownMenuItem
 import au.com.shiftyjelly.pocketcasts.component.TvEpisodeRow
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.components.PlaylistArtwork
+import au.com.shiftyjelly.pocketcasts.compose.components.displayLabel
 import au.com.shiftyjelly.pocketcasts.compose.loading.LoadingView
 import au.com.shiftyjelly.pocketcasts.localization.helper.RelativeDateFormatter
 import au.com.shiftyjelly.pocketcasts.localization.helper.TimeHelper
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.PlaylistEpisode
+import au.com.shiftyjelly.pocketcasts.models.type.PlaylistEpisodeSortType
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.ManualPlaylist
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.Playlist
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.availableSortTypes
 import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
 import au.com.shiftyjelly.pocketcasts.theme.TvColors
 import au.com.shiftyjelly.pocketcasts.theme.TvTextStyles
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.images.R as IR
 import java.util.Date
 import kotlinx.coroutines.flow.first
 import timber.log.Timber
@@ -77,6 +92,7 @@ fun TvPlaylistDetailsScreen(
 
     TvPlaylistDetailsContent(
         uiState = uiState,
+        onChangeSortType = viewModel::changeSortType,
         modifier = modifier,
     )
 }
@@ -84,6 +100,7 @@ fun TvPlaylistDetailsScreen(
 @Composable
 private fun TvPlaylistDetailsContent(
     uiState: TvPlaylistDetailsUiState,
+    onChangeSortType: (PlaylistEpisodeSortType) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Box(modifier = modifier.fillMaxSize()) {
@@ -112,12 +129,86 @@ private fun TvPlaylistDetailsContent(
                             modifier = Modifier.weight(1f).fillMaxHeight(),
                         )
                     } else {
-                        EpisodeList(
-                            episodes = uiState.episodes,
+                        SortableEpisodeList(
+                            uiState = uiState,
+                            onChangeSortType = onChangeSortType,
                             playAllFocusRequester = playAllFocusRequester,
                             modifier = Modifier.weight(1f),
                         )
                     }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SortableEpisodeList(
+    uiState: TvPlaylistDetailsUiState.Loaded,
+    onChangeSortType: (PlaylistEpisodeSortType) -> Unit,
+    playAllFocusRequester: FocusRequester,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier) {
+        SortDropdownButton(
+            selectedSortType = uiState.playlist.settings.sortType,
+            availableSortTypes = uiState.playlist.availableSortTypes,
+            onSelectSortType = onChangeSortType,
+            modifier = Modifier
+                .align(Alignment.End)
+                .padding(bottom = 12.dp),
+        )
+        if (uiState.episodes.isNotEmpty()) {
+            EpisodeList(
+                episodes = uiState.episodes,
+                playAllFocusRequester = playAllFocusRequester,
+                modifier = Modifier.weight(1f),
+            )
+        } else {
+            Spacer(modifier = Modifier.weight(1f))
+        }
+    }
+}
+
+@Composable
+private fun SortDropdownButton(
+    selectedSortType: PlaylistEpisodeSortType,
+    availableSortTypes: List<PlaylistEpisodeSortType>,
+    onSelectSortType: (PlaylistEpisodeSortType) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var isExpanded by rememberSaveable { mutableStateOf(false) }
+
+    Box(modifier = modifier) {
+        IconButton(
+            onClick = { isExpanded = true },
+            colors = IconButtonDefaults.colors(
+                containerColor = TvColors.BgActive20,
+                contentColor = Color.White,
+                focusedContainerColor = Color.White,
+                focusedContentColor = TvColors.Dark,
+            ),
+        ) {
+            Icon(
+                painter = painterResource(IR.drawable.ic_sort),
+                contentDescription = stringResource(LR.string.sort_by),
+                modifier = Modifier.size(20.dp),
+            )
+        }
+        if (isExpanded) {
+            TvDropdownMenu(
+                title = stringResource(LR.string.sort_by),
+                onDismissRequest = { isExpanded = false },
+            ) {
+                availableSortTypes.forEach { sortType ->
+                    TvDropdownMenuItem(
+                        label = sortType.displayLabel(),
+                        isSelected = sortType == selectedSortType,
+                        onClick = {
+                            isExpanded = false
+                            onSelectSortType(sortType)
+                        },
+                    )
                 }
             }
         }
@@ -275,6 +366,7 @@ private fun TvPlaylistDetailsPreview() {
                     ),
                     episodes = emptyList(),
                 ),
+                onChangeSortType = {},
             )
         }
     }
@@ -304,6 +396,7 @@ private fun TvPlaylistDetailsLoadedPreview() {
                     ),
                     episodes = episodes,
                 ),
+                onChangeSortType = {},
             )
         }
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -13,6 +12,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
@@ -64,10 +64,10 @@ import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
 import au.com.shiftyjelly.pocketcasts.theme.TvColors
 import au.com.shiftyjelly.pocketcasts.theme.TvTextStyles
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
-import au.com.shiftyjelly.pocketcasts.images.R as IR
 import java.util.Date
 import kotlinx.coroutines.flow.first
 import timber.log.Timber
+import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
@@ -114,7 +114,7 @@ private fun TvPlaylistDetailsContent(
                     horizontalArrangement = Arrangement.spacedBy(80.dp),
                     modifier = Modifier
                         .fillMaxSize()
-                        .padding(start = 32.dp, top = 16.dp, end = 32.dp),
+                        .padding(start = 32.dp, top = 16.dp, end = 56.dp),
                 ) {
                     PlaylistInfo(
                         playlist = uiState.playlist,
@@ -148,24 +148,30 @@ private fun SortableEpisodeList(
     playAllFocusRequester: FocusRequester,
     modifier: Modifier = Modifier,
 ) {
+    val listState = rememberLazyListState()
+    val sortType = uiState.playlist.settings.sortType
+    var lastSortType by remember { mutableStateOf(sortType) }
+    LaunchedEffect(sortType) {
+        if (sortType != lastSortType) {
+            lastSortType = sortType
+            listState.scrollToItem(0)
+        }
+    }
     Column(modifier = modifier) {
         SortDropdownButton(
-            selectedSortType = uiState.playlist.settings.sortType,
+            selectedSortType = sortType,
             availableSortTypes = uiState.playlist.availableSortTypes,
             onSelectSortType = onChangeSortType,
             modifier = Modifier
                 .align(Alignment.End)
                 .padding(bottom = 12.dp),
         )
-        if (uiState.episodes.isNotEmpty()) {
-            EpisodeList(
-                episodes = uiState.episodes,
-                playAllFocusRequester = playAllFocusRequester,
-                modifier = Modifier.weight(1f),
-            )
-        } else {
-            Spacer(modifier = Modifier.weight(1f))
-        }
+        EpisodeList(
+            episodes = uiState.episodes,
+            playAllFocusRequester = playAllFocusRequester,
+            listState = listState,
+            modifier = Modifier.weight(1f),
+        )
     }
 }
 
@@ -218,12 +224,12 @@ private fun SortDropdownButton(
 private fun EpisodeList(
     episodes: List<PodcastEpisode>,
     playAllFocusRequester: FocusRequester,
+    listState: LazyListState,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
     val dateFormatter = remember(context) { RelativeDateFormatter(context) }
     val firstEpisodeFocusRequester = remember { FocusRequester() }
-    val listState = rememberLazyListState()
     val initialFocusIndex = remember {
         Snapshot.withoutReadObservation { listState.firstVisibleItemIndex }
             .coerceIn(0, episodes.lastIndex)

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.snapshots.Snapshot
@@ -177,7 +176,7 @@ private fun SortDropdownButton(
     onSelectSortType: (PlaylistEpisodeSortType) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    var isExpanded by rememberSaveable { mutableStateOf(false) }
+    var isExpanded by remember { mutableStateOf(false) }
 
     Box(modifier = modifier) {
         IconButton(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.toPodcastEpisodes
+import au.com.shiftyjelly.pocketcasts.models.type.PlaylistEpisodeSortType
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.Playlist
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
 import dagger.assisted.Assisted
@@ -18,6 +19,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.WhileSubscribed
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 
 @HiltViewModel(assistedFactory = TvPlaylistDetailsViewModel.Factory::class)
 class TvPlaylistDetailsViewModel @AssistedInject constructor(
@@ -47,6 +49,12 @@ class TvPlaylistDetailsViewModel @AssistedInject constructor(
             SharingStarted.WhileSubscribed(stopTimeout = 300.milliseconds, replayExpiration = Duration.ZERO),
             TvPlaylistDetailsUiState.Loading,
         )
+
+    fun changeSortType(sortType: PlaylistEpisodeSortType) {
+        viewModelScope.launch {
+            playlistManager.updateSortType(playlistUuid, sortType)
+        }
+    }
 
     @AssistedFactory
     interface Factory {


### PR DESCRIPTION
## Description

Adds episode sorting to the TV playlist details screen: a circular sort button above the episode list opens an anchored dropdown with the playlist sort options (checkmark on the current one). Selection persists via `PlaylistManager.updateSortType`, so it syncs like sorting on mobile. Smart playlists exclude `Custom order`, matching the phone.

Architectural changes shared with the phone app:
- New reusable `TvDropdownMenu`/`TvDropdownMenuItem` components (anchored popup, customizable title/width/alignment/offset, selected item self-focuses) styled like `TvModal`.
- `PlaylistEpisodeSortType.displayLabel()` hoisted from the filters module into `modules/services/compose`, and the `Playlist.availableSortTypes` rule (manual → all, smart → no drag-and-drop) hoisted into `modules/services/repositories`; the phone's `OptionsFragment`/`PlaylistSortOptionsColumn` now consume the shared versions, so phone and TV can no longer drift.

Fixes PCDROID-693 https://linear.app/a8c/issue/PCDROID-693/playlist-details.
Designs: Ftk3KwnfqaK4g57yCN63p0-fi-3258_12136.

Stacked on `feat/tv-playlist-details-screen` — merge bottom-up.

## Testing Instructions

1. Install the TV app and open a playlist's details.
2. Focus the sort button (up/down arrows icon) above the episode list and press select.
3. Verify the dropdown shows the sort options with a checkmark on the current one, and that focus starts on it.
4. Pick another option — the list reorders and the choice persists across app restarts and syncs to the phone.
5. Verify a smart playlist offers four options while a manual playlist also offers `Custom order`.
6. On the phone, verify playlist sorting via the playlist options sheet still works (shared code moved).

## Screenshots or Screencast

| Sort button | Sort dropdown |
| --- | --- |
| <img width="1920" height="1080" alt="pr2-details-sort" src="https://github.com/user-attachments/assets/fcd7ab97-6ce0-4925-8176-244ae084c940" /> | <img width="1920" height="1080" alt="pr2-sort-dropdown" src="https://github.com/user-attachments/assets/d8608eb1-04d4-43ad-ab02-b8cbd8a25ec6" /> |

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md _(TV app is unreleased — skipped)_
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml` _(reuses existing sort strings)_
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics. _(analytics deliberately excluded — follow-up)_
