### PR TITLE
[TV] Add an episode actions menu to the TV playlist details screen

### DIFF
--- a/modules/services/images/src/main/res/drawable/ic_ellipsis_horizontal.xml
+++ b/modules/services/images/src/main/res/drawable/ic_ellipsis_horizontal.xml
@@ -1,8 +1,10 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
-    android:viewportHeight="24">
+    android:viewportHeight="24"
+    tools:ignore="UnusedResources">
 
     <path
         android:fillColor="#FF000000"

--- a/modules/services/images/src/main/res/drawable/ic_ellipsis_horizontal.xml
+++ b/modules/services/images/src/main/res/drawable/ic_ellipsis_horizontal.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M4,12a2,2 0 1,0 4,0a2,2 0 1,0 -4,0M10,12a2,2 0 1,0 4,0a2,2 0 1,0 -4,0M16,12a2,2 0 1,0 4,0a2,2 0 1,0 -4,0" />
+
+</vector>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -268,6 +268,7 @@
     <string name="tv_playlist_empty_title">No episodes</string>
     <string name="tv_playlist_empty_subtitle">Either it’s time to celebrate completing this list or edit your rules in the mobile app to get some more.</string>
     <string name="tv_playlist_empty_subtitle_manual">Add episodes to this playlist from the mobile app and they’ll show up here.</string>
+    <string name="tv_episode_details">Episode details</string>
     <string name="unavailable">Unavailable</string>
     <string name="browse_podcasts">Browse podcasts</string>
     <string name="pocket_casts_plus_badge">Pocket Casts Plus badge</string>

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionsModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionsModal.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -63,16 +62,14 @@ private fun ColumnScope.TvEpisodeActionsModalContent(episode: PodcastEpisode) {
     val playedToggle = stringResource(if (episode.isFinished) LR.string.mark_as_unplayed else LR.string.mark_as_played)
     val archiveToggle = stringResource(if (episode.isArchived) LR.string.unarchive else LR.string.archive)
 
-    val actions = buildList {
-        if (episode.podcastUuid.isNotBlank()) {
-            add(episodeDetails)
-        }
-        add(goToPodcast)
-        add(playNext)
-        add(playLast)
-        add(playedToggle)
-        add(archiveToggle)
-    }
+    val actions = listOf(
+        episodeDetails,
+        goToPodcast,
+        playNext,
+        playLast,
+        playedToggle,
+        archiveToggle,
+    )
 
     actions.forEachIndexed { index, label ->
         TvEpisodeActionButton(
@@ -96,7 +93,7 @@ private fun TvEpisodeActionButton(
     ) {
         Text(
             text = text,
-            textAlign = TextAlign.Center,
+            style = TvTextStyles.ModalButtonLabel,
             modifier = Modifier.fillMaxWidth(),
         )
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionsModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionsModal.kt
@@ -1,17 +1,15 @@
 package au.com.shiftyjelly.pocketcasts.component
 
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.Button
@@ -19,6 +17,7 @@ import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
 import au.com.shiftyjelly.pocketcasts.theme.TvTextStyles
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
@@ -33,27 +32,25 @@ fun TvEpisodeActionsModal(
 ) {
     TvModal(
         onDismissRequest = onDismissRequest,
+        contentPadding = ContentPadding,
         modifier = modifier,
     ) {
-        TvEpisodeActionsModalContent(episode = episode)
+        TvEpisodeActionsModalContent(
+            episode = episode,
+            onDismissRequest = onDismissRequest,
+        )
     }
 }
 
 @Composable
-private fun ColumnScope.TvEpisodeActionsModalContent(episode: PodcastEpisode) {
+private fun ColumnScope.TvEpisodeActionsModalContent(
+    episode: PodcastEpisode,
+    onDismissRequest: () -> Unit,
+) {
     val focusRequester = remember { FocusRequester() }
     LaunchedEffect(Unit) {
         focusRequester.requestFocus()
     }
-
-    Text(
-        text = episode.title,
-        color = Color.White,
-        style = TvTextStyles.ModalTitle,
-        maxLines = 2,
-        overflow = TextOverflow.Ellipsis,
-        modifier = Modifier.padding(bottom = 8.dp),
-    )
 
     val episodeDetails = stringResource(LR.string.tv_episode_details)
     val goToPodcast = stringResource(LR.string.go_to_podcast)
@@ -78,6 +75,11 @@ private fun ColumnScope.TvEpisodeActionsModalContent(episode: PodcastEpisode) {
             modifier = if (index == 0) Modifier.focusRequester(focusRequester) else Modifier,
         )
     }
+
+    TvEpisodeActionButton(
+        text = stringResource(LR.string.cancel),
+        onClick = onDismissRequest,
+    )
 }
 
 @Composable
@@ -102,18 +104,43 @@ private fun TvEpisodeActionButton(
 @Preview
 @Composable
 private fun TvEpisodeActionsModalPreview() {
+    TvEpisodeActionsModalPreviewContent(
+        episode = PodcastEpisode(
+            uuid = "episode-uuid",
+            title = "Episode title that might be quite long and wrap onto two lines",
+            podcastUuid = "podcast-uuid",
+            publishedDate = Date(0),
+        ),
+    )
+}
+
+@Preview
+@Composable
+private fun TvEpisodeActionsModalPlayedArchivedPreview() {
+    TvEpisodeActionsModalPreviewContent(
+        episode = PodcastEpisode(
+            uuid = "episode-uuid",
+            title = "Episode title that might be quite long and wrap onto two lines",
+            podcastUuid = "podcast-uuid",
+            publishedDate = Date(0),
+            playingStatus = EpisodePlayingStatus.COMPLETED,
+            isArchived = true,
+        ),
+    )
+}
+
+@Composable
+private fun TvEpisodeActionsModalPreviewContent(episode: PodcastEpisode) {
     AppTheme(themeType = Theme.ThemeType.EXTRA_DARK) {
         MaterialTheme {
-            TvModalSurface {
+            TvModalSurface(contentPadding = ContentPadding) {
                 TvEpisodeActionsModalContent(
-                    episode = PodcastEpisode(
-                        uuid = "episode-uuid",
-                        title = "Episode title that might be quite long and wrap onto two lines",
-                        podcastUuid = "podcast-uuid",
-                        publishedDate = Date(0),
-                    ),
+                    episode = episode,
+                    onDismissRequest = {},
                 )
             }
         }
     }
 }
+
+private val ContentPadding = PaddingValues(horizontal = 24.dp, vertical = 27.dp)

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionsModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionsModal.kt
@@ -1,0 +1,122 @@
+package au.com.shiftyjelly.pocketcasts.component
+
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.tv.material3.Button
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
+import au.com.shiftyjelly.pocketcasts.theme.TvTextStyles
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import java.util.Date
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+fun TvEpisodeActionsModal(
+    episode: PodcastEpisode,
+    onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    TvModal(
+        onDismissRequest = onDismissRequest,
+        modifier = modifier,
+    ) {
+        TvEpisodeActionsModalContent(episode = episode)
+    }
+}
+
+@Composable
+private fun ColumnScope.TvEpisodeActionsModalContent(episode: PodcastEpisode) {
+    val focusRequester = remember { FocusRequester() }
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+
+    Text(
+        text = episode.title,
+        color = Color.White,
+        style = TvTextStyles.ModalTitle,
+        maxLines = 2,
+        overflow = TextOverflow.Ellipsis,
+        modifier = Modifier.padding(bottom = 8.dp),
+    )
+
+    val episodeDetails = stringResource(LR.string.tv_episode_details)
+    val goToPodcast = stringResource(LR.string.go_to_podcast)
+    val playNext = stringResource(LR.string.add_to_up_next_top)
+    val playLast = stringResource(LR.string.add_to_up_next_bottom)
+    val playedToggle = stringResource(if (episode.isFinished) LR.string.mark_as_unplayed else LR.string.mark_as_played)
+    val archiveToggle = stringResource(if (episode.isArchived) LR.string.unarchive else LR.string.archive)
+
+    val actions = buildList {
+        if (episode.podcastUuid.isNotBlank()) {
+            add(episodeDetails)
+        }
+        add(goToPodcast)
+        add(playNext)
+        add(playLast)
+        add(playedToggle)
+        add(archiveToggle)
+    }
+
+    actions.forEachIndexed { index, label ->
+        TvEpisodeActionButton(
+            text = label,
+            onClick = {},
+            modifier = if (index == 0) Modifier.focusRequester(focusRequester) else Modifier,
+        )
+    }
+}
+
+@Composable
+private fun TvEpisodeActionButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Button(
+        onClick = onClick,
+        colors = TvButtonDefaults.filledButtonColors(),
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Text(
+            text = text,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun TvEpisodeActionsModalPreview() {
+    AppTheme(themeType = Theme.ThemeType.EXTRA_DARK) {
+        MaterialTheme {
+            TvModalSurface {
+                TvEpisodeActionsModalContent(
+                    episode = PodcastEpisode(
+                        uuid = "episode-uuid",
+                        title = "Episode title that might be quite long and wrap onto two lines",
+                        podcastUuid = "podcast-uuid",
+                        publishedDate = Date(0),
+                    ),
+                )
+            }
+        }
+    }
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvModal.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -37,6 +38,7 @@ fun TvModal(
     onDismissRequest: () -> Unit,
     modifier: Modifier = Modifier,
     width: Dp = DefaultModalWidth,
+    contentPadding: PaddingValues = DefaultContentPadding,
     content: @Composable ColumnScope.() -> Unit,
 ) {
     Dialog(
@@ -48,6 +50,7 @@ fun TvModal(
         TvModalSurface(
             isTranslucent = isBlurBehindEnabled,
             width = width,
+            contentPadding = contentPadding,
             modifier = modifier,
             content = content,
         )
@@ -59,6 +62,7 @@ internal fun TvModalSurface(
     modifier: Modifier = Modifier,
     isTranslucent: Boolean = false,
     width: Dp = DefaultModalWidth,
+    contentPadding: PaddingValues = DefaultContentPadding,
     content: @Composable ColumnScope.() -> Unit,
 ) {
     Column(
@@ -71,7 +75,7 @@ internal fun TvModalSurface(
             .background(if (isTranslucent) TranslucentContainerColor else TvOverlayContainerColor)
             .background(HighlightBrush)
             .border(1.dp, TvOverlayBorderColor, ModalShape)
-            .padding(horizontal = 53.dp, vertical = 40.dp),
+            .padding(contentPadding),
     )
 }
 
@@ -110,6 +114,7 @@ private fun rememberIsBlurBehindEnabled(): State<Boolean> {
 }
 
 private val DefaultModalWidth = 400.dp
+private val DefaultContentPadding = PaddingValues(horizontal = 53.dp, vertical = 40.dp)
 private val ModalShape = RoundedCornerShape(28.dp)
 private val TranslucentContainerColor = TvColors.Dark.copy(alpha = 0.6f)
 internal val TvOverlayContainerColor = TvColors.Dark.copy(alpha = 0.94f)

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvMoreButton.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvMoreButton.kt
@@ -1,0 +1,52 @@
+package au.com.shiftyjelly.pocketcasts.component
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.tv.material3.Icon
+import androidx.tv.material3.IconButton
+import androidx.tv.material3.IconButtonDefaults
+import androidx.tv.material3.MaterialTheme
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.theme.TvColors
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+fun TvMoreButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    IconButton(
+        onClick = onClick,
+        colors = IconButtonDefaults.colors(
+            containerColor = TvColors.BgActive20,
+            contentColor = Color.White,
+            focusedContainerColor = Color.White,
+            focusedContentColor = TvColors.Dark,
+        ),
+        modifier = modifier.size(48.dp),
+    ) {
+        Icon(
+            painter = painterResource(IR.drawable.ic_ellipsis_horizontal),
+            contentDescription = stringResource(LR.string.more_options),
+            modifier = Modifier.size(20.dp),
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun TvMoreButtonPreview() {
+    AppTheme(themeType = Theme.ThemeType.EXTRA_DARK) {
+        MaterialTheme {
+            TvMoreButton(onClick = {})
+        }
+    }
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvMoreButton.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvMoreButton.kt
@@ -3,17 +3,15 @@ package au.com.shiftyjelly.pocketcasts.component
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.Icon
 import androidx.tv.material3.IconButton
-import androidx.tv.material3.IconButtonDefaults
 import androidx.tv.material3.MaterialTheme
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
-import au.com.shiftyjelly.pocketcasts.theme.TvColors
+import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -25,13 +23,8 @@ fun TvMoreButton(
 ) {
     IconButton(
         onClick = onClick,
-        colors = IconButtonDefaults.colors(
-            containerColor = TvColors.BgActive20,
-            contentColor = Color.White,
-            focusedContainerColor = Color.White,
-            focusedContentColor = TvColors.Dark,
-        ),
-        modifier = modifier.size(48.dp),
+        colors = TvButtonDefaults.iconButtonColors(),
+        modifier = Modifier.size(48.dp).then(modifier),
     ) {
         Icon(
             painter = painterResource(IR.drawable.ic_ellipsis_horizontal),

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvTopBar.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvTopBar.kt
@@ -30,6 +30,7 @@ import androidx.tv.material3.IconButtonDefaults
 import androidx.tv.material3.MaterialTheme
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.images.GravatarProfileImage
+import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
 import au.com.shiftyjelly.pocketcasts.theme.TvColors
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.images.R as IR
@@ -77,12 +78,7 @@ private fun TvProfileButton(
 ) {
     IconButton(
         onClick = onClick,
-        colors = IconButtonDefaults.colors(
-            containerColor = TvColors.Gray,
-            contentColor = Color.White,
-            focusedContainerColor = Color.White,
-            focusedContentColor = TvColors.Dark,
-        ),
+        colors = TvButtonDefaults.iconButtonColors(containerColor = TvColors.Gray),
         // The avatar image covers the focused container color, so show focus with a border as well.
         border = IconButtonDefaults.border(
             focusedBorder = Border(BorderStroke(2.dp, Color.White), inset = 2.dp, shape = CircleShape),

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
@@ -53,7 +53,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.Button
 import androidx.tv.material3.Icon
 import androidx.tv.material3.IconButton
-import androidx.tv.material3.IconButtonDefaults
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.component.TvDropdownMenu
@@ -318,12 +317,7 @@ private fun SortDropdownButton(
     Box(modifier = modifier) {
         IconButton(
             onClick = { isExpanded = true },
-            colors = IconButtonDefaults.colors(
-                containerColor = TvColors.BgActive20,
-                contentColor = Color.White,
-                focusedContainerColor = Color.White,
-                focusedContentColor = TvColors.Dark,
-            ),
+            colors = TvButtonDefaults.iconButtonColors(),
         ) {
             Icon(
                 painter = painterResource(IR.drawable.ic_sort),
@@ -416,12 +410,12 @@ private fun EpisodeListItem(
         )
         AnimatedVisibility(
             visible = isItemFocused,
-            enter = expandHorizontally(tween(MORE_BUTTON_ANIMATION_MILLIS), expandFrom = Alignment.Start) +
-                slideInHorizontally(tween(MORE_BUTTON_ANIMATION_MILLIS), initialOffsetX = { it }) +
-                fadeIn(tween(MORE_BUTTON_ANIMATION_MILLIS)),
-            exit = shrinkHorizontally(tween(MORE_BUTTON_ANIMATION_MILLIS), shrinkTowards = Alignment.Start) +
-                slideOutHorizontally(tween(MORE_BUTTON_ANIMATION_MILLIS), targetOffsetX = { it }) +
-                fadeOut(tween(MORE_BUTTON_ANIMATION_MILLIS)),
+            enter = expandHorizontally(tween(MORE_BUTTON_ANIMATION_DURATION_MS), expandFrom = Alignment.Start) +
+                slideInHorizontally(tween(MORE_BUTTON_ANIMATION_DURATION_MS), initialOffsetX = { it }) +
+                fadeIn(tween(MORE_BUTTON_ANIMATION_DURATION_MS)),
+            exit = shrinkHorizontally(tween(MORE_BUTTON_ANIMATION_DURATION_MS), shrinkTowards = Alignment.Start) +
+                slideOutHorizontally(tween(MORE_BUTTON_ANIMATION_DURATION_MS), targetOffsetX = { it }) +
+                fadeOut(tween(MORE_BUTTON_ANIMATION_DURATION_MS)),
         ) {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Spacer(Modifier.width(16.dp))
@@ -524,7 +518,7 @@ private fun episodeSummaryText(episodes: List<PodcastEpisode>): String {
 }
 
 private val ArtworkSize = 200.dp
-private const val MORE_BUTTON_ANIMATION_MILLIS = 200
+private const val MORE_BUTTON_ANIMATION_DURATION_MS = 200
 
 @Preview(device = Devices.TV_1080p)
 @Composable

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
@@ -1,9 +1,18 @@
 package au.com.shiftyjelly.pocketcasts.playlists.details
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandHorizontally
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkHorizontally
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -392,7 +401,6 @@ private fun EpisodeListItem(
     var isItemFocused by remember { mutableStateOf(false) }
     Row(
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(16.dp),
         modifier = modifier
             .fillMaxWidth()
             .onFocusChanged { isItemFocused = it.hasFocus },
@@ -406,11 +414,17 @@ private fun EpisodeListItem(
                 .focusProperties { left = playAllFocusRequester }
                 .then(if (episodeFocusRequester != null) Modifier.focusRequester(episodeFocusRequester) else Modifier),
         )
-        Box(
-            contentAlignment = Alignment.Center,
-            modifier = Modifier.size(48.dp),
+        AnimatedVisibility(
+            visible = isItemFocused,
+            enter = expandHorizontally(tween(MORE_BUTTON_ANIMATION_MILLIS), expandFrom = Alignment.Start) +
+                slideInHorizontally(tween(MORE_BUTTON_ANIMATION_MILLIS), initialOffsetX = { it }) +
+                fadeIn(tween(MORE_BUTTON_ANIMATION_MILLIS)),
+            exit = shrinkHorizontally(tween(MORE_BUTTON_ANIMATION_MILLIS), shrinkTowards = Alignment.Start) +
+                slideOutHorizontally(tween(MORE_BUTTON_ANIMATION_MILLIS), targetOffsetX = { it }) +
+                fadeOut(tween(MORE_BUTTON_ANIMATION_MILLIS)),
         ) {
-            if (isItemFocused) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Spacer(Modifier.width(16.dp))
                 TvMoreButton(onClick = onOpenActions)
             }
         }
@@ -510,6 +524,7 @@ private fun episodeSummaryText(episodes: List<PodcastEpisode>): String {
 }
 
 private val ArtworkSize = 200.dp
+private const val MORE_BUTTON_ANIMATION_MILLIS = 200
 
 @Preview(device = Devices.TV_1080p)
 @Composable

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -48,7 +49,9 @@ import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.component.TvDropdownMenu
 import au.com.shiftyjelly.pocketcasts.component.TvDropdownMenuItem
+import au.com.shiftyjelly.pocketcasts.component.TvEpisodeActionsModal
 import au.com.shiftyjelly.pocketcasts.component.TvEpisodeRow
+import au.com.shiftyjelly.pocketcasts.component.TvMoreButton
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.components.PlaylistArtwork
 import au.com.shiftyjelly.pocketcasts.compose.components.displayLabel
@@ -350,6 +353,7 @@ private fun EpisodeList(
 ) {
     val context = LocalContext.current
     val dateFormatter = remember(context) { RelativeDateFormatter(context) }
+    var actionsEpisode by remember { mutableStateOf<PodcastEpisode?>(null) }
     LazyColumn(
         state = listState,
         verticalArrangement = Arrangement.spacedBy(12.dp),
@@ -359,15 +363,56 @@ private fun EpisodeList(
             items = episodes,
             key = { _, episode -> episode.uuid },
         ) { index, episode ->
-            TvEpisodeRow(
+            EpisodeListItem(
                 episode = episode,
-                onClick = {},
                 dateFormatter = dateFormatter,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .focusProperties { left = playAllFocusRequester }
-                    .then(if (index == initialFocusIndex) Modifier.focusRequester(firstEpisodeFocusRequester) else Modifier),
+                onOpenActions = { actionsEpisode = episode },
+                playAllFocusRequester = playAllFocusRequester,
+                episodeFocusRequester = firstEpisodeFocusRequester.takeIf { index == initialFocusIndex },
             )
+        }
+    }
+    actionsEpisode?.let { episode ->
+        TvEpisodeActionsModal(
+            episode = episode,
+            onDismissRequest = { actionsEpisode = null },
+        )
+    }
+}
+
+@Composable
+private fun EpisodeListItem(
+    episode: PodcastEpisode,
+    dateFormatter: RelativeDateFormatter,
+    onOpenActions: () -> Unit,
+    playAllFocusRequester: FocusRequester,
+    episodeFocusRequester: FocusRequester?,
+    modifier: Modifier = Modifier,
+) {
+    var isItemFocused by remember { mutableStateOf(false) }
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        modifier = modifier
+            .fillMaxWidth()
+            .onFocusChanged { isItemFocused = it.hasFocus },
+    ) {
+        TvEpisodeRow(
+            episode = episode,
+            onClick = {},
+            dateFormatter = dateFormatter,
+            modifier = Modifier
+                .weight(1f)
+                .focusProperties { left = playAllFocusRequester }
+                .then(if (episodeFocusRequester != null) Modifier.focusRequester(episodeFocusRequester) else Modifier),
+        )
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier.size(48.dp),
+        ) {
+            if (isItemFocused) {
+                TvMoreButton(onClick = onOpenActions)
+            }
         }
     }
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvButtonDefaults.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvButtonDefaults.kt
@@ -6,6 +6,7 @@ import androidx.tv.material3.Border
 import androidx.tv.material3.ButtonBorder
 import androidx.tv.material3.ButtonColors
 import androidx.tv.material3.ButtonDefaults
+import androidx.tv.material3.IconButtonDefaults
 
 object TvButtonDefaults {
 
@@ -37,5 +38,13 @@ object TvButtonDefaults {
     fun borderlessButtonBorder(): ButtonBorder = ButtonDefaults.border(
         border = Border.None,
         focusedBorder = Border.None,
+    )
+
+    @Composable
+    fun iconButtonColors(containerColor: Color = TvColors.BgActive20) = IconButtonDefaults.colors(
+        containerColor = containerColor,
+        contentColor = Color.White,
+        focusedContainerColor = Color.White,
+        focusedContentColor = TvColors.Dark,
     )
 }


### PR DESCRIPTION
## Description

Adds the per-episode actions menu to the TV playlist details screen, mirroring the Apple TV implementation: a circular `…` button appears next to the focused episode row and opens a modal action sheet titled with the episode. The menu lists the same actions in the same order as tvOS's playlist context (`.other(showGoToPodcast: true)`):

- Episode details
- Go to podcast
- Play next in Up Next
- Play last in Up Next
- Mark as played / Mark as unplayed (toggles on the episode's played state)
- Archive / Unarchive (toggles on the episode's archived state)

- New reusable `TvMoreButton` (circular ellipsis icon button, focus-scaled, styled like the existing TV icon buttons) and `TvEpisodeActionsModal` (built on `TvModal`, first action self-focuses), plus a horizontal-ellipsis drawable to match the tvOS glyph.
- The row and its `…` button are focus siblings: unfocused rows span the full width to the right margin, and when a row gains focus its container shrinks while the `…` button slides in from the right (and reverses on focus loss). LEFT from a row still focuses `Play all episodes`; RIGHT reaches the `…` button.
- **Scope is the menu UI only.** The action buttons are intentionally no-ops for now — wiring each action to the ViewModel/`EpisodeManager` comes in a follow-up, as does analytics (`episode_actions_shown` and per-action events).

Fixes PCDROID-693 https://linear.app/a8c/issue/PCDROID-693/playlist-details.
Designs: Ftk3KwnfqaK4g57yCN63p0-fi-3258_12136.

Stacked on `feat/tv-playlist-details-archived` (#5669) — merge bottom-up.

## Testing Instructions

1. Install the TV app (`./gradlew :tv:installDebugProd`) and open a playlist's details.
2. Move through the episode list with the d-pad — verify unfocused rows reach the right margin, and the focused row shrinks as the `…` button slides in from the right (and reverses when focus leaves).
3. Focus a row, press RIGHT to reach the `…` button, press select — a modal action sheet opens titled with the episode, first action focused.
4. Verify the actions and their order: Episode details, Go to podcast, Play next in Up Next, Play last in Up Next, Mark as played/unplayed, Archive/unarchive.
5. Verify the played/archive labels reflect the episode's state (e.g. an in-progress, unarchived episode reads "Mark as played" / "Archive").
6. Press back — the modal dismisses and focus returns to the `…` button.
7. Confirm the action buttons currently do nothing (no-op by design).

## Screenshots or Screencast

https://github.com/user-attachments/assets/c6d24dff-5314-42da-ac1a-21e4a9e2f2cc



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md _(TV app is unreleased — skipped)_
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes 
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics. _(analytics deliberately excluded — follow-up)_
