### PR TITLE
[TV] Add action toasts

### DIFF
--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -278,6 +278,12 @@
     <string name="tv_playlist_empty_subtitle">Either it’s time to celebrate completing this list or edit your rules in the mobile app to get some more.</string>
     <string name="tv_playlist_empty_subtitle_manual">Add episodes to this playlist from the mobile app and they’ll show up here.</string>
     <string name="tv_episode_details">Episode details</string>
+    <string name="tv_episode_marked_as_played">Marked as played</string>
+    <string name="tv_episode_marked_as_unplayed">Marked as unplayed</string>
+    <string name="tv_episode_archived">Archived</string>
+    <string name="tv_episode_unarchived">Unarchived</string>
+    <string name="tv_episode_will_play_next">Will play next</string>
+    <string name="tv_episode_will_play_last">Will play last</string>
     <string name="tv_up_next_empty_title">Nothing queued up</string>
     <string name="tv_up_next_empty_subtitle">Add episodes to Up Next and they’ll play in order, back to back</string>
     <string name="tv_up_next_empty_action_title">Add episodes</string>

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionsModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionsModal.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -55,6 +56,7 @@ private fun ColumnScope.TvEpisodeActionsModalContent(
         focusRequester.requestFocus()
     }
 
+    val toastHostState = LocalTvToastHostState.current
     val episodeDetails = stringResource(LR.string.tv_episode_details)
     val goToPodcast = stringResource(LR.string.go_to_podcast)
     val playNext = stringResource(LR.string.add_to_up_next_top)
@@ -62,13 +64,27 @@ private fun ColumnScope.TvEpisodeActionsModalContent(
     val playedToggle = stringResource(if (episode.isFinished) LR.string.mark_as_unplayed else LR.string.mark_as_played)
     val archiveToggle = stringResource(if (episode.isArchived) LR.string.unarchive else LR.string.archive)
 
+    val playNextToast = stringResource(LR.string.tv_episode_will_play_next)
+    val playLastToast = stringResource(LR.string.tv_episode_will_play_last)
+    val playedToast = stringResource(
+        if (episode.isFinished) LR.string.tv_episode_marked_as_unplayed else LR.string.tv_episode_marked_as_played,
+    )
+    val archiveToast = stringResource(
+        if (episode.isArchived) LR.string.tv_episode_unarchived else LR.string.tv_episode_archived,
+    )
+
+    fun withToast(message: String): () -> Unit = {
+        toastHostState.show(message)
+        onDismissRequest()
+    }
+
     val actions = listOf(
         episodeDetails to onShowEpisodeDetails,
-        goToPodcast to {},
-        playNext to {},
-        playLast to {},
-        playedToggle to {},
-        archiveToggle to {},
+        goToPodcast to onDismissRequest,
+        playNext to withToast(playNextToast),
+        playLast to withToast(playLastToast),
+        playedToggle to withToast(playedToast),
+        archiveToggle to withToast(archiveToast),
     )
 
     actions.forEachIndexed { index, (label, onClick) ->
@@ -136,12 +152,14 @@ private fun TvEpisodeActionsModalPlayedArchivedPreview() {
 private fun TvEpisodeActionsModalPreviewContent(episode: PodcastEpisode) {
     AppTheme(themeType = Theme.ThemeType.EXTRA_DARK) {
         MaterialTheme {
-            TvModalSurface(contentPadding = ContentPadding) {
-                TvEpisodeActionsModalContent(
-                    episode = episode,
-                    onDismissRequest = {},
-                    onShowEpisodeDetails = {},
-                )
+            CompositionLocalProvider(LocalTvToastHostState provides remember { TvToastHostState() }) {
+                TvModalSurface(contentPadding = ContentPadding) {
+                    TvEpisodeActionsModalContent(
+                        episode = episode,
+                        onDismissRequest = {},
+                        onShowEpisodeDetails = {},
+                    )
+                }
             }
         }
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvToast.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvToast.kt
@@ -22,10 +22,16 @@ import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.theme.TvTextStyles
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import kotlinx.coroutines.delay
 
 @Stable
@@ -93,6 +99,7 @@ private fun TvToastContent(
         color = Color.White,
         style = TvTextStyles.ModalBody,
         modifier = modifier
+            .semantics { liveRegion = LiveRegionMode.Polite }
             .widthIn(max = ToastMaxWidth)
             .clip(ToastShape)
             .background(TvOverlayContainerColor)
@@ -106,8 +113,10 @@ private val ToastAnimationMillis = 300
 private val ToastMaxWidth = 600.dp
 private val ToastShape = RoundedCornerShape(16.dp)
 
-@Preview
+@Preview(device = Devices.TV_1080p)
 @Composable
 private fun TvToastPreview() {
-    TvToastContent(message = "Marked as played")
+    AppTheme(themeType = Theme.ThemeType.EXTRA_DARK) {
+        TvToastContent(message = "Marked as played")
+    }
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvToast.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvToast.kt
@@ -1,0 +1,113 @@
+package au.com.shiftyjelly.pocketcasts.component
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.theme.TvTextStyles
+import kotlinx.coroutines.delay
+
+@Stable
+class TvToastHostState {
+    var currentToast by mutableStateOf<TvToast?>(null)
+        private set
+
+    private var counter = 0
+
+    fun show(message: String) {
+        counter += 1
+        currentToast = TvToast(id = counter, message = message)
+    }
+
+    internal fun dismiss(id: Int) {
+        if (currentToast?.id == id) {
+            currentToast = null
+        }
+    }
+}
+
+data class TvToast(
+    val id: Int,
+    val message: String,
+)
+
+val LocalTvToastHostState = staticCompositionLocalOf<TvToastHostState> {
+    error("TvToastHostState was not provided")
+}
+
+@Composable
+fun TvToastHost(
+    state: TvToastHostState,
+    modifier: Modifier = Modifier,
+) {
+    val toast = state.currentToast
+    LaunchedEffect(toast?.id) {
+        val id = toast?.id ?: return@LaunchedEffect
+        delay(ToastDurationMillis)
+        state.dismiss(id)
+    }
+
+    var lastMessage by remember { mutableStateOf("") }
+    if (toast != null) {
+        lastMessage = toast.message
+    }
+
+    AnimatedVisibility(
+        visible = toast != null,
+        enter = slideInHorizontally(tween(ToastAnimationMillis)) { it } + fadeIn(tween(ToastAnimationMillis)),
+        exit = slideOutVertically(tween(ToastAnimationMillis)) { it / 4 } + fadeOut(tween(ToastAnimationMillis)),
+        modifier = modifier,
+    ) {
+        TvToastContent(message = lastMessage)
+    }
+}
+
+@Composable
+private fun TvToastContent(
+    message: String,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = message,
+        color = Color.White,
+        style = TvTextStyles.ModalBody,
+        modifier = modifier
+            .widthIn(max = ToastMaxWidth)
+            .clip(ToastShape)
+            .background(TvOverlayContainerColor)
+            .border(1.dp, TvOverlayBorderColor, ToastShape)
+            .padding(horizontal = 30.dp, vertical = 20.dp),
+    )
+}
+
+private const val ToastDurationMillis = 3000L
+private const val ToastAnimationMillis = 300
+private val ToastMaxWidth = 600.dp
+private val ToastShape = RoundedCornerShape(16.dp)
+
+@Preview
+@Composable
+private fun TvToastPreview() {
+    TvToastContent(message = "Marked as played")
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvToast.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvToast.kt
@@ -101,8 +101,8 @@ private fun TvToastContent(
     )
 }
 
-private const val ToastDurationMillis = 3000L
-private const val ToastAnimationMillis = 300
+private val ToastDurationMillis = 3000L
+private val ToastAnimationMillis = 300
 private val ToastMaxWidth = 600.dp
 private val ToastShape = RoundedCornerShape(16.dp)
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingNavHost.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingNavHost.kt
@@ -88,7 +88,7 @@ fun TvOnboardingNavHost(
                         state = toastHostState,
                         modifier = Modifier
                             .align(Alignment.TopEnd)
-                            .padding(top = 48.dp, end = 48.dp),
+                            .padding(top = 80.dp, end = 48.dp),
                     )
                 }
             }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingNavHost.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingNavHost.kt
@@ -27,6 +27,7 @@ import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 
 @Composable
 fun TvOnboardingNavHost(
+    modifier: Modifier = Modifier,
     viewModel: TvOnboardingViewModel = hiltViewModel(),
 ) {
     AppTheme(themeType = Theme.ThemeType.EXTRA_DARK) {
@@ -34,53 +35,53 @@ fun TvOnboardingNavHost(
             val navController = rememberNavController()
             val toastHostState = remember { TvToastHostState() }
             CompositionLocalProvider(LocalTvToastHostState provides toastHostState) {
-                Box(modifier = Modifier.fillMaxSize()) {
+                Box(modifier = modifier.fillMaxSize()) {
                     NavHost(
                         navController = navController,
                         startDestination = viewModel.startDestination,
                     ) {
-                composable(TvOnboardingRoutes.LANDING) {
-                    TvWelcomeScreen(
-                        onSignIn = { navController.navigate(TvOnboardingRoutes.SIGN_IN) },
-                        onCreateAccount = { navController.navigate(TvOnboardingRoutes.CREATE_ACCOUNT) },
-                        onContinueWithoutAccount = {
-                            viewModel.completeOnboarding()
-                            navController.navigate(TvOnboardingRoutes.HOME) {
-                                popUpTo(TvOnboardingRoutes.LANDING) { inclusive = true }
-                            }
-                        },
-                    )
-                }
-                composable(TvOnboardingRoutes.CREATE_ACCOUNT) {
-                    TvCreateAccountScreen(
-                        onSignIn = { navController.navigate(TvOnboardingRoutes.SIGN_IN) },
-                    )
-                }
-                composable(TvOnboardingRoutes.SIGN_IN) {
-                    TvSignInScreen(
-                        onSignInComplete = {
-                            navController.navigate(TvOnboardingRoutes.SYNCING) {
-                                popUpTo(navController.graph.id) { inclusive = true }
-                            }
-                        },
-                    )
-                }
-                composable(TvOnboardingRoutes.SYNCING) {
-                    TvSyncingScreen(
-                        onSyncComplete = {
-                            viewModel.completeOnboarding()
-                            navController.navigate(TvOnboardingRoutes.HOME) {
-                                popUpTo(TvOnboardingRoutes.SYNCING) { inclusive = true }
-                            }
-                        },
-                    )
-                }
-                composable(TvOnboardingRoutes.HOME) {
-                    TvScaffold(
-                        onLogIn = { navController.navigate(TvOnboardingRoutes.SIGN_IN) },
-                        onCreateAccount = { navController.navigate(TvOnboardingRoutes.CREATE_ACCOUNT) },
-                    )
-                }
+                        composable(TvOnboardingRoutes.LANDING) {
+                            TvWelcomeScreen(
+                                onSignIn = { navController.navigate(TvOnboardingRoutes.SIGN_IN) },
+                                onCreateAccount = { navController.navigate(TvOnboardingRoutes.CREATE_ACCOUNT) },
+                                onContinueWithoutAccount = {
+                                    viewModel.completeOnboarding()
+                                    navController.navigate(TvOnboardingRoutes.HOME) {
+                                        popUpTo(TvOnboardingRoutes.LANDING) { inclusive = true }
+                                    }
+                                },
+                            )
+                        }
+                        composable(TvOnboardingRoutes.CREATE_ACCOUNT) {
+                            TvCreateAccountScreen(
+                                onSignIn = { navController.navigate(TvOnboardingRoutes.SIGN_IN) },
+                            )
+                        }
+                        composable(TvOnboardingRoutes.SIGN_IN) {
+                            TvSignInScreen(
+                                onSignInComplete = {
+                                    navController.navigate(TvOnboardingRoutes.SYNCING) {
+                                        popUpTo(navController.graph.id) { inclusive = true }
+                                    }
+                                },
+                            )
+                        }
+                        composable(TvOnboardingRoutes.SYNCING) {
+                            TvSyncingScreen(
+                                onSyncComplete = {
+                                    viewModel.completeOnboarding()
+                                    navController.navigate(TvOnboardingRoutes.HOME) {
+                                        popUpTo(TvOnboardingRoutes.SYNCING) { inclusive = true }
+                                    }
+                                },
+                            )
+                        }
+                        composable(TvOnboardingRoutes.HOME) {
+                            TvScaffold(
+                                onLogIn = { navController.navigate(TvOnboardingRoutes.SIGN_IN) },
+                                onCreateAccount = { navController.navigate(TvOnboardingRoutes.CREATE_ACCOUNT) },
+                            )
+                        }
                     }
                     TvToastHost(
                         state = toastHostState,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingNavHost.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingNavHost.kt
@@ -1,11 +1,22 @@
 package au.com.shiftyjelly.pocketcasts.onboarding
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.tv.material3.MaterialTheme
+import au.com.shiftyjelly.pocketcasts.component.LocalTvToastHostState
+import au.com.shiftyjelly.pocketcasts.component.TvToastHost
+import au.com.shiftyjelly.pocketcasts.component.TvToastHostState
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.home.TvScaffold
 import au.com.shiftyjelly.pocketcasts.onboarding.createaccount.TvCreateAccountScreen
@@ -21,10 +32,13 @@ fun TvOnboardingNavHost(
     AppTheme(themeType = Theme.ThemeType.EXTRA_DARK) {
         MaterialTheme {
             val navController = rememberNavController()
-            NavHost(
-                navController = navController,
-                startDestination = viewModel.startDestination,
-            ) {
+            val toastHostState = remember { TvToastHostState() }
+            CompositionLocalProvider(LocalTvToastHostState provides toastHostState) {
+                Box(modifier = Modifier.fillMaxSize()) {
+                    NavHost(
+                        navController = navController,
+                        startDestination = viewModel.startDestination,
+                    ) {
                 composable(TvOnboardingRoutes.LANDING) {
                     TvWelcomeScreen(
                         onSignIn = { navController.navigate(TvOnboardingRoutes.SIGN_IN) },
@@ -65,6 +79,14 @@ fun TvOnboardingNavHost(
                     TvScaffold(
                         onLogIn = { navController.navigate(TvOnboardingRoutes.SIGN_IN) },
                         onCreateAccount = { navController.navigate(TvOnboardingRoutes.CREATE_ACCOUNT) },
+                    )
+                }
+                    }
+                    TvToastHost(
+                        state = toastHostState,
+                        modifier = Modifier
+                            .align(Alignment.TopEnd)
+                            .padding(top = 48.dp, end = 48.dp),
                     )
                 }
             }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingNavHost.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingNavHost.kt
@@ -39,6 +39,7 @@ fun TvOnboardingNavHost(
                     NavHost(
                         navController = navController,
                         startDestination = viewModel.startDestination,
+                        modifier = Modifier.fillMaxSize(),
                     ) {
                         composable(TvOnboardingRoutes.LANDING) {
                             TvWelcomeScreen(

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/component/TvToastHostStateTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/component/TvToastHostStateTest.kt
@@ -1,0 +1,52 @@
+package au.com.shiftyjelly.pocketcasts.component
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class TvToastHostStateTest {
+
+    private val state = TvToastHostState()
+
+    @Test
+    fun `initial state has no toast`() {
+        assertNull(state.currentToast)
+    }
+
+    @Test
+    fun `show sets the current toast message`() {
+        state.show("Marked as played")
+        assertEquals("Marked as played", state.currentToast?.message)
+    }
+
+    @Test
+    fun `showing again replaces the current toast with a new id`() {
+        state.show("Will play next")
+        val first = state.currentToast
+
+        state.show("Will play last")
+        val second = state.currentToast
+
+        assertEquals("Will play last", second?.message)
+        assertNotEquals(first?.id, second?.id)
+    }
+
+    @Test
+    fun `dismiss clears the current toast when the id matches`() {
+        state.show("Archived")
+        state.dismiss(state.currentToast!!.id)
+        assertNull(state.currentToast)
+    }
+
+    @Test
+    fun `dismiss with a stale id keeps the current toast`() {
+        state.show("Archived")
+        val staleId = state.currentToast!!.id
+        state.show("Unarchived")
+
+        state.dismiss(staleId)
+
+        assertEquals("Unarchived", state.currentToast?.message)
+    }
+}


### PR DESCRIPTION
## Description

Adds a reusable **toast** (transient notification) component to the TV app. These are the short confirmations that appear after an episode action — "Marked as played", "Will play next", "Archived", etc.

The component is wired into the episode actions modal so that selecting an option gives immediate visual feedback.

> [!IMPORTANT]
> **The underlying actions are not implemented yet — this PR is visual feedback only.** Selecting e.g. "Mark as played" shows the toast and dismisses the modal, but does not yet change the episode's played/archived state or Up Next. Wiring the real actions is a follow-up. "Go to podcast" simply dismisses the modal (no toast, matching iOS, which treats it as navigation).

### What's added
- **`TvToast.kt`** — the reusable pieces:
  - `TvToastHostState` — a small state holder with `show(message)`; keeps a single toast at a time (a new toast replaces the current one and restarts its timer).
  - `TvToastHost` — the overlay composable. Small centered text on the same glassy surface as `TvModal` (reuses `TvOverlayContainerColor`/`TvOverlayBorderColor`), pinned top-right, slides in from the right + fades in (300ms), holds 3s, then fades out with a slight downward drift — matching the iOS animation.
  - `LocalTvToastHostState` — a `CompositionLocal` so any screen (including modal `Dialog` content) can enqueue a message.
- **`TvOnboardingNavHost`** — hosts `TvToastHost` above the whole navigation graph and provides the `CompositionLocal`.
- **`TvEpisodeActionsModal`** — the action buttons now show the matching toast and dismiss the modal.
- 6 new `tv_episode_*` strings mirroring the iOS toast copy.
- Unit tests for `TvToastHostState` (show / replace / dismiss / stale-dismiss).

Stacked on #5688 (`feat/tv-episode-details-modal`).

Fixes PCDROID-701 https://linear.app/a8c/issue/PCDROID-701/wire-up-actions
Figma: Ftk3KwnfqaK4g57yCN63p0-fi-3280_3432

## Testing Instructions

1. Run the TV app on an Android TV device/emulator and sign in (or continue without an account).
2. Go to **Your Podcasts** → open a podcast → focus an episode row and open the **⋯** actions menu.
3. Select **Play next**, **Play last**, **Mark as played/unplayed**, or **Archive/Unarchive**.
4. The modal closes and a toast slides in from the top-right ("Will play next", "Marked as played", "Archived", …), then fades out after ~3s.
5. Select **Go to podcast** → the modal just closes, no toast.
6. Trigger two actions quickly → only the latest toast is shown, and its timer restarts.

## Screenshots or Screencast
<img width="1920" height="1080" alt="Screenshot_20260731_165236" src="https://github.com/user-attachments/assets/6e9bfb05-78f3-4266-a5f1-d43ff270707a" />


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

#### I have tested any UI changes...
<!-- TV-only surface; phone theming/orientation/large-font items are not applicable -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
