### PR TITLE
[TV] More info modal on the podcast details screen

### DIFF
--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -282,6 +282,15 @@
     <string name="tv_folder_empty_message">Add podcasts to this folder in the mobile app and they’ll show up here.</string>
     <string name="tv_podcast_follow">Follow this podcast</string>
     <string name="tv_podcast_more_info">More info</string>
+    <string name="tv_podcast_info_network">Network</string>
+    <string name="tv_podcast_info_website">Website</string>
+    <string name="tv_podcast_info_schedule">Schedule</string>
+    <string name="tv_podcast_info_next_episode">Next episode</string>
+    <string name="tv_podcast_schedule_hourly">Hourly</string>
+    <string name="tv_podcast_schedule_daily">Daily</string>
+    <string name="tv_podcast_schedule_weekly">Weekly</string>
+    <string name="tv_podcast_schedule_fortnightly">Fortnightly</string>
+    <string name="tv_podcast_schedule_monthly">Monthly</string>
     <string name="unavailable">Unavailable</string>
     <string name="browse_podcasts">Browse podcasts</string>
     <string name="pocket_casts_plus_badge">Pocket Casts Plus badge</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -286,6 +286,8 @@
     <string name="tv_podcast_info_website">Website</string>
     <string name="tv_podcast_info_schedule">Schedule</string>
     <string name="tv_podcast_info_next_episode">Next episode</string>
+    <string name="tv_podcast_next_episode_tomorrow">Tomorrow</string>
+    <string name="tv_podcast_next_episode_soon">Any day now</string>
     <string name="tv_podcast_schedule_hourly">Hourly</string>
     <string name="tv_podcast_schedule_daily">Daily</string>
     <string name="tv_podcast_schedule_weekly">Weekly</string>

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastInfoModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastInfoModal.kt
@@ -1,7 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.component
 
 import android.content.Context
-import android.text.format.DateFormat
 import android.text.format.DateUtils
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.gestures.animateScrollBy
@@ -34,20 +33,18 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.localization.helper.RelativeDateFormatter
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImage
 import au.com.shiftyjelly.pocketcasts.theme.TvColors
 import au.com.shiftyjelly.pocketcasts.theme.TvTextStyles
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
-import java.text.SimpleDateFormat
-import java.util.Calendar
-import java.util.Date
-import java.util.Locale
 import kotlinx.coroutines.launch
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -86,6 +83,7 @@ private fun PodcastInfoPane(
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
+    val dateFormatter = remember(context) { RelativeDateFormatter(context) }
     Column(
         verticalArrangement = Arrangement.spacedBy(24.dp),
         modifier = modifier,
@@ -103,7 +101,7 @@ private fun PodcastInfoPane(
             )
             InfoRow(
                 label = stringResource(LR.string.tv_podcast_info_website),
-                value = podcast.podcastUrl?.takeIf { it.isNotBlank() },
+                value = podcast.getShortUrl().takeIf { it.isNotBlank() },
             )
             InfoRow(
                 label = stringResource(LR.string.tv_podcast_info_schedule),
@@ -111,7 +109,7 @@ private fun PodcastInfoPane(
             )
             InfoRow(
                 label = stringResource(LR.string.tv_podcast_info_next_episode),
-                value = podcast.displayableNextEpisode(context),
+                value = podcast.displayableNextEpisode(context, dateFormatter),
             )
         }
     }
@@ -136,6 +134,8 @@ private fun InfoRow(
             style = TvTextStyles.PlaylistCardCaption,
             fontWeight = FontWeight.Medium,
             color = Color.White,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
         )
     }
 }
@@ -205,7 +205,7 @@ private fun Podcast.displayableSchedule(context: Context): String? {
     return context.getString(stringId)
 }
 
-private fun Podcast.displayableNextEpisode(context: Context): String? {
+private fun Podcast.displayableNextEpisode(context: Context, dateFormatter: RelativeDateFormatter): String? {
     val expectedDate = estimatedNextEpisode ?: return null
     if (expectedDate.time <= 0) {
         return null
@@ -216,21 +216,8 @@ private fun Podcast.displayableNextEpisode(context: Context): String? {
         DateUtils.isToday(expectedDate.time) -> context.getString(LR.string.today)
         DateUtils.isToday(expectedDate.time - DateUtils.DAY_IN_MILLIS) -> context.getString(LR.string.tv_podcast_next_episode_tomorrow)
         expectedDate.time < now -> context.getString(LR.string.tv_podcast_next_episode_soon)
-        expectedDate.time < now + 6 * DateUtils.DAY_IN_MILLIS -> expectedDate.formatSkeleton("EEEE")
-        else -> expectedDate.formatSkeleton(if (expectedDate.isSameYearAsNow()) "dMMMM" else "yMMMMd")
+        else -> dateFormatter.format(expectedDate)
     }
-}
-
-private fun Date.isSameYearAsNow(): Boolean {
-    val calendar = Calendar.getInstance()
-    val currentYear = calendar.get(Calendar.YEAR)
-    calendar.time = this
-    return calendar.get(Calendar.YEAR) == currentYear
-}
-
-private fun Date.formatSkeleton(skeleton: String): String {
-    val locale = Locale.getDefault()
-    return SimpleDateFormat(DateFormat.getBestDateTimePattern(locale, skeleton), locale).format(this)
 }
 
 private val InfoModalWidth = 688.dp

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastInfoModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastInfoModal.kt
@@ -1,0 +1,258 @@
+package au.com.shiftyjelly.pocketcasts.component
+
+import android.content.Context
+import android.text.format.DateFormat
+import android.text.format.DateUtils
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.gestures.animateScrollBy
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImage
+import au.com.shiftyjelly.pocketcasts.theme.TvColors
+import au.com.shiftyjelly.pocketcasts.theme.TvTextStyles
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import kotlinx.coroutines.launch
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+fun TvPodcastInfoModal(
+    podcast: Podcast,
+    onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    TvModal(
+        onDismissRequest = onDismissRequest,
+        width = InfoModalWidth,
+        modifier = modifier,
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(48.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(InfoModalHeight),
+        ) {
+            PodcastInfoPane(
+                podcast = podcast,
+                modifier = Modifier.width(InfoPaneWidth),
+            )
+            PodcastDescriptionPane(
+                podcast = podcast,
+                modifier = Modifier.weight(1f).fillMaxHeight(),
+            )
+        }
+    }
+}
+
+@Composable
+private fun PodcastInfoPane(
+    podcast: Podcast,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    Column(
+        verticalArrangement = Arrangement.spacedBy(24.dp),
+        modifier = modifier,
+    ) {
+        TvArtworkImage(
+            model = PodcastImage.getMediumArtworkUrl(podcast.uuid),
+            modifier = Modifier
+                .size(InfoArtworkSize)
+                .clip(RoundedCornerShape(8.dp)),
+        )
+        Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+            InfoRow(
+                label = stringResource(LR.string.tv_podcast_info_network),
+                value = podcast.author.takeIf { it.isNotBlank() },
+            )
+            InfoRow(
+                label = stringResource(LR.string.tv_podcast_info_website),
+                value = podcast.getShortUrl().takeIf { it.isNotBlank() },
+            )
+            InfoRow(
+                label = stringResource(LR.string.tv_podcast_info_schedule),
+                value = podcast.displayableSchedule(context),
+            )
+            InfoRow(
+                label = stringResource(LR.string.tv_podcast_info_next_episode),
+                value = podcast.displayableNextEpisodeShortDate(),
+            )
+        }
+    }
+}
+
+@Composable
+private fun InfoRow(
+    label: String,
+    value: String?,
+) {
+    if (value == null) {
+        return
+    }
+    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+        Text(
+            text = label,
+            style = TvTextStyles.PlaylistCardCaption,
+            color = TvColors.TextSecondary,
+        )
+        Text(
+            text = value,
+            style = TvTextStyles.PlaylistCardCaption,
+            fontWeight = FontWeight.Medium,
+            color = Color.White,
+        )
+    }
+}
+
+@Composable
+private fun PodcastDescriptionPane(
+    podcast: Podcast,
+    modifier: Modifier = Modifier,
+) {
+    val scrollState = rememberScrollState()
+    val scope = rememberCoroutineScope()
+    val focusRequester = remember { FocusRequester() }
+    val scrollStep = with(LocalDensity.current) { 120.dp.toPx() }
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+    Column(
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+        modifier = modifier
+            .focusRequester(focusRequester)
+            .onKeyEvent { event ->
+                if (event.type != KeyEventType.KeyDown) {
+                    return@onKeyEvent false
+                }
+                val delta = when (event.key) {
+                    Key.DirectionUp -> -scrollStep
+                    Key.DirectionDown -> scrollStep
+                    else -> return@onKeyEvent false
+                }
+                scope.launch { scrollState.animateScrollBy(delta) }
+                true
+            }
+            .focusable()
+            .verticalScroll(scrollState),
+    ) {
+        if (podcast.author.isNotBlank()) {
+            Text(
+                text = podcast.author,
+                style = TvTextStyles.PlaylistCardCaption,
+                color = TvColors.TextSecondary,
+            )
+        }
+        Text(
+            text = podcast.title,
+            style = TvTextStyles.ScreenTitle,
+            color = Color.White,
+        )
+        if (podcast.podcastDescription.isNotBlank()) {
+            Text(
+                text = podcast.podcastDescription,
+                style = TvTextStyles.FeaturedTileDescription,
+                color = Color.White,
+            )
+        }
+    }
+}
+
+private fun Podcast.displayableSchedule(context: Context): String? {
+    val stringId = when (episodeFrequency?.lowercase()) {
+        "hourly" -> LR.string.tv_podcast_schedule_hourly
+        "daily" -> LR.string.tv_podcast_schedule_daily
+        "weekly" -> LR.string.tv_podcast_schedule_weekly
+        "fortnightly" -> LR.string.tv_podcast_schedule_fortnightly
+        "monthly" -> LR.string.tv_podcast_schedule_monthly
+        else -> return null
+    }
+    return context.getString(stringId)
+}
+
+private fun Podcast.displayableNextEpisodeShortDate(): String? {
+    val expectedDate = estimatedNextEpisode ?: return null
+    if (expectedDate.time <= 0) {
+        return null
+    }
+    if (!DateUtils.isToday(expectedDate.time) && expectedDate.time < System.currentTimeMillis()) {
+        return null
+    }
+    val locale = Locale.getDefault()
+    val pattern = DateFormat.getBestDateTimePattern(locale, "MMMMd")
+    return SimpleDateFormat(pattern, locale).format(expectedDate)
+}
+
+private val InfoModalWidth = 860.dp
+private val InfoModalHeight = 420.dp
+private val InfoPaneWidth = 220.dp
+private val InfoArtworkSize = 120.dp
+
+@Preview
+@Composable
+private fun TvPodcastInfoModalPreview() {
+    AppTheme(themeType = Theme.ThemeType.EXTRA_DARK) {
+        MaterialTheme {
+            TvModalSurface(width = InfoModalWidth) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(48.dp),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(InfoModalHeight),
+                ) {
+                    PodcastInfoPane(
+                        podcast = previewPodcast,
+                        modifier = Modifier.width(InfoPaneWidth),
+                    )
+                    PodcastDescriptionPane(
+                        podcast = previewPodcast,
+                        modifier = Modifier.weight(1f).fillMaxHeight(),
+                    )
+                }
+            }
+        }
+    }
+}
+
+private val previewPodcast = Podcast(
+    uuid = "podcast-uuid",
+    title = "The Writer's Voice",
+    author = "The New Yorker",
+    episodeFrequency = "weekly",
+    estimatedNextEpisode = Date(0),
+    podcastDescription = "New Yorker fiction writers read and discuss stories from the magazine's archive.",
+)

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastInfoModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastInfoModal.kt
@@ -45,6 +45,7 @@ import au.com.shiftyjelly.pocketcasts.theme.TvColors
 import au.com.shiftyjelly.pocketcasts.theme.TvTextStyles
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import java.text.SimpleDateFormat
+import java.util.Calendar
 import java.util.Date
 import java.util.Locale
 import kotlinx.coroutines.launch
@@ -102,7 +103,7 @@ private fun PodcastInfoPane(
             )
             InfoRow(
                 label = stringResource(LR.string.tv_podcast_info_website),
-                value = podcast.getShortUrl().takeIf { it.isNotBlank() },
+                value = podcast.podcastUrl?.takeIf { it.isNotBlank() },
             )
             InfoRow(
                 label = stringResource(LR.string.tv_podcast_info_schedule),
@@ -110,7 +111,7 @@ private fun PodcastInfoPane(
             )
             InfoRow(
                 label = stringResource(LR.string.tv_podcast_info_next_episode),
-                value = podcast.displayableNextEpisodeShortDate(),
+                value = podcast.displayableNextEpisode(context),
             )
         }
     }
@@ -204,17 +205,32 @@ private fun Podcast.displayableSchedule(context: Context): String? {
     return context.getString(stringId)
 }
 
-private fun Podcast.displayableNextEpisodeShortDate(): String? {
+private fun Podcast.displayableNextEpisode(context: Context): String? {
     val expectedDate = estimatedNextEpisode ?: return null
     if (expectedDate.time <= 0) {
         return null
     }
-    if (!DateUtils.isToday(expectedDate.time) && expectedDate.time < System.currentTimeMillis()) {
-        return null
+    val now = System.currentTimeMillis()
+    return when {
+        expectedDate.time < now - 7 * DateUtils.DAY_IN_MILLIS -> null
+        DateUtils.isToday(expectedDate.time) -> context.getString(LR.string.today)
+        DateUtils.isToday(expectedDate.time - DateUtils.DAY_IN_MILLIS) -> context.getString(LR.string.tv_podcast_next_episode_tomorrow)
+        expectedDate.time < now -> context.getString(LR.string.tv_podcast_next_episode_soon)
+        expectedDate.time < now + 6 * DateUtils.DAY_IN_MILLIS -> expectedDate.formatSkeleton("EEEE")
+        else -> expectedDate.formatSkeleton(if (expectedDate.isSameYearAsNow()) "dMMMM" else "yMMMMd")
     }
+}
+
+private fun Date.isSameYearAsNow(): Boolean {
+    val calendar = Calendar.getInstance()
+    val currentYear = calendar.get(Calendar.YEAR)
+    calendar.time = this
+    return calendar.get(Calendar.YEAR) == currentYear
+}
+
+private fun Date.formatSkeleton(skeleton: String): String {
     val locale = Locale.getDefault()
-    val pattern = DateFormat.getBestDateTimePattern(locale, "MMMMd")
-    return SimpleDateFormat(pattern, locale).format(expectedDate)
+    return SimpleDateFormat(DateFormat.getBestDateTimePattern(locale, skeleton), locale).format(this)
 }
 
 private val InfoModalWidth = 860.dp
@@ -252,7 +268,7 @@ private val previewPodcast = Podcast(
     uuid = "podcast-uuid",
     title = "The Writer's Voice",
     author = "The New Yorker",
+    podcastUrl = "https://www.newyorker.com/podcast/the-writers-voice",
     episodeFrequency = "weekly",
-    estimatedNextEpisode = Date(0),
     podcastDescription = "New Yorker fiction writers read and discuss stories from the magazine's archive.",
 )

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastInfoModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastInfoModal.kt
@@ -63,7 +63,7 @@ fun TvPodcastInfoModal(
         modifier = modifier,
     ) {
         Row(
-            horizontalArrangement = Arrangement.spacedBy(48.dp),
+            horizontalArrangement = Arrangement.spacedBy(38.dp),
             modifier = Modifier
                 .fillMaxWidth()
                 .height(InfoModalHeight),
@@ -233,10 +233,10 @@ private fun Date.formatSkeleton(skeleton: String): String {
     return SimpleDateFormat(DateFormat.getBestDateTimePattern(locale, skeleton), locale).format(this)
 }
 
-private val InfoModalWidth = 860.dp
-private val InfoModalHeight = 420.dp
-private val InfoPaneWidth = 220.dp
-private val InfoArtworkSize = 120.dp
+private val InfoModalWidth = 688.dp
+private val InfoModalHeight = 336.dp
+private val InfoPaneWidth = 176.dp
+private val InfoArtworkSize = 96.dp
 
 @Preview
 @Composable
@@ -245,7 +245,7 @@ private fun TvPodcastInfoModalPreview() {
         MaterialTheme {
             TvModalSurface(width = InfoModalWidth) {
                 Row(
-                    horizontalArrangement = Arrangement.spacedBy(48.dp),
+                    horizontalArrangement = Arrangement.spacedBy(38.dp),
                     modifier = Modifier
                         .fillMaxWidth()
                         .height(InfoModalHeight),

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
@@ -49,6 +49,7 @@ import au.com.shiftyjelly.pocketcasts.component.TvArtworkImage
 import au.com.shiftyjelly.pocketcasts.component.TvEmptyState
 import au.com.shiftyjelly.pocketcasts.component.TvEpisodeActionsModal
 import au.com.shiftyjelly.pocketcasts.component.TvEpisodeListItem
+import au.com.shiftyjelly.pocketcasts.component.TvPodcastInfoModal
 import au.com.shiftyjelly.pocketcasts.component.TvSortButton
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.components.displayLabel
@@ -110,6 +111,7 @@ private fun TvPodcastDetailsContent(
 
             is TvPodcastDetailsUiState.Loaded -> {
                 val followFocusRequester = remember { FocusRequester() }
+                var isShowingInfoModal by remember { mutableStateOf(false) }
                 Row(
                     horizontalArrangement = Arrangement.spacedBy(80.dp),
                     modifier = Modifier
@@ -119,6 +121,7 @@ private fun TvPodcastDetailsContent(
                     PodcastInfo(
                         podcast = uiState.podcast,
                         followFocusRequester = followFocusRequester,
+                        onMoreInfo = { isShowingInfoModal = true },
                         modifier = Modifier.width(InfoPaneWidth),
                     )
                     if (uiState.episodes.isEmpty() && uiState.archivedEpisodeCount == 0) {
@@ -140,6 +143,12 @@ private fun TvPodcastDetailsContent(
                         )
                     }
                 }
+                if (isShowingInfoModal) {
+                    TvPodcastInfoModal(
+                        podcast = uiState.podcast,
+                        onDismissRequest = { isShowingInfoModal = false },
+                    )
+                }
             }
         }
     }
@@ -149,6 +158,7 @@ private fun TvPodcastDetailsContent(
 private fun PodcastInfo(
     podcast: Podcast,
     followFocusRequester: FocusRequester,
+    onMoreInfo: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -199,7 +209,7 @@ private fun PodcastInfo(
                 Text(stringResource(if (podcast.isSubscribed) LR.string.podcast_subscribed else LR.string.tv_podcast_follow))
             }
             Button(
-                onClick = {},
+                onClick = onMoreInfo,
                 colors = TvButtonDefaults.filledButtonColors(),
             ) {
                 Text(stringResource(LR.string.tv_podcast_more_info))


### PR DESCRIPTION
## Description
Adds the **More info** modal to the Android TV podcast details screen, porting the Apple TV design. Tapping **More info** opens a glassy blur-behind dialog with:

- A **fixed left panel**: podcast artwork plus a metadata list — **Network** (podcast author), **Website** (short URL), **Schedule** (release frequency), and **Next episode** (upcoming date). Each row is hidden when its value is unavailable.
- A **scrollable right panel**: the network/author caption, the podcast title, and the full podcast description, which scrolls with the D-pad while the left panel stays put.

The modal reuses the existing glassy `TvModal` surface (as `TvEpisodeActionsModal` / `TvProfileModal` do), opened at a wider fixed width. The previously no-op **More info** button now opens it.

Fixes PCDROID-700 https://linear.app/a8c/issue/PCDROID-700/more-info
Design: Ftk3KwnfqaK4g57yCN63p0-fi-3279_2008

## Testing Instructions
1. On the Android TV app, open **Your Podcasts** and select a followed podcast (e.g. *BBC Inside Science* or *The Daily*).
2. Focus the **More info** button (next to Follow) and press select.
3. Confirm the modal shows artwork + Network / Website / Schedule / Next episode on the left, and the network caption + title + description on the right.
4. With the modal open, press D-pad **up/down** — a long description scrolls while the left metadata panel stays fixed.
5. Press **Back** to dismiss.

## Screenshots or Screencast

https://github.com/user-attachments/assets/d8837178-86ef-4c97-bfc0-b1bdb31e0b6c



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md 
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes 
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) the Event Horizon schema to reflect any new or changed analytics.
