### PR TITLE
[TV] Add an archived episodes filter to the TV playlist details screen

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerManualTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerManualTest.kt
@@ -612,6 +612,26 @@ class PlaylistManagerManualTest {
     }
 
     @Test
+    fun observeEpisodesIncludingArchived() = dsl.test {
+        insertManualPlaylist(0)
+        insertManualEpisode(index = 0, podcastIndex = 0, playlistIndex = 0)
+        insertManualEpisode(index = 1, podcastIndex = 0, playlistIndex = 0)
+        insertPodcastEpisode(index = 0, podcastIndex = 0) { it.copy(isArchived = true) }
+        insertPodcastEpisode(index = 1, podcastIndex = 0)
+
+        manager.manualPlaylistFlow("playlist-id-0", includeArchived = true).test {
+            val playlist = awaitItem()!!
+            assertEquals(
+                listOf(
+                    availablePlaylistEpisode(index = 0, podcastIndex = 0) { it.copy(isArchived = true) },
+                    availablePlaylistEpisode(index = 1, podcastIndex = 0),
+                ),
+                playlist.episodes,
+            )
+        }
+    }
+
+    @Test
     fun observeArchivedEpisodes() = dsl.test {
         insertManualPlaylist(0)
         insertManualEpisode(index = 0, podcastIndex = 1, playlistIndex = 0)

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerSmartTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerSmartTest.kt
@@ -378,6 +378,25 @@ class PlaylistManagerSmartTest {
     }
 
     @Test
+    fun observeEpisodesIncludingArchived() = dsl.test {
+        insertPodcast(index = 0)
+        val episodes = transaction {
+            listOf(
+                insertPodcastEpisode(index = 0, podcastIndex = 0),
+                insertPodcastEpisode(index = 1, podcastIndex = 0) { it.copy(isArchived = true) },
+            )
+        }
+
+        manager.smartEpisodesFlow(smartRules()).test {
+            assertEquals(episodes.take(1).map(PlaylistEpisode::Available), awaitItem())
+        }
+
+        manager.smartEpisodesFlow(smartRules(), includeArchived = true).test {
+            assertEquals(episodes.map(PlaylistEpisode::Available), awaitItem())
+        }
+    }
+
+    @Test
     fun observePlaylist() = dsl.test {
         insertPodcast(index = 0)
         insertPodcast(index = 1)

--- a/modules/features/filters/src/test/kotlin/au/com/shiftyjelly/pocketcasts/playlists/create/FakePlaylistManager.kt
+++ b/modules/features/filters/src/test/kotlin/au/com/shiftyjelly/pocketcasts/playlists/create/FakePlaylistManager.kt
@@ -73,12 +73,17 @@ class FakePlaylistManager : PlaylistManager {
     }
 
     val smartPlaylist = MutableStateFlow<SmartPlaylist?>(null)
-    override fun smartPlaylistFlow(uuid: String, searchTerm: String?): Flow<SmartPlaylist?> {
+    override fun smartPlaylistFlow(uuid: String, searchTerm: String?, includeArchived: Boolean): Flow<SmartPlaylist?> {
         return smartPlaylist
     }
 
     val smartEpisodes = MutableStateFlow(emptyList<PlaylistEpisode.Available>())
-    override fun smartEpisodesFlow(rules: SmartRules, sortType: PlaylistEpisodeSortType, searchTerm: String?): Flow<List<PlaylistEpisode.Available>> {
+    override fun smartEpisodesFlow(
+        rules: SmartRules,
+        sortType: PlaylistEpisodeSortType,
+        searchTerm: String?,
+        includeArchived: Boolean,
+    ): Flow<List<PlaylistEpisode.Available>> {
         return smartEpisodes
     }
 
@@ -100,7 +105,7 @@ class FakePlaylistManager : PlaylistManager {
     }
 
     val manualPlaylist = MutableStateFlow<ManualPlaylist?>(null)
-    override fun manualPlaylistFlow(uuid: String, searchTerm: String?): Flow<ManualPlaylist?> {
+    override fun manualPlaylistFlow(uuid: String, searchTerm: String?, includeArchived: Boolean): Flow<ManualPlaylist?> {
         return manualPlaylist
     }
 

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -261,6 +261,10 @@
     <string name="tv_playlists_download_title">Create playlists on your phone</string>
     <string name="tv_playlists_download_subtitle">They’ll be waiting here when you’re done. Scan to get the app</string>
     <string name="tv_playlist_play_all">Play all episodes</string>
+    <plurals name="tv_playlist_all_archived">
+        <item quantity="one">The only episode of this playlist has been archived.</item>
+        <item quantity="other">All %1$d episodes of this playlist have been archived.</item>
+    </plurals>
     <string name="tv_playlist_empty_title">No episodes</string>
     <string name="tv_playlist_empty_subtitle">Either it’s time to celebrate completing this list or edit your rules in the mobile app to get some more.</string>
     <string name="tv_playlist_empty_subtitle_manual">Add episodes to this playlist from the mobile app and they’ll show up here.</string>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
@@ -573,8 +573,9 @@ abstract class PlaylistDao {
         JOIN playlists AS playlist ON playlist.uuid IS :playlistUuid
         WHERE
           manual_episode.playlist_uuid IS :playlistUuid
-          AND (CASE 
-            WHEN playlist.showArchivedEpisodes IS NOT 0 THEN 1 
+          AND (CASE
+            WHEN :includeArchived IS NOT 0 THEN 1
+            WHEN playlist.showArchivedEpisodes IS NOT 0 THEN 1
             ELSE IFNULL(podcast_episode.archived, 0) IS 0
           END)
           AND (
@@ -606,13 +607,15 @@ abstract class PlaylistDao {
         playlistUuid: String,
         searchTerm: String,
         forcedEpisodeUuid: String?,
+        includeArchived: Boolean,
     ): Flow<List<RawManualEpisode>>
 
     fun manualEpisodesFlow(
         playlistUuid: String,
         searchTerm: String = "",
         forcedEpisodeUuid: String? = null,
-    ) = manualEpisodesRawFlow(playlistUuid, searchTerm.escapeLike('\\'), forcedEpisodeUuid).map { rawEpisodes ->
+        includeArchived: Boolean = false,
+    ) = manualEpisodesRawFlow(playlistUuid, searchTerm.escapeLike('\\'), forcedEpisodeUuid, includeArchived).map { rawEpisodes ->
         rawEpisodes.map(RawManualEpisode::toEpisode)
     }
 
@@ -644,12 +647,13 @@ abstract class PlaylistDao {
         limit: Int,
         searchTerm: String? = null,
         forcedEpisodeUuid: String? = null,
+        includeArchived: Boolean = false,
     ): Flow<List<PlaylistEpisode.Available>> {
         val escapedTerm = searchTerm?.takeIf(String::isNotBlank)?.escapeLike('\\')
         val query = createSmartPlaylistEpisodeQuery(
             selectClause = "episode.*",
             whereClause = buildString {
-                append(smartRules.toSqlWhereClause(clock))
+                append(smartRules.toSqlWhereClause(clock, includeArchived))
                 if (forcedEpisodeUuid != null) {
                     append(" OR (")
                     append("episode.uuid = '$forcedEpisodeUuid'")

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SmartRules.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SmartRules.kt
@@ -16,7 +16,7 @@ data class SmartRules(
     val podcasts: PodcastsRule,
     val episodeDuration: EpisodeDurationRule,
 ) {
-    fun toSqlWhereClause(clock: Clock) = buildString {
+    fun toSqlWhereClause(clock: Clock, includeArchived: Boolean = false) = buildString {
         episodeStatus.run { appendSqlQuery(clock) }
         downloadStatus.run { appendSqlQuery(clock) }
         mediaType.run { appendSqlQuery(clock) }
@@ -24,7 +24,9 @@ data class SmartRules(
         starred.run { appendSqlQuery(clock) }
         podcasts.run { appendSqlQuery(clock) }
         episodeDuration.run { appendSqlQuery(clock) }
-        NonArchivedRule.run { appendSqlQuery(clock) }
+        if (!includeArchived) {
+            NonArchivedRule.run { appendSqlQuery(clock) }
+        }
         FollowedPodcastRule.run { appendSqlQuery(clock) }
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManager.kt
@@ -49,9 +49,14 @@ interface PlaylistManager {
     // <editor-fold desc="Smart playlists">
     suspend fun createSmartPlaylist(draft: SmartPlaylistDraft): String
 
-    fun smartPlaylistFlow(uuid: String, searchTerm: String? = null): Flow<SmartPlaylist?>
+    fun smartPlaylistFlow(uuid: String, searchTerm: String? = null, includeArchived: Boolean = false): Flow<SmartPlaylist?>
 
-    fun smartEpisodesFlow(rules: SmartRules, sortType: SortType = SortType.NewestToOldest, searchTerm: String? = null): Flow<List<PlaylistEpisode.Available>>
+    fun smartEpisodesFlow(
+        rules: SmartRules,
+        sortType: SortType = SortType.NewestToOldest,
+        searchTerm: String? = null,
+        includeArchived: Boolean = false,
+    ): Flow<List<PlaylistEpisode.Available>>
 
     fun smartEpisodesMetadataFlow(rules: SmartRules): Flow<PlaylistEpisodeMetadata>
 
@@ -68,6 +73,7 @@ interface PlaylistManager {
     fun manualPlaylistFlow(
         uuid: String,
         searchTerm: String? = null,
+        includeArchived: Boolean = false,
     ): Flow<ManualPlaylist?>
 
     fun playlistPreviewsForEpisodeFlow(searchTerm: String? = null): Flow<List<PlaylistPreviewForEpisode>>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
@@ -217,7 +217,7 @@ class PlaylistManagerImpl(
         )
     }
 
-    override fun smartPlaylistFlow(uuid: String, searchTerm: String?): Flow<SmartPlaylist?> {
+    override fun smartPlaylistFlow(uuid: String, searchTerm: String?, includeArchived: Boolean): Flow<SmartPlaylist?> {
         return playlistDao
             .smartPlaylistFlow(uuid)
             .flatMapLatest { playlist ->
@@ -226,7 +226,7 @@ class PlaylistManagerImpl(
                 } else {
                     val smartRules = playlist.smartRules
                     val podcastsFlow = smartPlaylistArtworkPodcastsFlow(playlist.smartRules, playlist.sortType)
-                    val episodesFlow = smartEpisodesFlow(smartRules, playlist.sortType, searchTerm)
+                    val episodesFlow = smartEpisodesFlow(smartRules, playlist.sortType, searchTerm, includeArchived)
                     val metadataFlow = playlistDao.smartPlaylistMetadataFlow(clock, smartRules)
 
                     combine(podcastsFlow, episodesFlow, metadataFlow) { podcasts, episodes, metadata ->
@@ -257,7 +257,12 @@ class PlaylistManagerImpl(
             .distinctUntilChanged()
     }
 
-    override fun smartEpisodesFlow(rules: SmartRules, sortType: PlaylistEpisodeSortType, searchTerm: String?): Flow<List<PlaylistEpisode.Available>> {
+    override fun smartEpisodesFlow(
+        rules: SmartRules,
+        sortType: PlaylistEpisodeSortType,
+        searchTerm: String?,
+        includeArchived: Boolean,
+    ): Flow<List<PlaylistEpisode.Available>> {
         return playlistDao
             .smartEpisodesFlow(
                 clock = clock,
@@ -265,6 +270,7 @@ class PlaylistManagerImpl(
                 sortType = sortType,
                 limit = smartEpisodeLimit,
                 searchTerm = searchTerm,
+                includeArchived = includeArchived,
             )
             .distinctUntilChanged()
     }
@@ -326,14 +332,18 @@ class PlaylistManagerImpl(
         }
     }
 
-    override fun manualPlaylistFlow(uuid: String, searchTerm: String?): Flow<ManualPlaylist?> {
+    override fun manualPlaylistFlow(uuid: String, searchTerm: String?, includeArchived: Boolean): Flow<ManualPlaylist?> {
         return playlistDao.manualPlaylistFlow(uuid)
             .flatMapLatest { playlist ->
                 if (playlist == null) {
                     flowOf(null)
                 } else {
                     val podcastsFlow = manualPlaylistArtworkPodcastsFlow(playlist.uuid)
-                    val episodesFlow = playlistDao.manualEpisodesFlow(playlist.uuid, searchTerm.orEmpty())
+                    val episodesFlow = playlistDao.manualEpisodesFlow(
+                        playlistUuid = playlist.uuid,
+                        searchTerm = searchTerm.orEmpty(),
+                        includeArchived = includeArchived,
+                    )
                     val metadataFlow = playlistDao.manualPlaylistMetadataFlow(playlist.uuid)
 
                     combine(podcastsFlow, episodesFlow, metadataFlow) { podcasts, episodes, metadata ->

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/auth/TvSignOutManager.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/auth/TvSignOutManager.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.auth
 
 import au.com.shiftyjelly.pocketcasts.coroutines.di.ApplicationScope
+import au.com.shiftyjelly.pocketcasts.playlists.details.TvPlaylistPreferences
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.di.IoDispatcher
 import au.com.shiftyjelly.pocketcasts.repositories.file.FileStorage
@@ -29,6 +30,7 @@ class TvSignOutManager @Inject constructor(
     private val episodeManager: Lazy<EpisodeManager>,
     private val fileStorage: FileStorage,
     private val settings: Settings,
+    private val playlistPreferences: TvPlaylistPreferences,
     @ApplicationScope private val applicationScope: CoroutineScope,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) {
@@ -49,6 +51,7 @@ class TvSignOutManager @Inject constructor(
             }
             runWipeStep("delete downloaded files") { deleteDownloadedFiles() }
             runWipeStep("clear user preferences") { settings.clearUserPreferences() }
+            runWipeStep("clear playlist preferences") { playlistPreferences.clearAll() }
         }
     }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
@@ -162,6 +162,23 @@ private fun SortableEpisodeList(
             listState.scrollToItem(0)
         }
     }
+    val firstEpisodeFocusRequester = remember { FocusRequester() }
+    val initialFocusIndex = remember {
+        if (uiState.episodes.isEmpty()) {
+            0
+        } else {
+            Snapshot.withoutReadObservation { listState.firstVisibleItemIndex }.coerceIn(0, uiState.episodes.lastIndex)
+        }
+    }
+    var hasRequestedInitialFocus by remember { mutableStateOf(uiState.episodes.isEmpty()) }
+    LaunchedEffect(uiState.episodes.isNotEmpty()) {
+        if (uiState.episodes.isNotEmpty() && !hasRequestedInitialFocus) {
+            snapshotFlow { listState.layoutInfo.visibleItemsInfo.any { it.index == initialFocusIndex } }.first { it }
+            runCatching { firstEpisodeFocusRequester.requestFocus() }
+                .onFailure { Timber.e(it, "Failed to focus the first visible playlist episode") }
+            hasRequestedInitialFocus = true
+        }
+    }
     Column(modifier = modifier) {
         Row(
             horizontalArrangement = Arrangement.spacedBy(12.dp),
@@ -171,7 +188,7 @@ private fun SortableEpisodeList(
                 .padding(bottom = 12.dp),
         ) {
             ArchivedDropdownButton(
-                isShowingArchived = uiState.isShowingArchived,
+                isShowingArchived = uiState.isShowingArchivedOnDevice,
                 onToggleArchiveFilter = onToggleArchiveFilter,
                 playAllFocusRequester = playAllFocusRequester.takeIf { uiState.episodes.isNotEmpty() },
             )
@@ -185,6 +202,8 @@ private fun SortableEpisodeList(
             EpisodeList(
                 episodes = uiState.episodes,
                 playAllFocusRequester = playAllFocusRequester,
+                firstEpisodeFocusRequester = firstEpisodeFocusRequester,
+                initialFocusIndex = initialFocusIndex,
                 listState = listState,
                 modifier = Modifier.weight(1f),
             )
@@ -324,21 +343,13 @@ private fun SortDropdownButton(
 private fun EpisodeList(
     episodes: List<PodcastEpisode>,
     playAllFocusRequester: FocusRequester,
+    firstEpisodeFocusRequester: FocusRequester,
+    initialFocusIndex: Int,
     listState: LazyListState,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
     val dateFormatter = remember(context) { RelativeDateFormatter(context) }
-    val firstEpisodeFocusRequester = remember { FocusRequester() }
-    val initialFocusIndex = remember {
-        Snapshot.withoutReadObservation { listState.firstVisibleItemIndex }
-            .coerceIn(0, episodes.lastIndex)
-    }
-    LaunchedEffect(Unit) {
-        snapshotFlow { listState.layoutInfo.visibleItemsInfo.any { it.index == initialFocusIndex } }.first { it }
-        runCatching { firstEpisodeFocusRequester.requestFocus() }
-            .onFailure { Timber.e(it, "Failed to focus the first visible playlist episode") }
-    }
     LazyColumn(
         state = listState,
         verticalArrangement = Arrangement.spacedBy(12.dp),
@@ -470,7 +481,7 @@ private fun TvPlaylistDetailsPreview() {
                         metadata = Playlist.Metadata.ForPreview,
                     ),
                     episodes = emptyList(),
-                    isShowingArchived = false,
+                    isShowingArchivedOnDevice = false,
                 ),
                 onChangeSortType = {},
                 onToggleArchiveFilter = {},
@@ -502,8 +513,10 @@ private fun TvPlaylistDetailsLoadedPreview() {
                         metadata = Playlist.Metadata.ForPreview,
                     ),
                     episodes = episodes,
+                    isShowingArchivedOnDevice = false,
                 ),
                 onChangeSortType = {},
+                onToggleArchiveFilter = {},
             )
         }
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
@@ -92,6 +93,7 @@ fun TvPlaylistDetailsScreen(
     TvPlaylistDetailsContent(
         uiState = uiState,
         onChangeSortType = viewModel::changeSortType,
+        onToggleArchiveFilter = viewModel::toggleArchiveFilter,
         modifier = modifier,
     )
 }
@@ -100,6 +102,7 @@ fun TvPlaylistDetailsScreen(
 private fun TvPlaylistDetailsContent(
     uiState: TvPlaylistDetailsUiState,
     onChangeSortType: (PlaylistEpisodeSortType) -> Unit,
+    onToggleArchiveFilter: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Box(modifier = modifier.fillMaxSize()) {
@@ -122,7 +125,7 @@ private fun TvPlaylistDetailsContent(
                         playAllFocusRequester = playAllFocusRequester,
                         modifier = Modifier.width(ArtworkSize),
                     )
-                    if (uiState.episodes.isEmpty()) {
+                    if (uiState.availableEpisodeCount == 0) {
                         NoEpisodes(
                             playlistType = uiState.playlist.type,
                             modifier = Modifier.weight(1f).fillMaxHeight(),
@@ -131,6 +134,7 @@ private fun TvPlaylistDetailsContent(
                         SortableEpisodeList(
                             uiState = uiState,
                             onChangeSortType = onChangeSortType,
+                            onToggleArchiveFilter = onToggleArchiveFilter,
                             playAllFocusRequester = playAllFocusRequester,
                             modifier = Modifier.weight(1f),
                         )
@@ -145,6 +149,7 @@ private fun TvPlaylistDetailsContent(
 private fun SortableEpisodeList(
     uiState: TvPlaylistDetailsUiState.Loaded,
     onChangeSortType: (PlaylistEpisodeSortType) -> Unit,
+    onToggleArchiveFilter: () -> Unit,
     playAllFocusRequester: FocusRequester,
     modifier: Modifier = Modifier,
 ) {
@@ -158,20 +163,115 @@ private fun SortableEpisodeList(
         }
     }
     Column(modifier = modifier) {
-        SortDropdownButton(
-            selectedSortType = sortType,
-            availableSortTypes = uiState.playlist.availableSortTypes,
-            onSelectSortType = onChangeSortType,
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier
                 .align(Alignment.End)
                 .padding(bottom = 12.dp),
+        ) {
+            ArchivedDropdownButton(
+                isShowingArchived = uiState.isShowingArchived,
+                onToggleArchiveFilter = onToggleArchiveFilter,
+                playAllFocusRequester = playAllFocusRequester.takeIf { uiState.episodes.isNotEmpty() },
+            )
+            SortDropdownButton(
+                selectedSortType = sortType,
+                availableSortTypes = uiState.playlist.availableSortTypes,
+                onSelectSortType = onChangeSortType,
+            )
+        }
+        if (uiState.episodes.isNotEmpty()) {
+            EpisodeList(
+                episodes = uiState.episodes,
+                playAllFocusRequester = playAllFocusRequester,
+                listState = listState,
+                modifier = Modifier.weight(1f),
+            )
+        } else {
+            AllEpisodesArchived(
+                episodeCount = uiState.availableEpisodeCount,
+                modifier = Modifier.weight(1f).fillMaxWidth(),
+            )
+        }
+    }
+}
+
+@Composable
+private fun AllEpisodesArchived(
+    episodeCount: Int,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = modifier,
+    ) {
+        Text(
+            text = pluralStringResource(LR.plurals.tv_playlist_all_archived, episodeCount, episodeCount),
+            style = MaterialTheme.typography.bodyLarge,
+            color = TvColors.TextSecondary,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.widthIn(max = 400.dp),
         )
-        EpisodeList(
-            episodes = uiState.episodes,
-            playAllFocusRequester = playAllFocusRequester,
-            listState = listState,
-            modifier = Modifier.weight(1f),
-        )
+    }
+}
+
+@Composable
+private fun ArchivedDropdownButton(
+    isShowingArchived: Boolean,
+    onToggleArchiveFilter: () -> Unit,
+    playAllFocusRequester: FocusRequester?,
+    modifier: Modifier = Modifier,
+) {
+    var isExpanded by remember { mutableStateOf(false) }
+
+    Box(modifier = modifier) {
+        Button(
+            onClick = { isExpanded = true },
+            colors = TvButtonDefaults.filledButtonColors(),
+            modifier = if (playAllFocusRequester != null) {
+                Modifier.focusProperties { left = playAllFocusRequester }
+            } else {
+                Modifier
+            },
+        ) {
+            Text(
+                text = stringResource(if (isShowingArchived) LR.string.show_archived else LR.string.podcast_hide_archived),
+                style = TvTextStyles.PlaylistCardCaption,
+            )
+            Icon(
+                painter = painterResource(IR.drawable.ic_chevron_small_up),
+                contentDescription = null,
+                modifier = Modifier
+                    .padding(start = 6.dp)
+                    .size(16.dp)
+                    .rotate(180f),
+            )
+        }
+        if (isExpanded) {
+            TvDropdownMenu(onDismissRequest = { isExpanded = false }) {
+                TvDropdownMenuItem(
+                    label = stringResource(LR.string.podcast_hide_archived),
+                    isSelected = !isShowingArchived,
+                    onClick = {
+                        isExpanded = false
+                        if (isShowingArchived) {
+                            onToggleArchiveFilter()
+                        }
+                    },
+                )
+                TvDropdownMenuItem(
+                    label = stringResource(LR.string.show_archived),
+                    isSelected = isShowingArchived,
+                    onClick = {
+                        isExpanded = false
+                        if (!isShowingArchived) {
+                            onToggleArchiveFilter()
+                        }
+                    },
+                )
+            }
+        }
     }
 }
 
@@ -370,8 +470,10 @@ private fun TvPlaylistDetailsPreview() {
                         metadata = Playlist.Metadata.ForPreview,
                     ),
                     episodes = emptyList(),
+                    isShowingArchived = false,
                 ),
                 onChangeSortType = {},
+                onToggleArchiveFilter = {},
             )
         }
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModel.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.playlists.details
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.to.PlaylistEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.toPodcastEpisodes
 import au.com.shiftyjelly.pocketcasts.models.type.PlaylistEpisodeSortType
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.Playlist
@@ -14,10 +15,11 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.WhileSubscribed
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
@@ -26,34 +28,46 @@ class TvPlaylistDetailsViewModel @AssistedInject constructor(
     @Assisted private val playlistUuid: String,
     @Assisted private val playlistType: Playlist.Type,
     private val playlistManager: PlaylistManager,
+    private val preferences: TvPlaylistPreferences,
 ) : ViewModel() {
 
     private val playlistFlow: Flow<Playlist?> = when (playlistType) {
-        Playlist.Type.Manual -> playlistManager.manualPlaylistFlow(playlistUuid)
-        Playlist.Type.Smart -> playlistManager.smartPlaylistFlow(playlistUuid)
+        Playlist.Type.Manual -> playlistManager.manualPlaylistFlow(playlistUuid, includeArchived = true)
+        Playlist.Type.Smart -> playlistManager.smartPlaylistFlow(playlistUuid, includeArchived = true)
     }
 
-    val uiState: StateFlow<TvPlaylistDetailsUiState> = playlistFlow
-        .map { playlist ->
-            if (playlist == null) {
-                TvPlaylistDetailsUiState.NotFound
-            } else {
-                TvPlaylistDetailsUiState.Loaded(
-                    playlist = playlist,
-                    episodes = playlist.episodes.toPodcastEpisodes(),
-                )
-            }
+    private val isShowingArchivedFlow = MutableStateFlow(preferences.isShowingArchived(playlistUuid))
+
+    val uiState: StateFlow<TvPlaylistDetailsUiState> = combine(
+        playlistFlow,
+        isShowingArchivedFlow,
+    ) { playlist, isShowingArchived ->
+        if (playlist == null) {
+            TvPlaylistDetailsUiState.NotFound
+        } else {
+            val allEpisodes = playlist.episodes.toPodcastEpisodes()
+            TvPlaylistDetailsUiState.Loaded(
+                playlist = playlist,
+                episodes = if (isShowingArchived) allEpisodes else allEpisodes.filterNot(PodcastEpisode::isArchived),
+                isShowingArchived = isShowingArchived,
+            )
         }
-        .stateIn(
-            viewModelScope,
-            SharingStarted.WhileSubscribed(stopTimeout = 300.milliseconds, replayExpiration = Duration.ZERO),
-            TvPlaylistDetailsUiState.Loading,
-        )
+    }.stateIn(
+        viewModelScope,
+        SharingStarted.WhileSubscribed(stopTimeout = 300.milliseconds, replayExpiration = Duration.ZERO),
+        TvPlaylistDetailsUiState.Loading,
+    )
 
     fun changeSortType(sortType: PlaylistEpisodeSortType) {
         viewModelScope.launch {
             playlistManager.updateSortType(playlistUuid, sortType)
         }
+    }
+
+    fun toggleArchiveFilter() {
+        val isShowingArchived = !isShowingArchivedFlow.value
+        preferences.setShowingArchived(playlistUuid, isShowingArchived)
+        isShowingArchivedFlow.value = isShowingArchived
     }
 
     @AssistedFactory
@@ -70,5 +84,8 @@ sealed interface TvPlaylistDetailsUiState {
     data class Loaded(
         val playlist: Playlist,
         val episodes: List<PodcastEpisode>,
-    ) : TvPlaylistDetailsUiState
+        val isShowingArchived: Boolean,
+    ) : TvPlaylistDetailsUiState {
+        val availableEpisodeCount get() = playlist.episodes.count { it is PlaylistEpisode.Available }
+    }
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModel.kt
@@ -49,7 +49,7 @@ class TvPlaylistDetailsViewModel @AssistedInject constructor(
             TvPlaylistDetailsUiState.Loaded(
                 playlist = playlist,
                 episodes = if (isShowingArchived) allEpisodes else allEpisodes.filterNot(PodcastEpisode::isArchived),
-                isShowingArchived = isShowingArchived,
+                isShowingArchivedOnDevice = isShowingArchived,
             )
         }
     }.stateIn(
@@ -84,7 +84,7 @@ sealed interface TvPlaylistDetailsUiState {
     data class Loaded(
         val playlist: Playlist,
         val episodes: List<PodcastEpisode>,
-        val isShowingArchived: Boolean,
+        val isShowingArchivedOnDevice: Boolean,
     ) : TvPlaylistDetailsUiState {
         val availableEpisodeCount get() = playlist.episodes.count { it is PlaylistEpisode.Available }
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistPreferences.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistPreferences.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.playlists.details
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.SharedPreferences
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -20,8 +21,9 @@ class TvPlaylistPreferences @Inject constructor(
         prefs.edit().putBoolean(showArchivedKey(playlistUuid), isShowingArchived).apply()
     }
 
+    @SuppressLint("ApplySharedPref")
     fun clearAll() {
-        prefs.edit().clear().apply()
+        prefs.edit().clear().commit()
     }
 
     private fun showArchivedKey(playlistUuid: String) = "show_archived_playlist_$playlistUuid"

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistPreferences.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistPreferences.kt
@@ -1,0 +1,28 @@
+package au.com.shiftyjelly.pocketcasts.playlists.details
+
+import android.content.Context
+import android.content.SharedPreferences
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class TvPlaylistPreferences @Inject constructor(
+    @ApplicationContext context: Context,
+) {
+    private val prefs: SharedPreferences = context.getSharedPreferences("tv_playlists", Context.MODE_PRIVATE)
+
+    fun isShowingArchived(playlistUuid: String): Boolean {
+        return prefs.getBoolean(showArchivedKey(playlistUuid), false)
+    }
+
+    fun setShowingArchived(playlistUuid: String, isShowingArchived: Boolean) {
+        prefs.edit().putBoolean(showArchivedKey(playlistUuid), isShowingArchived).apply()
+    }
+
+    fun clearAll() {
+        prefs.edit().clear().apply()
+    }
+
+    private fun showArchivedKey(playlistUuid: String) = "show_archived_playlist_$playlistUuid"
+}

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/auth/TvSignOutManagerTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/auth/TvSignOutManagerTest.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.auth
 
+import au.com.shiftyjelly.pocketcasts.playlists.details.TvPlaylistPreferences
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.file.FileStorage
 import au.com.shiftyjelly.pocketcasts.repositories.file.StorageException
@@ -47,6 +48,7 @@ class TvSignOutManagerTest {
     private val searchHistoryManager = mock<SearchHistoryManager>()
     private val episodeManager = mock<EpisodeManager>()
     private val settings = mock<Settings>()
+    private val playlistPreferences = mock<TvPlaylistPreferences>()
 
     @Test
     fun `sign out clears the account data and caches in order`() = runTest {
@@ -148,6 +150,7 @@ class TvSignOutManagerTest {
         episodeManager = { episodeManager },
         fileStorage = fileStorage,
         settings = settings,
+        playlistPreferences = playlistPreferences,
         applicationScope = this,
         ioDispatcher = coroutineRule.testDispatcher,
     )

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/auth/TvSignOutManagerTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/auth/TvSignOutManagerTest.kt
@@ -57,7 +57,7 @@ class TvSignOutManagerTest {
         manager.signOutAndWipeData()
         advanceUntilIdle()
 
-        inOrder(userManager, settings) {
+        inOrder(userManager, settings, playlistPreferences) {
             verify(userManager).signOutAndClearData(
                 playbackManager = eq(playbackManager),
                 upNextQueue = eq(upNextQueue),
@@ -67,6 +67,7 @@ class TvSignOutManagerTest {
                 wasInitiatedByUser = eq(true),
             )
             verify(settings).clearUserPreferences()
+            verify(playlistPreferences).clearAll()
         }
     }
 

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModelTest.kt
@@ -60,7 +60,7 @@ class TvHomeViewModelTest {
         on { getUpNextBaseEpisodes(any()) }.thenReturn(emptyList())
     }
     private val playlistManager = mock<PlaylistManager> {
-        whenever(it.smartEpisodesFlow(any(), any(), anyOrNull())).thenReturn(flowOf(emptyList()))
+        whenever(it.smartEpisodesFlow(any(), any(), anyOrNull(), any())).thenReturn(flowOf(emptyList()))
     }
     private val resources = mock<Resources>()
     private val context = mock<Context> {
@@ -442,7 +442,7 @@ class TvHomeViewModelTest {
                 episode(uuid = "episode-3", podcastUuid = "podcast-2"),
             ),
         )
-        whenever(playlistManager.smartEpisodesFlow(any(), any(), anyOrNull())).thenReturn(
+        whenever(playlistManager.smartEpisodesFlow(any(), any(), anyOrNull(), any())).thenReturn(
             flowOf(listOf(PlaylistEpisode.Available(episode(uuid = "episode-new", podcastUuid = "podcast-2")))),
         )
         whenever(podcastDao.findAllIn(any())).thenReturn(

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModelTest.kt
@@ -49,7 +49,7 @@ class TvPlaylistDetailsViewModelTest {
             val state = awaitItem() as TvPlaylistDetailsUiState.Loaded
             assertEquals(listOf(availableEpisode), state.episodes)
             assertEquals(2, state.availableEpisodeCount)
-            assertEquals(false, state.isShowingArchived)
+            assertEquals(false, state.isShowingArchivedOnDevice)
         }
     }
 
@@ -67,13 +67,13 @@ class TvPlaylistDetailsViewModelTest {
 
             val state = awaitItem() as TvPlaylistDetailsUiState.Loaded
             assertEquals(listOf(availableEpisode, archivedEpisode), state.episodes)
-            assertEquals(true, state.isShowingArchived)
+            assertEquals(true, state.isShowingArchivedOnDevice)
         }
     }
 
     @Test
     fun `only available episodes are surfaced`() = runTest {
-        val available = episode(uuid = "available")
+        val available = episode(uuid = "available", isArchived = false)
         val unavailable = PlaylistEpisode.Unavailable(ManualPlaylistEpisode.test(episodeUuid = "unavailable"))
         val viewModel = createViewModel()
 
@@ -124,7 +124,7 @@ class TvPlaylistDetailsViewModelTest {
 
             val state = awaitItem() as TvPlaylistDetailsUiState.Loaded
             assertEquals(listOf(availableEpisode, archivedEpisode), state.episodes)
-            assertEquals(true, state.isShowingArchived)
+            assertEquals(true, state.isShowingArchivedOnDevice)
             verify(preferences).setShowingArchived(eq("playlist-uuid"), eq(true))
         }
     }

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModelTest.kt
@@ -18,7 +18,9 @@ import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class TvPlaylistDetailsViewModelTest {
@@ -28,22 +30,44 @@ class TvPlaylistDetailsViewModelTest {
 
     private val playlists = MutableSharedFlow<ManualPlaylist?>(replay = 1)
     private val playlistManager = mock<PlaylistManager> {
-        on { manualPlaylistFlow(any(), anyOrNull()) } doReturn playlists
+        on { manualPlaylistFlow(any(), anyOrNull(), any()) } doReturn playlists
     }
+    private val preferences = mock<TvPlaylistPreferences>()
 
-    private val episode = episode(uuid = "episode-1")
+    private val availableEpisode = episode(uuid = "episode-1", isArchived = false)
+    private val archivedEpisode = episode(uuid = "episode-2", isArchived = true)
 
     @Test
-    fun `playlist episodes load`() = runTest {
+    fun `archived episodes are hidden by default`() = runTest {
         val viewModel = createViewModel()
 
         viewModel.uiState.test {
             assertEquals(TvPlaylistDetailsUiState.Loading, awaitItem())
 
-            playlists.emit(playlist(episode))
+            playlists.emit(playlist(availableEpisode, archivedEpisode))
 
             val state = awaitItem() as TvPlaylistDetailsUiState.Loaded
-            assertEquals(listOf(episode), state.episodes)
+            assertEquals(listOf(availableEpisode), state.episodes)
+            assertEquals(2, state.availableEpisodeCount)
+            assertEquals(false, state.isShowingArchived)
+        }
+    }
+
+    @Test
+    fun `archived episodes are shown when the stored preference allows them`() = runTest {
+        val preferences = mock<TvPlaylistPreferences> {
+            on { isShowingArchived("playlist-uuid") } doReturn true
+        }
+        val viewModel = createViewModel(preferences)
+
+        viewModel.uiState.test {
+            assertEquals(TvPlaylistDetailsUiState.Loading, awaitItem())
+
+            playlists.emit(playlist(availableEpisode, archivedEpisode))
+
+            val state = awaitItem() as TvPlaylistDetailsUiState.Loaded
+            assertEquals(listOf(availableEpisode, archivedEpisode), state.episodes)
+            assertEquals(true, state.isShowingArchived)
         }
     }
 
@@ -78,18 +102,38 @@ class TvPlaylistDetailsViewModelTest {
         viewModel.uiState.test {
             assertEquals(TvPlaylistDetailsUiState.Loading, awaitItem())
 
-            playlists.emit(playlist(episode))
-            assertEquals(listOf(episode), (awaitItem() as TvPlaylistDetailsUiState.Loaded).episodes)
+            playlists.emit(playlist(availableEpisode))
+            assertEquals(listOf(availableEpisode), (awaitItem() as TvPlaylistDetailsUiState.Loaded).episodes)
 
             playlists.emit(null)
             assertEquals(TvPlaylistDetailsUiState.NotFound, awaitItem())
         }
     }
 
-    private fun createViewModel() = TvPlaylistDetailsViewModel(
+    @Test
+    fun `toggling the archive filter updates the list and persists the preference`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            assertEquals(TvPlaylistDetailsUiState.Loading, awaitItem())
+
+            playlists.emit(playlist(availableEpisode, archivedEpisode))
+            assertEquals(listOf(availableEpisode), (awaitItem() as TvPlaylistDetailsUiState.Loaded).episodes)
+
+            viewModel.toggleArchiveFilter()
+
+            val state = awaitItem() as TvPlaylistDetailsUiState.Loaded
+            assertEquals(listOf(availableEpisode, archivedEpisode), state.episodes)
+            assertEquals(true, state.isShowingArchived)
+            verify(preferences).setShowingArchived(eq("playlist-uuid"), eq(true))
+        }
+    }
+
+    private fun createViewModel(prefs: TvPlaylistPreferences = preferences) = TvPlaylistDetailsViewModel(
         playlistUuid = "playlist-uuid",
         playlistType = Playlist.Type.Manual,
         playlistManager = playlistManager,
+        preferences = prefs,
     )
 
     private fun playlist(vararg episodes: PodcastEpisode) = ManualPlaylist(
@@ -100,8 +144,9 @@ class TvPlaylistDetailsViewModelTest {
         metadata = Playlist.Metadata.ForPreview,
     )
 
-    private fun episode(uuid: String) = PodcastEpisode(
+    private fun episode(uuid: String, isArchived: Boolean) = PodcastEpisode(
         uuid = uuid,
         publishedDate = Date(0),
+        isArchived = isArchived,
     )
 }


### PR DESCRIPTION
## Description

Adds a `Hide archived`/`Show archived` filter to the TV playlist details screen with full Apple TV parity: the filter works for both manual and smart playlists, filters client-side in the ViewModel, and persists device-locally per playlist (`TvPlaylistPreferences`, mirroring tvOS's UserDefaults approach) — it never touches the synced `showArchivedEpisodes` setting, so toggling on TV doesn't change what the phone shows.

Data-layer change (defaults preserve existing behavior on all platforms):
- `includeArchived` flag threaded through `SmartRules.toSqlWhereClause`, `PlaylistDao`, and `PlaylistManager.smartPlaylistFlow`/`manualPlaylistFlow`/`smartEpisodesFlow` (default `false` everywhere; mirrors iOS's `shouldShowArchived` query-builder parameter). Covered by new instrumented tests in `PlaylistManagerSmartTest`/`PlaylistManagerManualTest`.

TV behavior:
- The filter button reuses the `TvDropdownMenu` component, sits left of the sort button, and its label reflects the current state.
- Archived rows render dimmed; when every episode is archived and hidden, a placeholder explains it while the controls stay reachable.
- The prefs file is wiped by `TvSignOutManager` on sign-out so archived choices can't leak across accounts.

Known parity quirk (matches tvOS exactly): smart playlists fetch up to 1000 episodes including archived before the client-side filter, so playlists over the limit may show fewer non-archived episodes than mobile.

Fixes PCDROID-693 https://linear.app/a8c/issue/PCDROID-693/playlist-details.
Designs: Ftk3KwnfqaK4g57yCN63p0-fi-3258_12136.

Stacked on `feat/tv-playlist-details-sorting` — merge bottom-up.

## Testing Instructions

1. Install the TV app and open a playlist containing archived episodes.
2. Verify archived episodes are hidden by default and the button reads `Hide archived`.
3. Open the dropdown, pick `Show archived` — archived episodes appear dimmed and the header count/duration update.
4. Restart the app — the choice persists per playlist; verify the phone's view of the same playlist is unaffected.
5. Archive all episodes of a playlist and hide archived — the "All N episodes of this playlist have been archived." placeholder shows and the filter stays reachable.
6. Sign out with data wipe, sign back in — archived filters are reset.
7. Regression: on the phone, verify playlist episode lists and the archived toggle in playlist options behave as before.

## Screenshots or Screencast

| Hide archived (default) | Dropdown |
| --- | --- | 
| <img width="1920" height="1080" alt="pr3-archived-dropdown" src="https://github.com/user-attachments/assets/e76b640c-3aff-49cf-8cae-bfa05ca759ac" /> | <img width="1920" height="1080" alt="pr3-details-hide-archived" src="https://github.com/user-attachments/assets/dd2e2412-bbdc-4034-82bb-2e077655f9ac" /> |


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md _(TV app is unreleased — skipped)_
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes _(ViewModel unit tests + instrumented query tests added)_
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics. _(analytics deliberately excluded — follow-up)_
