### PR TITLE
[TV] Add the Your Podcasts tab

### DIFF
--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -272,9 +272,9 @@
     <string name="tv_up_next_empty_title">Nothing queued up</string>
     <string name="tv_up_next_empty_subtitle">Add episodes to Up Next and they’ll play in order, back to back</string>
     <string name="tv_up_next_empty_action_title">Add episodes</string>
-    <string name="tv_podcasts_empty_title">Time to fill this up</string>
-    <string name="tv_podcasts_empty_subtitle">Followed podcasts show up here, ready to play.</string>
-    <string name="tv_podcasts_empty_action_title">Discover podcasts</string>
+    <string name="tv_your_podcasts_empty_title">Time to fill this up</string>
+    <string name="tv_your_podcasts_empty_subtitle">Followed podcasts show up here, ready to play.</string>
+    <string name="tv_your_podcasts_empty_action_title">Discover podcasts</string>
     <string name="unavailable">Unavailable</string>
     <string name="browse_podcasts">Browse podcasts</string>
     <string name="pocket_casts_plus_badge">Pocket Casts Plus badge</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -272,6 +272,9 @@
     <string name="tv_up_next_empty_title">Nothing queued up</string>
     <string name="tv_up_next_empty_subtitle">Add episodes to Up Next and they’ll play in order, back to back</string>
     <string name="tv_up_next_empty_action_title">Add episodes</string>
+    <string name="tv_podcasts_empty_title">Time to fill this up</string>
+    <string name="tv_podcasts_empty_subtitle">Followed podcasts show up here, ready to play.</string>
+    <string name="tv_podcasts_empty_action_title">Discover podcasts</string>
     <string name="unavailable">Unavailable</string>
     <string name="browse_podcasts">Browse podcasts</string>
     <string name="pocket_casts_plus_badge">Pocket Casts Plus badge</string>

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastTile.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastTile.kt
@@ -22,6 +22,7 @@ fun TvPodcastTile(
     podcastTitle: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    imageModifier: Modifier = Modifier.width(123.dp),
 ) {
     TvTile(
         onClick = onClick,
@@ -31,9 +32,7 @@ fun TvPodcastTile(
             model = artworkUrl,
             contentDescription = podcastTitle,
             contentScale = ContentScale.Crop,
-            modifier = Modifier
-                .width(123.dp)
-                .aspectRatio(1f),
+            modifier = imageModifier.aspectRatio(1f),
         )
     }
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastTile.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastTile.kt
@@ -37,6 +37,10 @@ fun TvPodcastTile(
     }
 }
 
+object TvPodcastTileDefaults {
+    val RowImageWidth = 123.dp
+}
+
 @Preview(device = Devices.TV_1080p)
 @Composable
 private fun TvPodcastTilePreview() {
@@ -47,7 +51,7 @@ private fun TvPodcastTilePreview() {
                     artworkUrl = "",
                     podcastTitle = "Sample Podcast",
                     onClick = {},
-                    imageModifier = Modifier.width(123.dp),
+                    imageModifier = Modifier.width(TvPodcastTileDefaults.RowImageWidth),
                 )
             }
         }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastTile.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastTile.kt
@@ -22,7 +22,7 @@ fun TvPodcastTile(
     podcastTitle: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    imageModifier: Modifier = Modifier.width(123.dp),
+    imageModifier: Modifier = Modifier,
 ) {
     TvTile(
         onClick = onClick,
@@ -47,6 +47,7 @@ private fun TvPodcastTilePreview() {
                     artworkUrl = "",
                     podcastTitle = "Sample Podcast",
                     onClick = {},
+                    imageModifier = Modifier.width(123.dp),
                 )
             }
         }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -146,6 +147,7 @@ private fun TvHomeRows(
                             artworkUrl = podcast.artworkUrl,
                             podcastTitle = podcast.title,
                             onClick = {},
+                            imageModifier = Modifier.width(123.dp),
                         )
                     }
                 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeScreen.kt
@@ -25,6 +25,7 @@ import androidx.tv.material3.OutlinedButton
 import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.component.TvFeaturedTile
 import au.com.shiftyjelly.pocketcasts.component.TvPodcastTile
+import au.com.shiftyjelly.pocketcasts.component.TvPodcastTileDefaults
 import au.com.shiftyjelly.pocketcasts.component.TvRow
 import au.com.shiftyjelly.pocketcasts.component.TvVideoTile
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
@@ -147,7 +148,7 @@ private fun TvHomeRows(
                             artworkUrl = podcast.artworkUrl,
                             podcastTitle = podcast.title,
                             onClick = {},
-                            imageModifier = Modifier.width(123.dp),
+                            imageModifier = Modifier.width(TvPodcastTileDefaults.RowImageWidth),
                         )
                     }
                 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
@@ -48,7 +48,7 @@ fun TvScaffold(
             is TvTab.Home -> TvHomeScreen()
 
             is TvTab.YourPodcasts -> TvYourPodcastsScreen(
-                onNavigateToDiscover = navigateToHome,
+                onNavigateToHome = navigateToHome,
             )
 
             is TvTab.Playlists -> TvPlaylistsScreen()

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
@@ -20,6 +20,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.MaterialTheme
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.playlists.TvPlaylistsScreen
+import au.com.shiftyjelly.pocketcasts.podcasts.TvYourPodcastsScreen
 import au.com.shiftyjelly.pocketcasts.theme.TvColors
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.upnext.TvUpNextScreen
@@ -42,13 +43,18 @@ fun TvScaffold(
         onProfileClick = { isProfileModalVisible = true },
         modifier = modifier,
     ) { tab ->
+        val navigateToHome = { viewModel.selectTab(TvTab.entries.indexOf(TvTab.Home)) }
         when (tab) {
             is TvTab.Home -> TvHomeScreen()
+
+            is TvTab.YourPodcasts -> TvYourPodcastsScreen(
+                onNavigateToDiscover = navigateToHome,
+            )
 
             is TvTab.Playlists -> TvPlaylistsScreen()
 
             is TvTab.UpNext -> TvUpNextScreen(
-                onNavigateToHome = { viewModel.selectTab(TvTab.entries.indexOf(TvTab.Home)) },
+                onNavigateToHome = navigateToHome,
             )
 
             else -> TvTabPlaceholder(tab = tab)

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvTabPlaceholder.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvTabPlaceholder.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -79,6 +80,7 @@ fun TvTabPlaceholder(
                     artworkUrl = "https://picsum.photos/seed/rec$index/272/272",
                     podcastTitle = "Podcast $index",
                     onClick = {},
+                    imageModifier = Modifier.width(123.dp),
                 )
             }
         }
@@ -92,6 +94,7 @@ fun TvTabPlaceholder(
                     artworkUrl = "https://picsum.photos/seed/liked$index/272/272",
                     podcastTitle = "Podcast $index",
                     onClick = {},
+                    imageModifier = Modifier.width(123.dp),
                 )
             }
         }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvTabPlaceholder.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvTabPlaceholder.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.unit.dp
 import androidx.tv.material3.MaterialTheme
 import au.com.shiftyjelly.pocketcasts.component.TvFeaturedTile
 import au.com.shiftyjelly.pocketcasts.component.TvPodcastTile
+import au.com.shiftyjelly.pocketcasts.component.TvPodcastTileDefaults
 import au.com.shiftyjelly.pocketcasts.component.TvRow
 import au.com.shiftyjelly.pocketcasts.component.TvVideoTile
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
@@ -80,7 +81,7 @@ fun TvTabPlaceholder(
                     artworkUrl = "https://picsum.photos/seed/rec$index/272/272",
                     podcastTitle = "Podcast $index",
                     onClick = {},
-                    imageModifier = Modifier.width(123.dp),
+                    imageModifier = Modifier.width(TvPodcastTileDefaults.RowImageWidth),
                 )
             }
         }
@@ -94,7 +95,7 @@ fun TvTabPlaceholder(
                     artworkUrl = "https://picsum.photos/seed/liked$index/272/272",
                     podcastTitle = "Podcast $index",
                     onClick = {},
-                    imageModifier = Modifier.width(123.dp),
+                    imageModifier = Modifier.width(TvPodcastTileDefaults.RowImageWidth),
                 )
             }
         }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsScreen.kt
@@ -11,24 +11,19 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
@@ -36,21 +31,19 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.tv.material3.Button
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.component.TvEmptyState
 import au.com.shiftyjelly.pocketcasts.component.TvPodcastTile
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.loading.LoadingView
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImage
-import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
 import au.com.shiftyjelly.pocketcasts.theme.TvColors
 import au.com.shiftyjelly.pocketcasts.theme.TvTextStyles
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
@@ -58,7 +51,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 fun TvYourPodcastsScreen(
-    onNavigateToDiscover: () -> Unit,
+    onNavigateToHome: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: TvYourPodcastsViewModel = hiltViewModel(),
 ) {
@@ -66,7 +59,7 @@ fun TvYourPodcastsScreen(
 
     TvYourPodcastsContent(
         uiState = uiState,
-        onNavigateToDiscover = onNavigateToDiscover,
+        onNavigateToHome = onNavigateToHome,
         modifier = modifier,
     )
 }
@@ -74,7 +67,7 @@ fun TvYourPodcastsScreen(
 @Composable
 private fun TvYourPodcastsContent(
     uiState: TvYourPodcastsUiState,
-    onNavigateToDiscover: () -> Unit,
+    onNavigateToHome: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     AnimatedContent(
@@ -93,8 +86,11 @@ private fun TvYourPodcastsContent(
         when (state) {
             is TvYourPodcastsUiState.Loading -> LoadingView(color = Color.White, modifier = Modifier.fillMaxSize())
 
-            is TvYourPodcastsUiState.Empty -> TvYourPodcastsEmpty(
-                onNavigateToDiscover = onNavigateToDiscover,
+            is TvYourPodcastsUiState.Empty -> TvEmptyState(
+                title = stringResource(LR.string.tv_your_podcasts_empty_title),
+                subtitle = stringResource(LR.string.tv_your_podcasts_empty_subtitle),
+                actionLabel = stringResource(LR.string.tv_your_podcasts_empty_action_title),
+                onAction = onNavigateToHome,
                 modifier = Modifier.fillMaxSize(),
             )
 
@@ -136,7 +132,7 @@ private fun TvYourPodcastsGrid(
                         val target = podcasts.indexOfFirst { it.uuid == lastFocusedUuid }
                             .takeIf { index -> index >= 0 && visible.any { it.index == index } }
                             ?: visible.firstOrNull()?.index
-                        target?.let { focusRequesters.getOrNull(it)?.requestFocus() }
+                        target?.let { runCatching { focusRequesters.getOrNull(it)?.requestFocus() } }
                     }
                 },
         ) {
@@ -162,46 +158,6 @@ private fun TvYourPodcastsGrid(
     }
 }
 
-@Composable
-private fun TvYourPodcastsEmpty(
-    onNavigateToDiscover: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    val focusRequester = remember { FocusRequester() }
-    LaunchedEffect(Unit) {
-        focusRequester.requestFocus()
-    }
-    Box(
-        contentAlignment = Alignment.Center,
-        modifier = modifier,
-    ) {
-        Column(horizontalAlignment = Alignment.CenterHorizontally) {
-            Text(
-                text = stringResource(LR.string.tv_your_podcasts_empty_title),
-                style = TvTextStyles.ScreenTitle,
-                color = Color.White,
-                textAlign = TextAlign.Center,
-            )
-            Spacer(modifier = Modifier.height(12.dp))
-            Text(
-                text = stringResource(LR.string.tv_your_podcasts_empty_subtitle),
-                style = MaterialTheme.typography.bodyLarge,
-                color = TvColors.TextSecondary,
-                textAlign = TextAlign.Center,
-                modifier = Modifier.widthIn(max = 400.dp),
-            )
-            Spacer(modifier = Modifier.height(32.dp))
-            Button(
-                onClick = onNavigateToDiscover,
-                colors = TvButtonDefaults.filledButtonColors(),
-                modifier = Modifier.focusRequester(focusRequester),
-            ) {
-                Text(stringResource(LR.string.tv_your_podcasts_empty_action_title))
-            }
-        }
-    }
-}
-
 private const val GRID_COLUMNS = 6
 
 @Preview(device = Devices.TV_1080p)
@@ -214,7 +170,7 @@ private fun TvYourPodcastsGridPreview() {
                     uiState = TvYourPodcastsUiState.Loaded(
                         podcasts = List(12) { index -> Podcast(uuid = "podcast-$index", title = "Podcast $index") },
                     ),
-                    onNavigateToDiscover = {},
+                    onNavigateToHome = {},
                 )
             }
         }
@@ -229,7 +185,7 @@ private fun TvYourPodcastsEmptyPreview() {
             Box(modifier = Modifier.background(TvColors.Dark)) {
                 TvYourPodcastsContent(
                     uiState = TvYourPodcastsUiState.Empty,
-                    onNavigateToDiscover = {},
+                    onNavigateToHome = {},
                 )
             }
         }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsScreen.kt
@@ -63,10 +63,6 @@ fun TvYourPodcastsScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
-    LaunchedEffect(Unit) {
-        viewModel.onShown()
-    }
-
     TvYourPodcastsContent(
         uiState = uiState,
         onNavigateToDiscover = onNavigateToDiscover,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsScreen.kt
@@ -122,8 +122,8 @@ private fun TvYourPodcastsGrid(
 
         LazyVerticalGrid(
             columns = GridCells.Fixed(GRID_COLUMNS),
-            horizontalArrangement = Arrangement.spacedBy(24.dp),
-            verticalArrangement = Arrangement.spacedBy(24.dp),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
             contentPadding = PaddingValues(start = 32.dp, top = 16.dp, end = 32.dp, bottom = 32.dp),
             modifier = Modifier
                 .focusGroup()

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsScreen.kt
@@ -20,10 +20,11 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.itemsIndexed
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
@@ -117,10 +118,12 @@ private fun TvYourPodcastsGrid(
             color = Color.White,
             modifier = Modifier.padding(start = 32.dp, top = 8.dp, bottom = 10.dp),
         )
-        var lastFocusedIndex by rememberSaveable(podcasts.size) { mutableIntStateOf(0) }
+        val gridState = rememberLazyGridState()
+        var lastFocusedUuid by rememberSaveable { mutableStateOf<String?>(null) }
         val focusRequesters = remember(podcasts.size) { List(podcasts.size) { FocusRequester() } }
 
         LazyVerticalGrid(
+            state = gridState,
             columns = GridCells.Fixed(GRID_COLUMNS),
             horizontalArrangement = Arrangement.spacedBy(16.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp),
@@ -129,7 +132,11 @@ private fun TvYourPodcastsGrid(
                 .focusGroup()
                 .focusProperties {
                     onEnter = {
-                        focusRequesters.getOrNull(lastFocusedIndex)?.requestFocus()
+                        val visible = gridState.layoutInfo.visibleItemsInfo
+                        val target = podcasts.indexOfFirst { it.uuid == lastFocusedUuid }
+                            .takeIf { index -> index >= 0 && visible.any { it.index == index } }
+                            ?: visible.firstOrNull()?.index
+                        target?.let { focusRequesters.getOrNull(it)?.requestFocus() }
                     }
                 },
         ) {
@@ -146,7 +153,7 @@ private fun TvYourPodcastsGrid(
                         .focusRequester(focusRequesters[index])
                         .onFocusChanged { focusState ->
                             if (focusState.hasFocus) {
-                                lastFocusedIndex = index
+                                lastFocusedUuid = podcast.uuid
                             }
                         },
                 )
@@ -170,14 +177,14 @@ private fun TvYourPodcastsEmpty(
     ) {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
             Text(
-                text = stringResource(LR.string.tv_podcasts_empty_title),
+                text = stringResource(LR.string.tv_your_podcasts_empty_title),
                 style = TvTextStyles.ScreenTitle,
                 color = Color.White,
                 textAlign = TextAlign.Center,
             )
             Spacer(modifier = Modifier.height(12.dp))
             Text(
-                text = stringResource(LR.string.tv_podcasts_empty_subtitle),
+                text = stringResource(LR.string.tv_your_podcasts_empty_subtitle),
                 style = MaterialTheme.typography.bodyLarge,
                 color = TvColors.TextSecondary,
                 textAlign = TextAlign.Center,
@@ -189,7 +196,7 @@ private fun TvYourPodcastsEmpty(
                 colors = TvButtonDefaults.filledButtonColors(),
                 modifier = Modifier.focusRequester(focusRequester),
             ) {
-                Text(stringResource(LR.string.tv_podcasts_empty_action_title))
+                Text(stringResource(LR.string.tv_your_podcasts_empty_action_title))
             }
         }
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsScreen.kt
@@ -110,12 +110,12 @@ private fun TvYourPodcastsGrid(
     podcasts: List<Podcast>,
     modifier: Modifier = Modifier,
 ) {
-    Column(modifier = modifier.padding(horizontal = 32.dp)) {
+    Column(modifier = modifier) {
         Text(
             text = stringResource(LR.string.tv_tab_your_podcasts),
             style = TvTextStyles.ScreenTitle,
             color = Color.White,
-            modifier = Modifier.padding(top = 8.dp, bottom = 26.dp),
+            modifier = Modifier.padding(start = 32.dp, top = 8.dp, bottom = 10.dp),
         )
         var lastFocusedIndex by rememberSaveable(podcasts.size) { mutableIntStateOf(0) }
         val focusRequesters = remember(podcasts.size) { List(podcasts.size) { FocusRequester() } }
@@ -124,7 +124,7 @@ private fun TvYourPodcastsGrid(
             columns = GridCells.Fixed(GRID_COLUMNS),
             horizontalArrangement = Arrangement.spacedBy(24.dp),
             verticalArrangement = Arrangement.spacedBy(24.dp),
-            contentPadding = PaddingValues(bottom = 32.dp),
+            contentPadding = PaddingValues(start = 32.dp, top = 16.dp, end = 32.dp, bottom = 32.dp),
             modifier = Modifier
                 .focusGroup()
                 .focusProperties {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -45,8 +44,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.Button
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
-import au.com.shiftyjelly.pocketcasts.component.TvArtworkImage
-import au.com.shiftyjelly.pocketcasts.component.TvTile
+import au.com.shiftyjelly.pocketcasts.component.TvPodcastTile
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.loading.LoadingView
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
@@ -124,7 +122,7 @@ private fun TvYourPodcastsGrid(
             modifier = Modifier.padding(top = 8.dp, bottom = 26.dp),
         )
         var lastFocusedIndex by rememberSaveable(podcasts.size) { mutableIntStateOf(0) }
-        val focusRequesters = remember(podcasts) { List(podcasts.size) { FocusRequester() } }
+        val focusRequesters = remember(podcasts.size) { List(podcasts.size) { FocusRequester() } }
 
         LazyVerticalGrid(
             columns = GridCells.Fixed(GRID_COLUMNS),
@@ -143,8 +141,11 @@ private fun TvYourPodcastsGrid(
                 items = podcasts,
                 key = { _, podcast -> podcast.uuid },
             ) { index, podcast ->
-                TvPodcastGridItem(
-                    podcast = podcast,
+                TvPodcastTile(
+                    artworkUrl = PodcastImage.getMediumArtworkUrl(podcast.uuid),
+                    podcastTitle = podcast.title,
+                    onClick = {},
+                    imageModifier = Modifier.fillMaxWidth(),
                     modifier = Modifier
                         .focusRequester(focusRequesters[index])
                         .onFocusChanged { focusState ->
@@ -155,24 +156,6 @@ private fun TvYourPodcastsGrid(
                 )
             }
         }
-    }
-}
-
-@Composable
-private fun TvPodcastGridItem(
-    podcast: Podcast,
-    modifier: Modifier = Modifier,
-) {
-    TvTile(
-        onClick = {},
-        modifier = modifier,
-    ) {
-        TvArtworkImage(
-            model = PodcastImage.getMediumArtworkUrl(podcast.uuid),
-            modifier = Modifier
-                .fillMaxWidth()
-                .aspectRatio(1f),
-        )
     }
 }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsScreen.kt
@@ -1,0 +1,251 @@
+package au.com.shiftyjelly.pocketcasts.podcasts
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.background
+import androidx.compose.foundation.focusGroup
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.itemsIndexed
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.tv.material3.Button
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.component.TvArtworkImage
+import au.com.shiftyjelly.pocketcasts.component.TvTile
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.compose.loading.LoadingView
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImage
+import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
+import au.com.shiftyjelly.pocketcasts.theme.TvColors
+import au.com.shiftyjelly.pocketcasts.theme.TvTextStyles
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+fun TvYourPodcastsScreen(
+    onNavigateToDiscover: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: TvYourPodcastsViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    LaunchedEffect(Unit) {
+        viewModel.onShown()
+    }
+
+    TvYourPodcastsContent(
+        uiState = uiState,
+        onNavigateToDiscover = onNavigateToDiscover,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun TvYourPodcastsContent(
+    uiState: TvYourPodcastsUiState,
+    onNavigateToDiscover: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    AnimatedContent(
+        targetState = uiState,
+        transitionSpec = { fadeIn(tween(durationMillis = 300)) togetherWith fadeOut(tween(durationMillis = 300)) },
+        contentKey = { state ->
+            when (state) {
+                is TvYourPodcastsUiState.Loading -> "loading"
+                is TvYourPodcastsUiState.Empty -> "empty"
+                is TvYourPodcastsUiState.Loaded -> "content"
+            }
+        },
+        label = "TvYourPodcastsContent",
+        modifier = modifier,
+    ) { state ->
+        when (state) {
+            is TvYourPodcastsUiState.Loading -> LoadingView(color = Color.White, modifier = Modifier.fillMaxSize())
+
+            is TvYourPodcastsUiState.Empty -> TvYourPodcastsEmpty(
+                onNavigateToDiscover = onNavigateToDiscover,
+                modifier = Modifier.fillMaxSize(),
+            )
+
+            is TvYourPodcastsUiState.Loaded -> TvYourPodcastsGrid(
+                podcasts = state.podcasts,
+                modifier = Modifier.fillMaxSize(),
+            )
+        }
+    }
+}
+
+@Composable
+private fun TvYourPodcastsGrid(
+    podcasts: List<Podcast>,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.padding(horizontal = 32.dp)) {
+        Text(
+            text = stringResource(LR.string.tv_tab_your_podcasts),
+            style = TvTextStyles.ScreenTitle,
+            color = Color.White,
+            modifier = Modifier.padding(top = 8.dp, bottom = 26.dp),
+        )
+        var lastFocusedIndex by rememberSaveable(podcasts.size) { mutableIntStateOf(0) }
+        val focusRequesters = remember(podcasts) { List(podcasts.size) { FocusRequester() } }
+
+        LazyVerticalGrid(
+            columns = GridCells.Fixed(GRID_COLUMNS),
+            horizontalArrangement = Arrangement.spacedBy(24.dp),
+            verticalArrangement = Arrangement.spacedBy(24.dp),
+            contentPadding = PaddingValues(bottom = 32.dp),
+            modifier = Modifier
+                .focusGroup()
+                .focusProperties {
+                    onEnter = {
+                        focusRequesters.getOrNull(lastFocusedIndex)?.requestFocus()
+                    }
+                },
+        ) {
+            itemsIndexed(
+                items = podcasts,
+                key = { _, podcast -> podcast.uuid },
+            ) { index, podcast ->
+                TvPodcastGridItem(
+                    podcast = podcast,
+                    modifier = Modifier
+                        .focusRequester(focusRequesters[index])
+                        .onFocusChanged { focusState ->
+                            if (focusState.hasFocus) {
+                                lastFocusedIndex = index
+                            }
+                        },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun TvPodcastGridItem(
+    podcast: Podcast,
+    modifier: Modifier = Modifier,
+) {
+    TvTile(
+        onClick = {},
+        modifier = modifier,
+    ) {
+        TvArtworkImage(
+            model = PodcastImage.getMediumArtworkUrl(podcast.uuid),
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(1f),
+        )
+    }
+}
+
+@Composable
+private fun TvYourPodcastsEmpty(
+    onNavigateToDiscover: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val focusRequester = remember { FocusRequester() }
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = modifier,
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text = stringResource(LR.string.tv_podcasts_empty_title),
+                style = TvTextStyles.ScreenTitle,
+                color = Color.White,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = stringResource(LR.string.tv_podcasts_empty_subtitle),
+                style = MaterialTheme.typography.bodyLarge,
+                color = TvColors.TextSecondary,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.widthIn(max = 400.dp),
+            )
+            Spacer(modifier = Modifier.height(32.dp))
+            Button(
+                onClick = onNavigateToDiscover,
+                colors = TvButtonDefaults.filledButtonColors(),
+                modifier = Modifier.focusRequester(focusRequester),
+            ) {
+                Text(stringResource(LR.string.tv_podcasts_empty_action_title))
+            }
+        }
+    }
+}
+
+private const val GRID_COLUMNS = 6
+
+@Preview(device = Devices.TV_1080p)
+@Composable
+private fun TvYourPodcastsGridPreview() {
+    AppTheme(themeType = Theme.ThemeType.EXTRA_DARK) {
+        MaterialTheme {
+            Box(modifier = Modifier.background(TvColors.Dark)) {
+                TvYourPodcastsContent(
+                    uiState = TvYourPodcastsUiState.Loaded(
+                        podcasts = List(12) { index -> Podcast(uuid = "podcast-$index", title = "Podcast $index") },
+                    ),
+                    onNavigateToDiscover = {},
+                )
+            }
+        }
+    }
+}
+
+@Preview(device = Devices.TV_1080p)
+@Composable
+private fun TvYourPodcastsEmptyPreview() {
+    AppTheme(themeType = Theme.ThemeType.EXTRA_DARK) {
+        MaterialTheme {
+            Box(modifier = Modifier.background(TvColors.Dark)) {
+                TvYourPodcastsContent(
+                    uiState = TvYourPodcastsUiState.Empty,
+                    onNavigateToDiscover = {},
+                )
+            }
+        }
+    }
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsViewModel.kt
@@ -3,36 +3,30 @@ package au.com.shiftyjelly.pocketcasts.podcasts
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
-import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
-import au.com.shiftyjelly.pocketcasts.repositories.di.DefaultDispatcher
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.milliseconds
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.WhileSubscribed
-import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 
 @HiltViewModel
 class TvYourPodcastsViewModel @Inject constructor(
     private val podcastManager: PodcastManager,
-    @DefaultDispatcher private val defaultDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
 
+    // PodcastDao orders subscribed podcasts by clean_title with a leading "the " stripped.
     val uiState: StateFlow<TvYourPodcastsUiState> = podcastManager.findSubscribedFlow()
         .map { podcasts ->
-            val sorted = podcasts.sortedWith(PodcastsSortType.NAME_A_TO_Z.podcastComparator)
-            if (sorted.isEmpty()) {
+            if (podcasts.isEmpty()) {
                 TvYourPodcastsUiState.Empty
             } else {
-                TvYourPodcastsUiState.Loaded(sorted)
+                TvYourPodcastsUiState.Loaded(podcasts)
             }
         }
-        .flowOn(defaultDispatcher)
         .stateIn(
             viewModelScope,
             SharingStarted.WhileSubscribed(stopTimeout = 300.milliseconds),

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsViewModel.kt
@@ -4,19 +4,23 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
+import au.com.shiftyjelly.pocketcasts.repositories.di.DefaultDispatcher
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.WhileSubscribed
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 
 @HiltViewModel
 class TvYourPodcastsViewModel @Inject constructor(
     private val podcastManager: PodcastManager,
+    @DefaultDispatcher private val defaultDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
 
     val uiState: StateFlow<TvYourPodcastsUiState> = podcastManager.findSubscribedFlow()
@@ -28,6 +32,7 @@ class TvYourPodcastsViewModel @Inject constructor(
                 TvYourPodcastsUiState.Loaded(sorted)
             }
         }
+        .flowOn(defaultDispatcher)
         .stateIn(
             viewModelScope,
             SharingStarted.WhileSubscribed(stopTimeout = 300.milliseconds),

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsViewModel.kt
@@ -33,10 +33,6 @@ class TvYourPodcastsViewModel @Inject constructor(
             SharingStarted.WhileSubscribed(stopTimeout = 300.milliseconds),
             TvYourPodcastsUiState.Loading,
         )
-
-    fun onShown() {
-        podcastManager.refreshPodcasts(fromLog = "tv your podcasts")
-    }
 }
 
 sealed interface TvYourPodcastsUiState {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsViewModel.kt
@@ -1,0 +1,50 @@
+package au.com.shiftyjelly.pocketcasts.podcasts
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.WhileSubscribed
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+
+@HiltViewModel
+class TvYourPodcastsViewModel @Inject constructor(
+    private val podcastManager: PodcastManager,
+) : ViewModel() {
+
+    val uiState: StateFlow<TvYourPodcastsUiState> = podcastManager.findSubscribedFlow()
+        .map { podcasts ->
+            val sorted = podcasts.sortedWith(PodcastsSortType.NAME_A_TO_Z.podcastComparator)
+            if (sorted.isEmpty()) {
+                TvYourPodcastsUiState.Empty
+            } else {
+                TvYourPodcastsUiState.Loaded(sorted)
+            }
+        }
+        .stateIn(
+            viewModelScope,
+            SharingStarted.WhileSubscribed(stopTimeout = 300.milliseconds),
+            TvYourPodcastsUiState.Loading,
+        )
+
+    fun onShown() {
+        podcastManager.refreshPodcasts(fromLog = "tv your podcasts")
+    }
+}
+
+sealed interface TvYourPodcastsUiState {
+    data object Loading : TvYourPodcastsUiState
+
+    data object Empty : TvYourPodcastsUiState
+
+    data class Loaded(
+        val podcasts: List<Podcast>,
+    ) : TvYourPodcastsUiState
+}

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsViewModelTest.kt
@@ -53,8 +53,25 @@ class TvYourPodcastsViewModelTest {
         }
     }
 
+    @Test
+    fun `unsubscribing the last podcast falls back to the empty state`() = runTest {
+        val viewModel = createViewModel()
+        val apple = podcast("apple", "Apple Cast")
+
+        viewModel.uiState.test {
+            assertEquals(TvYourPodcastsUiState.Loading, awaitItem())
+
+            subscribed.emit(listOf(apple))
+            assertEquals(TvYourPodcastsUiState.Loaded(listOf(apple)), awaitItem())
+
+            subscribed.emit(emptyList())
+            assertEquals(TvYourPodcastsUiState.Empty, awaitItem())
+        }
+    }
+
     private fun createViewModel() = TvYourPodcastsViewModel(
         podcastManager = podcastManager,
+        defaultDispatcher = coroutineRule.testDispatcher,
     )
 
     private fun podcast(uuid: String, title: String) = Podcast(uuid = uuid, title = title)

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsViewModelTest.kt
@@ -10,10 +10,8 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
-import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.verify
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class TvYourPodcastsViewModelTest {
@@ -53,15 +51,6 @@ class TvYourPodcastsViewModelTest {
 
             assertEquals(TvYourPodcastsUiState.Loaded(listOf(apple, theBeat, zebra)), awaitItem())
         }
-    }
-
-    @Test
-    fun `showing the tab refreshes podcasts`() = runTest {
-        val viewModel = createViewModel()
-
-        viewModel.onShown()
-
-        verify(podcastManager).refreshPodcasts(any())
     }
 
     private fun createViewModel() = TvYourPodcastsViewModel(

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsViewModelTest.kt
@@ -38,16 +38,16 @@ class TvYourPodcastsViewModelTest {
     }
 
     @Test
-    fun `subscriptions are exposed sorted by title`() = runTest {
+    fun `subscriptions preserve the order provided by the dao`() = runTest {
         val viewModel = createViewModel()
-        val zebra = podcast("zebra", "Zebra Cast")
         val apple = podcast("apple", "Apple Cast")
         val theBeat = podcast("beat", "The Beat")
+        val zebra = podcast("zebra", "Zebra Cast")
 
         viewModel.uiState.test {
             assertEquals(TvYourPodcastsUiState.Loading, awaitItem())
 
-            subscribed.emit(listOf(zebra, apple, theBeat))
+            subscribed.emit(listOf(apple, theBeat, zebra))
 
             assertEquals(TvYourPodcastsUiState.Loaded(listOf(apple, theBeat, zebra)), awaitItem())
         }
@@ -71,7 +71,6 @@ class TvYourPodcastsViewModelTest {
 
     private fun createViewModel() = TvYourPodcastsViewModel(
         podcastManager = podcastManager,
-        defaultDispatcher = coroutineRule.testDispatcher,
     )
 
     private fun podcast(uuid: String, title: String) = Podcast(uuid = uuid, title = title)

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsViewModelTest.kt
@@ -1,0 +1,72 @@
+package au.com.shiftyjelly.pocketcasts.podcasts
+
+import app.cash.turbine.test
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TvYourPodcastsViewModelTest {
+
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
+
+    private val subscribed = MutableSharedFlow<List<Podcast>>(replay = 1)
+    private val podcastManager = mock<PodcastManager> {
+        on { findSubscribedFlow() } doReturn subscribed
+    }
+
+    @Test
+    fun `no subscriptions map to the empty state`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            assertEquals(TvYourPodcastsUiState.Loading, awaitItem())
+
+            subscribed.emit(emptyList())
+
+            assertEquals(TvYourPodcastsUiState.Empty, awaitItem())
+        }
+    }
+
+    @Test
+    fun `subscriptions are exposed sorted by title`() = runTest {
+        val viewModel = createViewModel()
+        val zebra = podcast("zebra", "Zebra Cast")
+        val apple = podcast("apple", "Apple Cast")
+        val theBeat = podcast("beat", "The Beat")
+
+        viewModel.uiState.test {
+            assertEquals(TvYourPodcastsUiState.Loading, awaitItem())
+
+            subscribed.emit(listOf(zebra, apple, theBeat))
+
+            assertEquals(TvYourPodcastsUiState.Loaded(listOf(apple, theBeat, zebra)), awaitItem())
+        }
+    }
+
+    @Test
+    fun `showing the tab refreshes podcasts`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.onShown()
+
+        verify(podcastManager).refreshPodcasts(any())
+    }
+
+    private fun createViewModel() = TvYourPodcastsViewModel(
+        podcastManager = podcastManager,
+    )
+
+    private fun podcast(uuid: String, title: String) = Podcast(uuid = uuid, title = title)
+}


### PR DESCRIPTION
## Description

Adds the **Your Podcasts** tab to the TV app, mirroring the Apple TV `PodcastsView`. This PR covers the two states in scope — the empty view and the populated podcasts grid. Folders are handled as a follow-up (stacked on this branch).

- **Grid:** subscribed podcasts are shown as a 6-column grid of square artwork tiles, matching tvOS's `LazyVGrid` of 6 fixed columns. Focus scales the tile and the last-focused position is restored when re-entering the grid (the same focus pattern as the Playlists tab).
- **Data:** observes `PodcastManager.findSubscribedFlow()` and sorts with `PodcastsSortType.NAME_A_TO_Z` — the article-aware A→Z order tvOS uses (`HomeGridDataHelper.gridItems(orderedBy: .titleAtoZ)`). The list is kept fresh reactively from the DB (synced at sign-in); see the note below on why the tab doesn't force its own network refresh.
- **Empty state:** "Time to fill this up" with a **Discover podcasts** button that jumps to the Home tab, matching tvOS's `ContentUnavailableView` action (`tabRouter.selectedTab = .home`).
- **Reuse:** generalized the existing `TvPodcastTile` with an `imageModifier` (defaulting to the current fixed 123.dp used by the Home rows) so the same component fills a grid cell here — this also gives each tile a proper artwork content description.

**Scope / deliberate deviations** (consistent with the rest of the TV module):
- The screen title is pinned above the grid rather than scrolling with it as on tvOS — this matches the sibling Playlists / Up Next tabs, favouring platform-internal consistency.
- Tapping a podcast is a no-op — the podcast detail screen isn't wired anywhere on TV yet, and it's out of scope for this ticket (grid + empty view only). The tiles remain focusable, matching the Home tab tiles.
- No analytics — the TV module has none; adding the tvOS `podcastsListShown` events would need an EventHorizon schema change and would be inconsistent with the sibling tabs.

Fixes PCDROID-696 https://linear.app/a8c/issue/PCDROID-696/podcasts-grid-and-empty-view.
Designs: Ftk3KwnfqaK4g57yCN63p0-fi-2052_15345.

Stacked on `feat/tv-up-next` (#5679) — merge bottom-up.

## Testing Instructions

1. Install the TV app (`./gradlew :tv:installDebugProd`) and sign in with an account that follows several podcasts.
2. Open the **Your Podcasts** tab — verify the followed podcasts appear as a 6-column grid, sorted A→Z (ignoring a leading "The"), under a "Your Podcasts" title.
3. Navigate the grid with the d-pad — the focused tile scales up; leave and re-enter the grid and verify focus returns to the last-focused tile.
4. Empty state: with an account that follows no podcasts, verify "Time to fill this up" with a focused **Discover podcasts** button; selecting it switches to the Home tab.
5. Navigate in and out of the tab repeatedly — verify it never crashes (regression check for the token-refresh crash described above).

## Screenshots or Screencast


https://github.com/user-attachments/assets/91b45bd3-2d7b-4118-b0af-b53cff9428ff



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md _(TV app is unreleased — skipped)_
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes _(added `TvYourPodcastsViewModelTest`)_
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics. _(analytics deliberately excluded — matches the rest of the TV module)_