### PR TITLE
Open HLS videos in the player like mp4, and fix their content_type analytics

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -163,6 +163,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.opml.OpmlImportTask
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackNoticeType
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
+import au.com.shiftyjelly.pocketcasts.repositories.playback.StreamVideoState
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextSource
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.Playlist
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
@@ -716,7 +717,9 @@ class MainActivity :
     override fun onStart() {
         super.onStart()
         if (resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
-            if (!videoPlayerShown && playbackManager.getCurrentEpisode()?.isVideo == true && playbackManager.isPlaybackLocal() && playbackManager.isPlaying() && viewModel.isPlayerOpen) {
+            val isPlayingVideo = (playbackManager.getCurrentEpisode()?.isVideo == true && !settings.audioOnly.value) ||
+                playbackManager.streamVideoState.value == StreamVideoState.HasVideo
+            if (!videoPlayerShown && isPlayingVideo && playbackManager.isPlaybackLocal() && playbackManager.isPlaying() && viewModel.isPlayerOpen) {
                 openFullscreenViewPlayer()
             } else {
                 videoPlayerShown = false
@@ -733,6 +736,14 @@ class MainActivity :
         // addCallback() again in order to tell the media router that it no longer
         // needs to invest effort trying to discover routes of these kinds for now.
         mediaRouter?.addCallback(mediaRouteSelector, mediaRouterCallback, 0)
+    }
+
+    private fun openVideoPlayer() {
+        if (resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT) {
+            binding.playerBottomSheet.openPlayer()
+        } else {
+            openFullscreenViewPlayer()
+        }
     }
 
     private fun openFullscreenViewPlayer() {
@@ -1061,36 +1072,47 @@ class MainActivity :
 
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.playbackState.collect { state ->
-                    val lastPlaybackState = viewModel.lastPlaybackState
-                    val isEpisodeChanged = lastPlaybackState?.episodeUuid != state.episodeUuid
-                    val isPlaybackChanged = lastPlaybackState?.isPlaying == false && state.isPlaying
+                combine(
+                    viewModel.playbackState,
+                    playbackManager.streamVideoState,
+                ) { state, streamVideoState -> state to streamVideoState }
+                    .collect { (state, streamVideoState) ->
+                        val lastPlaybackState = viewModel.lastPlaybackState
+                        val isEpisodeChanged = lastPlaybackState?.episodeUuid != state.episodeUuid
+                        val isPlaybackChanged = lastPlaybackState?.isPlaying == false && state.isPlaying
+                        val didResolveVideoStream = viewModel.lastStreamVideoState == StreamVideoState.Unknown &&
+                            streamVideoState == StreamVideoState.HasVideo
 
-                    if (isEpisodeChanged || isPlaybackChanged) {
-                        val episode = withContext(Dispatchers.Default) {
-                            episodeManager.findEpisodeByUuid(state.episodeUuid)
-                        }
-                        if (episode?.isVideo == true && state.isPlaying) {
-                            if (resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT) {
-                                binding.playerBottomSheet.openPlayer()
-                            } else {
-                                openFullscreenViewPlayer()
+                        if (isEpisodeChanged || isPlaybackChanged) {
+                            val episode = withContext(Dispatchers.Default) {
+                                episodeManager.findEpisodeByUuid(state.episodeUuid)
+                            }
+                            if (episode?.isVideo == true && state.isPlaying && !settings.audioOnly.value) {
+                                openVideoPlayer()
                             }
                         }
+
+                        if (didResolveVideoStream &&
+                            state.isPlaying &&
+                            playbackManager.isPlaybackLocal() &&
+                            playbackManager.getCurrentEpisode()?.isVideo != true
+                        ) {
+                            openVideoPlayer()
+                        }
+
+                        if (viewModel.isPlayerOpen && isEpisodeChanged) {
+                            updateNavAndStatusColors(playerOpen = true, playingPodcast = state.podcast)
+                        }
+
+                        if (lastPlaybackState != null && (isEpisodeChanged || isPlaybackChanged) && settings.openPlayerAutomatically.value) {
+                            binding.playerBottomSheet.openPlayer()
+                        }
+
+                        updatePlaybackState(state)
+
+                        viewModel.lastPlaybackState = state
+                        viewModel.lastStreamVideoState = streamVideoState
                     }
-
-                    if (viewModel.isPlayerOpen && isEpisodeChanged) {
-                        updateNavAndStatusColors(playerOpen = true, playingPodcast = state.podcast)
-                    }
-
-                    if (lastPlaybackState != null && (isEpisodeChanged || isPlaybackChanged) && settings.openPlayerAutomatically.value) {
-                        binding.playerBottomSheet.openPlayer()
-                    }
-
-                    updatePlaybackState(state)
-
-                    viewModel.lastPlaybackState = state
-                }
             }
         }
 

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -717,8 +717,11 @@ class MainActivity :
     override fun onStart() {
         super.onStart()
         if (resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
-            val isPlayingVideo = (playbackManager.getCurrentEpisode()?.isVideo == true && !settings.audioOnly.value) ||
-                (playbackManager.streamVideoState.value == StreamVideoState.HasVideo && playbackManager.videoRenderingEnabled.value)
+            val isPlayingVideo = playbackManager.videoRenderingEnabled.value &&
+                (
+                    (playbackManager.getCurrentEpisode()?.isVideo == true && !settings.audioOnly.value) ||
+                        playbackManager.streamVideoState.value == StreamVideoState.HasVideo
+                    )
             if (!videoPlayerShown && isPlayingVideo && playbackManager.isPlaybackLocal() && playbackManager.isPlaying() && viewModel.isPlayerOpen) {
                 openFullscreenViewPlayer()
             } else {

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -1084,7 +1084,7 @@ class MainActivity :
                         val episode = withContext(Dispatchers.Default) {
                             episodeManager.findEpisodeByUuid(state.episodeUuid)
                         }
-                        if (episode?.isVideo == true && state.isPlaying && !settings.audioOnly.value) {
+                        if (episode?.isVideo == true && state.isPlaying && !settings.audioOnly.value && playbackManager.videoRenderingEnabled.value) {
                             openVideoPlayer()
                         }
                     }

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -718,7 +718,7 @@ class MainActivity :
         super.onStart()
         if (resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
             val isPlayingVideo = (playbackManager.getCurrentEpisode()?.isVideo == true && !settings.audioOnly.value) ||
-                playbackManager.streamVideoState.value == StreamVideoState.HasVideo
+                (playbackManager.streamVideoState.value == StreamVideoState.HasVideo && playbackManager.videoRenderingEnabled.value)
             if (!videoPlayerShown && isPlayingVideo && playbackManager.isPlaybackLocal() && playbackManager.isPlaying() && viewModel.isPlayerOpen) {
                 openFullscreenViewPlayer()
             } else {
@@ -1072,47 +1072,52 @@ class MainActivity :
 
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
-                combine(
-                    viewModel.playbackState,
-                    playbackManager.streamVideoState,
-                ) { state, streamVideoState -> state to streamVideoState }
-                    .collect { (state, streamVideoState) ->
-                        val lastPlaybackState = viewModel.lastPlaybackState
-                        val isEpisodeChanged = lastPlaybackState?.episodeUuid != state.episodeUuid
-                        val isPlaybackChanged = lastPlaybackState?.isPlaying == false && state.isPlaying
-                        val didResolveVideoStream = viewModel.lastStreamVideoState == StreamVideoState.Unknown &&
-                            streamVideoState == StreamVideoState.HasVideo
+                viewModel.playbackState.collect { state ->
+                    val lastPlaybackState = viewModel.lastPlaybackState
+                    val isEpisodeChanged = lastPlaybackState?.episodeUuid != state.episodeUuid
+                    val isPlaybackChanged = lastPlaybackState?.isPlaying == false && state.isPlaying
 
-                        if (isEpisodeChanged || isPlaybackChanged) {
-                            val episode = withContext(Dispatchers.Default) {
-                                episodeManager.findEpisodeByUuid(state.episodeUuid)
-                            }
-                            if (episode?.isVideo == true && state.isPlaying && !settings.audioOnly.value) {
-                                openVideoPlayer()
-                            }
+                    if (isEpisodeChanged || isPlaybackChanged) {
+                        val episode = withContext(Dispatchers.Default) {
+                            episodeManager.findEpisodeByUuid(state.episodeUuid)
                         }
-
-                        if (didResolveVideoStream &&
-                            state.isPlaying &&
-                            playbackManager.isPlaybackLocal() &&
-                            playbackManager.getCurrentEpisode()?.isVideo != true
-                        ) {
+                        if (episode?.isVideo == true && state.isPlaying && !settings.audioOnly.value) {
                             openVideoPlayer()
                         }
-
-                        if (viewModel.isPlayerOpen && isEpisodeChanged) {
-                            updateNavAndStatusColors(playerOpen = true, playingPodcast = state.podcast)
-                        }
-
-                        if (lastPlaybackState != null && (isEpisodeChanged || isPlaybackChanged) && settings.openPlayerAutomatically.value) {
-                            binding.playerBottomSheet.openPlayer()
-                        }
-
-                        updatePlaybackState(state)
-
-                        viewModel.lastPlaybackState = state
-                        viewModel.lastStreamVideoState = streamVideoState
                     }
+
+                    if (viewModel.isPlayerOpen && isEpisodeChanged) {
+                        updateNavAndStatusColors(playerOpen = true, playingPodcast = state.podcast)
+                    }
+
+                    if (lastPlaybackState != null && (isEpisodeChanged || isPlaybackChanged) && settings.openPlayerAutomatically.value) {
+                        binding.playerBottomSheet.openPlayer()
+                    }
+
+                    updatePlaybackState(state)
+
+                    viewModel.lastPlaybackState = state
+                }
+            }
+        }
+
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                var previousStreamVideoState: StreamVideoState? = null
+                playbackManager.streamVideoState.collect { streamVideoState ->
+                    val didResolveVideoStream = previousStreamVideoState == StreamVideoState.Unknown &&
+                        streamVideoState == StreamVideoState.HasVideo
+                    previousStreamVideoState = streamVideoState
+
+                    if (didResolveVideoStream &&
+                        playbackManager.isPlaying() &&
+                        playbackManager.isPlaybackLocal() &&
+                        playbackManager.videoRenderingEnabled.value &&
+                        playbackManager.getCurrentEpisode()?.isVideo != true
+                    ) {
+                        openVideoPlayer()
+                    }
+                }
             }
         }
 

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModel.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModel.kt
@@ -18,7 +18,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackNoticeInfo
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackNoticeManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
-import au.com.shiftyjelly.pocketcasts.repositories.playback.StreamVideoState
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
@@ -78,7 +77,6 @@ class MainActivityViewModel
             _isPlayerOpen.value = value
         }
     var lastPlaybackState: PlaybackState? = null
-    var lastStreamVideoState: StreamVideoState = StreamVideoState.NotVideo
 
     val playbackNoticeFlow: StateFlow<PlaybackNoticeInfo?> = playbackNoticeManager.playbackNotice
         .stateIn(viewModelScope, started = SharingStarted.WhileSubscribed(5_000), initialValue = null)

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModel.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModel.kt
@@ -18,6 +18,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackNoticeInfo
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackNoticeManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
+import au.com.shiftyjelly.pocketcasts.repositories.playback.StreamVideoState
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
@@ -77,6 +78,7 @@ class MainActivityViewModel
             _isPlayerOpen.value = value
         }
     var lastPlaybackState: PlaybackState? = null
+    var lastStreamVideoState: StreamVideoState = StreamVideoState.NotVideo
 
     val playbackNoticeFlow: StateFlow<PlaybackNoticeInfo?> = playbackNoticeManager.playbackNotice
         .stateIn(viewModelScope, started = SharingStarted.WhileSubscribed(5_000), initialValue = null)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -403,7 +403,7 @@ open class PlaybackManager @Inject constructor(
             PlaybackEpisodeAutoplayedEvent(
                 episodeUuid = autoPlayEpisode.uuid,
                 hlsAvailable = autoPlayOffersHls,
-                audioOnlyMode = audioOnlyModeOrNull(autoPlayEpisode, hlsRelevant = autoPlayOffersHls),
+                audioOnlyMode = if (autoPlayOffersHls || autoPlayEpisode.isVideo) settings.audioOnly.value else null,
             ),
         )
         return autoPlayEpisode
@@ -2169,12 +2169,15 @@ open class PlaybackManager @Inject constructor(
 
         flushPendingContentTypeEvents()
 
+        val playingRemotely = castManager.isConnected()
+
         // Audio only forces video content to audio. Otherwise HLS starts Unknown until the tracks resolve it; non-HLS keeps its own flag.
         synchronized(pendingContentTypeEvents) {
             _streamVideoState.value = StreamVideoState.initialFor(
                 episode,
                 audioOnly = settings.audioOnly.value,
                 playingHlsStream = playingStream && episode.isStreamUrlHls,
+                isRemote = playingRemotely,
             )
         }
         _videoRenderingEnabled.value = true
@@ -2930,7 +2933,7 @@ open class PlaybackManager @Inject constructor(
                 source = source.analyticsValue,
                 contentType = contentType,
                 hlsAvailable = hlsAvailable,
-                audioOnlyMode = audioOnlyModeOrNull(),
+                audioOnlyMode = audioOnlyModeOrNull(episode, hlsRelevant = _streamVideoState.value != StreamVideoState.NotVideo),
             )
         }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -403,7 +403,7 @@ open class PlaybackManager @Inject constructor(
             PlaybackEpisodeAutoplayedEvent(
                 episodeUuid = autoPlayEpisode.uuid,
                 hlsAvailable = autoPlayOffersHls,
-                audioOnlyMode = if (autoPlayOffersHls) settings.audioOnly.value else null,
+                audioOnlyMode = audioOnlyModeOrNull(autoPlayEpisode, hlsRelevant = autoPlayOffersHls),
             ),
         )
         return autoPlayEpisode
@@ -499,8 +499,12 @@ open class PlaybackManager @Inject constructor(
 
     private fun audioOnlyModeOrNull(): Boolean? {
         val episode = getCurrentEpisode() ?: return null
-        val playingHlsStream = episode.isStreamUrlHls && player?.isStreaming == true
-        if (!playingHlsStream && !episode.isVideo) return null
+        return audioOnlyModeOrNull(episode, hlsRelevant = _streamVideoState.value != StreamVideoState.NotVideo)
+    }
+
+    private fun audioOnlyModeOrNull(episode: BaseEpisode?, hlsRelevant: Boolean): Boolean? {
+        if (episode == null) return null
+        if (!hlsRelevant && !episode.isVideo) return null
         return settings.audioOnly.value || !_videoRenderingEnabled.value
     }
 
@@ -2921,13 +2925,12 @@ open class PlaybackManager @Inject constructor(
             return
         }
         val hlsAvailable = _streamHlsAvailable.value
-        val audioOnlyMode = audioOnlyModeOrNull()
         trackWithContentType(episode) { contentType ->
             PlaybackPlayEvent(
                 source = source.analyticsValue,
                 contentType = contentType,
                 hlsAvailable = hlsAvailable,
-                audioOnlyMode = audioOnlyMode,
+                audioOnlyMode = audioOnlyModeOrNull(),
             )
         }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -2165,11 +2165,10 @@ open class PlaybackManager @Inject constructor(
             videoStreamPreferredEpisodeUuid = null
         }
 
-        val playingStream = !episode.isDownloaded || (videoStreamPreferred && episode.isStreamUrlHls && !castManager.isConnected())
+        val castConnected = castManager.isConnected()
+        val playingStream = !episode.isDownloaded || (videoStreamPreferred && episode.isStreamUrlHls && !castConnected)
 
         flushPendingContentTypeEvents()
-
-        val playingRemotely = castManager.isConnected()
 
         // Audio only forces video content to audio. Otherwise HLS starts Unknown until the tracks resolve it; non-HLS keeps its own flag.
         synchronized(pendingContentTypeEvents) {
@@ -2177,7 +2176,7 @@ open class PlaybackManager @Inject constructor(
                 episode,
                 audioOnly = settings.audioOnly.value,
                 playingHlsStream = playingStream && episode.isStreamUrlHls,
-                isRemote = playingRemotely,
+                isRemote = castConnected,
             )
         }
         _videoRenderingEnabled.value = true
@@ -2283,7 +2282,7 @@ open class PlaybackManager @Inject constructor(
         // We want to make sure we get the current position at the last possible moment before changing/resetting the player
         val currentPositionMs = if (
             isPlayerSwitchRequired() ||
-            isPlayerResetNeeded(episode, sameEpisode, castManager.isConnected(), playingStream)
+            isPlayerResetNeeded(episode, sameEpisode, castConnected, playingStream)
         ) {
             // Don't create a player if we aren't playing because it will start to buffer
             if (play) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1042,6 +1042,8 @@ open class PlaybackManager @Inject constructor(
     suspend fun stop() {
         LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Stopping playback")
 
+        flushPendingContentTypeEvents()
+
         cancelPrefetchNextEpisode()
         cancelUpdateTimer()
         cancelBufferUpdateTimer()
@@ -2923,24 +2925,30 @@ open class PlaybackManager @Inject constructor(
     private fun trackWithContentType(episode: BaseEpisode, build: (PlaybackContentType) -> Trackable) {
         val contentType = playbackContentTypeFor(episode)
         if (contentType == PlaybackContentType.Unknown) {
-            pendingContentTypeEvents += PendingContentTypeEvent(episode.uuid, build)
+            synchronized(pendingContentTypeEvents) {
+                pendingContentTypeEvents += PendingContentTypeEvent(episode.uuid, build)
+            }
         } else {
             eventHorizon.track(build(contentType))
         }
     }
 
     private fun firePendingContentTypeEvents(contentType: PlaybackContentType) {
-        if (pendingContentTypeEvents.isEmpty()) return
         val currentUuid = getCurrentEpisode()?.uuid
-        val ready = pendingContentTypeEvents.filter { it.episodeUuid == currentUuid }
-        pendingContentTypeEvents.removeAll(ready)
+        val ready = synchronized(pendingContentTypeEvents) {
+            val matched = pendingContentTypeEvents.filter { it.episodeUuid == currentUuid }
+            pendingContentTypeEvents.removeAll(matched)
+            matched
+        }
         ready.forEach { eventHorizon.track(it.build(contentType)) }
     }
 
     private fun flushPendingContentTypeEvents() {
-        if (pendingContentTypeEvents.isEmpty()) return
-        val pending = pendingContentTypeEvents.toList()
-        pendingContentTypeEvents.clear()
+        val pending = synchronized(pendingContentTypeEvents) {
+            val copy = pendingContentTypeEvents.toList()
+            pendingContentTypeEvents.clear()
+            copy
+        }
         pending.forEach { eventHorizon.track(it.build(PlaybackContentType.Unknown)) }
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -286,6 +286,14 @@ open class PlaybackManager @Inject constructor(
 
     private var lastPlaybackSource: SourceView? = null
 
+    private data class PendingPlayEvent(
+        val source: SourceView,
+        val episodeUuid: String,
+        val hlsAvailable: Boolean?,
+        val audioOnlyMode: Boolean?,
+    )
+    private var pendingPlayEvent: PendingPlayEvent? = null
+
     var player: Player?
         get() = _playerFlow.value
         set(value) {
@@ -2154,6 +2162,8 @@ open class PlaybackManager @Inject constructor(
 
         val playingStream = !episode.isDownloaded || (videoStreamPreferred && episode.isStreamUrlHls && !castManager.isConnected())
 
+        flushPendingPlayEvent()
+
         // Audio only forces video content to audio. Otherwise HLS starts Unknown until the tracks resolve it; non-HLS keeps its own flag.
         _streamVideoState.value = StreamVideoState.initialFor(
             episode,
@@ -2504,14 +2514,7 @@ open class PlaybackManager @Inject constructor(
         sleepTimer.restartSleepTimerIfApplies(currentEpisodeUuid = episode.uuid)
 
         lastPlaybackSource = sourceView
-        trackPlaybackEvent(sourceView) { source, contentType ->
-            PlaybackPlayEvent(
-                source = source.analyticsValue,
-                contentType = contentType,
-                hlsAvailable = _streamHlsAvailable.value,
-                audioOnlyMode = audioOnlyModeOrNull(),
-            )
-        }
+        trackPlaybackPlay(sourceView, episode.uuid)
     }
 
     private suspend fun addPodcastStartFromSettings(episode: PodcastEpisode, podcast: Podcast?, isPlaying: Boolean) {
@@ -2584,6 +2587,13 @@ open class PlaybackManager @Inject constructor(
 
     private fun onVideoTrackChanged(hasVideo: Boolean) {
         _streamVideoState.value = if (hasVideo) StreamVideoState.HasVideo else StreamVideoState.AudioOnly
+
+        val pending = pendingPlayEvent
+        if (pending != null && pending.episodeUuid == getCurrentEpisode()?.uuid) {
+            pendingPlayEvent = null
+            val contentType = if (hasVideo) PlaybackContentType.Video else PlaybackContentType.Audio
+            firePlaybackPlayEvent(pending.source, contentType, pending.hlsAvailable, pending.audioOnlyMode)
+        }
     }
 
     private suspend fun updateCurrentPositionInDatabase() {
@@ -2895,12 +2905,47 @@ open class PlaybackManager @Inject constructor(
         if (source == SourceView.AUTO_PLAY || source == SourceView.AUTO_PAUSE) {
             return
         }
-        val contentType = if (getCurrentEpisode()?.isVideo == true) {
-            PlaybackContentType.Video
-        } else {
-            PlaybackContentType.Audio
-        }
+        val contentType = playbackContentTypeFor(getCurrentEpisode())
         eventHorizon.track(event(source, contentType))
+    }
+
+    private fun trackPlaybackPlay(source: SourceView, episodeUuid: String) {
+        if (source == SourceView.UNKNOWN) {
+            Timber.w("Found unknown playback source.")
+        }
+        if (source == SourceView.AUTO_PLAY || source == SourceView.AUTO_PAUSE) {
+            return
+        }
+        val hlsAvailable = _streamHlsAvailable.value
+        val audioOnlyMode = audioOnlyModeOrNull()
+        val contentType = playbackContentTypeFor(getCurrentEpisode())
+        if (contentType == PlaybackContentType.Unknown) {
+            pendingPlayEvent = PendingPlayEvent(source, episodeUuid, hlsAvailable, audioOnlyMode)
+        } else {
+            firePlaybackPlayEvent(source, contentType, hlsAvailable, audioOnlyMode)
+        }
+    }
+
+    private fun firePlaybackPlayEvent(
+        source: SourceView,
+        contentType: PlaybackContentType,
+        hlsAvailable: Boolean?,
+        audioOnlyMode: Boolean?,
+    ) {
+        eventHorizon.track(
+            PlaybackPlayEvent(
+                source = source.analyticsValue,
+                contentType = contentType,
+                hlsAvailable = hlsAvailable,
+                audioOnlyMode = audioOnlyMode,
+            ),
+        )
+    }
+
+    private fun flushPendingPlayEvent() {
+        val pending = pendingPlayEvent ?: return
+        pendingPlayEvent = null
+        firePlaybackPlayEvent(pending.source, PlaybackContentType.Unknown, pending.hlsAvailable, pending.audioOnlyMode)
     }
 
     fun trackPlaybackSeek(

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -2586,8 +2586,15 @@ open class PlaybackManager @Inject constructor(
     }
 
     private fun onVideoTrackChanged(hasVideo: Boolean) {
-        _streamVideoState.value = if (hasVideo) StreamVideoState.HasVideo else StreamVideoState.AudioOnly
-        firePendingContentTypeEvents(if (hasVideo) PlaybackContentType.Video else PlaybackContentType.Audio)
+        val currentUuid = getCurrentEpisode()?.uuid
+        val contentType = if (hasVideo) PlaybackContentType.Video else PlaybackContentType.Audio
+        val ready = synchronized(pendingContentTypeEvents) {
+            _streamVideoState.value = if (hasVideo) StreamVideoState.HasVideo else StreamVideoState.AudioOnly
+            val matched = pendingContentTypeEvents.filter { it.episodeUuid == currentUuid }
+            pendingContentTypeEvents.removeAll(matched)
+            matched
+        }
+        ready.forEach { eventHorizon.track(it.build(contentType)) }
     }
 
     private suspend fun updateCurrentPositionInDatabase() {
@@ -2923,24 +2930,16 @@ open class PlaybackManager @Inject constructor(
     }
 
     private fun trackWithContentType(episode: BaseEpisode, build: (PlaybackContentType) -> Trackable) {
-        val contentType = playbackContentTypeFor(episode)
-        if (contentType == PlaybackContentType.Unknown) {
-            synchronized(pendingContentTypeEvents) {
+        val event = synchronized(pendingContentTypeEvents) {
+            val contentType = playbackContentTypeFor(episode)
+            if (contentType == PlaybackContentType.Unknown) {
                 pendingContentTypeEvents += PendingContentTypeEvent(episode.uuid, build)
+                null
+            } else {
+                build(contentType)
             }
-        } else {
-            eventHorizon.track(build(contentType))
         }
-    }
-
-    private fun firePendingContentTypeEvents(contentType: PlaybackContentType) {
-        val currentUuid = getCurrentEpisode()?.uuid
-        val ready = synchronized(pendingContentTypeEvents) {
-            val matched = pendingContentTypeEvents.filter { it.episodeUuid == currentUuid }
-            pendingContentTypeEvents.removeAll(matched)
-            matched
-        }
-        ready.forEach { eventHorizon.track(it.build(contentType)) }
+        event?.let(eventHorizon::track)
     }
 
     private fun flushPendingContentTypeEvents() {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -286,13 +286,11 @@ open class PlaybackManager @Inject constructor(
 
     private var lastPlaybackSource: SourceView? = null
 
-    private data class PendingPlayEvent(
-        val source: SourceView,
+    private class PendingContentTypeEvent(
         val episodeUuid: String,
-        val hlsAvailable: Boolean?,
-        val audioOnlyMode: Boolean?,
+        val build: (PlaybackContentType) -> Trackable,
     )
-    private var pendingPlayEvent: PendingPlayEvent? = null
+    private val pendingContentTypeEvents = mutableListOf<PendingContentTypeEvent>()
 
     var player: Player?
         get() = _playerFlow.value
@@ -2162,7 +2160,7 @@ open class PlaybackManager @Inject constructor(
 
         val playingStream = !episode.isDownloaded || (videoStreamPreferred && episode.isStreamUrlHls && !castManager.isConnected())
 
-        flushPendingPlayEvent()
+        flushPendingContentTypeEvents()
 
         // Audio only forces video content to audio. Otherwise HLS starts Unknown until the tracks resolve it; non-HLS keeps its own flag.
         _streamVideoState.value = StreamVideoState.initialFor(
@@ -2174,16 +2172,16 @@ open class PlaybackManager @Inject constructor(
 
         lastPlaybackSource = sourceView
 
-        eventHorizon.track(
+        trackWithContentType(episode) { contentType ->
             PlaybackSourceResolvedEvent(
                 playbackProtocol = if (playingStream && episode.isStreamUrlHls) PlaybackProtocolType.Hls else PlaybackProtocolType.Progressive,
                 isFallback = false,
-                contentType = playbackContentTypeFor(episode),
+                contentType = contentType,
                 episodeUuid = episode.uuid,
                 podcastUuid = episode.podcastOrSubstituteUuid,
                 hlsEngine = if (playingStream && episode.isStreamUrlHls) HLS_ENGINE_EXOPLAYER else null,
-            ),
-        )
+            )
+        }
 
         LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Opening episode. %s Downloaded: %b Downloading: %b Audio: %b File: %s Uuid: %s", episode.title, episode.isDownloaded, episode.isDownloading, episode.isAudio, episode.downloadUrl ?: "", episode.uuid)
         if (BuildConfig.DEBUG) {
@@ -2514,7 +2512,7 @@ open class PlaybackManager @Inject constructor(
         sleepTimer.restartSleepTimerIfApplies(currentEpisodeUuid = episode.uuid)
 
         lastPlaybackSource = sourceView
-        trackPlaybackPlay(sourceView, episode.uuid)
+        trackPlaybackPlay(sourceView, episode)
     }
 
     private suspend fun addPodcastStartFromSettings(episode: PodcastEpisode, podcast: Podcast?, isPlaying: Boolean) {
@@ -2587,13 +2585,7 @@ open class PlaybackManager @Inject constructor(
 
     private fun onVideoTrackChanged(hasVideo: Boolean) {
         _streamVideoState.value = if (hasVideo) StreamVideoState.HasVideo else StreamVideoState.AudioOnly
-
-        val pending = pendingPlayEvent
-        if (pending != null && pending.episodeUuid == getCurrentEpisode()?.uuid) {
-            pendingPlayEvent = null
-            val contentType = if (hasVideo) PlaybackContentType.Video else PlaybackContentType.Audio
-            firePlaybackPlayEvent(pending.source, contentType, pending.hlsAvailable, pending.audioOnlyMode)
-        }
+        firePendingContentTypeEvents(if (hasVideo) PlaybackContentType.Video else PlaybackContentType.Audio)
     }
 
     private suspend fun updateCurrentPositionInDatabase() {
@@ -2909,7 +2901,7 @@ open class PlaybackManager @Inject constructor(
         eventHorizon.track(event(source, contentType))
     }
 
-    private fun trackPlaybackPlay(source: SourceView, episodeUuid: String) {
+    private fun trackPlaybackPlay(source: SourceView, episode: BaseEpisode) {
         if (source == SourceView.UNKNOWN) {
             Timber.w("Found unknown playback source.")
         }
@@ -2918,34 +2910,38 @@ open class PlaybackManager @Inject constructor(
         }
         val hlsAvailable = _streamHlsAvailable.value
         val audioOnlyMode = audioOnlyModeOrNull()
-        val contentType = playbackContentTypeFor(getCurrentEpisode())
-        if (contentType == PlaybackContentType.Unknown) {
-            pendingPlayEvent = PendingPlayEvent(source, episodeUuid, hlsAvailable, audioOnlyMode)
-        } else {
-            firePlaybackPlayEvent(source, contentType, hlsAvailable, audioOnlyMode)
-        }
-    }
-
-    private fun firePlaybackPlayEvent(
-        source: SourceView,
-        contentType: PlaybackContentType,
-        hlsAvailable: Boolean?,
-        audioOnlyMode: Boolean?,
-    ) {
-        eventHorizon.track(
+        trackWithContentType(episode) { contentType ->
             PlaybackPlayEvent(
                 source = source.analyticsValue,
                 contentType = contentType,
                 hlsAvailable = hlsAvailable,
                 audioOnlyMode = audioOnlyMode,
-            ),
-        )
+            )
+        }
     }
 
-    private fun flushPendingPlayEvent() {
-        val pending = pendingPlayEvent ?: return
-        pendingPlayEvent = null
-        firePlaybackPlayEvent(pending.source, PlaybackContentType.Unknown, pending.hlsAvailable, pending.audioOnlyMode)
+    private fun trackWithContentType(episode: BaseEpisode, build: (PlaybackContentType) -> Trackable) {
+        val contentType = playbackContentTypeFor(episode)
+        if (contentType == PlaybackContentType.Unknown) {
+            pendingContentTypeEvents += PendingContentTypeEvent(episode.uuid, build)
+        } else {
+            eventHorizon.track(build(contentType))
+        }
+    }
+
+    private fun firePendingContentTypeEvents(contentType: PlaybackContentType) {
+        if (pendingContentTypeEvents.isEmpty()) return
+        val currentUuid = getCurrentEpisode()?.uuid
+        val ready = pendingContentTypeEvents.filter { it.episodeUuid == currentUuid }
+        pendingContentTypeEvents.removeAll(ready)
+        ready.forEach { eventHorizon.track(it.build(contentType)) }
+    }
+
+    private fun flushPendingContentTypeEvents() {
+        if (pendingContentTypeEvents.isEmpty()) return
+        val pending = pendingContentTypeEvents.toList()
+        pendingContentTypeEvents.clear()
+        pending.forEach { eventHorizon.track(it.build(PlaybackContentType.Unknown)) }
     }
 
     fun trackPlaybackSeek(

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1028,6 +1028,7 @@ open class PlaybackManager @Inject constructor(
     }
 
     suspend fun stopSuspend(isAudioFocusFailed: Boolean = false, sourceView: SourceView = SourceView.UNKNOWN) {
+        flushPendingContentTypeEvents()
         if (!isAudioFocusFailed) {
             trackPlaybackEvent(sourceView) { source, contentType ->
                 PlaybackStopEvent(
@@ -2165,11 +2166,13 @@ open class PlaybackManager @Inject constructor(
         flushPendingContentTypeEvents()
 
         // Audio only forces video content to audio. Otherwise HLS starts Unknown until the tracks resolve it; non-HLS keeps its own flag.
-        _streamVideoState.value = StreamVideoState.initialFor(
-            episode,
-            audioOnly = settings.audioOnly.value,
-            playingHlsStream = playingStream && episode.isStreamUrlHls,
-        )
+        synchronized(pendingContentTypeEvents) {
+            _streamVideoState.value = StreamVideoState.initialFor(
+                episode,
+                audioOnly = settings.audioOnly.value,
+                playingHlsStream = playingStream && episode.isStreamUrlHls,
+            )
+        }
         _videoRenderingEnabled.value = true
 
         lastPlaybackSource = sourceView

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Player.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Player.kt
@@ -43,9 +43,9 @@ enum class StreamVideoState {
     ;
 
     companion object {
-        fun initialFor(episode: BaseEpisode, audioOnly: Boolean, playingHlsStream: Boolean) = when {
+        fun initialFor(episode: BaseEpisode, audioOnly: Boolean, playingHlsStream: Boolean, isRemote: Boolean) = when {
             audioOnly && (episode.isVideo || playingHlsStream) -> AudioOnly
-            playingHlsStream -> Unknown
+            playingHlsStream && !isRemote -> Unknown
             else -> NotVideo
         }
     }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/StreamVideoStateTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/StreamVideoStateTest.kt
@@ -11,56 +11,70 @@ class StreamVideoStateTest {
     fun `audio episode starts not video`() {
         val episode = createEpisode(fileType = "audio/mpeg")
 
-        assertEquals(StreamVideoState.NotVideo, StreamVideoState.initialFor(episode, audioOnly = false, playingHlsStream = false))
+        assertEquals(StreamVideoState.NotVideo, StreamVideoState.initialFor(episode, audioOnly = false, playingHlsStream = false, isRemote = false))
     }
 
     @Test
     fun `audio episode ignores audio only`() {
         val episode = createEpisode(fileType = "audio/mpeg")
 
-        assertEquals(StreamVideoState.NotVideo, StreamVideoState.initialFor(episode, audioOnly = true, playingHlsStream = false))
+        assertEquals(StreamVideoState.NotVideo, StreamVideoState.initialFor(episode, audioOnly = true, playingHlsStream = false, isRemote = false))
     }
 
     @Test
     fun `video episode starts not video so its own flag decides`() {
         val episode = createEpisode(fileType = "video/mp4")
 
-        assertEquals(StreamVideoState.NotVideo, StreamVideoState.initialFor(episode, audioOnly = false, playingHlsStream = false))
+        assertEquals(StreamVideoState.NotVideo, StreamVideoState.initialFor(episode, audioOnly = false, playingHlsStream = false, isRemote = false))
     }
 
     @Test
     fun `audio only forces a video episode to audio`() {
         val episode = createEpisode(fileType = "video/mp4")
 
-        assertEquals(StreamVideoState.AudioOnly, StreamVideoState.initialFor(episode, audioOnly = true, playingHlsStream = false))
+        assertEquals(StreamVideoState.AudioOnly, StreamVideoState.initialFor(episode, audioOnly = true, playingHlsStream = false, isRemote = false))
     }
 
     @Test
     fun `hls stream starts unknown`() {
         val episode = createHlsEpisode()
 
-        assertEquals(StreamVideoState.Unknown, StreamVideoState.initialFor(episode, audioOnly = false, playingHlsStream = true))
+        assertEquals(StreamVideoState.Unknown, StreamVideoState.initialFor(episode, audioOnly = false, playingHlsStream = true, isRemote = false))
     }
 
     @Test
     fun `audio only forces an hls stream to audio`() {
         val episode = createHlsEpisode()
 
-        assertEquals(StreamVideoState.AudioOnly, StreamVideoState.initialFor(episode, audioOnly = true, playingHlsStream = true))
+        assertEquals(StreamVideoState.AudioOnly, StreamVideoState.initialFor(episode, audioOnly = true, playingHlsStream = true, isRemote = false))
+    }
+
+    @Test
+    fun `remote hls stream resolves without waiting for tracks`() {
+        val episode = createHlsEpisode()
+
+        assertEquals(StreamVideoState.NotVideo, StreamVideoState.initialFor(episode, audioOnly = false, playingHlsStream = true, isRemote = true))
+    }
+
+    @Test
+    fun `audio only forces a remote hls stream to audio`() {
+        val episode = createHlsEpisode()
+
+        assertEquals(StreamVideoState.AudioOnly, StreamVideoState.initialFor(episode, audioOnly = true, playingHlsStream = true, isRemote = true))
     }
 
     @Test
     fun `downloaded hls episode playing its local file starts not video`() {
         val episode = createHlsEpisode()
 
-        assertEquals(StreamVideoState.NotVideo, StreamVideoState.initialFor(episode, audioOnly = false, playingHlsStream = false))
+        assertEquals(StreamVideoState.NotVideo, StreamVideoState.initialFor(episode, audioOnly = false, playingHlsStream = false, isRemote = false))
     }
 
     @Test
     fun `downloaded hls episode playing its local audio file ignores audio only`() {
         val episode = createHlsEpisode()
 
-        assertEquals(StreamVideoState.NotVideo, StreamVideoState.initialFor(episode, audioOnly = true, playingHlsStream = false))
+        assertEquals(StreamVideoState.NotVideo, StreamVideoState.initialFor(episode, audioOnly = true, playingHlsStream = false, isRemote = false))
     }
 
     private fun createEpisode(fileType: String) = PodcastEpisode(


### PR DESCRIPTION
## Description

When you play a video episode, the player opens on its own (fullscreen in landscape). Until now this only worked for mp4 videos, not HLS ones. That's because an HLS episode isn't known to be video until its stream starts. This makes HLS videos behave the same: once the stream reports video, the player opens like it does for mp4.

Two related things came up while testing and are fixed here too:
- mp4 videos no longer open when Audio-only mode is on.
- Toggling Audio-only off mid-playback no longer pops the player open.

It also fixes the analytics. `playback_play` and `playback_source_resolved` were reporting the wrong `content_type` for HLS (`audio`, then `unknown`) because the type isn't known yet when playback starts. These events now wait for the stream to resolve and report the real value.

**Known limitation (casting):** `CastPlayer` doesn't report its stream tracks, so while casting we can't resolve an HLS stream to video. To avoid `content_type=unknown` (and events that never fire until stop), a Cast session resolves the type up front from the episode metadata. For the usual alternate-enclosure shape (audio enclosure + HLS video alternate) this means casting an HLS video reports `content_type=audio`. This restores the pre-existing behaviour and only affects the Cast path. Follow-up to make it exact: have `CastPlayer` emit `VideoTrackChanged` from the media metadata it already computes, then drop the remote short-circuit in `StreamVideoState.initialFor`.

## Testing Instructions

Best tested on a real device — video rendering is flaky on emulators. You'll need a build with HLS enabled, a Plus account, and a podcast with an HLS video episode.

**Auto-open**
1. Play an HLS video episode. The player should open by itself once the video starts (fullscreen if you're in landscape).
2. Play an mp4 video episode. Same thing should happen (existing behavior — just check it still works).
3. Play an audio-only episode. The player should not auto-open into video.

**Audio-only setting**
4. Turn Audio-only on (Settings → General, or the toolbar toggle).
5. Play an mp4 video. It should not open fullscreen and should not show video.
6. Play an HLS video. Same — no fullscreen, audio only.
7. With that HLS video playing in Audio-only, turn Audio-only off. The player should not pop open on its own. Video can start rendering in place, but nothing should jump to fullscreen.
8. Toggle Audio-only on and off a few more times while it plays. No unexpected fullscreen.

**Orientation**
9. Rotate to landscape while an HLS video plays → it should go fullscreen.
10. Send the app to the background in landscape during an HLS video, then reopen it → it should return to fullscreen.

**Analytics** (watch the Tracks debug log)
11. Play an HLS video → `playback_play` and `playback_source_resolved` should both report `content_type=video` (not `audio` or `unknown`).
12. Play an HLS audio-only stream → `content_type=audio`.
13. Play an mp4 video → `content_type=video`, fired right away.
14. Tap play then quickly skip to another episode before the first one loads → the first play should still report an event (falls back to `unknown`), nothing lost.

## Screenshots or Screencast

https://github.com/user-attachments/assets/e7556630-ae6e-4b4c-9146-7a05e70e03ea

<img width="1565" height="76" alt="SCR-20260729-nosy" src="https://github.com/user-attachments/assets/13ee815d-f1ed-4eea-99e7-dc55332b917a" />


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md 
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

#### I have tested any UI changes...
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
