### PR TITLE
Realign the release branch on its remote during checkout

### DIFF
--- a/.buildkite/commands/checkout-release-branch.sh
+++ b/.buildkite/commands/checkout-release-branch.sh
@@ -24,5 +24,6 @@ BRANCH_NAME="release/${RELEASE_VERSION}"
 git fetch origin "$BRANCH_NAME"
 git checkout "$BRANCH_NAME"
 # Buildkite can reuse a working copy where "$BRANCH_NAME" was left at an older commit by a previous job,
-# so realign it on the remote. `reset --hard` rather than `git pull`, to avoid merging if the two diverged.
+# so force the local branch to the fetched commit. `reset --hard` rather than
+# `git pull`, to avoid merging if the two diverged.
 git reset --hard "origin/$BRANCH_NAME"

--- a/.buildkite/commands/checkout-release-branch.sh
+++ b/.buildkite/commands/checkout-release-branch.sh
@@ -25,5 +25,6 @@ git fetch origin "$BRANCH_NAME"
 git checkout "$BRANCH_NAME"
 # Buildkite can reuse a working copy where "$BRANCH_NAME" was left at an older commit by a previous job,
 # so force the local branch to the fetched commit. `reset --hard` rather than
-# `git pull`, to avoid merging if the two diverged.
-git reset --hard "origin/$BRANCH_NAME"
+# `git pull`, to avoid merging if the two diverged; `FETCH_HEAD` rather than
+# `origin/$BRANCH_NAME`, which `git fetch <branch>` only updates opportunistically.
+git reset --hard FETCH_HEAD

--- a/.buildkite/commands/checkout-release-branch.sh
+++ b/.buildkite/commands/checkout-release-branch.sh
@@ -32,7 +32,7 @@ BRANCH_NAME="release/${RELEASE_VERSION}"
 git fetch origin "$BRANCH_NAME"
 git checkout "$BRANCH_NAME"
 # Buildkite can reuse a working copy where "$BRANCH_NAME" was left at a different commit by a previous job,
-# so force the local branch to the fetched commit. `reset --hard` rather than
-# `git pull`, to avoid merging if the two diverged; `FETCH_HEAD` rather than
-# `origin/$BRANCH_NAME`, which `git fetch <branch>` only updates opportunistically.
+# so force the local branch to the fetched commit.
+#  - `reset --hard` rather than `git pull`, to avoid merging if the two diverged
+#  - `FETCH_HEAD` rather than `origin/$BRANCH_NAME`, which `git fetch <branch>` only updates opportunistically.
 git reset --hard FETCH_HEAD

--- a/.buildkite/commands/checkout-release-branch.sh
+++ b/.buildkite/commands/checkout-release-branch.sh
@@ -4,8 +4,8 @@
 #
 # Usage: checkout-release-branch.sh [<RELEASE_VERSION>]
 #
-# The release version is taken from, in order of precedence:
-#  1. the first argument, if one is passed
+# The release version is taken from the first of these that is set and non-empty:
+#  1. the first argument
 #  2. the `RELEASE_VERSION` environment variable
 #  3. the `release/*` branch the build is running on, via `BUILDKITE_BRANCH`
 #
@@ -17,15 +17,13 @@
 
 echo "--- :git: Checkout Release Branch"
 
-if [[ $# -gt 0 ]]; then
-  # An argument was passed explicitly, so it must not be empty — that would mean the caller
-  # meant to forward a version but it resolved to nothing, which is a pipeline misconfiguration.
-  RELEASE_VERSION="${1:?release version argument was passed but is empty}"
-elif [[ -n "${RELEASE_VERSION:-}" ]]; then
-  : # Already provided through the pipeline environment
-elif [[ "${BUILDKITE_BRANCH:-}" =~ ^release/ ]]; then
+RELEASE_VERSION="${1:-${RELEASE_VERSION:-}}"
+
+if [[ -z "$RELEASE_VERSION" && "${BUILDKITE_BRANCH:-}" =~ ^release/ ]]; then
   RELEASE_VERSION="${BUILDKITE_BRANCH#release/}"
-else
+fi
+
+if [[ -z "$RELEASE_VERSION" ]]; then
   echo "Error: no release version. Pass it as \$1, set RELEASE_VERSION, or run on a release/* branch." >&2
   exit 1
 fi
@@ -33,7 +31,7 @@ fi
 BRANCH_NAME="release/${RELEASE_VERSION}"
 git fetch origin "$BRANCH_NAME"
 git checkout "$BRANCH_NAME"
-# Buildkite can reuse a working copy where "$BRANCH_NAME" was left at an older commit by a previous job,
+# Buildkite can reuse a working copy where "$BRANCH_NAME" was left at a different commit by a previous job,
 # so force the local branch to the fetched commit. `reset --hard` rather than
 # `git pull`, to avoid merging if the two diverged; `FETCH_HEAD` rather than
 # `origin/$BRANCH_NAME`, which `git fetch <branch>` only updates opportunistically.

--- a/.buildkite/commands/checkout-release-branch.sh
+++ b/.buildkite/commands/checkout-release-branch.sh
@@ -23,4 +23,6 @@ BRANCH_NAME="release/${RELEASE_VERSION}"
 
 git fetch origin "$BRANCH_NAME"
 git checkout "$BRANCH_NAME"
-git pull
+# Buildkite can reuse a working copy where "$BRANCH_NAME" was left at an older commit by a previous job,
+# so realign it on the remote. `reset --hard` rather than `git pull`, to avoid merging if the two diverged.
+git reset --hard "origin/$BRANCH_NAME"

--- a/.buildkite/commands/checkout-release-branch.sh
+++ b/.buildkite/commands/checkout-release-branch.sh
@@ -1,26 +1,36 @@
 #!/bin/bash -eu
 
-# Script to checkout a specific release branch
-# Usage: ./checkout-release-branch.sh <RELEASE_VERSION>
-
+# Checks out the `release/*` branch for a given release version.
+#
+# Usage: checkout-release-branch.sh [<RELEASE_VERSION>]
+#
+# The release version is taken from, in order of precedence:
+#  1. the first argument, if one is passed
+#  2. the `RELEASE_VERSION` environment variable
+#  3. the `release/*` branch the build is running on, via `BUILDKITE_BRANCH`
+#
 # Buildkite, by default, checks out a specific commit, ending up in a detached HEAD state.
-# But in some cases, we need to ensure to be checked out on the `release/*` branch instead, namely:
-# - When a `release-pipelines/*.yml` will end up needing to do a `git push` to the `release/*` branch (for version bumps)
-# - When doing a new `release-build.sh` from a job that was `pipeline upload`'d by such a pipeline,
-#   to ensure that the job doing the build would include that recent extra commit before starting doing the build.
+# But some release steps need to be on the `release/*` branch instead, namely:
+#  - when a `release-pipelines/*.yml` needs to `git push` to the `release/*` branch (for version bumps)
+#  - when a job `pipeline upload`'d by such a pipeline builds from that branch, so that the build
+#    includes the commit that the version bump just added.
 
 echo "--- :git: Checkout Release Branch"
 
-if [[ -n "${1:-}" ]]; then
-  RELEASE_VERSION="$1"
+if [[ $# -gt 0 ]]; then
+  # An argument was passed explicitly, so it must not be empty — that would mean the caller
+  # meant to forward a version but it resolved to nothing, which is a pipeline misconfiguration.
+  RELEASE_VERSION="${1:?release version argument was passed but is empty}"
+elif [[ -n "${RELEASE_VERSION:-}" ]]; then
+  : # Already provided through the pipeline environment
 elif [[ "${BUILDKITE_BRANCH:-}" =~ ^release/ ]]; then
   RELEASE_VERSION="${BUILDKITE_BRANCH#release/}"
 else
-  echo "Error: RELEASE_VERSION parameter missing and BUILDKITE_BRANCH is not a release branch"
+  echo "Error: no release version. Pass it as \$1, set RELEASE_VERSION, or run on a release/* branch." >&2
   exit 1
 fi
-BRANCH_NAME="release/${RELEASE_VERSION}"
 
+BRANCH_NAME="release/${RELEASE_VERSION}"
 git fetch origin "$BRANCH_NAME"
 git checkout "$BRANCH_NAME"
 # Buildkite can reuse a working copy where "$BRANCH_NAME" was left at an older commit by a previous job,

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GEM
     ast (2.4.3)
     atomos (0.1.3)
     aws-eventstream (1.4.0)
-    aws-partitions (1.1274.0)
+    aws-partitions (1.1277.0)
     aws-sdk-core (3.254.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
@@ -21,7 +21,7 @@ GEM
     aws-sdk-kms (1.130.0)
       aws-sdk-core (~> 3, >= 3.254.0)
       aws-sigv4 (~> 1.5)
-    aws-sdk-s3 (1.228.1)
+    aws-sdk-s3 (1.228.2)
       aws-sdk-core (~> 3, >= 3.254.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.5)
@@ -166,7 +166,7 @@ GEM
       fastlane (>= 2.232.0)
       google-apis-firebaseappdistribution_v1 (>= 0.9.0)
       google-apis-firebaseappdistribution_v1alpha (>= 0.12.0)
-    fastlane-plugin-wpmreleasetoolkit (14.11.1)
+    fastlane-plugin-wpmreleasetoolkit (14.11.2)
       buildkit (~> 1.5)
       chroma (= 0.2.0)
       diffy (~> 3.3)
@@ -251,7 +251,7 @@ GEM
       mutex_m
     java-properties (0.3.0)
     jmespath (1.6.2)
-    json (2.21.1)
+    json (2.21.2)
     jwt (3.2.0)
       base64
     kramdown (2.5.2)
@@ -381,4 +381,4 @@ DEPENDENCIES
   openssl (~> 4.0)
 
 BUNDLED WITH
-  4.0.16
+  4.0.17


### PR DESCRIPTION
## What does it do?

Part of [AINFRA-2725](https://linear.app/a8c/issue/AINFRA-2725/fix-release-selection-and-checkout-release-branchsh-in-release-tooling), following the [WooCommerce iOS 25.1 release incident](https://woomobilep2.wordpress.com/2026/07/20/retrospective-dotview-crash-recurrence-woo-ios-25-1-2/). The same change is going out to every mobile product repo.

### 1. Realign the release branch on the remote (the actual fix)

`.buildkite/commands/checkout-release-branch.sh` fetched the release branch and checked it out, but never moved the local branch onto the fetched commit:

```sh
git fetch origin "$BRANCH_NAME"
git checkout "$BRANCH_NAME"
```

Buildkite cleans the working copy between jobs, but it can *reuse* it. A `refs/heads/release/x.y` left behind by an earlier job on the same agent therefore survives, and `git checkout` then simply switches to that stale local ref rather than to what was just fetched. Whatever runs next — the version bump, or the GitHub Release draft that `finalize_release` creates from `HEAD` — would then be based on the wrong commit.

The fix adds the missing realignment. `reset --hard` rather than `git pull`: no extra network round trip, and no merge commit if the refs diverged.

### 2. Reset to `FETCH_HEAD` rather than the remote-tracking ref

`git fetch origin <branch>` always writes `FETCH_HEAD`, but it only updates `refs/remotes/origin/<branch>` when the remote's fetch refspec covers that branch. With Buildkite's default `+refs/heads/*:refs/remotes/origin/*` the two are equivalent — but on a clone whose refspec was narrowed after `origin/<branch>` already existed, the fetch leaves that ref stale and `reset --hard "origin/$BRANCH_NAME"` lands on the old commit: the very failure this script exists to prevent, reintroduced through the back door. Resetting to `FETCH_HEAD` drops the refspec dependency entirely.

### 3. Standardize the script across all repos

Slightly tangent to the issue, but bundled deliberately: the script had drifted into **five different shapes** across the repos — argument required via `${1?…}` or `${1:?…}`, argument plus a `BUILDKITE_BRANCH` fallback, argument with a hand-rolled usage check, the same under a different variable name, and (in one repo) no argument at all, reading `RELEASE_VERSION` from the environment. Having rolled the same one-line fix out thirteen times this week, that divergence is pure friction.

All repos now share one canonical script. The resolution order is a **superset** of what every repo did before — argument, then `RELEASE_VERSION` from the environment, then the `release/*` branch the build runs on — so **no call site needed changing**. The `BUILDKITE_BRANCH` fallback only fires on a branch matching `^release/`, and derives the branch name back from that same value, so it cannot select a branch other than the one the build was already triggered on.

It also closes two latent bugs: under `bash -eu`, both `[[ -z "${RELEASE_VERSION}" ]]` on an unset variable and a bare `RELEASE_VERSION=$1` with no arguments abort with `unbound variable` before their intended usage message can print. And an argument that is *passed but empty* — what happens when a pipeline forwards an unset `$RELEASE_VERSION` — no longer resolves to a bare `release/`: it falls through to the environment variable, then to the `release/*` branch the build runs on, and finally to a clear error if none of those yields a version.

### 4. Bump `release-toolkit` to 14.11.2

Picks up [wordpress-mobile/release-toolkit#763](https://github.com/wordpress-mobile/release-toolkit/pull/763), the first half of AINFRA-2725: `publish_github_release` now publishes the most recently created GitHub Release when several share the same name, rather than whichever one the API happened to list first. Without it, a re-run of `finalize_release` can still leave the git tag on the wrong commit — the root cause of the 25.1 incident.

`bundle update` also refreshed a few unrelated transitive gems and bumped `BUNDLED WITH` to the current 4.0.17.

## Testing instructions

No behaviour change on a fresh checkout, which is the normal case: the local branch is already at the fetched commit, so the reset is a no-op. The argument-resolution logic was exercised across all combinations (argument / empty argument / environment variable / `release/*` branch / trunk / feature branch / unset), and the resulting script passes `shellcheck` in every repo. The next release build exercising this script is the real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


