### PR TITLE
[TV] Add folder support to the Your Podcasts tab

### DIFF
--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -275,7 +275,7 @@
     <string name="tv_your_podcasts_empty_title">Time to fill this up</string>
     <string name="tv_your_podcasts_empty_subtitle">Followed podcasts show up here, ready to play.</string>
     <string name="tv_your_podcasts_empty_action_title">Discover podcasts</string>
-    <string name="tv_folder_empty_message">Edit your folder in the mobile app, they’ll be waiting here when you’re done.</string>
+    <string name="tv_folder_empty_message">Add podcasts to this folder in the mobile app and they’ll show up here.</string>
     <string name="unavailable">Unavailable</string>
     <string name="browse_podcasts">Browse podcasts</string>
     <string name="pocket_casts_plus_badge">Pocket Casts Plus badge</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -275,6 +275,7 @@
     <string name="tv_your_podcasts_empty_title">Time to fill this up</string>
     <string name="tv_your_podcasts_empty_subtitle">Followed podcasts show up here, ready to play.</string>
     <string name="tv_your_podcasts_empty_action_title">Discover podcasts</string>
+    <string name="tv_folder_empty_message">Edit your folder in the mobile app, they’ll be waiting here when you’re done.</string>
     <string name="unavailable">Unavailable</string>
     <string name="browse_podcasts">Browse podcasts</string>
     <string name="pocket_casts_plus_badge">Pocket Casts Plus badge</string>

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEmptyState.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEmptyState.kt
@@ -8,8 +8,13 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Devices
@@ -31,7 +36,15 @@ fun TvEmptyState(
     actionLabel: String,
     onAction: () -> Unit,
     modifier: Modifier = Modifier,
+    autoFocusAction: Boolean = false,
 ) {
+    val focusRequester = remember { FocusRequester() }
+    if (autoFocusAction) {
+        LaunchedEffect(Unit) {
+            withFrameNanos {}
+            runCatching { focusRequester.requestFocus() }
+        }
+    }
     Box(
         contentAlignment = Alignment.Center,
         modifier = modifier,
@@ -55,6 +68,7 @@ fun TvEmptyState(
             Button(
                 onClick = onAction,
                 colors = TvButtonDefaults.filledButtonColors(),
+                modifier = if (autoFocusAction) Modifier.focusRequester(focusRequester) else Modifier,
             ) {
                 Text(actionLabel, style = TvTextStyles.ModalButtonLabel)
             }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvFolderCard.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvFolderCard.kt
@@ -1,0 +1,119 @@
+package au.com.shiftyjelly.pocketcasts.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.tv.material3.CardDefaults
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.compose.LocalColors
+import au.com.shiftyjelly.pocketcasts.models.entity.Folder
+import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
+import au.com.shiftyjelly.pocketcasts.theme.TvColors
+import au.com.shiftyjelly.pocketcasts.theme.TvTextStyles
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import java.util.Date
+
+@Composable
+fun TvFolderCard(
+    folder: Folder,
+    coverUrls: List<String>,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val folderColor = LocalColors.current.colors.getFolderColor(folder.color)
+
+    TvTile(
+        onClick = onClick,
+        colors = CardDefaults.colors(
+            containerColor = folderColor,
+            focusedContainerColor = folderColor,
+        ),
+        modifier = modifier,
+    ) {
+        BoxWithConstraints(
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(1f),
+        ) {
+            val cardWidth = maxWidth
+            val coverSize = cardWidth * 0.32f
+            val coverSpacing = cardWidth * 0.024f
+            val coverCornerRadius = cardWidth * 0.024f
+
+            Column(
+                verticalArrangement = Arrangement.spacedBy(coverSpacing),
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    .padding(top = cardWidth * 0.096f),
+            ) {
+                repeat(2) { row ->
+                    Row(horizontalArrangement = Arrangement.spacedBy(coverSpacing)) {
+                        repeat(2) { column ->
+                            TvArtworkImage(
+                                model = coverUrls.getOrNull(row * 2 + column),
+                                modifier = Modifier
+                                    .size(coverSize)
+                                    .clip(RoundedCornerShape(coverCornerRadius)),
+                            )
+                        }
+                    }
+                }
+            }
+
+            Text(
+                text = folder.name,
+                style = TvTextStyles.FolderCardTitle,
+                color = Color.White,
+                maxLines = 1,
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(horizontal = 16.dp, vertical = cardWidth * 0.064f)
+                    .fillMaxWidth(),
+            )
+        }
+    }
+}
+
+@Preview(device = Devices.TV_1080p)
+@Composable
+private fun TvFolderCardPreview() {
+    AppTheme(themeType = Theme.ThemeType.EXTRA_DARK) {
+        MaterialTheme {
+            Box(modifier = Modifier.background(TvColors.Dark).padding(32.dp)) {
+                TvFolderCard(
+                    folder = Folder(
+                        uuid = "folder",
+                        name = "Tech & Science",
+                        color = 3,
+                        addedDate = Date(0),
+                        sortPosition = 0,
+                        podcastsSortType = PodcastsSortType.NAME_A_TO_Z,
+                        deleted = false,
+                        syncModified = 0,
+                    ),
+                    coverUrls = listOf("", ""),
+                    onClick = {},
+                    modifier = Modifier.size(160.dp),
+                )
+            }
+        }
+    }
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvFolderCard.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvFolderCard.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -54,15 +55,15 @@ fun TvFolderCard(
                 .aspectRatio(1f),
         ) {
             val cardWidth = maxWidth
-            val coverSize = cardWidth * 0.32f
-            val coverSpacing = cardWidth * 0.024f
-            val coverCornerRadius = cardWidth * 0.024f
+            val coverSize = cardWidth * COVER_SIZE_RATIO
+            val coverSpacing = cardWidth * COVER_SPACING_RATIO
+            val coverCornerRadius = cardWidth * COVER_SPACING_RATIO
 
             Column(
                 verticalArrangement = Arrangement.spacedBy(coverSpacing),
                 modifier = Modifier
                     .align(Alignment.TopCenter)
-                    .padding(top = cardWidth * 0.096f),
+                    .padding(top = cardWidth * COVERS_TOP_PADDING_RATIO),
             ) {
                 repeat(2) { row ->
                     Row(horizontalArrangement = Arrangement.spacedBy(coverSpacing)) {
@@ -83,14 +84,21 @@ fun TvFolderCard(
                 style = TvTextStyles.FolderCardTitle,
                 color = Color.White,
                 maxLines = 1,
+                softWrap = false,
+                overflow = TextOverflow.Ellipsis,
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
-                    .padding(horizontal = 16.dp, vertical = cardWidth * 0.064f)
+                    .padding(horizontal = 16.dp, vertical = cardWidth * TITLE_VERTICAL_PADDING_RATIO)
                     .fillMaxWidth(),
             )
         }
     }
 }
+
+private const val COVER_SIZE_RATIO = 0.32f
+private const val COVER_SPACING_RATIO = 0.024f
+private const val COVERS_TOP_PADDING_RATIO = 0.096f
+private const val TITLE_VERTICAL_PADDING_RATIO = 0.064f
 
 @Preview(device = Devices.TV_1080p)
 @Composable

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastGridScaffold.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastGridScaffold.kt
@@ -1,0 +1,93 @@
+package au.com.shiftyjelly.pocketcasts.component
+
+import androidx.compose.foundation.focusGroup
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.theme.TvTextStyles
+import kotlinx.coroutines.flow.first
+
+@Composable
+internal fun TvPodcastGridScaffold(
+    title: String,
+    itemKeys: List<Any>,
+    modifier: Modifier = Modifier,
+    autoFocusFirstItem: Boolean = false,
+    itemContent: @Composable (index: Int, itemModifier: Modifier) -> Unit,
+) {
+    Column(modifier = modifier) {
+        Text(
+            text = title,
+            style = TvTextStyles.ScreenTitle,
+            color = Color.White,
+            modifier = Modifier.padding(start = 32.dp, top = 8.dp, bottom = 10.dp),
+        )
+        val gridState = rememberLazyGridState()
+        var lastFocusedKey by rememberSaveable { mutableStateOf<String?>(null) }
+        val focusRequesters = remember(itemKeys.size) { List(itemKeys.size) { FocusRequester() } }
+
+        if (autoFocusFirstItem) {
+            LaunchedEffect(Unit) {
+                snapshotFlow { gridState.layoutInfo.visibleItemsInfo.isNotEmpty() }.first { it }
+                runCatching { focusRequesters.firstOrNull()?.requestFocus() }
+            }
+        }
+
+        LazyVerticalGrid(
+            state = gridState,
+            columns = GridCells.Fixed(GRID_COLUMNS),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            contentPadding = PaddingValues(start = 32.dp, top = 16.dp, end = 32.dp, bottom = 32.dp),
+            modifier = Modifier
+                .focusGroup()
+                .focusProperties {
+                    onEnter = {
+                        val visible = gridState.layoutInfo.visibleItemsInfo
+                        val target = itemKeys.indexOfFirst { it.toString() == lastFocusedKey }
+                            .takeIf { index -> index >= 0 && visible.any { it.index == index } }
+                            ?: visible.firstOrNull()?.index
+                        target?.let { runCatching { focusRequesters.getOrNull(it)?.requestFocus() } }
+                    }
+                },
+        ) {
+            items(
+                count = itemKeys.size,
+                key = { index -> itemKeys[index] },
+            ) { index ->
+                itemContent(
+                    index,
+                    Modifier
+                        .focusRequester(focusRequesters[index])
+                        .onFocusChanged { focusState ->
+                            if (focusState.hasFocus) {
+                                lastFocusedKey = itemKeys[index].toString()
+                            }
+                        },
+                )
+            }
+        }
+    }
+}
+
+private const val GRID_COLUMNS = 6

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvFolderDetailScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvFolderDetailScreen.kt
@@ -7,39 +7,29 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.widthIn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
-import androidx.tv.material3.Button
 import androidx.tv.material3.MaterialTheme
-import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.component.TvEmptyState
+import au.com.shiftyjelly.pocketcasts.component.TvPodcastGridScaffold
 import au.com.shiftyjelly.pocketcasts.component.TvPodcastTile
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.loading.LoadingView
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImage
-import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
 import au.com.shiftyjelly.pocketcasts.theme.TvColors
-import au.com.shiftyjelly.pocketcasts.theme.TvTextStyles
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -52,8 +42,9 @@ fun TvFolderDetailScreen(
     modifier: Modifier = Modifier,
 ) {
     var uiState by remember(folderUuid) { mutableStateOf<TvFolderDetailUiState>(TvFolderDetailUiState.Loading) }
-    LaunchedEffect(folderUuid, getFolderPodcasts) {
-        val podcasts = getFolderPodcasts(folderUuid)
+    val currentGetFolderPodcasts by rememberUpdatedState(getFolderPodcasts)
+    LaunchedEffect(folderUuid) {
+        val podcasts = currentGetFolderPodcasts(folderUuid)
         uiState = if (podcasts.isEmpty()) TvFolderDetailUiState.Empty else TvFolderDetailUiState.Loaded(podcasts)
     }
 
@@ -88,8 +79,12 @@ private fun TvFolderDetailContent(
         when (state) {
             is TvFolderDetailUiState.Loading -> LoadingView(color = Color.White, modifier = Modifier.fillMaxSize())
 
-            is TvFolderDetailUiState.Empty -> TvFolderDetailEmpty(
-                onClose = onClose,
+            is TvFolderDetailUiState.Empty -> TvEmptyState(
+                title = stringResource(LR.string.podcasts_empty_folder),
+                subtitle = stringResource(LR.string.tv_folder_empty_message),
+                actionLabel = stringResource(LR.string.ok),
+                onAction = onClose,
+                autoFocusAction = true,
                 modifier = Modifier.fillMaxSize(),
             )
 
@@ -107,46 +102,6 @@ private fun TvFolderDetailContent(
                     imageModifier = Modifier.fillMaxWidth(),
                     modifier = itemModifier,
                 )
-            }
-        }
-    }
-}
-
-@Composable
-private fun TvFolderDetailEmpty(
-    onClose: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    val focusRequester = remember { FocusRequester() }
-    LaunchedEffect(Unit) {
-        focusRequester.requestFocus()
-    }
-    Box(
-        contentAlignment = Alignment.Center,
-        modifier = modifier,
-    ) {
-        Column(horizontalAlignment = Alignment.CenterHorizontally) {
-            Text(
-                text = stringResource(LR.string.podcasts_empty_folder),
-                style = TvTextStyles.ScreenTitle,
-                color = Color.White,
-                textAlign = TextAlign.Center,
-            )
-            Spacer(modifier = Modifier.height(12.dp))
-            Text(
-                text = stringResource(LR.string.tv_folder_empty_message),
-                style = MaterialTheme.typography.bodyLarge,
-                color = TvColors.TextSecondary,
-                textAlign = TextAlign.Center,
-                modifier = Modifier.widthIn(max = 400.dp),
-            )
-            Spacer(modifier = Modifier.height(32.dp))
-            Button(
-                onClick = onClose,
-                colors = TvButtonDefaults.filledButtonColors(),
-                modifier = Modifier.focusRequester(focusRequester),
-            ) {
-                Text(stringResource(LR.string.ok))
             }
         }
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvFolderDetailScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvFolderDetailScreen.kt
@@ -1,0 +1,181 @@
+package au.com.shiftyjelly.pocketcasts.podcasts
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.tv.material3.Button
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.component.TvPodcastTile
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.compose.loading.LoadingView
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImage
+import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
+import au.com.shiftyjelly.pocketcasts.theme.TvColors
+import au.com.shiftyjelly.pocketcasts.theme.TvTextStyles
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+fun TvFolderDetailScreen(
+    folderUuid: String,
+    folderName: String,
+    getFolderPodcasts: suspend (String) -> List<Podcast>,
+    onClose: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var uiState by remember(folderUuid) { mutableStateOf<TvFolderDetailUiState>(TvFolderDetailUiState.Loading) }
+    LaunchedEffect(folderUuid, getFolderPodcasts) {
+        val podcasts = getFolderPodcasts(folderUuid)
+        uiState = if (podcasts.isEmpty()) TvFolderDetailUiState.Empty else TvFolderDetailUiState.Loaded(podcasts)
+    }
+
+    TvFolderDetailContent(
+        folderName = folderName,
+        uiState = uiState,
+        onClose = onClose,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun TvFolderDetailContent(
+    folderName: String,
+    uiState: TvFolderDetailUiState,
+    onClose: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    AnimatedContent(
+        targetState = uiState,
+        transitionSpec = { fadeIn(tween(durationMillis = 300)) togetherWith fadeOut(tween(durationMillis = 300)) },
+        contentKey = { state ->
+            when (state) {
+                is TvFolderDetailUiState.Loading -> "loading"
+                is TvFolderDetailUiState.Empty -> "empty"
+                is TvFolderDetailUiState.Loaded -> "content"
+            }
+        },
+        label = "TvFolderDetailContent",
+        modifier = modifier,
+    ) { state ->
+        when (state) {
+            is TvFolderDetailUiState.Loading -> LoadingView(color = Color.White, modifier = Modifier.fillMaxSize())
+
+            is TvFolderDetailUiState.Empty -> TvFolderDetailEmpty(
+                onClose = onClose,
+                modifier = Modifier.fillMaxSize(),
+            )
+
+            is TvFolderDetailUiState.Loaded -> TvPodcastGridScaffold(
+                title = folderName,
+                itemKeys = state.podcasts.map(Podcast::uuid),
+                autoFocusFirstItem = true,
+                modifier = Modifier.fillMaxSize(),
+            ) { index, itemModifier ->
+                val podcast = state.podcasts[index]
+                TvPodcastTile(
+                    artworkUrl = PodcastImage.getMediumArtworkUrl(podcast.uuid),
+                    podcastTitle = podcast.title,
+                    onClick = {},
+                    imageModifier = Modifier.fillMaxWidth(),
+                    modifier = itemModifier,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun TvFolderDetailEmpty(
+    onClose: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val focusRequester = remember { FocusRequester() }
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = modifier,
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text = stringResource(LR.string.podcasts_empty_folder),
+                style = TvTextStyles.ScreenTitle,
+                color = Color.White,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = stringResource(LR.string.tv_folder_empty_message),
+                style = MaterialTheme.typography.bodyLarge,
+                color = TvColors.TextSecondary,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.widthIn(max = 400.dp),
+            )
+            Spacer(modifier = Modifier.height(32.dp))
+            Button(
+                onClick = onClose,
+                colors = TvButtonDefaults.filledButtonColors(),
+                modifier = Modifier.focusRequester(focusRequester),
+            ) {
+                Text(stringResource(LR.string.ok))
+            }
+        }
+    }
+}
+
+private sealed interface TvFolderDetailUiState {
+    data object Loading : TvFolderDetailUiState
+
+    data object Empty : TvFolderDetailUiState
+
+    data class Loaded(
+        val podcasts: List<Podcast>,
+    ) : TvFolderDetailUiState
+}
+
+@Preview(device = Devices.TV_1080p)
+@Composable
+private fun TvFolderDetailPreview() {
+    AppTheme(themeType = Theme.ThemeType.EXTRA_DARK) {
+        MaterialTheme {
+            Box(modifier = Modifier.background(TvColors.Dark)) {
+                TvFolderDetailContent(
+                    folderName = "Tech & Science",
+                    uiState = TvFolderDetailUiState.Loaded(
+                        podcasts = List(6) { index -> Podcast(uuid = "podcast-$index", title = "Podcast $index") },
+                    ),
+                    onClose = {},
+                )
+            }
+        }
+    }
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsScreen.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.podcasts
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
@@ -16,12 +17,14 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.grid.itemsIndexed
+import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -39,14 +42,19 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.component.TvEmptyState
+import au.com.shiftyjelly.pocketcasts.component.TvFolderCard
 import au.com.shiftyjelly.pocketcasts.component.TvPodcastTile
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.loading.LoadingView
+import au.com.shiftyjelly.pocketcasts.models.entity.Folder
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
+import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
 import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImage
 import au.com.shiftyjelly.pocketcasts.theme.TvColors
 import au.com.shiftyjelly.pocketcasts.theme.TvTextStyles
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import java.util.Date
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
@@ -56,18 +64,44 @@ fun TvYourPodcastsScreen(
     viewModel: TvYourPodcastsViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    var openedFolder by rememberSaveable(stateSaver = OpenedFolderSaver) { mutableStateOf<OpenedFolder?>(null) }
 
-    TvYourPodcastsContent(
-        uiState = uiState,
-        onNavigateToHome = onNavigateToHome,
-        modifier = modifier,
-    )
+    val folder = openedFolder
+    if (folder != null) {
+        BackHandler {
+            openedFolder = null
+        }
+        TvFolderDetailScreen(
+            folderUuid = folder.uuid,
+            folderName = folder.name,
+            getFolderPodcasts = viewModel::folderPodcasts,
+            onClose = { openedFolder = null },
+            modifier = modifier,
+        )
+    } else {
+        TvYourPodcastsContent(
+            uiState = uiState,
+            getFolderCoverUuids = viewModel::folderCoverUuids,
+            onNavigateToHome = onNavigateToHome,
+            onOpenFolder = { openedFolder = OpenedFolder(it.uuid, it.name) },
+            modifier = modifier,
+        )
+    }
 }
+
+private data class OpenedFolder(val uuid: String, val name: String)
+
+private val OpenedFolderSaver = listSaver<OpenedFolder?, String>(
+    save = { folder -> folder?.let { listOf(it.uuid, it.name) }.orEmpty() },
+    restore = { saved -> saved.takeIf { it.size == 2 }?.let { (uuid, name) -> OpenedFolder(uuid, name) } },
+)
 
 @Composable
 private fun TvYourPodcastsContent(
     uiState: TvYourPodcastsUiState,
+    getFolderCoverUuids: suspend (String) -> List<String>,
     onNavigateToHome: () -> Unit,
+    onOpenFolder: (Folder) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     AnimatedContent(
@@ -95,7 +129,9 @@ private fun TvYourPodcastsContent(
             )
 
             is TvYourPodcastsUiState.Loaded -> TvYourPodcastsGrid(
-                podcasts = state.podcasts,
+                items = state.items,
+                getFolderCoverUuids = getFolderCoverUuids,
+                onOpenFolder = onOpenFolder,
                 modifier = Modifier.fillMaxSize(),
             )
         }
@@ -104,19 +140,78 @@ private fun TvYourPodcastsContent(
 
 @Composable
 private fun TvYourPodcastsGrid(
-    podcasts: List<Podcast>,
+    items: List<FolderItem>,
+    getFolderCoverUuids: suspend (String) -> List<String>,
+    onOpenFolder: (Folder) -> Unit,
     modifier: Modifier = Modifier,
+) {
+    TvPodcastGridScaffold(
+        title = stringResource(LR.string.tv_tab_your_podcasts),
+        itemKeys = items.map(FolderItem::uuid),
+        modifier = modifier,
+    ) { index, itemModifier ->
+        when (val item = items[index]) {
+            is FolderItem.Podcast -> TvPodcastTile(
+                artworkUrl = PodcastImage.getMediumArtworkUrl(item.podcast.uuid),
+                podcastTitle = item.podcast.title,
+                onClick = {},
+                imageModifier = Modifier.fillMaxWidth(),
+                modifier = itemModifier,
+            )
+
+            is FolderItem.Folder -> FolderGridItem(
+                folder = item.folder,
+                getFolderCoverUuids = getFolderCoverUuids,
+                onOpenFolder = onOpenFolder,
+                modifier = itemModifier,
+            )
+        }
+    }
+}
+
+@Composable
+private fun FolderGridItem(
+    folder: Folder,
+    getFolderCoverUuids: suspend (String) -> List<String>,
+    onOpenFolder: (Folder) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var coverUrls by remember(folder.uuid) { mutableStateOf(emptyList<String>()) }
+    LaunchedEffect(folder.uuid, getFolderCoverUuids) {
+        coverUrls = getFolderCoverUuids(folder.uuid).map(PodcastImage::getMediumArtworkUrl)
+    }
+    TvFolderCard(
+        folder = folder,
+        coverUrls = coverUrls,
+        onClick = { onOpenFolder(folder) },
+        modifier = modifier,
+    )
+}
+
+@Composable
+internal fun TvPodcastGridScaffold(
+    title: String,
+    itemKeys: List<Any>,
+    modifier: Modifier = Modifier,
+    autoFocusFirstItem: Boolean = false,
+    itemContent: @Composable (index: Int, itemModifier: Modifier) -> Unit,
 ) {
     Column(modifier = modifier) {
         Text(
-            text = stringResource(LR.string.tv_tab_your_podcasts),
+            text = title,
             style = TvTextStyles.ScreenTitle,
             color = Color.White,
             modifier = Modifier.padding(start = 32.dp, top = 8.dp, bottom = 10.dp),
         )
         val gridState = rememberLazyGridState()
-        var lastFocusedUuid by rememberSaveable { mutableStateOf<String?>(null) }
-        val focusRequesters = remember(podcasts.size) { List(podcasts.size) { FocusRequester() } }
+        var lastFocusedKey by rememberSaveable { mutableStateOf<String?>(null) }
+        val focusRequesters = remember(itemKeys.size) { List(itemKeys.size) { FocusRequester() } }
+
+        if (autoFocusFirstItem) {
+            LaunchedEffect(focusRequesters) {
+                focusRequesters.firstOrNull()?.requestFocus()
+            }
+        }
 
         LazyVerticalGrid(
             state = gridState,
@@ -129,27 +224,24 @@ private fun TvYourPodcastsGrid(
                 .focusProperties {
                     onEnter = {
                         val visible = gridState.layoutInfo.visibleItemsInfo
-                        val target = podcasts.indexOfFirst { it.uuid == lastFocusedUuid }
+                        val target = itemKeys.indexOfFirst { it.toString() == lastFocusedKey }
                             .takeIf { index -> index >= 0 && visible.any { it.index == index } }
                             ?: visible.firstOrNull()?.index
                         target?.let { runCatching { focusRequesters.getOrNull(it)?.requestFocus() } }
                     }
                 },
         ) {
-            itemsIndexed(
-                items = podcasts,
-                key = { _, podcast -> podcast.uuid },
-            ) { index, podcast ->
-                TvPodcastTile(
-                    artworkUrl = PodcastImage.getMediumArtworkUrl(podcast.uuid),
-                    podcastTitle = podcast.title,
-                    onClick = {},
-                    imageModifier = Modifier.fillMaxWidth(),
-                    modifier = Modifier
+            items(
+                count = itemKeys.size,
+                key = { index -> itemKeys[index] },
+            ) { index ->
+                itemContent(
+                    index,
+                    Modifier
                         .focusRequester(focusRequesters[index])
                         .onFocusChanged { focusState ->
                             if (focusState.hasFocus) {
-                                lastFocusedUuid = podcast.uuid
+                                lastFocusedKey = itemKeys[index].toString()
                             }
                         },
                 )
@@ -168,9 +260,30 @@ private fun TvYourPodcastsGridPreview() {
             Box(modifier = Modifier.background(TvColors.Dark)) {
                 TvYourPodcastsContent(
                     uiState = TvYourPodcastsUiState.Loaded(
-                        podcasts = List(12) { index -> Podcast(uuid = "podcast-$index", title = "Podcast $index") },
+                        items = buildList {
+                            add(
+                                FolderItem.Folder(
+                                    folder = Folder(
+                                        uuid = "folder",
+                                        name = "Tech & Science",
+                                        color = 3,
+                                        addedDate = Date(0),
+                                        sortPosition = 0,
+                                        podcastsSortType = PodcastsSortType.NAME_A_TO_Z,
+                                        deleted = false,
+                                        syncModified = 0,
+                                    ),
+                                    podcasts = emptyList(),
+                                ),
+                            )
+                            repeat(11) { index ->
+                                add(FolderItem.Podcast(Podcast(uuid = "podcast-$index", title = "Podcast $index")))
+                            }
+                        },
                     ),
+                    getFolderCoverUuids = { emptyList() },
                     onNavigateToHome = {},
+                    onOpenFolder = {},
                 )
             }
         }
@@ -185,7 +298,9 @@ private fun TvYourPodcastsEmptyPreview() {
             Box(modifier = Modifier.background(TvColors.Dark)) {
                 TvYourPodcastsContent(
                     uiState = TvYourPodcastsUiState.Empty,
+                    getFolderCoverUuids = { emptyList() },
                     onNavigateToHome = {},
+                    onOpenFolder = {},
                 )
             }
         }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsScreen.kt
@@ -7,42 +7,26 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
-import androidx.compose.foundation.focusGroup
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.grid.GridCells
-import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.grid.items
-import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusProperties
-import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.MaterialTheme
-import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.component.TvEmptyState
 import au.com.shiftyjelly.pocketcasts.component.TvFolderCard
+import au.com.shiftyjelly.pocketcasts.component.TvPodcastGridScaffold
 import au.com.shiftyjelly.pocketcasts.component.TvPodcastTile
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.loading.LoadingView
@@ -52,7 +36,6 @@ import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
 import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
 import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImage
 import au.com.shiftyjelly.pocketcasts.theme.TvColors
-import au.com.shiftyjelly.pocketcasts.theme.TvTextStyles
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import java.util.Date
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -81,7 +64,6 @@ fun TvYourPodcastsScreen(
     } else {
         TvYourPodcastsContent(
             uiState = uiState,
-            getFolderCoverUuids = viewModel::folderCoverUuids,
             onNavigateToHome = onNavigateToHome,
             onOpenFolder = { openedFolder = OpenedFolder(it.uuid, it.name) },
             modifier = modifier,
@@ -99,7 +81,6 @@ private val OpenedFolderSaver = listSaver<OpenedFolder?, String>(
 @Composable
 private fun TvYourPodcastsContent(
     uiState: TvYourPodcastsUiState,
-    getFolderCoverUuids: suspend (String) -> List<String>,
     onNavigateToHome: () -> Unit,
     onOpenFolder: (Folder) -> Unit,
     modifier: Modifier = Modifier,
@@ -130,7 +111,6 @@ private fun TvYourPodcastsContent(
 
             is TvYourPodcastsUiState.Loaded -> TvYourPodcastsGrid(
                 items = state.items,
-                getFolderCoverUuids = getFolderCoverUuids,
                 onOpenFolder = onOpenFolder,
                 modifier = Modifier.fillMaxSize(),
             )
@@ -141,7 +121,6 @@ private fun TvYourPodcastsContent(
 @Composable
 private fun TvYourPodcastsGrid(
     items: List<FolderItem>,
-    getFolderCoverUuids: suspend (String) -> List<String>,
     onOpenFolder: (Folder) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -159,98 +138,17 @@ private fun TvYourPodcastsGrid(
                 modifier = itemModifier,
             )
 
-            is FolderItem.Folder -> FolderGridItem(
+            is FolderItem.Folder -> TvFolderCard(
                 folder = item.folder,
-                getFolderCoverUuids = getFolderCoverUuids,
-                onOpenFolder = onOpenFolder,
+                coverUrls = item.podcasts.take(FOLDER_COVER_COUNT).map { PodcastImage.getMediumArtworkUrl(it.uuid) },
+                onClick = { onOpenFolder(item.folder) },
                 modifier = itemModifier,
             )
         }
     }
 }
 
-@Composable
-private fun FolderGridItem(
-    folder: Folder,
-    getFolderCoverUuids: suspend (String) -> List<String>,
-    onOpenFolder: (Folder) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    var coverUrls by remember(folder.uuid) { mutableStateOf(emptyList<String>()) }
-    LaunchedEffect(folder.uuid, getFolderCoverUuids) {
-        coverUrls = getFolderCoverUuids(folder.uuid).map(PodcastImage::getMediumArtworkUrl)
-    }
-    TvFolderCard(
-        folder = folder,
-        coverUrls = coverUrls,
-        onClick = { onOpenFolder(folder) },
-        modifier = modifier,
-    )
-}
-
-@Composable
-internal fun TvPodcastGridScaffold(
-    title: String,
-    itemKeys: List<Any>,
-    modifier: Modifier = Modifier,
-    autoFocusFirstItem: Boolean = false,
-    itemContent: @Composable (index: Int, itemModifier: Modifier) -> Unit,
-) {
-    Column(modifier = modifier) {
-        Text(
-            text = title,
-            style = TvTextStyles.ScreenTitle,
-            color = Color.White,
-            modifier = Modifier.padding(start = 32.dp, top = 8.dp, bottom = 10.dp),
-        )
-        val gridState = rememberLazyGridState()
-        var lastFocusedKey by rememberSaveable { mutableStateOf<String?>(null) }
-        val focusRequesters = remember(itemKeys.size) { List(itemKeys.size) { FocusRequester() } }
-
-        if (autoFocusFirstItem) {
-            LaunchedEffect(focusRequesters) {
-                focusRequesters.firstOrNull()?.requestFocus()
-            }
-        }
-
-        LazyVerticalGrid(
-            state = gridState,
-            columns = GridCells.Fixed(GRID_COLUMNS),
-            horizontalArrangement = Arrangement.spacedBy(16.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp),
-            contentPadding = PaddingValues(start = 32.dp, top = 16.dp, end = 32.dp, bottom = 32.dp),
-            modifier = Modifier
-                .focusGroup()
-                .focusProperties {
-                    onEnter = {
-                        val visible = gridState.layoutInfo.visibleItemsInfo
-                        val target = itemKeys.indexOfFirst { it.toString() == lastFocusedKey }
-                            .takeIf { index -> index >= 0 && visible.any { it.index == index } }
-                            ?: visible.firstOrNull()?.index
-                        target?.let { runCatching { focusRequesters.getOrNull(it)?.requestFocus() } }
-                    }
-                },
-        ) {
-            items(
-                count = itemKeys.size,
-                key = { index -> itemKeys[index] },
-            ) { index ->
-                itemContent(
-                    index,
-                    Modifier
-                        .focusRequester(focusRequesters[index])
-                        .onFocusChanged { focusState ->
-                            if (focusState.hasFocus) {
-                                lastFocusedKey = itemKeys[index].toString()
-                            }
-                        },
-                )
-            }
-        }
-    }
-}
-
-private const val GRID_COLUMNS = 6
+private const val FOLDER_COVER_COUNT = 4
 
 @Preview(device = Devices.TV_1080p)
 @Composable
@@ -273,7 +171,7 @@ private fun TvYourPodcastsGridPreview() {
                                         deleted = false,
                                         syncModified = 0,
                                     ),
-                                    podcasts = emptyList(),
+                                    podcasts = List(4) { index -> Podcast(uuid = "cover-$index") },
                                 ),
                             )
                             repeat(11) { index ->
@@ -281,7 +179,6 @@ private fun TvYourPodcastsGridPreview() {
                             }
                         },
                     ),
-                    getFolderCoverUuids = { emptyList() },
                     onNavigateToHome = {},
                     onOpenFolder = {},
                 )
@@ -298,7 +195,6 @@ private fun TvYourPodcastsEmptyPreview() {
             Box(modifier = Modifier.background(TvColors.Dark)) {
                 TvYourPodcastsContent(
                     uiState = TvYourPodcastsUiState.Empty,
-                    getFolderCoverUuids = { emptyList() },
                     onNavigateToHome = {},
                     onOpenFolder = {},
                 )

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsViewModel.kt
@@ -3,35 +3,62 @@ package au.com.shiftyjelly.pocketcasts.podcasts
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
+import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
+import au.com.shiftyjelly.pocketcasts.repositories.di.DefaultDispatcher
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.FolderManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.WhileSubscribed
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.stateIn
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class TvYourPodcastsViewModel @Inject constructor(
     private val podcastManager: PodcastManager,
+    private val folderManager: FolderManager,
+    @DefaultDispatcher private val defaultDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
 
-    // PodcastDao orders subscribed podcasts by clean_title with a leading "the " stripped.
-    val uiState: StateFlow<TvYourPodcastsUiState> = podcastManager.findSubscribedFlow()
-        .map { podcasts ->
-            if (podcasts.isEmpty()) {
+    val uiState: StateFlow<TvYourPodcastsUiState> = combine(
+        folderManager.observeFolders(),
+        podcastManager.findSubscribedFlow(),
+    ) { _, _ -> }
+        .mapLatest {
+            val items = folderManager.getHomeFolder().sortedWith(PodcastsSortType.NAME_A_TO_Z.folderComparator)
+            if (items.isEmpty()) {
                 TvYourPodcastsUiState.Empty
             } else {
-                TvYourPodcastsUiState.Loaded(podcasts)
+                TvYourPodcastsUiState.Loaded(items)
             }
         }
+        .flowOn(defaultDispatcher)
         .stateIn(
             viewModelScope,
             SharingStarted.WhileSubscribed(stopTimeout = 300.milliseconds),
             TvYourPodcastsUiState.Loading,
         )
+
+    suspend fun folderCoverUuids(folderUuid: String): List<String> {
+        return folderManager.findFolderPodcastsSorted(folderUuid).take(FOLDER_COVER_COUNT).map(Podcast::uuid)
+    }
+
+    suspend fun folderPodcasts(folderUuid: String): List<Podcast> {
+        return folderManager.findFolderPodcastsSorted(folderUuid)
+    }
+
+    private companion object {
+        const val FOLDER_COVER_COUNT = 4
+    }
 }
 
 sealed interface TvYourPodcastsUiState {
@@ -40,6 +67,6 @@ sealed interface TvYourPodcastsUiState {
     data object Empty : TvYourPodcastsUiState
 
     data class Loaded(
-        val podcasts: List<Podcast>,
+        val items: List<FolderItem>,
     ) : TvYourPodcastsUiState
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsViewModel.kt
@@ -17,7 +17,9 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.WhileSubscribed
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.stateIn
 
@@ -31,10 +33,18 @@ class TvYourPodcastsViewModel @Inject constructor(
 
     val uiState: StateFlow<TvYourPodcastsUiState> = combine(
         folderManager.observeFolders(),
-        podcastManager.findSubscribedFlow(),
-    ) { _, _ -> }
+        podcastManager.findSubscribedFlow().map { podcasts -> podcasts.map { it.uuid to it.folderUuid } },
+    ) { folders, membership -> folders to membership }
+        .distinctUntilChanged()
         .mapLatest {
-            val items = folderManager.getHomeFolder().sortedWith(PodcastsSortType.NAME_A_TO_Z.folderComparator)
+            val items = folderManager.getHomeFolder()
+                .map { item ->
+                    when (item) {
+                        is FolderItem.Folder -> item.copy(podcasts = folderManager.findFolderPodcastsSorted(item.folder.uuid))
+                        is FolderItem.Podcast -> item
+                    }
+                }
+                .sortedWith(PodcastsSortType.NAME_A_TO_Z.folderComparator)
             if (items.isEmpty()) {
                 TvYourPodcastsUiState.Empty
             } else {
@@ -48,16 +58,8 @@ class TvYourPodcastsViewModel @Inject constructor(
             TvYourPodcastsUiState.Loading,
         )
 
-    suspend fun folderCoverUuids(folderUuid: String): List<String> {
-        return folderManager.findFolderPodcastsSorted(folderUuid).take(FOLDER_COVER_COUNT).map(Podcast::uuid)
-    }
-
     suspend fun folderPodcasts(folderUuid: String): List<Podcast> {
         return folderManager.findFolderPodcastsSorted(folderUuid)
-    }
-
-    private companion object {
-        const val FOLDER_COVER_COUNT = 4
     }
 }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvTextStyles.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvTextStyles.kt
@@ -45,6 +45,13 @@ object TvTextStyles {
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 
+    val FolderCardTitle = TextStyle(
+        fontSize = 14.sp,
+        fontWeight = FontWeight.SemiBold,
+        textAlign = TextAlign.Center,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
     val EpisodeRowTitle = TextStyle(
         fontSize = 19.sp,
         fontWeight = FontWeight.Medium,

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsViewModelTest.kt
@@ -11,14 +11,14 @@ import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import java.util.Date
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class TvYourPodcastsViewModelTest {
@@ -27,12 +27,18 @@ class TvYourPodcastsViewModelTest {
     val coroutineRule = MainCoroutineRule()
 
     private val subscribed = MutableSharedFlow<List<Podcast>>(replay = 1)
+    private val folders = MutableSharedFlow<List<Folder>>(replay = 1)
     private var homeFolder: List<FolderItem> = emptyList()
+    private var folderPodcasts: Map<String, List<Podcast>> = emptyMap()
     private val podcastManager = mock<PodcastManager> {
         on { findSubscribedFlow() } doReturn subscribed
     }
     private val folderManager = mock<FolderManager> {
-        on { observeFolders() } doReturn flowOf(emptyList())
+        on { observeFolders() } doReturn folders
+        on { getHomeFolder() } doAnswer { homeFolder }
+        on { findFolderPodcastsSorted(any()) } doAnswer { invocation ->
+            folderPodcasts[invocation.getArgument<String>(0)].orEmpty()
+        }
     }
 
     @Test
@@ -42,7 +48,7 @@ class TvYourPodcastsViewModelTest {
         viewModel.uiState.test {
             assertEquals(TvYourPodcastsUiState.Loading, awaitItem())
 
-            homeFolder = emptyList()
+            folders.emit(emptyList())
             subscribed.emit(emptyList())
 
             assertEquals(TvYourPodcastsUiState.Empty, awaitItem())
@@ -52,42 +58,82 @@ class TvYourPodcastsViewModelTest {
     @Test
     fun `folders and podcasts are exposed sorted by title`() = runTest {
         val viewModel = createViewModel()
-        val zebra = folderItem("Zebra Cast")
-        val apple = folderItem("Apple Cast")
-        val theBeat = folder("The Beat")
+        val zebra = podcastItem("Zebra Cast")
+        val apple = podcastItem("Apple Cast")
+        val theBeat = folderItem("The Beat")
         homeFolder = listOf(zebra, apple, theBeat)
 
         viewModel.uiState.test {
             assertEquals(TvYourPodcastsUiState.Loading, awaitItem())
 
+            folders.emit(emptyList())
             subscribed.emit(listOf(Podcast(uuid = "any")))
 
             assertEquals(TvYourPodcastsUiState.Loaded(listOf(apple, theBeat, zebra)), awaitItem())
         }
     }
 
-    private suspend fun createViewModel(): TvYourPodcastsViewModel {
-        whenever(folderManager.getHomeFolder()).thenAnswer { homeFolder }
-        return TvYourPodcastsViewModel(
-            podcastManager = podcastManager,
-            folderManager = folderManager,
-            defaultDispatcher = coroutineRule.testDispatcher,
-        )
+    @Test
+    fun `the grid is re-queried when the folders change`() = runTest {
+        val viewModel = createViewModel()
+        val apple = podcastItem("Apple Cast")
+        homeFolder = listOf(apple)
+
+        viewModel.uiState.test {
+            assertEquals(TvYourPodcastsUiState.Loading, awaitItem())
+
+            folders.emit(emptyList())
+            subscribed.emit(emptyList())
+            assertEquals(TvYourPodcastsUiState.Loaded(listOf(apple)), awaitItem())
+
+            val beat = podcastItem("Beat Cast")
+            homeFolder = listOf(apple, beat)
+            folders.emit(listOf(folderEntity("New Folder")))
+
+            assertEquals(TvYourPodcastsUiState.Loaded(listOf(apple, beat)), awaitItem())
+        }
     }
 
-    private fun folderItem(title: String) = FolderItem.Podcast(Podcast(uuid = title, title = title))
+    @Test
+    fun `folder items are enriched with their cover podcasts`() = runTest {
+        val viewModel = createViewModel()
+        val tech = folderItem("Tech")
+        homeFolder = listOf(tech)
+        folderPodcasts = mapOf("Tech" to listOf(Podcast(uuid = "p1"), Podcast(uuid = "p2")))
 
-    private fun folder(name: String) = FolderItem.Folder(
-        folder = Folder(
-            uuid = name,
-            name = name,
-            color = 0,
-            addedDate = Date(0),
-            sortPosition = 0,
-            podcastsSortType = PodcastsSortType.NAME_A_TO_Z,
-            deleted = false,
-            syncModified = 0,
-        ),
+        viewModel.uiState.test {
+            assertEquals(TvYourPodcastsUiState.Loading, awaitItem())
+
+            folders.emit(emptyList())
+            subscribed.emit(emptyList())
+
+            val loaded = awaitItem() as TvYourPodcastsUiState.Loaded
+            val folder = loaded.items.single() as FolderItem.Folder
+            assertEquals(listOf("p1", "p2"), folder.podcasts.map(Podcast::uuid))
+        }
+    }
+
+    private fun createViewModel() = TvYourPodcastsViewModel(
+        podcastManager = podcastManager,
+        folderManager = folderManager,
+        defaultDispatcher = coroutineRule.testDispatcher,
+    )
+
+    private fun podcastItem(title: String) = FolderItem.Podcast(Podcast(uuid = title, title = title))
+
+    private fun folderItem(name: String) = FolderItem.Folder(
+        folder = folderEntity(name),
         podcasts = emptyList(),
+    )
+
+    private fun folderEntity(name: String) = Folder(
+        uuid = name,
+        name = name,
+        color = 0,
+        addedDate = Date(0),
+        sortPosition = 0,
+        podcastsSortType = PodcastsSortType.NAME_A_TO_Z,
+        deleted = false,
+        syncModified = 0,
     )
 }

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsViewModelTest.kt
@@ -1,17 +1,24 @@
 package au.com.shiftyjelly.pocketcasts.podcasts
 
 import app.cash.turbine.test
+import au.com.shiftyjelly.pocketcasts.models.entity.Folder
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
+import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.FolderManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import java.util.Date
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class TvYourPodcastsViewModelTest {
@@ -20,17 +27,22 @@ class TvYourPodcastsViewModelTest {
     val coroutineRule = MainCoroutineRule()
 
     private val subscribed = MutableSharedFlow<List<Podcast>>(replay = 1)
+    private var homeFolder: List<FolderItem> = emptyList()
     private val podcastManager = mock<PodcastManager> {
         on { findSubscribedFlow() } doReturn subscribed
     }
+    private val folderManager = mock<FolderManager> {
+        on { observeFolders() } doReturn flowOf(emptyList())
+    }
 
     @Test
-    fun `no subscriptions map to the empty state`() = runTest {
+    fun `no podcasts or folders map to the empty state`() = runTest {
         val viewModel = createViewModel()
 
         viewModel.uiState.test {
             assertEquals(TvYourPodcastsUiState.Loading, awaitItem())
 
+            homeFolder = emptyList()
             subscribed.emit(emptyList())
 
             assertEquals(TvYourPodcastsUiState.Empty, awaitItem())
@@ -38,40 +50,44 @@ class TvYourPodcastsViewModelTest {
     }
 
     @Test
-    fun `subscriptions preserve the order provided by the dao`() = runTest {
+    fun `folders and podcasts are exposed sorted by title`() = runTest {
         val viewModel = createViewModel()
-        val apple = podcast("apple", "Apple Cast")
-        val theBeat = podcast("beat", "The Beat")
-        val zebra = podcast("zebra", "Zebra Cast")
+        val zebra = folderItem("Zebra Cast")
+        val apple = folderItem("Apple Cast")
+        val theBeat = folder("The Beat")
+        homeFolder = listOf(zebra, apple, theBeat)
 
         viewModel.uiState.test {
             assertEquals(TvYourPodcastsUiState.Loading, awaitItem())
 
-            subscribed.emit(listOf(apple, theBeat, zebra))
+            subscribed.emit(listOf(Podcast(uuid = "any")))
 
             assertEquals(TvYourPodcastsUiState.Loaded(listOf(apple, theBeat, zebra)), awaitItem())
         }
     }
 
-    @Test
-    fun `unsubscribing the last podcast falls back to the empty state`() = runTest {
-        val viewModel = createViewModel()
-        val apple = podcast("apple", "Apple Cast")
-
-        viewModel.uiState.test {
-            assertEquals(TvYourPodcastsUiState.Loading, awaitItem())
-
-            subscribed.emit(listOf(apple))
-            assertEquals(TvYourPodcastsUiState.Loaded(listOf(apple)), awaitItem())
-
-            subscribed.emit(emptyList())
-            assertEquals(TvYourPodcastsUiState.Empty, awaitItem())
-        }
+    private suspend fun createViewModel(): TvYourPodcastsViewModel {
+        whenever(folderManager.getHomeFolder()).thenAnswer { homeFolder }
+        return TvYourPodcastsViewModel(
+            podcastManager = podcastManager,
+            folderManager = folderManager,
+            defaultDispatcher = coroutineRule.testDispatcher,
+        )
     }
 
-    private fun createViewModel() = TvYourPodcastsViewModel(
-        podcastManager = podcastManager,
-    )
+    private fun folderItem(title: String) = FolderItem.Podcast(Podcast(uuid = title, title = title))
 
-    private fun podcast(uuid: String, title: String) = Podcast(uuid = uuid, title = title)
+    private fun folder(name: String) = FolderItem.Folder(
+        folder = Folder(
+            uuid = name,
+            name = name,
+            color = 0,
+            addedDate = Date(0),
+            sortPosition = 0,
+            podcastsSortType = PodcastsSortType.NAME_A_TO_Z,
+            deleted = false,
+            syncModified = 0,
+        ),
+        podcasts = emptyList(),
+    )
 }


### PR DESCRIPTION
## Description

Adds folder support to the TV **Your Podcasts** tab, mirroring the Apple TV `FolderCardView` / `FolderDetailView`. Follow-up to the podcasts grid (#5680).

- **Grid:** the top-level grid now shows folders alongside loose podcasts. Folders render as a square card in the folder's colour with a 2×2 grid of the folder's top-4 podcast covers and the folder name at the bottom — the same layout tvOS's `FolderCardView` draws (covers top, name bottom, 12dp corners).
- **Folder detail:** selecting a folder opens a detail screen — the folder name over a 6-column grid of that folder's podcasts, matching tvOS `FolderDetailView`. Back (or the empty-state button) returns to the grid.
- **Data:** the view model reuses `FolderManager.getHomeFolder()` (folders + podcasts-not-in-a-folder) and re-queries it reactively whenever folders or subscriptions change, re-sorting the items A→Z with `PodcastsSortType.NAME_A_TO_Z` to match tvOS's `titleAtoZ`. Folder covers and detail podcasts come from `FolderManager.findFolderPodcastsSorted()`.
- **Colour:** the card resolves the folder colour through the Compose theme (`LocalColors.current.colors.getFolderColor(...)`), so it uses the TV app's Extra Dark palette — the analog of tvOS `AppTheme.folderColor(colorInt:)`.
- **Reuse:** extracted the title + focus-restoring 6-column grid into a shared `TvPodcastGridScaffold`, now used by both the top-level grid and the folder detail. The new `TvFolderCard` reuses the existing `TvTile` + `TvArtworkImage` (whose placeholder already matches tvOS's empty-cover fill).
- **Empty folder:** "Your folder is empty" with an **OK** button that returns to the grid, matching tvOS's `ContentUnavailableView`.

Fixes PCDROID-697 https://linear.app/a8c/issue/PCDROID-697/folder-support.
Designs: Ftk3KwnfqaK4g57yCN63p0-fi-3246_3336.

Stacked on `feat/tv-your-podcasts` (#5680) — merge bottom-up.

## Testing Instructions

1. Install the TV app (`./gradlew :tv:installDebugProd`) and sign in with an account that has at least one folder with podcasts and some podcasts outside folders.
2. Open the **Your Podcasts** tab — verify folders and loose podcasts are interleaved A→Z; each folder card shows the folder colour, up to four covers in a 2×2 grid, and the folder name.
3. Select a folder — verify the detail screen opens with the folder name and a grid of that folder's podcasts, and the first tile is focused. Press Back — verify it returns to the grid.
4. Open a folder that has no podcasts (create one in the mobile app) — verify "Your folder is empty" with a focused **OK** button that returns to the grid.
5. Add/remove a folder or move a podcast in/out of a folder on another device — re-open the tab and verify the grid reflects the change.

## Screenshots or Screencast

https://github.com/user-attachments/assets/13d1f239-5c5f-4f0b-bf7c-23077b0f8d55




## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md _(TV app is unreleased — skipped)_
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes _(extended `TvYourPodcastsViewModelTest`)_
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics. _(analytics deliberately excluded — matches the rest of the TV module)_