### PR TITLE
Release fingerprint codec buffers before suspending

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
@@ -1350,14 +1350,17 @@ class FingerprintTimingManager @Inject constructor(
                 outputIndex >= 0 -> {
                     val isEos = bufferInfo.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM != 0
 
-                    val outputBuffer = codec.getOutputBuffer(outputIndex)
-                    val samples = if (outputBuffer != null && bufferInfo.size > 0) {
-                        extractFloatSamples(outputBuffer, bufferInfo, isOutputFloat)
-                    } else {
-                        emptyList()
+                    // Never hold a buffer across onWindows suspending or an extraction throw, OMX decoders crash on it.
+                    val samples = try {
+                        val outputBuffer = codec.getOutputBuffer(outputIndex)
+                        if (outputBuffer != null && bufferInfo.size > 0) {
+                            extractFloatSamples(outputBuffer, bufferInfo, isOutputFloat)
+                        } else {
+                            emptyList()
+                        }
+                    } finally {
+                        codec.releaseOutputBuffer(outputIndex, false)
                     }
-                    // Release before onWindows suspends, a buffer held across cancellation crashes some OMX decoders.
-                    codec.releaseOutputBuffer(outputIndex, false)
                     if (samples.isNotEmpty()) {
                         val windows = streamer.pushSamplesF32(samples, stream.channelCount.toUShort())
                         if (windows.isNotEmpty()) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
@@ -1111,10 +1111,10 @@ class FingerprintTimingManager @Inject constructor(
         }
 
         override fun close() {
-            runCatching { codec.stop() }
-            codec.release()
-            extractor.release()
-            cacheSource?.close()
+            // Skip stop(): release() works from any state and the Executing→Idle transition crashes some OMX decoders.
+            runCatching { codec.release() }
+            runCatching { extractor.release() }
+            runCatching { cacheSource?.close() }
         }
     }
 
@@ -1184,34 +1184,34 @@ class FingerprintTimingManager @Inject constructor(
             throw AudioUnavailableException("no audio track found")
         }
 
-        extractor.selectTrack(audioTrackIndex)
-        val format = extractor.getTrackFormat(audioTrackIndex)
-        val sampleRate = format.getInteger(MediaFormat.KEY_SAMPLE_RATE)
-        val channelCount = format.getInteger(MediaFormat.KEY_CHANNEL_COUNT)
-        val mime = format.getString(MediaFormat.KEY_MIME) ?: "audio/mpeg"
+        try {
+            extractor.selectTrack(audioTrackIndex)
+            val format = extractor.getTrackFormat(audioTrackIndex)
+            val sampleRate = format.getInteger(MediaFormat.KEY_SAMPLE_RATE)
+            val channelCount = format.getInteger(MediaFormat.KEY_CHANNEL_COUNT)
+            val mime = format.getString(MediaFormat.KEY_MIME) ?: "audio/mpeg"
 
-        var startSec = startingAt
-        if (startingAt > 0) {
-            extractor.seekTo((startingAt * 1_000_000).toLong(), MediaExtractor.SEEK_TO_CLOSEST_SYNC)
-            val landedUs = extractor.sampleTime
-            if (landedUs >= 0) {
-                startSec = landedUs / 1_000_000.0
+            var startSec = startingAt
+            if (startingAt > 0) {
+                extractor.seekTo((startingAt * 1_000_000).toLong(), MediaExtractor.SEEK_TO_CLOSEST_SYNC)
+                val landedUs = extractor.sampleTime
+                if (landedUs >= 0) {
+                    startSec = landedUs / 1_000_000.0
+                }
+                Timber.d(
+                    "FingerprintTimingManager: extractor seek requested=%.2fs landed=%.2fs",
+                    startingAt,
+                    startSec,
+                )
             }
-            Timber.d(
-                "FingerprintTimingManager: extractor seek requested=%.2fs landed=%.2fs",
-                startingAt,
-                startSec,
-            )
-        }
 
-        val codec = try {
-            MediaCodec.createDecoderByType(mime)
+            val codec = MediaCodec.createDecoderByType(mime)
+            return AudioStream(extractor, codec, format, sampleRate, channelCount, startSec, cacheSource)
         } catch (e: Exception) {
             extractor.release()
             cacheSource?.close()
             throw AudioOpenException(e)
         }
-        return AudioStream(extractor, codec, format, sampleRate, channelCount, startSec, cacheSource)
     }
 
     private suspend fun streamFingerprint(
@@ -1341,19 +1341,22 @@ class FingerprintTimingManager @Inject constructor(
                     val isEos = bufferInfo.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM != 0
 
                     val outputBuffer = codec.getOutputBuffer(outputIndex)
-                    if (outputBuffer != null && bufferInfo.size > 0) {
-                        val samples = extractFloatSamples(outputBuffer, bufferInfo, isOutputFloat)
-                        if (samples.isNotEmpty()) {
-                            val windows = streamer.pushSamplesF32(samples, stream.channelCount.toUShort())
-                            if (windows.isNotEmpty()) {
-                                onWindows(windows)
-                                if (stopWhen?.invoke() == true) {
-                                    stopRequested = true
-                                }
+                    val samples = if (outputBuffer != null && bufferInfo.size > 0) {
+                        extractFloatSamples(outputBuffer, bufferInfo, isOutputFloat)
+                    } else {
+                        emptyList()
+                    }
+                    // Release before onWindows suspends, a buffer held across cancellation crashes some OMX decoders.
+                    codec.releaseOutputBuffer(outputIndex, false)
+                    if (samples.isNotEmpty()) {
+                        val windows = streamer.pushSamplesF32(samples, stream.channelCount.toUShort())
+                        if (windows.isNotEmpty()) {
+                            onWindows(windows)
+                            if (stopWhen?.invoke() == true) {
+                                stopRequested = true
                             }
                         }
                     }
-                    codec.releaseOutputBuffer(outputIndex, false)
                     if (isEos || stopRequested) break
                     if (endingAt != null && startOffset + streamer.durationMs().toDouble() / 1000.0 >= endingAt) break
                 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
@@ -1112,9 +1112,9 @@ class FingerprintTimingManager @Inject constructor(
 
         override fun close() {
             // Skip stop(): release() works from any state and the Executing→Idle transition crashes some OMX decoders.
-            runCatching { codec.release() }
-            runCatching { extractor.release() }
-            runCatching { cacheSource?.close() }
+            runCatching { codec.release() }.onFailure { Timber.d(it, "FingerprintTimingManager: codec release failed") }
+            runCatching { extractor.release() }.onFailure { Timber.d(it, "FingerprintTimingManager: extractor release failed") }
+            runCatching { cacheSource?.close() }.onFailure { Timber.d(it, "FingerprintTimingManager: cache source close failed") }
         }
     }
 
@@ -1359,7 +1359,9 @@ class FingerprintTimingManager @Inject constructor(
                             emptyList()
                         }
                     } finally {
-                        codec.releaseOutputBuffer(outputIndex, false)
+                        runCatching { codec.releaseOutputBuffer(outputIndex, false) }.onFailure {
+                            Timber.d(it, "FingerprintTimingManager: codec releaseOutputBuffer failed")
+                        }
                     }
                     if (samples.isNotEmpty()) {
                         val windows = streamer.pushSamplesF32(samples, stream.channelCount.toUShort())

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
@@ -1169,6 +1169,11 @@ class FingerprintTimingManager @Inject constructor(
             } else {
                 extractor.setDataSource(audioFilePath)
             }
+        } catch (e: CancellationException) {
+            // Cancellation is not an open failure, don't let it reach markFailed.
+            extractor.release()
+            cacheSource?.close()
+            throw e
         } catch (e: Exception) {
             extractor.release()
             cacheSource?.close()
@@ -1207,6 +1212,11 @@ class FingerprintTimingManager @Inject constructor(
 
             val codec = MediaCodec.createDecoderByType(mime)
             return AudioStream(extractor, codec, format, sampleRate, channelCount, startSec, cacheSource)
+        } catch (e: CancellationException) {
+            // Cancellation is not an open failure, don't let it reach markFailed.
+            extractor.release()
+            cacheSource?.close()
+            throw e
         } catch (e: Exception) {
             extractor.release()
             cacheSource?.close()


### PR DESCRIPTION
## Description

This replaces #5647, which has become difficult to merge.

#5647 was branched off `feat/fingerprint-pcm-tap` rather than `main`, so it carried the entire fingerprint feature stack (~50 commits) underneath the one commit that actually mattered. That stack has since landed in `main` through its own PRs, but the branch's history had diverged far enough that reconciling it against `main` was more work than it was worth. This branch is cut fresh from `main` with the single fix cherry-picked on top, so the diff is now just the one file it was always meant to be.

The change itself is unmodified from #5647 apart from dropping a stray IDE auto-import (a self-referential companion import of `isWithinMatchedContent`) that the original commit picked up. `main` compiles without it, and with warnings-as-errors it was a build risk. The full investigation and reasoning are in the description of #5647 and still apply; a summary follows.

### The crash

A native crash reported mainly on Huawei devices, on Android 9 and below:

```
#00  /system/lib64/libstagefright.so (android::ACodec::BaseState::onOMXFillBufferDone(...)+2064)
#01  /system/lib64/libstagefright.so (android::ACodec::BaseState::onOMXMessage(...)+764)
```

No Java frames: a SIGSEGV on the codec's own looper thread, inside the handler that runs when an OMX component returns a filled output buffer. That crashes when the buffer's bookkeeping entry has been freed while the component still had it in flight, the classic ACodec teardown race. `ACodec` is the legacy OMX path, which is why it clusters on vendor decoders like HiSilicon's rather than on Codec2 devices.

The only hand-rolled `MediaCodec` loop we have is the fingerprint decoder, and it had exactly that race. In `decodeAndFingerprint`, the dequeued output buffer was held across the `onWindows` callback, which suspends on `mutex.withLock` for the continuous path and runs under `withTimeoutOrNull` for both the on-demand and catch-up resolve paths. Cancelling at that point skipped `releaseOutputBuffer`, and `AudioStream.close()` then tore the codec down while we still owned a buffer. Cancellation there is routine, not an edge case: every generation change and every resolve timeout hits it.

### What changed

- **`decodeAndFingerprint`**: copy the samples out and call `releaseOutputBuffer` *before* any suspending work. `extractFloatSamples` already copies into a `FloatArray`, so the `ByteBuffer` is not referenced afterwards. The codec now owns all of its buffers at every cancellation point.
- **`AudioStream.close()`**: drop `stop()`. `release()` is valid from any state, while `stop()` forces the Executing to Idle transition that requires a full buffer census and is where these decoders fail. Each teardown step is individually guarded so one failure cannot leak the others.
- **`openAudioStream`**: a malformed track format (missing sample rate or channel count) or a failing `createDecoderByType` used to leak the extractor and cache source and escape the `AudioOpenException` classification. Both are now cleaned up and rethrown as `AudioOpenException`, which callers already degrade gracefully on.

### Notes for reviewers

- The native crash cannot be caught from Kotlin, so the only available handling is to stop provoking it. I checked the Java-level paths separately: every entry into the codec loop already catches `Exception` and degrades gracefully (eager decode marks failed, chapter resolve returns `Unresolved(REASON_AUDIO_UNAVAILABLE)`, catch-up resolve is logged and dropped), so `CodecException`/`IllegalStateException` were never app-killers.
- One residual case left alone deliberately: a cancelled network read can abandon a dequeued *input* buffer. There is no API to hand an unqueued input buffer back, `release()` is documented to cope with it, and the crash is on the output (`FillBufferDone`) side.
- The PCM-tap rework already in `main` removed the largest exposure by dropping the always-on parallel decoder during playback. On top of that, the codec loop now only runs for eager passes on downloaded episodes and short bounded resolves.
- If Huawei crash volume does not drop after this ships, we should decide whether to disable this feature for those users.

## Testing Instructions

This is a race on a cancellation path, so the useful test is to exercise cancellation hard while the eager decoder runs:

1. Make sure the Synced Transcripts feature flag is on in Developer settings.
2. Play a **downloaded** episode of a podcast with a generated transcript (the eager local decode only runs for downloaded episodes).
3. Open the transcript and seek repeatedly and rapidly, including tapping transcript rows to seek. Each seek cancels and restarts the decode generation, which is the path that used to abandon a buffer.
4. Confirm playback and transcript highlighting stay correct and the app does not crash.
5. Ideally repeat on a Huawei or other HiSilicon device, or any Android 9 or below device, where the legacy ACodec path is in use.

## Screenshots or Screencast

n/a, no UI changes.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md — n/a, this fixes an unreleased feature behind the `synced_transcripts` flag
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting) — `spotlessCheck` passes
- [x] I have considered whether it makes sense to add tests for my changes — the existing fingerprint suite passes; the race is in real `MediaCodec` buffer ownership and is not reachable from JVM unit tests
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml` — n/a, no strings
- [x] Any jetpack compose components I added or changed are covered by compose previews — n/a, no UI
- [x] I have updated (or requested that someone edit) the Event Horizon schema — n/a, no analytics changes
