### PR TITLE
Open HLS videos in the player like mp4, and fix their content_type analytics (cherry-pick to 8.17)

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -163,6 +163,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.opml.OpmlImportTask
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackNoticeType
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
+import au.com.shiftyjelly.pocketcasts.repositories.playback.StreamVideoState
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextSource
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.Playlist
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
@@ -716,7 +717,12 @@ class MainActivity :
     override fun onStart() {
         super.onStart()
         if (resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
-            if (!videoPlayerShown && playbackManager.getCurrentEpisode()?.isVideo == true && playbackManager.isPlaybackLocal() && playbackManager.isPlaying() && viewModel.isPlayerOpen) {
+            val isPlayingVideo = playbackManager.videoRenderingEnabled.value &&
+                (
+                    (playbackManager.getCurrentEpisode()?.isVideo == true && !settings.audioOnly.value) ||
+                        playbackManager.streamVideoState.value == StreamVideoState.HasVideo
+                    )
+            if (!videoPlayerShown && isPlayingVideo && playbackManager.isPlaybackLocal() && playbackManager.isPlaying() && viewModel.isPlayerOpen) {
                 openFullscreenViewPlayer()
             } else {
                 videoPlayerShown = false
@@ -733,6 +739,14 @@ class MainActivity :
         // addCallback() again in order to tell the media router that it no longer
         // needs to invest effort trying to discover routes of these kinds for now.
         mediaRouter?.addCallback(mediaRouteSelector, mediaRouterCallback, 0)
+    }
+
+    private fun openVideoPlayer() {
+        if (resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT) {
+            binding.playerBottomSheet.openPlayer()
+        } else {
+            openFullscreenViewPlayer()
+        }
     }
 
     private fun openFullscreenViewPlayer() {
@@ -1070,12 +1084,8 @@ class MainActivity :
                         val episode = withContext(Dispatchers.Default) {
                             episodeManager.findEpisodeByUuid(state.episodeUuid)
                         }
-                        if (episode?.isVideo == true && state.isPlaying) {
-                            if (resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT) {
-                                binding.playerBottomSheet.openPlayer()
-                            } else {
-                                openFullscreenViewPlayer()
-                            }
+                        if (episode?.isVideo == true && state.isPlaying && !settings.audioOnly.value && playbackManager.videoRenderingEnabled.value) {
+                            openVideoPlayer()
                         }
                     }
 
@@ -1090,6 +1100,26 @@ class MainActivity :
                     updatePlaybackState(state)
 
                     viewModel.lastPlaybackState = state
+                }
+            }
+        }
+
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                var previousStreamVideoState: StreamVideoState? = null
+                playbackManager.streamVideoState.collect { streamVideoState ->
+                    val didResolveVideoStream = previousStreamVideoState == StreamVideoState.Unknown &&
+                        streamVideoState == StreamVideoState.HasVideo
+                    previousStreamVideoState = streamVideoState
+
+                    if (didResolveVideoStream &&
+                        playbackManager.isPlaying() &&
+                        playbackManager.isPlaybackLocal() &&
+                        playbackManager.videoRenderingEnabled.value &&
+                        playbackManager.getCurrentEpisode()?.isVideo != true
+                    ) {
+                        openVideoPlayer()
+                    }
                 }
             }
         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -286,6 +286,12 @@ open class PlaybackManager @Inject constructor(
 
     private var lastPlaybackSource: SourceView? = null
 
+    private class PendingContentTypeEvent(
+        val episodeUuid: String,
+        val build: (PlaybackContentType) -> Trackable,
+    )
+    private val pendingContentTypeEvents = mutableListOf<PendingContentTypeEvent>()
+
     var player: Player?
         get() = _playerFlow.value
         set(value) {
@@ -397,7 +403,7 @@ open class PlaybackManager @Inject constructor(
             PlaybackEpisodeAutoplayedEvent(
                 episodeUuid = autoPlayEpisode.uuid,
                 hlsAvailable = autoPlayOffersHls,
-                audioOnlyMode = if (autoPlayOffersHls) settings.audioOnly.value else null,
+                audioOnlyMode = if (autoPlayOffersHls || autoPlayEpisode.isVideo) settings.audioOnly.value else null,
             ),
         )
         return autoPlayEpisode
@@ -491,8 +497,12 @@ open class PlaybackManager @Inject constructor(
 
     private fun audioOnlyModeOrNull(): Boolean? {
         val episode = getCurrentEpisode() ?: return null
-        val playingHlsStream = episode.isStreamUrlHls && player?.isStreaming == true
-        if (!playingHlsStream && !episode.isVideo) return null
+        return audioOnlyModeOrNull(episode, hlsRelevant = _streamVideoState.value != StreamVideoState.NotVideo)
+    }
+
+    private fun audioOnlyModeOrNull(episode: BaseEpisode?, hlsRelevant: Boolean): Boolean? {
+        if (episode == null) return null
+        if (!hlsRelevant && !episode.isVideo) return null
         return settings.audioOnly.value || !_videoRenderingEnabled.value
     }
 
@@ -1020,6 +1030,7 @@ open class PlaybackManager @Inject constructor(
     }
 
     suspend fun stopSuspend(isAudioFocusFailed: Boolean = false, sourceView: SourceView = SourceView.UNKNOWN) {
+        flushPendingContentTypeEvents()
         if (!isAudioFocusFailed) {
             trackPlaybackEvent(sourceView) { source, contentType ->
                 PlaybackStopEvent(
@@ -1033,6 +1044,8 @@ open class PlaybackManager @Inject constructor(
 
     suspend fun stop() {
         LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Stopping playback")
+
+        flushPendingContentTypeEvents()
 
         cancelPrefetchNextEpisode()
         cancelUpdateTimer()
@@ -2150,28 +2163,34 @@ open class PlaybackManager @Inject constructor(
             videoStreamPreferredEpisodeUuid = null
         }
 
-        val playingStream = !episode.isDownloaded || (videoStreamPreferred && episode.isStreamUrlHls && !castManager.isConnected())
+        val castConnected = castManager.isConnected()
+        val playingStream = !episode.isDownloaded || (videoStreamPreferred && episode.isStreamUrlHls && !castConnected)
+
+        flushPendingContentTypeEvents()
 
         // Audio only forces video content to audio. Otherwise HLS starts Unknown until the tracks resolve it; non-HLS keeps its own flag.
-        _streamVideoState.value = StreamVideoState.initialFor(
-            episode,
-            audioOnly = settings.audioOnly.value,
-            playingHlsStream = playingStream && episode.isStreamUrlHls,
-        )
+        synchronized(pendingContentTypeEvents) {
+            _streamVideoState.value = StreamVideoState.initialFor(
+                episode,
+                audioOnly = settings.audioOnly.value,
+                playingHlsStream = playingStream && episode.isStreamUrlHls,
+                isRemote = castConnected,
+            )
+        }
         _videoRenderingEnabled.value = true
 
         lastPlaybackSource = sourceView
 
-        eventHorizon.track(
+        trackWithContentType(episode) { contentType ->
             PlaybackSourceResolvedEvent(
                 playbackProtocol = if (playingStream && episode.isStreamUrlHls) PlaybackProtocolType.Hls else PlaybackProtocolType.Progressive,
                 isFallback = false,
-                contentType = playbackContentTypeFor(episode),
+                contentType = contentType,
                 episodeUuid = episode.uuid,
                 podcastUuid = episode.podcastOrSubstituteUuid,
                 hlsEngine = if (playingStream && episode.isStreamUrlHls) HLS_ENGINE_EXOPLAYER else null,
-            ),
-        )
+            )
+        }
 
         LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Opening episode. %s Downloaded: %b Downloading: %b Audio: %b File: %s Uuid: %s", episode.title, episode.isDownloaded, episode.isDownloading, episode.isAudio, episode.downloadUrl ?: "", episode.uuid)
         if (BuildConfig.DEBUG) {
@@ -2261,7 +2280,7 @@ open class PlaybackManager @Inject constructor(
         // We want to make sure we get the current position at the last possible moment before changing/resetting the player
         val currentPositionMs = if (
             isPlayerSwitchRequired() ||
-            isPlayerResetNeeded(episode, sameEpisode, castManager.isConnected(), playingStream)
+            isPlayerResetNeeded(episode, sameEpisode, castConnected, playingStream)
         ) {
             // Don't create a player if we aren't playing because it will start to buffer
             if (play) {
@@ -2502,14 +2521,7 @@ open class PlaybackManager @Inject constructor(
         sleepTimer.restartSleepTimerIfApplies(currentEpisodeUuid = episode.uuid)
 
         lastPlaybackSource = sourceView
-        trackPlaybackEvent(sourceView) { source, contentType ->
-            PlaybackPlayEvent(
-                source = source.analyticsValue,
-                contentType = contentType,
-                hlsAvailable = _streamHlsAvailable.value,
-                audioOnlyMode = audioOnlyModeOrNull(),
-            )
-        }
+        trackPlaybackPlay(sourceView, episode)
     }
 
     private suspend fun addPodcastStartFromSettings(episode: PodcastEpisode, podcast: Podcast?, isPlaying: Boolean) {
@@ -2581,7 +2593,15 @@ open class PlaybackManager @Inject constructor(
     }
 
     private fun onVideoTrackChanged(hasVideo: Boolean) {
-        _streamVideoState.value = if (hasVideo) StreamVideoState.HasVideo else StreamVideoState.AudioOnly
+        val currentUuid = getCurrentEpisode()?.uuid
+        val contentType = if (hasVideo) PlaybackContentType.Video else PlaybackContentType.Audio
+        val ready = synchronized(pendingContentTypeEvents) {
+            _streamVideoState.value = if (hasVideo) StreamVideoState.HasVideo else StreamVideoState.AudioOnly
+            val matched = pendingContentTypeEvents.filter { it.episodeUuid == currentUuid }
+            pendingContentTypeEvents.removeAll(matched)
+            matched
+        }
+        ready.forEach { eventHorizon.track(it.build(contentType)) }
     }
 
     private suspend fun updateCurrentPositionInDatabase() {
@@ -2893,12 +2913,48 @@ open class PlaybackManager @Inject constructor(
         if (source == SourceView.AUTO_PLAY || source == SourceView.AUTO_PAUSE) {
             return
         }
-        val contentType = if (getCurrentEpisode()?.isVideo == true) {
-            PlaybackContentType.Video
-        } else {
-            PlaybackContentType.Audio
-        }
+        val contentType = playbackContentTypeFor(getCurrentEpisode())
         eventHorizon.track(event(source, contentType))
+    }
+
+    private fun trackPlaybackPlay(source: SourceView, episode: BaseEpisode) {
+        if (source == SourceView.UNKNOWN) {
+            Timber.w("Found unknown playback source.")
+        }
+        if (source == SourceView.AUTO_PLAY || source == SourceView.AUTO_PAUSE) {
+            return
+        }
+        val hlsAvailable = _streamHlsAvailable.value
+        trackWithContentType(episode) { contentType ->
+            PlaybackPlayEvent(
+                source = source.analyticsValue,
+                contentType = contentType,
+                hlsAvailable = hlsAvailable,
+                audioOnlyMode = audioOnlyModeOrNull(episode, hlsRelevant = _streamVideoState.value != StreamVideoState.NotVideo),
+            )
+        }
+    }
+
+    private fun trackWithContentType(episode: BaseEpisode, build: (PlaybackContentType) -> Trackable) {
+        val event = synchronized(pendingContentTypeEvents) {
+            val contentType = playbackContentTypeFor(episode)
+            if (contentType == PlaybackContentType.Unknown) {
+                pendingContentTypeEvents += PendingContentTypeEvent(episode.uuid, build)
+                null
+            } else {
+                build(contentType)
+            }
+        }
+        event?.let(eventHorizon::track)
+    }
+
+    private fun flushPendingContentTypeEvents() {
+        val pending = synchronized(pendingContentTypeEvents) {
+            val copy = pendingContentTypeEvents.toList()
+            pendingContentTypeEvents.clear()
+            copy
+        }
+        pending.forEach { eventHorizon.track(it.build(PlaybackContentType.Unknown)) }
     }
 
     fun trackPlaybackSeek(

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Player.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Player.kt
@@ -43,9 +43,9 @@ enum class StreamVideoState {
     ;
 
     companion object {
-        fun initialFor(episode: BaseEpisode, audioOnly: Boolean, playingHlsStream: Boolean) = when {
+        fun initialFor(episode: BaseEpisode, audioOnly: Boolean, playingHlsStream: Boolean, isRemote: Boolean) = when {
             audioOnly && (episode.isVideo || playingHlsStream) -> AudioOnly
-            playingHlsStream -> Unknown
+            playingHlsStream && !isRemote -> Unknown
             else -> NotVideo
         }
     }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/StreamVideoStateTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/StreamVideoStateTest.kt
@@ -11,56 +11,70 @@ class StreamVideoStateTest {
     fun `audio episode starts not video`() {
         val episode = createEpisode(fileType = "audio/mpeg")
 
-        assertEquals(StreamVideoState.NotVideo, StreamVideoState.initialFor(episode, audioOnly = false, playingHlsStream = false))
+        assertEquals(StreamVideoState.NotVideo, StreamVideoState.initialFor(episode, audioOnly = false, playingHlsStream = false, isRemote = false))
     }
 
     @Test
     fun `audio episode ignores audio only`() {
         val episode = createEpisode(fileType = "audio/mpeg")
 
-        assertEquals(StreamVideoState.NotVideo, StreamVideoState.initialFor(episode, audioOnly = true, playingHlsStream = false))
+        assertEquals(StreamVideoState.NotVideo, StreamVideoState.initialFor(episode, audioOnly = true, playingHlsStream = false, isRemote = false))
     }
 
     @Test
     fun `video episode starts not video so its own flag decides`() {
         val episode = createEpisode(fileType = "video/mp4")
 
-        assertEquals(StreamVideoState.NotVideo, StreamVideoState.initialFor(episode, audioOnly = false, playingHlsStream = false))
+        assertEquals(StreamVideoState.NotVideo, StreamVideoState.initialFor(episode, audioOnly = false, playingHlsStream = false, isRemote = false))
     }
 
     @Test
     fun `audio only forces a video episode to audio`() {
         val episode = createEpisode(fileType = "video/mp4")
 
-        assertEquals(StreamVideoState.AudioOnly, StreamVideoState.initialFor(episode, audioOnly = true, playingHlsStream = false))
+        assertEquals(StreamVideoState.AudioOnly, StreamVideoState.initialFor(episode, audioOnly = true, playingHlsStream = false, isRemote = false))
     }
 
     @Test
     fun `hls stream starts unknown`() {
         val episode = createHlsEpisode()
 
-        assertEquals(StreamVideoState.Unknown, StreamVideoState.initialFor(episode, audioOnly = false, playingHlsStream = true))
+        assertEquals(StreamVideoState.Unknown, StreamVideoState.initialFor(episode, audioOnly = false, playingHlsStream = true, isRemote = false))
     }
 
     @Test
     fun `audio only forces an hls stream to audio`() {
         val episode = createHlsEpisode()
 
-        assertEquals(StreamVideoState.AudioOnly, StreamVideoState.initialFor(episode, audioOnly = true, playingHlsStream = true))
+        assertEquals(StreamVideoState.AudioOnly, StreamVideoState.initialFor(episode, audioOnly = true, playingHlsStream = true, isRemote = false))
+    }
+
+    @Test
+    fun `remote hls stream resolves without waiting for tracks`() {
+        val episode = createHlsEpisode()
+
+        assertEquals(StreamVideoState.NotVideo, StreamVideoState.initialFor(episode, audioOnly = false, playingHlsStream = true, isRemote = true))
+    }
+
+    @Test
+    fun `audio only forces a remote hls stream to audio`() {
+        val episode = createHlsEpisode()
+
+        assertEquals(StreamVideoState.AudioOnly, StreamVideoState.initialFor(episode, audioOnly = true, playingHlsStream = true, isRemote = true))
     }
 
     @Test
     fun `downloaded hls episode playing its local file starts not video`() {
         val episode = createHlsEpisode()
 
-        assertEquals(StreamVideoState.NotVideo, StreamVideoState.initialFor(episode, audioOnly = false, playingHlsStream = false))
+        assertEquals(StreamVideoState.NotVideo, StreamVideoState.initialFor(episode, audioOnly = false, playingHlsStream = false, isRemote = false))
     }
 
     @Test
     fun `downloaded hls episode playing its local audio file ignores audio only`() {
         val episode = createHlsEpisode()
 
-        assertEquals(StreamVideoState.NotVideo, StreamVideoState.initialFor(episode, audioOnly = true, playingHlsStream = false))
+        assertEquals(StreamVideoState.NotVideo, StreamVideoState.initialFor(episode, audioOnly = true, playingHlsStream = false, isRemote = false))
     }
 
     private fun createEpisode(fileType: String) = PodcastEpisode(


### PR DESCRIPTION
## Description

Cherry-pick of #5678 into `release/8.17`.

> **This change was already reviewed and merged on `main`.** This PR exists to land it in the upcoming release. CI and a quick review should still run to confirm the cherry-pick applies cleanly and introduces no issues on the release branch, since `release/8.17` may have diverged from `main`.

- Original PR: https://github.com/Automattic/pocket-casts-android/pull/5678
- Cherry-picked commit: `815b477bf0`

## Testing Instructions

See the original PR (https://github.com/Automattic/pocket-casts-android/pull/5678) for full testing steps. In addition, verify the change behaves as described on top of `release/8.17`.