### PR TITLE
[TV] Add the Up Next tab

### DIFF
--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -269,6 +269,9 @@
     <string name="tv_playlist_empty_subtitle">Either it’s time to celebrate completing this list or edit your rules in the mobile app to get some more.</string>
     <string name="tv_playlist_empty_subtitle_manual">Add episodes to this playlist from the mobile app and they’ll show up here.</string>
     <string name="tv_episode_details">Episode details</string>
+    <string name="tv_up_next_empty_title">Nothing queued up</string>
+    <string name="tv_up_next_empty_subtitle">Add episodes to Up Next and they’ll play in order, back to back</string>
+    <string name="tv_up_next_empty_action_title">Add episodes</string>
     <string name="unavailable">Unavailable</string>
     <string name="browse_podcasts">Browse podcasts</string>
     <string name="pocket_casts_plus_badge">Pocket Casts Plus badge</string>

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvApplication.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvApplication.kt
@@ -22,13 +22,14 @@ class TvApplication :
 
     @Inject lateinit var upNextQueue: UpNextQueue
 
-    private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     override fun onCreate() {
         super.onCreate()
         if (BuildConfig.DEBUG) {
             Timber.plant(TimberDebugTree())
         }
+        // The only setupBlocking() call on TV; there is no PlaybackManager.setup() here, so calling it again would double-subscribe the queue's sync pipeline.
         applicationScope.launch {
             upNextQueue.setupBlocking()
         }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvApplication.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvApplication.kt
@@ -3,9 +3,14 @@ package au.com.shiftyjelly.pocketcasts
 import android.app.Application
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
+import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.utils.TimberDebugTree
 import dagger.hilt.android.HiltAndroidApp
 import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import timber.log.Timber
 
 @HiltAndroidApp
@@ -15,10 +20,17 @@ class TvApplication :
 
     @Inject lateinit var workerFactory: HiltWorkerFactory
 
+    @Inject lateinit var upNextQueue: UpNextQueue
+
+    private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
     override fun onCreate() {
         super.onCreate()
         if (BuildConfig.DEBUG) {
             Timber.plant(TimberDebugTree())
+        }
+        applicationScope.launch {
+            upNextQueue.setupBlocking()
         }
     }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvApplication.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvApplication.kt
@@ -29,7 +29,8 @@ class TvApplication :
         if (BuildConfig.DEBUG) {
             Timber.plant(TimberDebugTree())
         }
-        // The only setupBlocking() call on TV; there is no PlaybackManager.setup() here, so calling it again would double-subscribe the queue's sync pipeline.
+        // The only setupBlocking() call on TV; there is no PlaybackManager.setup() here,
+        // so calling it again would double-subscribe the queue's sync pipeline.
         applicationScope.launch {
             upNextQueue.setupBlocking()
         }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeListItem.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeListItem.kt
@@ -1,0 +1,74 @@
+package au.com.shiftyjelly.pocketcasts.component
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandHorizontally
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkHorizontally
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.localization.helper.RelativeDateFormatter
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+
+@Composable
+fun TvEpisodeListItem(
+    episode: PodcastEpisode,
+    dateFormatter: RelativeDateFormatter,
+    onClick: () -> Unit,
+    onOpenActions: () -> Unit,
+    modifier: Modifier = Modifier,
+    episodeFocusRequester: FocusRequester? = null,
+    leftFocusRequester: FocusRequester? = null,
+) {
+    var isItemFocused by remember { mutableStateOf(false) }
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier
+            .fillMaxWidth()
+            .onFocusChanged { isItemFocused = it.hasFocus },
+    ) {
+        TvEpisodeRow(
+            episode = episode,
+            onClick = onClick,
+            dateFormatter = dateFormatter,
+            modifier = Modifier
+                .weight(1f)
+                .then(if (leftFocusRequester != null) Modifier.focusProperties { left = leftFocusRequester } else Modifier)
+                .then(if (episodeFocusRequester != null) Modifier.focusRequester(episodeFocusRequester) else Modifier),
+        )
+        AnimatedVisibility(
+            visible = isItemFocused,
+            enter = expandHorizontally(tween(MORE_BUTTON_ANIMATION_MILLIS), expandFrom = Alignment.Start) +
+                slideInHorizontally(tween(MORE_BUTTON_ANIMATION_MILLIS), initialOffsetX = { it }) +
+                fadeIn(tween(MORE_BUTTON_ANIMATION_MILLIS)),
+            exit = shrinkHorizontally(tween(MORE_BUTTON_ANIMATION_MILLIS), shrinkTowards = Alignment.Start) +
+                slideOutHorizontally(tween(MORE_BUTTON_ANIMATION_MILLIS), targetOffsetX = { it }) +
+                fadeOut(tween(MORE_BUTTON_ANIMATION_MILLIS)),
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Spacer(Modifier.width(16.dp))
+                TvMoreButton(onClick = onOpenActions)
+            }
+        }
+    }
+}
+
+private const val MORE_BUTTON_ANIMATION_MILLIS = 200

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeListItem.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeListItem.kt
@@ -8,7 +8,6 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkHorizontally
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeListItem.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeListItem.kt
@@ -55,12 +55,12 @@ fun TvEpisodeListItem(
         )
         AnimatedVisibility(
             visible = isItemFocused,
-            enter = expandHorizontally(tween(MORE_BUTTON_ANIMATION_MILLIS), expandFrom = Alignment.Start) +
-                slideInHorizontally(tween(MORE_BUTTON_ANIMATION_MILLIS), initialOffsetX = { it }) +
-                fadeIn(tween(MORE_BUTTON_ANIMATION_MILLIS)),
-            exit = shrinkHorizontally(tween(MORE_BUTTON_ANIMATION_MILLIS), shrinkTowards = Alignment.Start) +
-                slideOutHorizontally(tween(MORE_BUTTON_ANIMATION_MILLIS), targetOffsetX = { it }) +
-                fadeOut(tween(MORE_BUTTON_ANIMATION_MILLIS)),
+            enter = expandHorizontally(tween(MORE_BUTTON_ANIMATION_DURATION_MS), expandFrom = Alignment.Start) +
+                slideInHorizontally(tween(MORE_BUTTON_ANIMATION_DURATION_MS), initialOffsetX = { it }) +
+                fadeIn(tween(MORE_BUTTON_ANIMATION_DURATION_MS)),
+            exit = shrinkHorizontally(tween(MORE_BUTTON_ANIMATION_DURATION_MS), shrinkTowards = Alignment.Start) +
+                slideOutHorizontally(tween(MORE_BUTTON_ANIMATION_DURATION_MS), targetOffsetX = { it }) +
+                fadeOut(tween(MORE_BUTTON_ANIMATION_DURATION_MS)),
         ) {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Spacer(Modifier.width(16.dp))
@@ -70,4 +70,4 @@ fun TvEpisodeListItem(
     }
 }
 
-private const val MORE_BUTTON_ANIMATION_MILLIS = 200
+private const val MORE_BUTTON_ANIMATION_DURATION_MS = 200

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
@@ -22,6 +22,7 @@ import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.playlists.TvPlaylistsScreen
 import au.com.shiftyjelly.pocketcasts.theme.TvColors
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.upnext.TvUpNextScreen
 
 @Composable
 fun TvScaffold(
@@ -43,7 +44,18 @@ fun TvScaffold(
     ) { tab ->
         when (tab) {
             is TvTab.Home -> TvHomeScreen()
+
             is TvTab.Playlists -> TvPlaylistsScreen()
+
+            is TvTab.UpNext -> TvUpNextScreen(
+                onNavigateToDiscover = {
+                    val homeIndex = uiState.tabs.indexOfFirst { it is TvTab.Home }
+                    if (homeIndex >= 0) {
+                        viewModel.selectTab(homeIndex)
+                    }
+                },
+            )
+
             else -> TvTabPlaceholder(tab = tab)
         }
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
@@ -48,12 +48,7 @@ fun TvScaffold(
             is TvTab.Playlists -> TvPlaylistsScreen()
 
             is TvTab.UpNext -> TvUpNextScreen(
-                onNavigateToDiscover = {
-                    val homeIndex = uiState.tabs.indexOfFirst { it is TvTab.Home }
-                    if (homeIndex >= 0) {
-                        viewModel.selectTab(homeIndex)
-                    }
-                },
+                onNavigateToHome = { viewModel.selectTab(TvTab.entries.indexOf(TvTab.Home)) },
             )
 
             else -> TvTabPlaceholder(tab = tab)

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
@@ -1,18 +1,9 @@
 package au.com.shiftyjelly.pocketcasts.playlists.details
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.expandHorizontally
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.shrinkHorizontally
-import androidx.compose.animation.slideInHorizontally
-import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -38,7 +29,6 @@ import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -58,8 +48,7 @@ import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.component.TvDropdownMenu
 import au.com.shiftyjelly.pocketcasts.component.TvDropdownMenuItem
 import au.com.shiftyjelly.pocketcasts.component.TvEpisodeActionsModal
-import au.com.shiftyjelly.pocketcasts.component.TvEpisodeRow
-import au.com.shiftyjelly.pocketcasts.component.TvMoreButton
+import au.com.shiftyjelly.pocketcasts.component.TvEpisodeListItem
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.components.PlaylistArtwork
 import au.com.shiftyjelly.pocketcasts.compose.components.displayLabel
@@ -366,12 +355,13 @@ private fun EpisodeList(
             items = episodes,
             key = { _, episode -> episode.uuid },
         ) { index, episode ->
-            EpisodeListItem(
+            TvEpisodeListItem(
                 episode = episode,
                 dateFormatter = dateFormatter,
+                onClick = {},
                 onOpenActions = { actionsEpisode = episode },
-                playAllFocusRequester = playAllFocusRequester,
                 episodeFocusRequester = firstEpisodeFocusRequester.takeIf { index == initialFocusIndex },
+                leftFocusRequester = playAllFocusRequester,
             )
         }
     }
@@ -380,48 +370,6 @@ private fun EpisodeList(
             episode = episode,
             onDismissRequest = { actionsEpisode = null },
         )
-    }
-}
-
-@Composable
-private fun EpisodeListItem(
-    episode: PodcastEpisode,
-    dateFormatter: RelativeDateFormatter,
-    onOpenActions: () -> Unit,
-    playAllFocusRequester: FocusRequester,
-    episodeFocusRequester: FocusRequester?,
-    modifier: Modifier = Modifier,
-) {
-    var isItemFocused by remember { mutableStateOf(false) }
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = modifier
-            .fillMaxWidth()
-            .onFocusChanged { isItemFocused = it.hasFocus },
-    ) {
-        TvEpisodeRow(
-            episode = episode,
-            onClick = {},
-            dateFormatter = dateFormatter,
-            modifier = Modifier
-                .weight(1f)
-                .focusProperties { left = playAllFocusRequester }
-                .then(if (episodeFocusRequester != null) Modifier.focusRequester(episodeFocusRequester) else Modifier),
-        )
-        AnimatedVisibility(
-            visible = isItemFocused,
-            enter = expandHorizontally(tween(MORE_BUTTON_ANIMATION_DURATION_MS), expandFrom = Alignment.Start) +
-                slideInHorizontally(tween(MORE_BUTTON_ANIMATION_DURATION_MS), initialOffsetX = { it }) +
-                fadeIn(tween(MORE_BUTTON_ANIMATION_DURATION_MS)),
-            exit = shrinkHorizontally(tween(MORE_BUTTON_ANIMATION_DURATION_MS), shrinkTowards = Alignment.Start) +
-                slideOutHorizontally(tween(MORE_BUTTON_ANIMATION_DURATION_MS), targetOffsetX = { it }) +
-                fadeOut(tween(MORE_BUTTON_ANIMATION_DURATION_MS)),
-        ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Spacer(Modifier.width(16.dp))
-                TvMoreButton(onClick = onOpenActions)
-            }
-        }
     }
 }
 
@@ -518,7 +466,6 @@ private fun episodeSummaryText(episodes: List<PodcastEpisode>): String {
 }
 
 private val ArtworkSize = 200.dp
-private const val MORE_BUTTON_ANIMATION_DURATION_MS = 200
 
 @Preview(device = Devices.TV_1080p)
 @Composable

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.snapshots.Snapshot
@@ -177,13 +176,6 @@ private fun SortableEpisodeList(
             snapshotFlow { listState.layoutInfo.visibleItemsInfo.any { it.index == initialFocusIndex } }.first { it }
             runCatching { firstEpisodeFocusRequester.requestFocus() }
                 .onFailure { Timber.e(it, "Failed to focus the first visible playlist episode") }
-            hasRequestedInitialFocus = true
-        }
-    }
-    LaunchedEffect(uiState.episodes.isNotEmpty()) {
-        if (uiState.episodes.isNotEmpty() && !hasRequestedInitialFocus) {
-            snapshotFlow { listState.layoutInfo.visibleItemsInfo.isNotEmpty() }.first { it }
-            runCatching { firstEpisodeFocusRequester.requestFocus() }
             hasRequestedInitialFocus = true
         }
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.snapshots.Snapshot
@@ -176,6 +177,13 @@ private fun SortableEpisodeList(
             snapshotFlow { listState.layoutInfo.visibleItemsInfo.any { it.index == initialFocusIndex } }.first { it }
             runCatching { firstEpisodeFocusRequester.requestFocus() }
                 .onFailure { Timber.e(it, "Failed to focus the first visible playlist episode") }
+            hasRequestedInitialFocus = true
+        }
+    }
+    LaunchedEffect(uiState.episodes.isNotEmpty()) {
+        if (uiState.episodes.isNotEmpty() && !hasRequestedInitialFocus) {
+            snapshotFlow { listState.layoutInfo.visibleItemsInfo.isNotEmpty() }.first { it }
+            runCatching { firstEpisodeFocusRequester.requestFocus() }
             hasRequestedInitialFocus = true
         }
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextScreen.kt
@@ -53,7 +53,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 fun TvUpNextScreen(
-    onNavigateToDiscover: () -> Unit,
+    onNavigateToHome: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: TvUpNextViewModel = hiltViewModel(),
 ) {
@@ -65,7 +65,7 @@ fun TvUpNextScreen(
 
     TvUpNextContent(
         uiState = uiState,
-        onNavigateToDiscover = onNavigateToDiscover,
+        onNavigateToHome = onNavigateToHome,
         modifier = modifier,
     )
 }
@@ -73,7 +73,7 @@ fun TvUpNextScreen(
 @Composable
 private fun TvUpNextContent(
     uiState: TvUpNextUiState,
-    onNavigateToDiscover: () -> Unit,
+    onNavigateToHome: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Box(modifier = modifier.fillMaxSize()) {
@@ -84,7 +84,7 @@ private fun TvUpNextContent(
 
             is TvUpNextUiState.Empty -> {
                 UpNextEmpty(
-                    onNavigateToDiscover = onNavigateToDiscover,
+                    onNavigateToHome = onNavigateToHome,
                     modifier = Modifier.fillMaxSize(),
                 )
             }
@@ -103,10 +103,6 @@ private fun UpNextList(
 ) {
     val context = LocalContext.current
     val dateFormatter = remember(context) { RelativeDateFormatter(context) }
-    val firstEpisodeFocusRequester = remember { FocusRequester() }
-    LaunchedEffect(Unit) {
-        firstEpisodeFocusRequester.requestFocus()
-    }
     var actionsEpisode by remember { mutableStateOf<PodcastEpisode?>(null) }
 
     Column(
@@ -125,13 +121,12 @@ private fun UpNextList(
             itemsIndexed(
                 items = episodes,
                 key = { _, episode -> episode.uuid },
-            ) { index, episode ->
+            ) { _, episode ->
                 TvEpisodeListItem(
                     episode = episode,
                     dateFormatter = dateFormatter,
                     onClick = {},
                     onOpenActions = { actionsEpisode = episode },
-                    episodeFocusRequester = firstEpisodeFocusRequester.takeIf { index == 0 },
                 )
             }
         }
@@ -172,7 +167,7 @@ private fun episodeSummaryText(episodes: List<PodcastEpisode>): String {
     val context = LocalContext.current
     val countText = pluralStringResource(LR.plurals.episode_count, episodes.size, episodes.size)
     val remainingMs = episodes.sumOf { episode ->
-        ((episode.duration - episode.playedUpTo).coerceAtLeast(0.0) * 1000).toLong()
+        (episode.durationMs - episode.playedUpToMs).coerceAtLeast(0).toLong()
     }
     val timeLeftText = stringResource(LR.string.time_left, TimeHelper.getTimeDurationShortString(remainingMs, context))
     return "$countText · $timeLeftText"
@@ -180,13 +175,9 @@ private fun episodeSummaryText(episodes: List<PodcastEpisode>): String {
 
 @Composable
 private fun UpNextEmpty(
-    onNavigateToDiscover: () -> Unit,
+    onNavigateToHome: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val focusRequester = remember { FocusRequester() }
-    LaunchedEffect(Unit) {
-        focusRequester.requestFocus()
-    }
     Box(
         contentAlignment = Alignment.Center,
         modifier = modifier,
@@ -208,9 +199,8 @@ private fun UpNextEmpty(
             )
             Spacer(modifier = Modifier.height(32.dp))
             Button(
-                onClick = onNavigateToDiscover,
+                onClick = onNavigateToHome,
                 colors = TvButtonDefaults.filledButtonColors(),
-                modifier = Modifier.focusRequester(focusRequester),
             ) {
                 Text(stringResource(LR.string.tv_up_next_empty_action_title))
             }
@@ -238,7 +228,7 @@ private fun TvUpNextLoadedPreview() {
                             )
                         },
                     ),
-                    onNavigateToDiscover = {},
+                    onNavigateToHome = {},
                 )
             }
         }
@@ -253,7 +243,7 @@ private fun TvUpNextEmptyPreview() {
             Box(modifier = Modifier.background(TvColors.Dark)) {
                 TvUpNextContent(
                     uiState = TvUpNextUiState.Empty,
-                    onNavigateToDiscover = {},
+                    onNavigateToHome = {},
                 )
             }
         }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextScreen.kt
@@ -57,6 +57,10 @@ fun TvUpNextScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
+    LaunchedEffect(Unit) {
+        viewModel.onShown()
+    }
+
     TvUpNextContent(
         uiState = uiState,
         onNavigateToDiscover = onNavigateToDiscover,
@@ -179,6 +183,10 @@ private fun UpNextEmpty(
     onNavigateToDiscover: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val focusRequester = remember { FocusRequester() }
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
     Box(
         contentAlignment = Alignment.Center,
         modifier = modifier,
@@ -202,6 +210,7 @@ private fun UpNextEmpty(
             Button(
                 onClick = onNavigateToDiscover,
                 colors = TvButtonDefaults.filledButtonColors(),
+                modifier = Modifier.focusRequester(focusRequester),
             ) {
                 Text(stringResource(LR.string.tv_up_next_empty_action_title))
             }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextScreen.kt
@@ -1,0 +1,252 @@
+package au.com.shiftyjelly.pocketcasts.upnext
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.tv.material3.Button
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.component.TvEpisodeActionsModal
+import au.com.shiftyjelly.pocketcasts.component.TvEpisodeListItem
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.compose.loading.LoadingView
+import au.com.shiftyjelly.pocketcasts.localization.helper.RelativeDateFormatter
+import au.com.shiftyjelly.pocketcasts.localization.helper.TimeHelper
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
+import au.com.shiftyjelly.pocketcasts.theme.TvColors
+import au.com.shiftyjelly.pocketcasts.theme.TvTextStyles
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import java.util.Date
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+fun TvUpNextScreen(
+    onNavigateToDiscover: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: TvUpNextViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    TvUpNextContent(
+        uiState = uiState,
+        onNavigateToDiscover = onNavigateToDiscover,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun TvUpNextContent(
+    uiState: TvUpNextUiState,
+    onNavigateToDiscover: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(modifier = modifier.fillMaxSize()) {
+        when (uiState) {
+            is TvUpNextUiState.Loading -> {
+                LoadingView(color = Color.White, modifier = Modifier.fillMaxSize())
+            }
+
+            is TvUpNextUiState.Empty -> {
+                UpNextEmpty(
+                    onNavigateToDiscover = onNavigateToDiscover,
+                    modifier = Modifier.fillMaxSize(),
+                )
+            }
+
+            is TvUpNextUiState.Loaded -> {
+                UpNextList(
+                    episodes = uiState.episodes,
+                    modifier = Modifier.fillMaxSize(),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun UpNextList(
+    episodes: List<PodcastEpisode>,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val dateFormatter = remember(context) { RelativeDateFormatter(context) }
+    val firstEpisodeFocusRequester = remember { FocusRequester() }
+    LaunchedEffect(Unit) {
+        firstEpisodeFocusRequester.requestFocus()
+    }
+    var actionsEpisode by remember { mutableStateOf<PodcastEpisode?>(null) }
+
+    Column(
+        modifier = modifier
+            .padding(start = 32.dp, top = 16.dp, end = 32.dp)
+            .widthIn(max = ContentWidth),
+    ) {
+        UpNextHeader(episodes = episodes)
+        Spacer(Modifier.height(24.dp))
+        LazyColumn(
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            contentPadding = PaddingValues(bottom = 32.dp),
+            modifier = Modifier.weight(1f),
+        ) {
+            itemsIndexed(
+                items = episodes,
+                key = { _, episode -> episode.uuid },
+            ) { index, episode ->
+                TvEpisodeListItem(
+                    episode = episode,
+                    dateFormatter = dateFormatter,
+                    onClick = {},
+                    onOpenActions = { actionsEpisode = episode },
+                    episodeFocusRequester = firstEpisodeFocusRequester.takeIf { index == 0 },
+                )
+            }
+        }
+    }
+
+    actionsEpisode?.let { episode ->
+        TvEpisodeActionsModal(
+            episode = episode,
+            onDismissRequest = { actionsEpisode = null },
+        )
+    }
+}
+
+@Composable
+private fun UpNextHeader(
+    episodes: List<PodcastEpisode>,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+        modifier = modifier,
+    ) {
+        Text(
+            text = stringResource(LR.string.up_next),
+            style = TvTextStyles.ScreenTitle,
+            color = Color.White,
+        )
+        Text(
+            text = episodeSummaryText(episodes),
+            style = TvTextStyles.PlaylistCardCaption,
+            color = TvColors.TextSecondary,
+        )
+    }
+}
+
+@Composable
+private fun episodeSummaryText(episodes: List<PodcastEpisode>): String {
+    val context = LocalContext.current
+    val countText = pluralStringResource(LR.plurals.episode_count, episodes.size, episodes.size)
+    val remainingMs = episodes.sumOf { episode ->
+        ((episode.duration - episode.playedUpTo).coerceAtLeast(0.0) * 1000).toLong()
+    }
+    val timeLeftText = stringResource(LR.string.time_left, TimeHelper.getTimeDurationShortString(remainingMs, context))
+    return "$countText · $timeLeftText"
+}
+
+@Composable
+private fun UpNextEmpty(
+    onNavigateToDiscover: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = modifier,
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text = stringResource(LR.string.tv_up_next_empty_title),
+                style = TvTextStyles.ScreenTitle,
+                color = Color.White,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = stringResource(LR.string.tv_up_next_empty_subtitle),
+                style = MaterialTheme.typography.bodyLarge,
+                color = TvColors.TextSecondary,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.widthIn(max = 400.dp),
+            )
+            Spacer(modifier = Modifier.height(32.dp))
+            Button(
+                onClick = onNavigateToDiscover,
+                colors = TvButtonDefaults.filledButtonColors(),
+            ) {
+                Text(stringResource(LR.string.tv_up_next_empty_action_title))
+            }
+        }
+    }
+}
+
+private val ContentWidth = 800.dp
+
+@Preview(device = Devices.TV_1080p)
+@Composable
+private fun TvUpNextLoadedPreview() {
+    AppTheme(themeType = Theme.ThemeType.EXTRA_DARK) {
+        MaterialTheme {
+            Box(modifier = Modifier.background(TvColors.Dark)) {
+                TvUpNextContent(
+                    uiState = TvUpNextUiState.Loaded(
+                        episodes = List(4) { index ->
+                            PodcastEpisode(
+                                uuid = "episode-$index",
+                                title = "Episode $index title that may span multiple lines to test the layout",
+                                duration = 3600.0,
+                                playedUpTo = 600.0,
+                                publishedDate = Date(0),
+                            )
+                        },
+                    ),
+                    onNavigateToDiscover = {},
+                )
+            }
+        }
+    }
+}
+
+@Preview(device = Devices.TV_1080p)
+@Composable
+private fun TvUpNextEmptyPreview() {
+    AppTheme(themeType = Theme.ThemeType.EXTRA_DARK) {
+        MaterialTheme {
+            Box(modifier = Modifier.background(TvColors.Dark)) {
+                TvUpNextContent(
+                    uiState = TvUpNextUiState.Empty,
+                    onNavigateToDiscover = {},
+                )
+            }
+        }
+    }
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextScreen.kt
@@ -13,7 +13,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -22,8 +22,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.pluralStringResource
@@ -118,10 +116,10 @@ private fun UpNextList(
             contentPadding = PaddingValues(bottom = 32.dp),
             modifier = Modifier.weight(1f),
         ) {
-            itemsIndexed(
+            items(
                 items = episodes,
-                key = { _, episode -> episode.uuid },
-            ) { _, episode ->
+                key = { episode -> episode.uuid },
+            ) { episode ->
                 TvEpisodeListItem(
                     episode = episode,
                     dateFormatter = dateFormatter,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextScreen.kt
@@ -6,7 +6,9 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
@@ -88,10 +90,7 @@ private fun TvUpNextContent(
             }
 
             is TvUpNextUiState.Loaded -> {
-                UpNextList(
-                    episodes = uiState.episodes,
-                    modifier = Modifier.fillMaxSize(),
-                )
+                UpNextList(episodes = uiState.episodes)
             }
         }
     }
@@ -112,8 +111,9 @@ private fun UpNextList(
 
     Column(
         modifier = modifier
-            .padding(start = 32.dp, top = 16.dp, end = 32.dp)
-            .widthIn(max = ContentWidth),
+            .fillMaxHeight()
+            .fillMaxWidth(ROW_WIDTH_FRACTION)
+            .padding(start = 32.dp, top = 16.dp),
     ) {
         UpNextHeader(episodes = episodes)
         Spacer(Modifier.height(24.dp))
@@ -218,7 +218,7 @@ private fun UpNextEmpty(
     }
 }
 
-private val ContentWidth = 800.dp
+private const val ROW_WIDTH_FRACTION = 0.75f
 
 @Preview(device = Devices.TV_1080p)
 @Composable

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextViewModel.kt
@@ -44,13 +44,7 @@ class TvUpNextViewModel @Inject constructor(
             TvUpNextUiState.Loading,
         )
 
-    private var hasSynced = false
-
     fun onShown() {
-        if (hasSynced) {
-            return
-        }
-        hasSynced = true
         UpNextSyncWorker.enqueue(syncManager, context)
     }
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextViewModel.kt
@@ -1,10 +1,14 @@
 package au.com.shiftyjelly.pocketcasts.upnext
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
+import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
+import au.com.shiftyjelly.pocketcasts.repositories.sync.UpNextSyncWorker
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -17,6 +21,8 @@ import kotlinx.coroutines.rx2.asFlow
 
 @HiltViewModel
 class TvUpNextViewModel @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val syncManager: SyncManager,
     private val upNextQueue: UpNextQueue,
 ) : ViewModel() {
 
@@ -37,6 +43,10 @@ class TvUpNextViewModel @Inject constructor(
             SharingStarted.WhileSubscribed(stopTimeout = 300.milliseconds, replayExpiration = Duration.ZERO),
             TvUpNextUiState.Loading,
         )
+
+    fun onShown() {
+        UpNextSyncWorker.enqueue(syncManager, context)
+    }
 }
 
 sealed interface TvUpNextUiState {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextViewModel.kt
@@ -1,0 +1,50 @@
+package au.com.shiftyjelly.pocketcasts.upnext
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.WhileSubscribed
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.rx2.asFlow
+
+@HiltViewModel
+class TvUpNextViewModel @Inject constructor(
+    private val upNextQueue: UpNextQueue,
+) : ViewModel() {
+
+    val uiState: StateFlow<TvUpNextUiState> = upNextQueue.changesObservable.asFlow()
+        .map { state ->
+            val episodes = when (state) {
+                is UpNextQueue.State.Empty -> emptyList()
+                is UpNextQueue.State.Loaded -> state.queue.filterIsInstance<PodcastEpisode>()
+            }
+            if (episodes.isEmpty()) {
+                TvUpNextUiState.Empty
+            } else {
+                TvUpNextUiState.Loaded(episodes)
+            }
+        }
+        .stateIn(
+            viewModelScope,
+            SharingStarted.WhileSubscribed(stopTimeout = 300.milliseconds, replayExpiration = Duration.ZERO),
+            TvUpNextUiState.Loading,
+        )
+}
+
+sealed interface TvUpNextUiState {
+    data object Loading : TvUpNextUiState
+
+    data object Empty : TvUpNextUiState
+
+    data class Loaded(
+        val episodes: List<PodcastEpisode>,
+    ) : TvUpNextUiState
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextViewModel.kt
@@ -44,7 +44,13 @@ class TvUpNextViewModel @Inject constructor(
             TvUpNextUiState.Loading,
         )
 
+    private var hasSynced = false
+
     fun onShown() {
+        if (hasSynced) {
+            return
+        }
+        hasSynced = true
         UpNextSyncWorker.enqueue(syncManager, context)
     }
 }

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextViewModelTest.kt
@@ -12,6 +12,7 @@ import java.util.Date
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.doReturn
@@ -85,6 +86,38 @@ class TvUpNextViewModelTest {
 
             changes.onNext(UpNextQueue.State.Loaded(currentEpisode, null, listOf(userEpisode)))
 
+            assertEquals(TvUpNextUiState.Empty, awaitItem())
+        }
+    }
+
+    @Test
+    fun `the current episode is excluded from the exposed queue`() = runTest {
+        val viewModel = createViewModel()
+        val queued = episode("queued")
+
+        viewModel.uiState.test {
+            assertEquals(TvUpNextUiState.Loading, awaitItem())
+
+            changes.onNext(UpNextQueue.State.Loaded(currentEpisode, null, listOf(queued)))
+
+            val loaded = awaitItem() as TvUpNextUiState.Loaded
+            assertFalse(loaded.episodes.contains(currentEpisode))
+            assertEquals(listOf(queued), loaded.episodes)
+        }
+    }
+
+    @Test
+    fun `a queue that empties maps back to the empty state`() = runTest {
+        val viewModel = createViewModel()
+        val queued = episode("queued")
+
+        viewModel.uiState.test {
+            assertEquals(TvUpNextUiState.Loading, awaitItem())
+
+            changes.onNext(UpNextQueue.State.Loaded(currentEpisode, null, listOf(queued)))
+            assertEquals(TvUpNextUiState.Loaded(listOf(queued)), awaitItem())
+
+            changes.onNext(UpNextQueue.State.Empty)
             assertEquals(TvUpNextUiState.Empty, awaitItem())
         }
     }

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextViewModelTest.kt
@@ -1,0 +1,99 @@
+package au.com.shiftyjelly.pocketcasts.upnext
+
+import android.content.Context
+import app.cash.turbine.test
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
+import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
+import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
+import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import io.reactivex.subjects.BehaviorSubject
+import java.util.Date
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TvUpNextViewModelTest {
+
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
+
+    private val changes = BehaviorSubject.create<UpNextQueue.State>()
+    private val upNextQueue = mock<UpNextQueue> {
+        on { changesObservable } doReturn changes
+    }
+    private val syncManager = mock<SyncManager>()
+    private val context = mock<Context>()
+
+    private val currentEpisode = episode("current")
+
+    @Test
+    fun `an empty queue maps to the empty state`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            assertEquals(TvUpNextUiState.Loading, awaitItem())
+
+            changes.onNext(UpNextQueue.State.Empty)
+
+            assertEquals(TvUpNextUiState.Empty, awaitItem())
+        }
+    }
+
+    @Test
+    fun `a loaded queue exposes the queued podcast episodes`() = runTest {
+        val viewModel = createViewModel()
+        val first = episode("first")
+        val second = episode("second")
+
+        viewModel.uiState.test {
+            assertEquals(TvUpNextUiState.Loading, awaitItem())
+
+            changes.onNext(UpNextQueue.State.Loaded(currentEpisode, null, listOf(first, second)))
+
+            assertEquals(TvUpNextUiState.Loaded(listOf(first, second)), awaitItem())
+        }
+    }
+
+    @Test
+    fun `user episodes are excluded from the queue`() = runTest {
+        val viewModel = createViewModel()
+        val podcastEpisode = episode("podcast")
+        val userEpisode = UserEpisode(uuid = "user", publishedDate = Date(0))
+
+        viewModel.uiState.test {
+            assertEquals(TvUpNextUiState.Loading, awaitItem())
+
+            changes.onNext(UpNextQueue.State.Loaded(currentEpisode, null, listOf(podcastEpisode, userEpisode)))
+
+            assertEquals(TvUpNextUiState.Loaded(listOf(podcastEpisode)), awaitItem())
+        }
+    }
+
+    @Test
+    fun `a queue of only user episodes maps to the empty state`() = runTest {
+        val viewModel = createViewModel()
+        val userEpisode = UserEpisode(uuid = "user", publishedDate = Date(0))
+
+        viewModel.uiState.test {
+            assertEquals(TvUpNextUiState.Loading, awaitItem())
+
+            changes.onNext(UpNextQueue.State.Loaded(currentEpisode, null, listOf(userEpisode)))
+
+            assertEquals(TvUpNextUiState.Empty, awaitItem())
+        }
+    }
+
+    private fun createViewModel() = TvUpNextViewModel(
+        context = context,
+        syncManager = syncManager,
+        upNextQueue = upNextQueue,
+    )
+
+    private fun episode(uuid: String) = PodcastEpisode(uuid = uuid, publishedDate = Date(0))
+}


### PR DESCRIPTION
## Description

Adds the **Up Next** tab to the TV app, mirroring the Apple TV implementation. The tab shows the queued episodes (the currently-playing episode is excluded, matching tvOS's `allUpNextEpisodes().dropFirst()`) as a vertical list, reusing the same episode row + focus-driven `…` actions menu as the playlist details screen.

- **Reuse:** extracted the row-with-actions from the playlist details screen into a shared `TvEpisodeListItem` (episode row + the `…` button that slides in on focus + the actions modal), now used by both the playlist details screen and Up Next.
- **Data:** observes `UpNextQueue.changesObservable`. Because the TV app has no `PlaybackManager`, the queue relay was never seeded from the DB, so `TvApplication` now calls `upNextQueue.setupBlocking()` once at startup (the mobile-startup analog). `UpNextQueue` is a singleton, so the tab reflects the real queue and updates reactively.
- **Server refresh:** when the tab is shown it enqueues `UpNextSyncWorker` (the Android analog of tvOS `refreshManager.syncUpNext()`), so changes made on other devices show up without a restart.
- **Empty state:** "Nothing queued up" with an **Add episodes** button that jumps to the Home tab, matching tvOS's `ContentUnavailableView` action.
- **Header:** the row below the "Up Next" title shows the episode count and time left — we kept it to align with the Apple TV app, which renders the same summary line (the Figma omits it, but tvOS is the source of truth here).
- Rows/header span ~75% of the screen width, per the design.

**Scope / deliberate deviations** (consistent with the rest of the TV module):
- `UserEpisode`s (uploaded files) are filtered out — the whole TV module's episode UI is `PodcastEpisode`-only. tvOS shows them; rendering them here would mean generalizing the shared row. Follow-up if needed.
- Episode tap and the actions-menu buttons are no-ops (no playback is wired anywhere on TV yet), and there's no analytics (the TV module has none) — both matching the sibling screens.

Fixes PCDROID-578 https://linear.app/a8c/issue/PCDROID-578/up-next-tab.
Designs: Ftk3KwnfqaK4g57yCN63p0-fi-2021_5935.

Stacked on `feat/tv-playlist-episode-actions` (#5676) — merge bottom-up.

## Testing Instructions

1. Install the TV app (`./gradlew :tv:installDebugProd`) and sign in with an account that has episodes in Up Next.
2. Open the **Up Next** tab — verify the queued episodes appear (excluding the currently-playing one), rows reach ~75% width, and the first row is focused.
3. Verify the header shows "Up Next" with a "N episodes · X left" summary line below it.
4. Focus a row with the d-pad — the `…` button slides in from the right; press RIGHT then select to open the actions modal, and back to dismiss.
5. Empty state: with an empty Up Next queue, verify "Nothing queued up" with a focused **Add episodes** button; selecting it switches to the Home tab.
6. Add or remove an episode from Up Next on another device (or the mobile app), then re-open the TV Up Next tab — the list refreshes (server sync on show).

## Screenshots or Screencast
<img width="1920" height="1080" alt="Screenshot_20260729_163000" src="https://github.com/user-attachments/assets/0466e217-5f67-48ca-9c10-0a05a4b8224e" />

<!-- TODO: attach a screencap of the Up Next tab (loaded + empty) -->

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md _(TV app is unreleased — skipped)_
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes _(added `TvUpNextViewModelTest`)_
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics. _(analytics deliberately excluded — matches the rest of the TV module)_