### PR TITLE
[TV] Implement follow action on podcast details

### DIFF
--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -253,8 +253,6 @@
     <string name="tv_row_because_you_liked">Because you liked Podcast</string>
     <string name="tv_home_keep_listening">Keep Listening</string>
     <string name="tv_profile_starred_episodes">Starred Episodes</string>
-    <string name="tv_sign_in_or_enter_code">or enter the following code</string>
-    <string name="tv_sign_in_go_to_url">going to %1$s</string>
     <string name="tv_sign_in_title">Log in to Pocket Casts</string>
     <string name="tv_sign_in_step_scan">Scan the QR code or go to %1$s</string>
     <string name="tv_sign_in_step_login">Log in to your account</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -255,6 +255,13 @@
     <string name="tv_profile_starred_episodes">Starred Episodes</string>
     <string name="tv_sign_in_or_enter_code">or enter the following code</string>
     <string name="tv_sign_in_go_to_url">going to %1$s</string>
+    <string name="tv_sign_in_title">Log in to Pocket Casts</string>
+    <string name="tv_sign_in_step_scan">Scan the QR code or go to %1$s</string>
+    <string name="tv_sign_in_step_login">Log in to your account</string>
+    <string name="tv_sign_in_step_confirm_code">If asked, confirm with the code below</string>
+    <string name="tv_create_account_modal_title">Your podcasts deserve a home</string>
+    <string name="tv_create_account_modal_subtitle">Create a free account to follow podcasts, build your Up Next, and pick up right where you left off, on any device.</string>
+    <string name="tv_create_account_modal_step_create">Create your account or log in</string>
     <string name="tv_playlists_empty_title">Your playlists live here</string>
     <string name="tv_playlists_empty_subtitle">Build one manually or let Smart Rules do the sorting for you.</string>
     <string name="tv_playlists_empty_action_title">Create a playlist</string>

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/createaccount/TvCreateAccountModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/createaccount/TvCreateAccountModal.kt
@@ -4,15 +4,12 @@ import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -21,15 +18,13 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.Button
 import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.component.TvModal
 import au.com.shiftyjelly.pocketcasts.compose.loading.LoadingView
 import au.com.shiftyjelly.pocketcasts.onboarding.signin.TvSignInQrContent
 import au.com.shiftyjelly.pocketcasts.onboarding.signin.TvSignInUiState
-import au.com.shiftyjelly.pocketcasts.onboarding.signin.TvSignInViewModel
+import au.com.shiftyjelly.pocketcasts.onboarding.signin.verificationDisplayUrl
 import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
 import au.com.shiftyjelly.pocketcasts.theme.TvColors
 import au.com.shiftyjelly.pocketcasts.theme.TvTextStyles
@@ -37,46 +32,26 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 fun TvCreateAccountModal(
+    uiState: TvSignInUiState,
+    onRetry: () -> Unit,
     onDismissRequest: () -> Unit,
-    onSignedIn: () -> Unit,
     modifier: Modifier = Modifier,
-    viewModel: TvSignInViewModel = hiltViewModel(),
 ) {
-    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    val currentOnSignedIn by rememberUpdatedState(onSignedIn)
-
-    LaunchedEffect(uiState) {
-        if (uiState is TvSignInUiState.Complete) {
-            currentOnSignedIn()
-        }
-    }
-
     TvModal(
         onDismissRequest = onDismissRequest,
         width = ModalWidth,
         modifier = modifier,
     ) {
-        TvCreateAccountModalContent(
-            uiState = uiState,
-            onRetry = viewModel::retry,
-        )
-    }
-}
-
-@Composable
-private fun ColumnScope.TvCreateAccountModalContent(
-    uiState: TvSignInUiState,
-    onRetry: () -> Unit,
-) {
-    Column(
-        verticalArrangement = Arrangement.spacedBy(32.dp),
-        modifier = Modifier.fillMaxWidth(),
-    ) {
-        Header()
-        when (uiState) {
-            is TvSignInUiState.Ready -> ReadyContent(uiState)
-            is TvSignInUiState.Error -> ErrorContent(onRetry = onRetry)
-            is TvSignInUiState.Loading, is TvSignInUiState.Complete -> LoadingContent()
+        Column(
+            verticalArrangement = Arrangement.spacedBy(32.dp),
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Header()
+            when (uiState) {
+                is TvSignInUiState.Ready -> ReadyContent(uiState)
+                is TvSignInUiState.Error -> ErrorContent(onRetry = onRetry)
+                is TvSignInUiState.Loading, is TvSignInUiState.Complete -> LoadingContent()
+            }
         }
     }
 }
@@ -105,12 +80,7 @@ private fun Header(modifier: Modifier = Modifier) {
 @Composable
 private fun ReadyContent(state: TvSignInUiState.Ready, modifier: Modifier = Modifier) {
     val focusRequester = remember { FocusRequester() }
-    val url = remember(state.verificationUri) {
-        state.verificationUri
-            .removePrefix("https://")
-            .removePrefix("http://")
-            .trimEnd('/')
-    }
+    val url = remember(state.verificationUri) { verificationDisplayUrl(state.verificationUri) }
     val steps = listOf(
         stringResource(LR.string.tv_sign_in_step_scan, url),
         stringResource(LR.string.tv_create_account_modal_step_create),

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/createaccount/TvCreateAccountModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/createaccount/TvCreateAccountModal.kt
@@ -1,0 +1,180 @@
+package au.com.shiftyjelly.pocketcasts.onboarding.createaccount
+
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.tv.material3.Button
+import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.component.TvModal
+import au.com.shiftyjelly.pocketcasts.compose.loading.LoadingView
+import au.com.shiftyjelly.pocketcasts.onboarding.signin.TvSignInQrContent
+import au.com.shiftyjelly.pocketcasts.onboarding.signin.TvSignInUiState
+import au.com.shiftyjelly.pocketcasts.onboarding.signin.TvSignInViewModel
+import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
+import au.com.shiftyjelly.pocketcasts.theme.TvColors
+import au.com.shiftyjelly.pocketcasts.theme.TvTextStyles
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+fun TvCreateAccountModal(
+    onDismissRequest: () -> Unit,
+    onSignedIn: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: TvSignInViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val currentOnSignedIn by rememberUpdatedState(onSignedIn)
+
+    LaunchedEffect(uiState) {
+        if (uiState is TvSignInUiState.Complete) {
+            currentOnSignedIn()
+        }
+    }
+
+    TvModal(
+        onDismissRequest = onDismissRequest,
+        width = ModalWidth,
+        modifier = modifier,
+    ) {
+        TvCreateAccountModalContent(
+            uiState = uiState,
+            onRetry = viewModel::retry,
+        )
+    }
+}
+
+@Composable
+private fun ColumnScope.TvCreateAccountModalContent(
+    uiState: TvSignInUiState,
+    onRetry: () -> Unit,
+) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(32.dp),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Header()
+        when (uiState) {
+            is TvSignInUiState.Ready -> ReadyContent(uiState)
+            is TvSignInUiState.Error -> ErrorContent(onRetry = onRetry)
+            is TvSignInUiState.Loading, is TvSignInUiState.Complete -> LoadingContent()
+        }
+    }
+}
+
+@Composable
+private fun Header(modifier: Modifier = Modifier) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Text(
+            text = stringResource(LR.string.tv_create_account_modal_title),
+            color = Color.White,
+            style = TvTextStyles.ModalTitle,
+            textAlign = TextAlign.Start,
+        )
+        Text(
+            text = stringResource(LR.string.tv_create_account_modal_subtitle),
+            color = TvColors.TextSecondary,
+            style = TvTextStyles.ModalBody,
+            textAlign = TextAlign.Start,
+        )
+    }
+}
+
+@Composable
+private fun ReadyContent(state: TvSignInUiState.Ready, modifier: Modifier = Modifier) {
+    val focusRequester = remember { FocusRequester() }
+    val url = remember(state.verificationUri) {
+        state.verificationUri
+            .removePrefix("https://")
+            .removePrefix("http://")
+            .trimEnd('/')
+    }
+    val steps = listOf(
+        stringResource(LR.string.tv_sign_in_step_scan, url),
+        stringResource(LR.string.tv_create_account_modal_step_create),
+        stringResource(LR.string.tv_sign_in_step_confirm_code),
+    )
+
+    TvSignInQrContent(
+        userCode = state.userCode,
+        verificationUriComplete = state.verificationUriComplete,
+        steps = steps,
+        modifier = modifier
+            .focusRequester(focusRequester)
+            .focusable(),
+    )
+
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+}
+
+@Composable
+private fun LoadingContent(modifier: Modifier = Modifier) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = modifier
+            .fillMaxWidth()
+            .height(LoadingHeight),
+    ) {
+        LoadingView(color = Color.White)
+    }
+}
+
+@Composable
+private fun ErrorContent(
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val focusRequester = remember { FocusRequester() }
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+        modifier = modifier
+            .fillMaxWidth()
+            .height(LoadingHeight),
+    ) {
+        Text(
+            text = stringResource(LR.string.error_generic_message),
+            color = TvColors.TextSecondary,
+            style = TvTextStyles.SignInSubtitle,
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+        Button(
+            onClick = onRetry,
+            colors = TvButtonDefaults.filledButtonColors(),
+            modifier = Modifier.focusRequester(focusRequester),
+        ) {
+            Text(text = stringResource(LR.string.retry))
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+}
+
+private val ModalWidth = 760.dp
+private val LoadingHeight = 220.dp

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/createaccount/TvCreateAccountModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/createaccount/TvCreateAccountModal.kt
@@ -103,13 +103,20 @@ private fun ReadyContent(state: TvSignInUiState.Ready, modifier: Modifier = Modi
 
 @Composable
 private fun LoadingContent(modifier: Modifier = Modifier) {
+    val focusRequester = remember { FocusRequester() }
     Box(
         contentAlignment = Alignment.Center,
         modifier = modifier
             .fillMaxWidth()
-            .height(LoadingHeight),
+            .height(LoadingHeight)
+            .focusRequester(focusRequester)
+            .focusable(),
     ) {
         LoadingView(color = Color.White)
+    }
+
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
     }
 }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvDeviceAuth.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvDeviceAuth.kt
@@ -1,0 +1,55 @@
+package au.com.shiftyjelly.pocketcasts.onboarding.signin
+
+import au.com.shiftyjelly.pocketcasts.repositories.sync.LoginResult
+import au.com.shiftyjelly.pocketcasts.repositories.sync.SignInSource
+import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
+import kotlin.coroutines.cancellation.CancellationException
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import timber.log.Timber
+
+private const val AUTHORIZATION_PENDING = "authorization_pending"
+private const val MIN_POLL_INTERVAL_SECONDS = 5L
+
+fun deviceAuthFlow(syncManager: SyncManager): Flow<TvSignInUiState> = flow {
+    emit(TvSignInUiState.Loading)
+    val response = try {
+        syncManager.deviceAuthorize()
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        Timber.e(e, "Failed to request device code")
+        emit(TvSignInUiState.Error)
+        return@flow
+    }
+    emit(
+        TvSignInUiState.Ready(
+            userCode = response.userCode.map { it.toString() },
+            verificationUri = response.verificationUri,
+            verificationUriComplete = response.verificationUriComplete,
+        ),
+    )
+    val intervalSeconds = response.interval.toLong().coerceAtLeast(MIN_POLL_INTERVAL_SECONDS)
+    while (true) {
+        delay(intervalSeconds * 1000)
+        val result = syncManager.loginWithDeviceAuth(
+            deviceCode = response.deviceCode,
+            signInSource = SignInSource.UserInitiated.Onboarding,
+        )
+        when {
+            result is LoginResult.Success -> {
+                emit(TvSignInUiState.Complete)
+                return@flow
+            }
+
+            result is LoginResult.Failed && result.messageId == AUTHORIZATION_PENDING -> Unit
+
+            else -> {
+                Timber.w("Device auth polling stopped: ${(result as? LoginResult.Failed)?.message}")
+                emit(TvSignInUiState.Error)
+                return@flow
+            }
+        }
+    }
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInQrContent.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInQrContent.kt
@@ -42,7 +42,10 @@ fun TvSignInQrContent(
             QrCode(content = verificationUriComplete)
             StepList(steps = steps)
         }
-        CodeRow(userCode = userCode)
+        CodeRow(
+            userCode = userCode,
+            modifier = Modifier.align(Alignment.CenterHorizontally),
+        )
     }
 }
 
@@ -131,6 +134,7 @@ fun verificationDisplayUrl(verificationUri: String): String {
     return verificationUri
         .removePrefix("https://")
         .removePrefix("http://")
+        .removePrefix("www.")
         .trimEnd('/')
 }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInQrContent.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInQrContent.kt
@@ -1,0 +1,130 @@
+package au.com.shiftyjelly.pocketcasts.onboarding.signin
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.qr.rememberQrPainter
+import au.com.shiftyjelly.pocketcasts.theme.TvColors
+import au.com.shiftyjelly.pocketcasts.theme.TvTextStyles
+
+@Composable
+fun TvSignInQrContent(
+    userCode: List<String>,
+    verificationUriComplete: String,
+    steps: List<String>,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(28.dp),
+        modifier = modifier,
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(40.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            QrCode(content = verificationUriComplete)
+            StepList(steps = steps)
+        }
+        CodeRow(userCode = userCode)
+    }
+}
+
+@Composable
+private fun QrCode(content: String, modifier: Modifier = Modifier) {
+    val qrPainter = rememberQrPainter(content = content, size = QrSize)
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(8.dp))
+            .background(Color.White)
+            .padding(10.dp),
+    ) {
+        Image(
+            painter = qrPainter,
+            contentDescription = null,
+            modifier = Modifier.size(QrSize),
+        )
+    }
+}
+
+@Composable
+private fun StepList(steps: List<String>, modifier: Modifier = Modifier) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(20.dp),
+        modifier = modifier,
+    ) {
+        steps.forEachIndexed { index, step ->
+            StepRow(number = index + 1, text = step)
+        }
+    }
+}
+
+@Composable
+private fun StepRow(number: Int, text: String, modifier: Modifier = Modifier) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier,
+    ) {
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier
+                .size(28.dp)
+                .background(TvColors.BgActive20, CircleShape),
+        ) {
+            Text(
+                text = number.toString(),
+                color = TvColors.TextSecondary,
+                fontSize = 14.sp,
+                fontWeight = FontWeight.Medium,
+            )
+        }
+        Text(
+            text = text,
+            color = Color.White,
+            style = TvTextStyles.SignInSubtitle,
+        )
+    }
+}
+
+@Composable
+private fun CodeRow(userCode: List<String>, modifier: Modifier = Modifier) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = modifier,
+    ) {
+        userCode.forEach { character ->
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier
+                    .size(44.dp)
+                    .background(TvColors.BgActive20, CircleShape),
+            ) {
+                Text(
+                    text = character,
+                    color = TvColors.TextSecondary,
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.Bold,
+                )
+            }
+        }
+    }
+}
+
+private val QrSize = 132.dp

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInQrContent.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInQrContent.kt
@@ -127,4 +127,11 @@ private fun CodeRow(userCode: List<String>, modifier: Modifier = Modifier) {
     }
 }
 
+fun verificationDisplayUrl(verificationUri: String): String {
+    return verificationUri
+        .removePrefix("https://")
+        .removePrefix("http://")
+        .trimEnd('/')
+}
+
 private val QrSize = 132.dp

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInScreen.kt
@@ -6,14 +6,10 @@ import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -26,20 +22,15 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.Button
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
-import au.com.shiftyjelly.pocketcasts.qr.rememberQrPainter
 import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
 import au.com.shiftyjelly.pocketcasts.theme.TvColors
 import au.com.shiftyjelly.pocketcasts.theme.TvTextStyles
@@ -159,13 +150,7 @@ private fun TvSignInContent(
     modifier: Modifier = Modifier,
 ) {
     val focusRequester = remember { FocusRequester() }
-    val qrPainter = rememberQrPainter(content = verificationUriComplete, size = 118.dp)
-    val url = remember(verificationUri) {
-        verificationUri
-            .removePrefix("https://")
-            .removePrefix("http://")
-            .trimEnd('/')
-    }
+    val steps = signInSteps(verificationUri)
 
     Box(
         contentAlignment = Alignment.Center,
@@ -177,71 +162,17 @@ private fun TvSignInContent(
     ) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(48.dp),
         ) {
-            Image(
-                painter = painterResource(IR.drawable.ic_pocket_casts_logo),
-                contentDescription = null,
-                modifier = Modifier.size(36.dp),
-            )
-            Spacer(modifier = Modifier.height(16.dp))
             Text(
-                text = stringResource(LR.string.tv_onboarding_sign_in_title),
+                text = stringResource(LR.string.tv_sign_in_title),
                 color = Color.White,
                 style = TvTextStyles.WelcomeTitle,
             )
-            Spacer(modifier = Modifier.height(8.dp))
-            Text(
-                text = stringResource(LR.string.tv_onboarding_sign_in_instructions),
-                color = TvColors.TextSecondary,
-                style = TvTextStyles.SignInSubtitle,
-            )
-            Spacer(modifier = Modifier.height(24.dp))
-            Box(
-                modifier = Modifier
-                    .background(Color.White, RoundedCornerShape(4.dp))
-                    .padding(4.dp),
-            ) {
-                Image(
-                    painter = qrPainter,
-                    contentDescription = stringResource(LR.string.tv_onboarding_sign_in_instructions),
-                    modifier = Modifier.size(118.dp),
-                )
-            }
-            Spacer(modifier = Modifier.height(24.dp))
-            Box(
-                modifier = Modifier
-                    .width(377.dp)
-                    .height(0.5.dp)
-                    .background(TvColors.Divider),
-            )
-            Spacer(modifier = Modifier.height(16.dp))
-            Text(
-                text = stringResource(LR.string.tv_sign_in_or_enter_code),
-                color = TvColors.TextSecondary,
-                style = TvTextStyles.SignInSubtitle,
-            )
-            Spacer(modifier = Modifier.height(16.dp))
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                userCode.forEach { char ->
-                    CodeCharacterBox(character = char)
-                }
-            }
-            Spacer(modifier = Modifier.height(12.dp))
-            val formattedGoToUrl = stringResource(LR.string.tv_sign_in_go_to_url, url)
-            val urlStart = formattedGoToUrl.indexOf(url)
-            Text(
-                text = buildAnnotatedString {
-                    append(formattedGoToUrl)
-                    addStyle(SpanStyle(color = TvColors.TextSecondary), 0, formattedGoToUrl.length)
-                    if (urlStart >= 0) {
-                        addStyle(
-                            SpanStyle(color = Color.White, fontWeight = FontWeight.Bold),
-                            urlStart,
-                            urlStart + url.length,
-                        )
-                    }
-                },
-                style = TvTextStyles.SignInSubtitle,
+            TvSignInQrContent(
+                userCode = userCode,
+                verificationUriComplete = verificationUriComplete,
+                steps = steps,
             )
         }
     }
@@ -252,23 +183,18 @@ private fun TvSignInContent(
 }
 
 @Composable
-private fun CodeCharacterBox(
-    character: String,
-    modifier: Modifier = Modifier,
-) {
-    Box(
-        contentAlignment = Alignment.Center,
-        modifier = modifier
-            .size(width = 48.dp, height = 56.dp)
-            .background(TvColors.TextPrimary20, RoundedCornerShape(8.dp)),
-    ) {
-        Text(
-            text = character,
-            color = TvColors.TextSecondary,
-            fontSize = 24.sp,
-            fontWeight = FontWeight.Bold,
-        )
+private fun signInSteps(verificationUri: String): List<String> {
+    val url = remember(verificationUri) {
+        verificationUri
+            .removePrefix("https://")
+            .removePrefix("http://")
+            .trimEnd('/')
     }
+    return listOf(
+        stringResource(LR.string.tv_sign_in_step_scan, url),
+        stringResource(LR.string.tv_sign_in_step_login),
+        stringResource(LR.string.tv_sign_in_step_confirm_code),
+    )
 }
 
 @Preview(device = Devices.TV_1080p)

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInScreen.kt
@@ -184,12 +184,7 @@ private fun TvSignInContent(
 
 @Composable
 private fun signInSteps(verificationUri: String): List<String> {
-    val url = remember(verificationUri) {
-        verificationUri
-            .removePrefix("https://")
-            .removePrefix("http://")
-            .trimEnd('/')
-    }
+    val url = remember(verificationUri) { verificationDisplayUrl(verificationUri) }
     return listOf(
         stringResource(LR.string.tv_sign_in_step_scan, url),
         stringResource(LR.string.tv_sign_in_step_login),

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInViewModel.kt
@@ -2,18 +2,14 @@ package au.com.shiftyjelly.pocketcasts.onboarding.signin
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import au.com.shiftyjelly.pocketcasts.repositories.sync.LoginResult
-import au.com.shiftyjelly.pocketcasts.repositories.sync.SignInSource
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
-import kotlin.coroutines.cancellation.CancellationException
-import kotlinx.coroutines.delay
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import timber.log.Timber
 
 @HiltViewModel
 class TvSignInViewModel @Inject constructor(
@@ -23,63 +19,22 @@ class TvSignInViewModel @Inject constructor(
     private val _uiState = MutableStateFlow<TvSignInUiState>(TvSignInUiState.Loading)
     val uiState: StateFlow<TvSignInUiState> = _uiState.asStateFlow()
 
+    private var pollingJob: Job? = null
+
     init {
         requestDeviceCode()
     }
 
     private fun requestDeviceCode() {
-        viewModelScope.launch {
-            _uiState.value = TvSignInUiState.Loading
-            try {
-                val response = syncManager.deviceAuthorize()
-                _uiState.value = TvSignInUiState.Ready(
-                    userCode = response.userCode.map { it.toString() },
-                    verificationUri = response.verificationUri,
-                    verificationUriComplete = response.verificationUriComplete,
-                )
-                pollForApproval(response.deviceCode, response.interval.toLong())
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                Timber.e(e, "Failed to request device code")
-                _uiState.value = TvSignInUiState.Error
-            }
-        }
-    }
-
-    private suspend fun pollForApproval(deviceCode: String, intervalSeconds: Long) {
-        while (true) {
-            delay(intervalSeconds.coerceAtLeast(MIN_POLL_INTERVAL_SECONDS) * 1000)
-            val result = syncManager.loginWithDeviceAuth(
-                deviceCode = deviceCode,
-                signInSource = SignInSource.UserInitiated.Onboarding,
-            )
-            when {
-                result is LoginResult.Success -> {
-                    _uiState.value = TvSignInUiState.Complete
-                    return
-                }
-
-                result is LoginResult.Failed && result.messageId == AUTHORIZATION_PENDING -> {
-                    // Keep polling
-                }
-
-                else -> {
-                    Timber.w("Device auth polling stopped: ${(result as? LoginResult.Failed)?.message}")
-                    _uiState.value = TvSignInUiState.Error
-                    return
-                }
-            }
+        pollingJob?.cancel()
+        _uiState.value = TvSignInUiState.Loading
+        pollingJob = viewModelScope.launch {
+            deviceAuthFlow(syncManager).collect { _uiState.value = it }
         }
     }
 
     fun retry() {
         requestDeviceCode()
-    }
-
-    companion object {
-        private const val AUTHORIZATION_PENDING = "authorization_pending"
-        private const val MIN_POLL_INTERVAL_SECONDS = 5L
     }
 }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
@@ -362,7 +362,7 @@ private fun AllEpisodesArchived(
     }
 }
 
-private const val INFO_PANE_WEIGHT = 0.3f
+private const val INFO_PANE_WEIGHT = 0.35f
 
 private val PodcastSortOptions = listOf(
     EpisodesSortType.EPISODES_SORT_BY_TITLE_ASC,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
@@ -146,13 +146,13 @@ private fun TvPodcastDetailsContent(
                             }
                         },
                         onMoreInfo = { isShowingInfoModal = true },
-                        modifier = Modifier.width(InfoPaneWidth),
+                        modifier = Modifier.weight(INFO_PANE_WEIGHT),
                     )
                     if (uiState.episodes.isEmpty() && uiState.archivedEpisodeCount == 0) {
                         TvEmptyState(
                             title = stringResource(LR.string.podcast_no_episodes_found),
                             subtitle = stringResource(LR.string.podcast_no_episodes),
-                            modifier = Modifier.weight(1f).fillMaxHeight(),
+                            modifier = Modifier.weight(1f - INFO_PANE_WEIGHT).fillMaxHeight(),
                         )
                     } else {
                         EpisodeList(
@@ -163,7 +163,7 @@ private fun TvPodcastDetailsContent(
                             onChangeSortType = onChangeSortType,
                             onToggleArchiveFilter = onToggleArchiveFilter,
                             leftFocusRequester = followFocusRequester,
-                            modifier = Modifier.weight(1f),
+                            modifier = Modifier.weight(1f - INFO_PANE_WEIGHT),
                         )
                     }
                 }
@@ -364,7 +364,7 @@ private fun AllEpisodesArchived(
     }
 }
 
-private val InfoPaneWidth = 380.dp
+private const val INFO_PANE_WEIGHT = 0.3f
 
 private val PodcastSortOptions = listOf(
     EpisodesSortType.EPISODES_SORT_BY_TITLE_ASC,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
@@ -67,9 +68,9 @@ import au.com.shiftyjelly.pocketcasts.theme.TvDetailsArtworkSize
 import au.com.shiftyjelly.pocketcasts.theme.TvTextStyles
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import java.util.Date
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
 import timber.log.Timber
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -95,7 +96,6 @@ fun TvPodcastDetailsScreen(
         uiState = uiState,
         accountAuthState = viewModel.accountAuthState,
         onToggleSubscribe = viewModel::toggleSubscribe,
-        onSubscribe = viewModel::subscribe,
         onStartAccountAuth = viewModel::startAccountAuth,
         onStopAccountAuth = viewModel::stopAccountAuth,
         onRetryAccountAuth = viewModel::retryAccountAuth,
@@ -110,7 +110,6 @@ private fun TvPodcastDetailsContent(
     uiState: TvPodcastDetailsUiState,
     accountAuthState: StateFlow<TvSignInUiState>,
     onToggleSubscribe: () -> Unit,
-    onSubscribe: () -> Unit,
     onStartAccountAuth: () -> Unit,
     onStopAccountAuth: () -> Unit,
     onRetryAccountAuth: () -> Unit,
@@ -127,7 +126,7 @@ private fun TvPodcastDetailsContent(
             is TvPodcastDetailsUiState.Loaded -> {
                 val followFocusRequester = remember { FocusRequester() }
                 var isShowingInfoModal by remember { mutableStateOf(false) }
-                var isShowingAccountModal by remember { mutableStateOf(false) }
+                var isShowingAccountModal by rememberSaveable { mutableStateOf(false) }
                 Row(
                     horizontalArrangement = Arrangement.spacedBy(80.dp),
                     modifier = Modifier
@@ -138,10 +137,9 @@ private fun TvPodcastDetailsContent(
                         podcast = uiState.podcast,
                         followFocusRequester = followFocusRequester,
                         onFollow = {
-                            if (uiState.isLoggedIn) {
+                            if (uiState.isLoggedIn || uiState.podcast.isSubscribed) {
                                 onToggleSubscribe()
                             } else {
-                                onStartAccountAuth()
                                 isShowingAccountModal = true
                             }
                         },
@@ -175,15 +173,15 @@ private fun TvPodcastDetailsContent(
                 }
                 if (isShowingAccountModal) {
                     val authState by accountAuthState.collectAsStateWithLifecycle()
-                    val currentOnSubscribe by rememberUpdatedState(onSubscribe)
+                    val currentOnStartAccountAuth by rememberUpdatedState(onStartAccountAuth)
                     val currentOnStopAccountAuth by rememberUpdatedState(onStopAccountAuth)
                     DisposableEffect(Unit) {
+                        currentOnStartAccountAuth()
                         onDispose { currentOnStopAccountAuth() }
                     }
                     LaunchedEffect(authState) {
                         if (authState is TvSignInUiState.Complete) {
                             isShowingAccountModal = false
-                            currentOnSubscribe()
                         }
                     }
                     TvCreateAccountModal(
@@ -423,7 +421,6 @@ private fun TvPodcastDetailsContentPreview(
                 ),
                 accountAuthState = MutableStateFlow(TvSignInUiState.Loading),
                 onToggleSubscribe = {},
-                onSubscribe = {},
                 onStartAccountAuth = {},
                 onStopAccountAuth = {},
                 onRetryAccountAuth = {},

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
@@ -17,10 +17,12 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
@@ -59,6 +61,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodesSortType
 import au.com.shiftyjelly.pocketcasts.onboarding.createaccount.TvCreateAccountModal
+import au.com.shiftyjelly.pocketcasts.onboarding.signin.TvSignInUiState
 import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImage
 import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
 import au.com.shiftyjelly.pocketcasts.theme.TvColors
@@ -67,6 +70,8 @@ import au.com.shiftyjelly.pocketcasts.theme.TvTextStyles
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import java.util.Date
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import timber.log.Timber
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -91,8 +96,12 @@ fun TvPodcastDetailsScreen(
 
     TvPodcastDetailsContent(
         uiState = uiState,
+        accountAuthState = viewModel.accountAuthState,
         onToggleSubscribe = viewModel::toggleSubscribe,
         onSubscribe = viewModel::subscribe,
+        onStartAccountAuth = viewModel::startAccountAuth,
+        onStopAccountAuth = viewModel::stopAccountAuth,
+        onRetryAccountAuth = viewModel::retryAccountAuth,
         onChangeSortType = viewModel::changeSortType,
         onToggleArchiveFilter = viewModel::toggleArchiveFilter,
         modifier = modifier,
@@ -102,8 +111,12 @@ fun TvPodcastDetailsScreen(
 @Composable
 private fun TvPodcastDetailsContent(
     uiState: TvPodcastDetailsUiState,
+    accountAuthState: StateFlow<TvSignInUiState>,
     onToggleSubscribe: () -> Unit,
     onSubscribe: () -> Unit,
+    onStartAccountAuth: () -> Unit,
+    onStopAccountAuth: () -> Unit,
+    onRetryAccountAuth: () -> Unit,
     onChangeSortType: (EpisodesSortType) -> Unit,
     onToggleArchiveFilter: () -> Unit,
     modifier: Modifier = Modifier,
@@ -131,6 +144,7 @@ private fun TvPodcastDetailsContent(
                             if (uiState.isLoggedIn) {
                                 onToggleSubscribe()
                             } else {
+                                onStartAccountAuth()
                                 isShowingAccountModal = true
                             }
                         },
@@ -163,12 +177,22 @@ private fun TvPodcastDetailsContent(
                     )
                 }
                 if (isShowingAccountModal) {
-                    TvCreateAccountModal(
-                        onDismissRequest = { isShowingAccountModal = false },
-                        onSignedIn = {
+                    val authState by accountAuthState.collectAsStateWithLifecycle()
+                    val currentOnSubscribe by rememberUpdatedState(onSubscribe)
+                    val currentOnStopAccountAuth by rememberUpdatedState(onStopAccountAuth)
+                    DisposableEffect(Unit) {
+                        onDispose { currentOnStopAccountAuth() }
+                    }
+                    LaunchedEffect(authState) {
+                        if (authState is TvSignInUiState.Complete) {
                             isShowingAccountModal = false
-                            onSubscribe()
-                        },
+                            currentOnSubscribe()
+                        }
+                    }
+                    TvCreateAccountModal(
+                        uiState = authState,
+                        onRetry = onRetryAccountAuth,
+                        onDismissRequest = { isShowingAccountModal = false },
                     )
                 }
             }
@@ -406,8 +430,12 @@ private fun TvPodcastDetailsContentPreview(
                     isShowingArchived = false,
                     isLoggedIn = true,
                 ),
+                accountAuthState = MutableStateFlow(TvSignInUiState.Loading),
                 onToggleSubscribe = {},
                 onSubscribe = {},
+                onStartAccountAuth = {},
+                onStopAccountAuth = {},
+                onRetryAccountAuth = {},
                 onChangeSortType = {},
                 onToggleArchiveFilter = {},
             )

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
@@ -58,6 +58,7 @@ import au.com.shiftyjelly.pocketcasts.localization.helper.RelativeDateFormatter
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodesSortType
+import au.com.shiftyjelly.pocketcasts.onboarding.createaccount.TvCreateAccountModal
 import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImage
 import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
 import au.com.shiftyjelly.pocketcasts.theme.TvColors
@@ -90,6 +91,8 @@ fun TvPodcastDetailsScreen(
 
     TvPodcastDetailsContent(
         uiState = uiState,
+        onToggleSubscribe = viewModel::toggleSubscribe,
+        onSubscribe = viewModel::subscribe,
         onChangeSortType = viewModel::changeSortType,
         onToggleArchiveFilter = viewModel::toggleArchiveFilter,
         modifier = modifier,
@@ -99,6 +102,8 @@ fun TvPodcastDetailsScreen(
 @Composable
 private fun TvPodcastDetailsContent(
     uiState: TvPodcastDetailsUiState,
+    onToggleSubscribe: () -> Unit,
+    onSubscribe: () -> Unit,
     onChangeSortType: (EpisodesSortType) -> Unit,
     onToggleArchiveFilter: () -> Unit,
     modifier: Modifier = Modifier,
@@ -112,6 +117,7 @@ private fun TvPodcastDetailsContent(
             is TvPodcastDetailsUiState.Loaded -> {
                 val followFocusRequester = remember { FocusRequester() }
                 var isShowingInfoModal by remember { mutableStateOf(false) }
+                var isShowingAccountModal by remember { mutableStateOf(false) }
                 Row(
                     horizontalArrangement = Arrangement.spacedBy(80.dp),
                     modifier = Modifier
@@ -121,6 +127,13 @@ private fun TvPodcastDetailsContent(
                     PodcastInfo(
                         podcast = uiState.podcast,
                         followFocusRequester = followFocusRequester,
+                        onFollow = {
+                            if (uiState.isLoggedIn) {
+                                onToggleSubscribe()
+                            } else {
+                                isShowingAccountModal = true
+                            }
+                        },
                         onMoreInfo = { isShowingInfoModal = true },
                         modifier = Modifier.width(InfoPaneWidth),
                     )
@@ -149,6 +162,15 @@ private fun TvPodcastDetailsContent(
                         onDismissRequest = { isShowingInfoModal = false },
                     )
                 }
+                if (isShowingAccountModal) {
+                    TvCreateAccountModal(
+                        onDismissRequest = { isShowingAccountModal = false },
+                        onSignedIn = {
+                            isShowingAccountModal = false
+                            onSubscribe()
+                        },
+                    )
+                }
             }
         }
     }
@@ -158,6 +180,7 @@ private fun TvPodcastDetailsContent(
 private fun PodcastInfo(
     podcast: Podcast,
     followFocusRequester: FocusRequester,
+    onFollow: () -> Unit,
     onMoreInfo: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -196,7 +219,7 @@ private fun PodcastInfo(
         }
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
             Button(
-                onClick = {},
+                onClick = onFollow,
                 colors = TvButtonDefaults.filledButtonColors(),
                 modifier = Modifier.focusRequester(followFocusRequester),
             ) {
@@ -381,7 +404,10 @@ private fun TvPodcastDetailsContentPreview(
                     episodes = episodes,
                     archivedEpisodeCount = 0,
                     isShowingArchived = false,
+                    isLoggedIn = true,
                 ),
+                onToggleSubscribe = {},
+                onSubscribe = {},
                 onChangeSortType = {},
                 onToggleArchiveFilter = {},
             )

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
@@ -32,7 +32,6 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -43,7 +42,6 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.Button
-import androidx.tv.material3.Icon
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.component.TvArchivedFilterButton
@@ -73,7 +71,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import timber.log.Timber
-import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
@@ -247,12 +244,6 @@ private fun PodcastInfo(
                 colors = TvButtonDefaults.filledButtonColors(),
                 modifier = Modifier.focusRequester(followFocusRequester),
             ) {
-                Icon(
-                    painter = painterResource(if (podcast.isSubscribed) IR.drawable.ic_check else IR.drawable.ic_plus),
-                    contentDescription = null,
-                    modifier = Modifier.size(18.dp),
-                )
-                Spacer(Modifier.width(8.dp))
                 Text(stringResource(if (podcast.isSubscribed) LR.string.podcast_subscribed else LR.string.tv_podcast_follow))
             }
             Button(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsViewModel.kt
@@ -6,6 +6,8 @@ import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodesSortType
+import au.com.shiftyjelly.pocketcasts.onboarding.signin.TvSignInUiState
+import au.com.shiftyjelly.pocketcasts.onboarding.signin.deviceAuthFlow
 import au.com.shiftyjelly.pocketcasts.preferences.TvPreferences
 import au.com.shiftyjelly.pocketcasts.repositories.di.DefaultDispatcher
 import au.com.shiftyjelly.pocketcasts.repositories.di.IoDispatcher
@@ -22,10 +24,12 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.WhileSubscribed
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.emitAll
@@ -51,6 +55,10 @@ class TvPodcastDetailsViewModel @AssistedInject constructor(
 ) : ViewModel() {
 
     private val isShowingArchivedFlow = MutableStateFlow(preferences.isPodcastShowingArchived(podcastUuid))
+
+    private val _accountAuthState = MutableStateFlow<TvSignInUiState>(TvSignInUiState.Loading)
+    val accountAuthState: StateFlow<TvSignInUiState> = _accountAuthState.asStateFlow()
+    private var accountAuthJob: Job? = null
 
     val uiState: StateFlow<TvPodcastDetailsUiState> = flow {
         val podcast = try {
@@ -90,6 +98,23 @@ class TvPodcastDetailsViewModel @AssistedInject constructor(
 
     fun subscribe() {
         podcastManager.subscribeToPodcast(podcastUuid, sync = true)
+    }
+
+    fun startAccountAuth() {
+        accountAuthJob?.cancel()
+        _accountAuthState.value = TvSignInUiState.Loading
+        accountAuthJob = viewModelScope.launch {
+            deviceAuthFlow(syncManager).collect { _accountAuthState.value = it }
+        }
+    }
+
+    fun retryAccountAuth() {
+        startAccountAuth()
+    }
+
+    fun stopAccountAuth() {
+        accountAuthJob?.cancel()
+        accountAuthJob = null
     }
 
     fun toggleSubscribe() {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsViewModel.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.podcasts
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodesSortType
@@ -10,6 +11,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.di.DefaultDispatcher
 import au.com.shiftyjelly.pocketcasts.repositories.di.IoDispatcher
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -33,6 +35,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.rx2.asFlow
 import kotlinx.coroutines.rx2.await
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -41,6 +44,7 @@ class TvPodcastDetailsViewModel @AssistedInject constructor(
     @Assisted private val podcastUuid: String,
     private val podcastManager: PodcastManager,
     private val episodeManager: EpisodeManager,
+    private val syncManager: SyncManager,
     private val preferences: TvPreferences,
     @DefaultDispatcher private val defaultDispatcher: CoroutineDispatcher,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
@@ -64,13 +68,15 @@ class TvPodcastDetailsViewModel @AssistedInject constructor(
             val episodesFlow = podcastFlow
                 .distinctUntilChangedBy { it.episodesSortType }
                 .flatMapLatest { episodeManager.findEpisodesByPodcastOrderedFlow(it) }
+            val isLoggedInFlow = syncManager.isLoggedInObservable.asFlow()
             emitAll(
-                combine(podcastFlow, episodesFlow, isShowingArchivedFlow) { loadedPodcast, episodes, isShowingArchived ->
+                combine(podcastFlow, episodesFlow, isShowingArchivedFlow, isLoggedInFlow) { loadedPodcast, episodes, isShowingArchived, isLoggedIn ->
                     TvPodcastDetailsUiState.Loaded(
                         podcast = loadedPodcast,
                         episodes = if (isShowingArchived) episodes else episodes.filterNot(PodcastEpisode::isArchived),
                         archivedEpisodeCount = episodes.count(PodcastEpisode::isArchived),
                         isShowingArchived = isShowingArchived,
+                        isLoggedIn = isLoggedIn,
                     )
                 },
             )
@@ -81,6 +87,21 @@ class TvPodcastDetailsViewModel @AssistedInject constructor(
             SharingStarted.WhileSubscribed(stopTimeout = 300.milliseconds, replayExpiration = Duration.ZERO),
             TvPodcastDetailsUiState.Loading,
         )
+
+    fun subscribe() {
+        podcastManager.subscribeToPodcast(podcastUuid, sync = true)
+    }
+
+    fun toggleSubscribe() {
+        val podcast = (uiState.value as? TvPodcastDetailsUiState.Loaded)?.podcast ?: return
+        if (podcast.isSubscribed) {
+            viewModelScope.launch(ioDispatcher) {
+                podcastManager.unsubscribe(podcastUuid, SourceView.PODCAST_SCREEN)
+            }
+        } else {
+            podcastManager.subscribeToPodcast(podcastUuid, sync = true)
+        }
+    }
 
     fun changeSortType(sortType: EpisodesSortType) {
         viewModelScope.launch(ioDispatcher) {
@@ -110,5 +131,6 @@ sealed interface TvPodcastDetailsUiState {
         val episodes: List<PodcastEpisode>,
         val archivedEpisodeCount: Int,
         val isShowingArchived: Boolean,
+        val isLoggedIn: Boolean,
     ) : TvPodcastDetailsUiState
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsViewModel.kt
@@ -96,15 +96,26 @@ class TvPodcastDetailsViewModel @AssistedInject constructor(
             TvPodcastDetailsUiState.Loading,
         )
 
-    fun subscribe() {
-        podcastManager.subscribeToPodcast(podcastUuid, sync = true)
-    }
-
     fun startAccountAuth() {
         accountAuthJob?.cancel()
         _accountAuthState.value = TvSignInUiState.Loading
         accountAuthJob = viewModelScope.launch {
-            deviceAuthFlow(syncManager).collect { _accountAuthState.value = it }
+            deviceAuthFlow(syncManager).collect { state ->
+                _accountAuthState.value = state
+                if (state is TvSignInUiState.Complete) {
+                    podcastManager.subscribeToPodcast(podcastUuid, sync = true)
+                    // Sibling of accountAuthJob so the modal dismiss cancel doesn't kill the refresh.
+                    viewModelScope.launch {
+                        try {
+                            podcastManager.refreshPodcastsAfterSignIn()
+                        } catch (e: CancellationException) {
+                            throw e
+                        } catch (e: Exception) {
+                            LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, e, "Failed to refresh podcasts after TV account sign in")
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsViewModelTest.kt
@@ -1,18 +1,22 @@
 package au.com.shiftyjelly.pocketcasts.podcasts
 
 import app.cash.turbine.test
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodesSortType
 import au.com.shiftyjelly.pocketcasts.preferences.TvPreferences
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import com.jakewharton.rxrelay2.BehaviorRelay
 import io.reactivex.Single
 import java.util.Date
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Rule
@@ -23,6 +27,7 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyBlocking
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class TvPodcastDetailsViewModelTest {
@@ -43,6 +48,10 @@ class TvPodcastDetailsViewModelTest {
         on { findEpisodesByPodcastOrderedFlow(any()) } doReturn episodes
     }
     private val preferences = mock<TvPreferences>()
+    private val loggedIn = BehaviorRelay.createDefault(false)
+    private val syncManager = mock<SyncManager> {
+        on { isLoggedInObservable } doReturn loggedIn
+    }
 
     @Test
     fun `archived episodes are hidden by default`() = runTest {
@@ -206,6 +215,67 @@ class TvPodcastDetailsViewModelTest {
         }
     }
 
+    @Test
+    fun `the logged in state is reflected in the loaded state`() = runTest {
+        loggedIn.accept(true)
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            assertEquals(TvPodcastDetailsUiState.Loading, awaitItem())
+            episodes.emit(listOf(availableEpisode))
+            assertEquals(true, (awaitItem() as TvPodcastDetailsUiState.Loaded).isLoggedIn)
+        }
+    }
+
+    @Test
+    fun `subscribe follows the podcast and syncs`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.subscribe()
+
+        verify(podcastManager).subscribeToPodcast(podcastUuid = "podcast-uuid", sync = true)
+    }
+
+    @Test
+    fun `toggling an unsubscribed podcast follows it`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            assertEquals(TvPodcastDetailsUiState.Loading, awaitItem())
+            episodes.emit(listOf(availableEpisode))
+            awaitItem() as TvPodcastDetailsUiState.Loaded
+
+            viewModel.toggleSubscribe()
+
+            cancelAndConsumeRemainingEvents()
+        }
+
+        verify(podcastManager).subscribeToPodcast(podcastUuid = "podcast-uuid", sync = true)
+    }
+
+    @Test
+    fun `toggling a subscribed podcast unfollows it`() = runTest {
+        val subscribedPodcast = podcast.copy(isSubscribed = true)
+        val podcastManager = mock<PodcastManager> {
+            on { findOrDownloadPodcastRxSingle(any(), any()) } doReturn Single.just(subscribedPodcast)
+            on { podcastByUuidFlow(any()) } doReturn MutableStateFlow(subscribedPodcast)
+        }
+        val viewModel = createViewModel(podcastManager = podcastManager)
+
+        viewModel.uiState.test {
+            assertEquals(TvPodcastDetailsUiState.Loading, awaitItem())
+            episodes.emit(listOf(availableEpisode))
+            awaitItem() as TvPodcastDetailsUiState.Loaded
+
+            viewModel.toggleSubscribe()
+
+            cancelAndConsumeRemainingEvents()
+        }
+        advanceUntilIdle()
+
+        verifyBlocking(podcastManager) { unsubscribe("podcast-uuid", SourceView.PODCAST_SCREEN) }
+    }
+
     private fun createViewModel(
         prefs: TvPreferences = preferences,
         podcastManager: PodcastManager = this.podcastManager,
@@ -213,6 +283,7 @@ class TvPodcastDetailsViewModelTest {
         podcastUuid = "podcast-uuid",
         podcastManager = podcastManager,
         episodeManager = episodeManager,
+        syncManager = syncManager,
         preferences = prefs,
         defaultDispatcher = coroutineRule.testDispatcher,
         ioDispatcher = coroutineRule.testDispatcher,

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsViewModelTest.kt
@@ -235,15 +235,6 @@ class TvPodcastDetailsViewModelTest {
     }
 
     @Test
-    fun `subscribe follows the podcast and syncs`() = runTest {
-        val viewModel = createViewModel()
-
-        viewModel.subscribe()
-
-        verify(podcastManager).subscribeToPodcast(podcastUuid = "podcast-uuid", sync = true)
-    }
-
-    @Test
     fun `toggling an unsubscribed podcast follows it`() = runTest {
         val viewModel = createViewModel()
 
@@ -301,6 +292,10 @@ class TvPodcastDetailsViewModelTest {
             assertTrue(states.any { it is TvSignInUiState.Ready })
             assertEquals(TvSignInUiState.Complete, states.last())
         }
+        advanceUntilIdle()
+
+        verify(podcastManager).subscribeToPodcast(podcastUuid = "podcast-uuid", sync = true)
+        verify(podcastManager).refreshPodcastsAfterSignIn()
     }
 
     private fun deviceAuthorizeResponse() = DeviceAuthorizeResponse(

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsViewModelTest.kt
@@ -5,10 +5,15 @@ import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodesSortType
+import au.com.shiftyjelly.pocketcasts.onboarding.signin.TvSignInUiState
+import au.com.shiftyjelly.pocketcasts.preferences.AccessToken
 import au.com.shiftyjelly.pocketcasts.preferences.TvPreferences
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import au.com.shiftyjelly.pocketcasts.repositories.sync.LoginResult
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
+import au.com.shiftyjelly.pocketcasts.servers.model.AuthResultModel
+import au.com.shiftyjelly.pocketcasts.servers.sync.login.DeviceAuthorizeResponse
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import com.jakewharton.rxrelay2.BehaviorRelay
 import io.reactivex.Single
@@ -19,6 +24,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
@@ -28,6 +34,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyBlocking
+import org.mockito.kotlin.whenever
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class TvPodcastDetailsViewModelTest {
@@ -275,6 +282,43 @@ class TvPodcastDetailsViewModelTest {
 
         verifyBlocking(podcastManager) { unsubscribe("podcast-uuid", SourceView.PODCAST_SCREEN) }
     }
+
+    @Test
+    fun `starting account auth drives the account state to complete`() = runTest {
+        whenever(syncManager.deviceAuthorize()).thenReturn(deviceAuthorizeResponse())
+        whenever(syncManager.loginWithDeviceAuth(any(), any())).thenReturn(loginSuccess())
+        val viewModel = createViewModel()
+
+        viewModel.accountAuthState.test {
+            assertEquals(TvSignInUiState.Loading, awaitItem())
+
+            viewModel.startAccountAuth()
+
+            val states = mutableListOf<TvSignInUiState>()
+            while (states.lastOrNull() !is TvSignInUiState.Complete) {
+                states.add(awaitItem())
+            }
+            assertTrue(states.any { it is TvSignInUiState.Ready })
+            assertEquals(TvSignInUiState.Complete, states.last())
+        }
+    }
+
+    private fun deviceAuthorizeResponse() = DeviceAuthorizeResponse(
+        deviceCode = "device-code",
+        userCode = "ABC123",
+        verificationUri = "https://pocketcasts.com/pair",
+        verificationUriComplete = "https://pocketcasts.com/pair?code=ABC123",
+        expiresIn = 1800,
+        interval = 1,
+    )
+
+    private fun loginSuccess() = LoginResult.Success(
+        AuthResultModel(
+            token = AccessToken("access-token"),
+            uuid = "user-uuid",
+            isNewAccount = false,
+        ),
+    )
 
     private fun createViewModel(
         prefs: TvPreferences = preferences,

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsViewModelTest.kt
@@ -95,6 +95,27 @@ class TvYourPodcastsViewModelTest {
     }
 
     @Test
+    fun `following a new podcast adds it to the grid`() = runTest {
+        val viewModel = createViewModel()
+        val apple = podcastItem("Apple Cast")
+        homeFolder = listOf(apple)
+
+        viewModel.uiState.test {
+            assertEquals(TvYourPodcastsUiState.Loading, awaitItem())
+
+            folders.emit(emptyList())
+            subscribed.emit(listOf(Podcast(uuid = "apple")))
+            assertEquals(TvYourPodcastsUiState.Loaded(listOf(apple)), awaitItem())
+
+            val beat = podcastItem("Beat Cast")
+            homeFolder = listOf(apple, beat)
+            subscribed.emit(listOf(Podcast(uuid = "apple"), Podcast(uuid = "beat")))
+
+            assertEquals(TvYourPodcastsUiState.Loaded(listOf(apple, beat)), awaitItem())
+        }
+    }
+
+    @Test
     fun `folder items are enriched with their cover podcasts`() = runTest {
         val viewModel = createViewModel()
         val tech = folderItem("Tech")


### PR DESCRIPTION
## Description
- **Signed in:** the Follow button now toggles subscribe/unsubscribe (`PodcastManager.subscribeToPodcast` / `unsubscribe`); the subscription state flows back through `podcastByUuidFlow`, so the button's icon/label update reactively.
- **Signed out:** tapping Follow opens a **"Your podcasts deserve a home"** modal (`TvCreateAccountModal`) that reuses the existing device-auth QR pairing flow. Once the phone completes sign-in, the modal closes and the podcast is followed automatically.

**Bonnus:** To match the updated Figma, the QR "pairing" area was reworked into a shared `TvSignInQrContent` composable (QR + numbered steps + circular code chips), used by **both** the new modal and the restyled full-screen `TvSignInScreen` ("Log in to Pocket Casts").

Fixes PCDROID-698 https://linear.app/a8c/issue/PCDROID-698/signed-off-modal

## Testing Instructions

Signed-out follow:
1. On the TV app, sign out (Profile → Log out).
2. Open any podcast's details (Home or search → a podcast → **More info** is next to Follow).
3. Focus **Follow this podcast** and press select.
4. The "Your podcasts deserve a home" modal appears with a QR code, numbered steps, and the pairing code.
5. Scan/pair on your phone and complete sign-in → the modal closes and the podcast is followed.
6. Repeat: reopen the modal — it always shows a fresh code, never an instant close.
7. Open the modal and press **Back** before pairing → polling stops (you are not silently signed in).

Signed-in follow:
1. While signed in, open a podcast's details.
2. Press **Follow this podcast** → the button switches to the followed state; the podcast appears under Your Podcasts.
3. Press it again → it unfollows.

Sign-in screen restyle:
1. From onboarding, choose **Sign in with your phone** → the QR screen now shows the numbered step list + circular code chips.

## Screenshots or Screencast
<img width="1920" height="1080" alt="Screenshot_20260731_085320" src="https://github.com/user-attachments/assets/eef920fc-0f20-4079-b9fb-8062a247a686" />


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) the Event Horizon schema to reflect any new or changed analytics.

#### I have tested any UI changes...
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
