### PR TITLE
[TV] Hide the top bar on nested detail screens

### DIFF
--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvDetailOverlay.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvDetailOverlay.kt
@@ -1,0 +1,73 @@
+package au.com.shiftyjelly.pocketcasts.component
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.focusProperties
+import au.com.shiftyjelly.pocketcasts.theme.TvDetailTopInset
+import au.com.shiftyjelly.pocketcasts.theme.TvScreenBackgroundBrush
+
+/**
+ * Fades a detail screen in over the top of the still-composed parent it was opened from, so the
+ * parent keeps its scroll position and focus and never reflows. The overlay is opaque (it carries
+ * the screen background), hides the top bar while shown, and handles Back.
+ *
+ * [target] drives visibility: non-null shows the overlay, null fades it out. The last non-null
+ * value is retained so [content] still renders during the exit animation. Render this as the last
+ * child of the tab's root [Box] and mark the layers behind it inactive with [tvFocusInactiveWhen]
+ * so the D-pad can't reach them.
+ */
+@Composable
+fun <T> TvDetailOverlay(
+    target: T?,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable (T) -> Unit,
+) {
+    val visible = target != null
+    if (visible) {
+        HideTvTopBar()
+        BackHandler(onBack = onBack)
+    }
+    var retained by remember { mutableStateOf<T?>(null) }
+    if (target != null) {
+        retained = target
+    }
+    AnimatedVisibility(
+        visible = visible,
+        enter = fadeIn(tween(durationMillis = ANIMATION_MILLIS, easing = FastOutSlowInEasing)),
+        exit = fadeOut(tween(durationMillis = ANIMATION_MILLIS, easing = FastOutSlowInEasing)),
+        modifier = modifier.fillMaxSize(),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(TvScreenBackgroundBrush)
+                .padding(top = TvDetailTopInset),
+        ) {
+            retained?.let { content(it) }
+        }
+    }
+}
+
+/** Deactivates focus for this subtree while [inactive] so a covered layer can't steal the D-pad. */
+fun Modifier.tvFocusInactiveWhen(inactive: Boolean): Modifier = if (inactive) {
+    focusProperties { canFocus = false }
+} else {
+    this
+}
+
+private const val ANIMATION_MILLIS = 300

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvDetailOverlay.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvDetailOverlay.kt
@@ -11,9 +11,11 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.focusProperties
@@ -26,21 +28,31 @@ import au.com.shiftyjelly.pocketcasts.theme.TvScreenBackgroundBrush
  * the screen background), hides the top bar while shown, and handles Back.
  *
  * [target] drives visibility: non-null shows the overlay, null fades it out. The last non-null
- * value is retained so [content] still renders during the exit animation. Render this as the last
- * child of the tab's root [Box] and mark the layers behind it inactive with [tvFocusInactiveWhen]
- * so the D-pad can't reach them.
+ * value is retained so [content] still renders during the exit animation. [onHide] fires when the
+ * overlay starts hiding, so the caller can hand focus back to the layer underneath. Render this as
+ * the last child of the tab's root [Box] and mark the layers behind it inactive with
+ * [tvFocusInactiveWhen] so the D-pad can't reach them.
  */
 @Composable
 fun <T> TvDetailOverlay(
     target: T?,
     onBack: () -> Unit,
     modifier: Modifier = Modifier,
+    onHide: () -> Unit = {},
     content: @Composable (T) -> Unit,
 ) {
     val visible = target != null
     if (visible) {
         HideTvTopBar()
         BackHandler(onBack = onBack)
+    }
+    val currentOnHide by rememberUpdatedState(onHide)
+    var wasVisible by remember { mutableStateOf(false) }
+    LaunchedEffect(visible) {
+        if (!visible && wasVisible) {
+            currentOnHide()
+        }
+        wasVisible = visible
     }
     var retained by remember { mutableStateOf<T?>(null) }
     if (target != null) {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvDetailOverlay.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvDetailOverlay.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.component
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -25,7 +26,8 @@ import au.com.shiftyjelly.pocketcasts.theme.TvScreenBackgroundBrush
 /**
  * Fades a detail screen in over the top of the still-composed parent it was opened from, so the
  * parent keeps its scroll position and focus and never reflows. The overlay is opaque (it carries
- * the screen background), hides the top bar while shown, and handles Back.
+ * the screen background), hides the top bar while shown, and handles Back for as long as it is on
+ * screen (including the fade-out).
  *
  * [target] drives visibility: non-null shows the overlay, null fades it out. The last non-null
  * value is retained so [content] still renders during the exit animation. [onHide] fires when the
@@ -44,8 +46,16 @@ fun <T> TvDetailOverlay(
     val visible = target != null
     if (visible) {
         HideTvTopBar()
+    }
+
+    val transitionState = remember { MutableTransitionState(false) }
+    transitionState.targetState = visible
+    // Keep Back handled while the overlay is on screen, including the fade-out, so a quick second
+    // Back can't fall through to the nav host and pop/exit while the detail is still visible.
+    if (transitionState.currentState || transitionState.targetState) {
         BackHandler(onBack = onBack)
     }
+
     val currentOnHide by rememberUpdatedState(onHide)
     var wasVisible by remember { mutableStateOf(false) }
     LaunchedEffect(visible) {
@@ -59,7 +69,7 @@ fun <T> TvDetailOverlay(
         retained = target
     }
     AnimatedVisibility(
-        visible = visible,
+        visibleState = transitionState,
         enter = fadeIn(tween(durationMillis = ANIMATION_MILLIS, easing = FastOutSlowInEasing)),
         exit = fadeOut(tween(durationMillis = ANIMATION_MILLIS, easing = FastOutSlowInEasing)),
         modifier = modifier.fillMaxSize(),

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastGridScaffold.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastGridScaffold.kt
@@ -33,6 +33,7 @@ internal fun TvPodcastGridScaffold(
     itemKeys: List<Any>,
     modifier: Modifier = Modifier,
     autoFocusFirstItem: Boolean = false,
+    restoreFocusTrigger: Int = 0,
     itemContent: @Composable (index: Int, itemModifier: Modifier) -> Unit,
 ) {
     Column(modifier = modifier) {
@@ -45,11 +46,18 @@ internal fun TvPodcastGridScaffold(
         val gridState = rememberLazyGridState()
         var lastFocusedKey by rememberSaveable { mutableStateOf<String?>(null) }
         val focusRequesters = remember(itemKeys.size) { List(itemKeys.size) { FocusRequester() } }
+        val gridFocusRequester = remember { FocusRequester() }
 
         if (autoFocusFirstItem) {
             LaunchedEffect(Unit) {
                 snapshotFlow { gridState.layoutInfo.visibleItemsInfo.isNotEmpty() }.first { it }
                 runCatching { focusRequesters.firstOrNull()?.requestFocus() }
+            }
+        }
+
+        LaunchedEffect(restoreFocusTrigger) {
+            if (restoreFocusTrigger > 0) {
+                runCatching { gridFocusRequester.requestFocus() }
             }
         }
 
@@ -60,6 +68,7 @@ internal fun TvPodcastGridScaffold(
             verticalArrangement = Arrangement.spacedBy(16.dp),
             contentPadding = PaddingValues(start = 32.dp, top = 16.dp, end = 32.dp, bottom = 32.dp),
             modifier = Modifier
+                .focusRequester(gridFocusRequester)
                 .focusGroup()
                 .focusProperties {
                     onEnter = {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastGridScaffold.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastGridScaffold.kt
@@ -55,8 +55,13 @@ internal fun TvPodcastGridScaffold(
             }
         }
 
+        var isInitialComposition by remember { mutableStateOf(true) }
         LaunchedEffect(restoreFocusTrigger) {
-            if (restoreFocusTrigger > 0) {
+            // Only restore on an actual trigger change, not when a fresh grid mounts with a
+            // non-zero trigger inherited from a hoisted state holder.
+            if (isInitialComposition) {
+                isInitialComposition = false
+            } else {
                 runCatching { gridFocusRequester.requestFocus() }
             }
         }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvRow.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvRow.kt
@@ -50,6 +50,7 @@ fun <T> TvRow(
     contentPadding: PaddingValues = PaddingValues(horizontal = 32.dp),
     itemSpacing: Dp = 16.dp,
     key: ((T) -> Any)? = null,
+    focusRequester: FocusRequester? = null,
     content: @Composable (T) -> Unit,
 ) {
     var hasFocus by remember { mutableStateOf(false) }
@@ -83,6 +84,7 @@ fun <T> TvRow(
             contentPadding = contentPadding,
             horizontalArrangement = Arrangement.spacedBy(itemSpacing),
             modifier = Modifier
+                .then(if (focusRequester != null) Modifier.focusRequester(focusRequester) else Modifier)
                 .focusGroup()
                 .focusProperties {
                     onEnter = {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvRow.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvRow.kt
@@ -88,7 +88,7 @@ fun <T> TvRow(
                 .focusGroup()
                 .focusProperties {
                     onEnter = {
-                        focusRequesters.getOrNull(lastFocusedIndex)?.requestFocus()
+                        runCatching { focusRequesters.getOrNull(lastFocusedIndex)?.requestFocus() }
                     }
                 },
         ) {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvTopBarVisibility.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvTopBarVisibility.kt
@@ -12,7 +12,7 @@ import androidx.compose.runtime.staticCompositionLocalOf
 class TvTopBarVisibility {
     private var detailCount by mutableIntStateOf(0)
 
-    val isVisible: Boolean get() = detailCount == 0
+    val isVisible: Boolean get() = detailCount <= 0
 
     internal fun enterDetail() {
         detailCount += 1

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvTopBarVisibility.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvTopBarVisibility.kt
@@ -23,7 +23,9 @@ class TvTopBarVisibility {
     }
 }
 
-val LocalTvTopBarVisibility = staticCompositionLocalOf { TvTopBarVisibility() }
+val LocalTvTopBarVisibility = staticCompositionLocalOf<TvTopBarVisibility> {
+    error("TvTopBarVisibility was not provided")
+}
 
 @Composable
 fun HideTvTopBar() {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvTopBarVisibility.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvTopBarVisibility.kt
@@ -1,0 +1,35 @@
+package au.com.shiftyjelly.pocketcasts.component
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.staticCompositionLocalOf
+
+@Stable
+class TvTopBarVisibility {
+    private var detailCount by mutableIntStateOf(0)
+
+    val isVisible: Boolean get() = detailCount == 0
+
+    internal fun enterDetail() {
+        detailCount += 1
+    }
+
+    internal fun exitDetail() {
+        detailCount -= 1
+    }
+}
+
+val LocalTvTopBarVisibility = staticCompositionLocalOf { TvTopBarVisibility() }
+
+@Composable
+fun HideTvTopBar() {
+    val visibility = LocalTvTopBarVisibility.current
+    DisposableEffect(visibility) {
+        visibility.enterDetail()
+        onDispose { visibility.exitDetail() }
+    }
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeScreen.kt
@@ -11,12 +11,17 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Devices
@@ -49,6 +54,7 @@ fun TvHomeScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     var openedPodcastUuid by rememberSaveable { mutableStateOf<String?>(null) }
+    var restoreFocusTrigger by remember { mutableIntStateOf(0) }
 
     val podcastUuid = openedPodcastUuid
     Box(modifier = modifier.fillMaxSize()) {
@@ -60,10 +66,12 @@ fun TvHomeScreen(
                 .fillMaxSize()
                 .padding(top = TvTopBarHeight)
                 .tvFocusInactiveWhen(podcastUuid != null),
+            restoreFocusTrigger = restoreFocusTrigger,
         )
         TvDetailOverlay(
             target = podcastUuid,
             onBack = { openedPodcastUuid = null },
+            onHide = { restoreFocusTrigger++ },
         ) { uuid ->
             TvPodcastDetailsScreen(
                 podcastUuid = uuid,
@@ -79,6 +87,7 @@ private fun TvHomeContent(
     onRetry: () -> Unit,
     onOpenPodcast: (String) -> Unit,
     modifier: Modifier = Modifier,
+    restoreFocusTrigger: Int = 0,
 ) {
     when (uiState) {
         is TvHomeUiState.Loading -> LoadingView(color = Color.White, modifier = modifier)
@@ -88,7 +97,12 @@ private fun TvHomeContent(
         is TvHomeUiState.Ready -> if (uiState.rows.isEmpty()) {
             TvHomeError(onRetry = onRetry, modifier = modifier)
         } else {
-            TvHomeRows(rows = uiState.rows, onOpenPodcast = onOpenPodcast, modifier = modifier)
+            TvHomeRows(
+                rows = uiState.rows,
+                onOpenPodcast = onOpenPodcast,
+                modifier = modifier,
+                restoreFocusTrigger = restoreFocusTrigger,
+            )
         }
     }
 }
@@ -121,14 +135,30 @@ private fun TvHomeRows(
     rows: List<TvHomeRow>,
     onOpenPodcast: (String) -> Unit,
     modifier: Modifier = Modifier,
+    restoreFocusTrigger: Int = 0,
 ) {
+    var lastFocusedRowIndex by rememberSaveable(rows.size) { mutableIntStateOf(0) }
+    val rowFocusRequesters = remember(rows.size) { List(rows.size) { FocusRequester() } }
+
+    LaunchedEffect(restoreFocusTrigger) {
+        if (restoreFocusTrigger > 0) {
+            runCatching { rowFocusRequesters.getOrNull(lastFocusedRowIndex)?.requestFocus() }
+        }
+    }
+
     LazyColumn(
         modifier = modifier.fillMaxSize(),
         verticalArrangement = Arrangement.spacedBy(24.dp),
     ) {
         item { Spacer(modifier = Modifier.height(8.dp)) }
 
-        rows.forEach { row ->
+        rows.forEachIndexed { rowIndex, row ->
+            val rowModifier = Modifier.onFocusChanged { focusState ->
+                if (focusState.hasFocus) {
+                    lastFocusedRowIndex = rowIndex
+                }
+            }
+            val rowFocusRequester = rowFocusRequesters[rowIndex]
             when (row) {
                 is TvHomeRow.FeaturedPodcasts -> item(key = row.id) {
                     TvRow(
@@ -136,6 +166,8 @@ private fun TvHomeRows(
                         items = row.podcasts,
                         itemSpacing = 32.dp,
                         key = TvHomePodcast::uuid,
+                        focusRequester = rowFocusRequester,
+                        modifier = rowModifier,
                     ) { podcast ->
                         TvFeaturedTile(
                             artworkUrl = podcast.artworkUrl,
@@ -154,6 +186,8 @@ private fun TvHomeRows(
                         items = row.episodes,
                         itemSpacing = 32.dp,
                         key = TvHomeEpisode::episodeUuid,
+                        focusRequester = rowFocusRequester,
+                        modifier = rowModifier,
                     ) { episode ->
                         TvVideoTile(
                             thumbnailUrl = episode.thumbnailUrl,
@@ -171,6 +205,8 @@ private fun TvHomeRows(
                         title = row.title,
                         items = row.podcasts,
                         key = TvHomePodcast::uuid,
+                        focusRequester = rowFocusRequester,
+                        modifier = rowModifier,
                     ) { podcast ->
                         TvPodcastTile(
                             artworkUrl = podcast.artworkUrl,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeScreen.kt
@@ -1,6 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.home
 
-import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -8,6 +7,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
@@ -27,16 +27,18 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.OutlinedButton
 import androidx.tv.material3.Text
-import au.com.shiftyjelly.pocketcasts.component.HideTvTopBar
+import au.com.shiftyjelly.pocketcasts.component.TvDetailOverlay
 import au.com.shiftyjelly.pocketcasts.component.TvFeaturedTile
 import au.com.shiftyjelly.pocketcasts.component.TvPodcastTile
 import au.com.shiftyjelly.pocketcasts.component.TvPodcastTileDefaults
 import au.com.shiftyjelly.pocketcasts.component.TvRow
 import au.com.shiftyjelly.pocketcasts.component.TvVideoTile
+import au.com.shiftyjelly.pocketcasts.component.tvFocusInactiveWhen
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.loading.LoadingView
 import au.com.shiftyjelly.pocketcasts.podcasts.TvPodcastDetailsScreen
 import au.com.shiftyjelly.pocketcasts.theme.TvColors
+import au.com.shiftyjelly.pocketcasts.theme.TvTopBarHeight
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -49,21 +51,25 @@ fun TvHomeScreen(
     var openedPodcastUuid by rememberSaveable { mutableStateOf<String?>(null) }
 
     val podcastUuid = openedPodcastUuid
-    if (podcastUuid != null) {
-        HideTvTopBar()
-        BackHandler { openedPodcastUuid = null }
-        TvPodcastDetailsScreen(
-            podcastUuid = podcastUuid,
-            onClose = { openedPodcastUuid = null },
-            modifier = modifier,
-        )
-    } else {
+    Box(modifier = modifier.fillMaxSize()) {
         TvHomeContent(
             uiState = uiState,
             onRetry = viewModel::load,
             onOpenPodcast = { openedPodcastUuid = it },
-            modifier = modifier,
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(top = TvTopBarHeight)
+                .tvFocusInactiveWhen(podcastUuid != null),
         )
+        TvDetailOverlay(
+            target = podcastUuid,
+            onBack = { openedPodcastUuid = null },
+        ) { uuid ->
+            TvPodcastDetailsScreen(
+                podcastUuid = uuid,
+                onClose = { openedPodcastUuid = null },
+            )
+        }
     }
 }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeScreen.kt
@@ -140,8 +140,12 @@ private fun TvHomeRows(
     var lastFocusedRowIndex by rememberSaveable(rows.size) { mutableIntStateOf(0) }
     val rowFocusRequesters = remember(rows.size) { List(rows.size) { FocusRequester() } }
 
+    var isInitialComposition by remember { mutableStateOf(true) }
     LaunchedEffect(restoreFocusTrigger) {
-        if (restoreFocusTrigger > 0) {
+        // Only restore on an actual trigger change, not on the initial composition.
+        if (isInitialComposition) {
+            isInitialComposition = false
+        } else {
             runCatching { rowFocusRequesters.getOrNull(lastFocusedRowIndex)?.requestFocus() }
         }
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeScreen.kt
@@ -27,6 +27,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.OutlinedButton
 import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.component.HideTvTopBar
 import au.com.shiftyjelly.pocketcasts.component.TvFeaturedTile
 import au.com.shiftyjelly.pocketcasts.component.TvPodcastTile
 import au.com.shiftyjelly.pocketcasts.component.TvPodcastTileDefaults
@@ -49,6 +50,7 @@ fun TvHomeScreen(
 
     val podcastUuid = openedPodcastUuid
     if (podcastUuid != null) {
+        HideTvTopBar()
         BackHandler { openedPodcastUuid = null }
         TvPodcastDetailsScreen(
             podcastUuid = podcastUuid,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
@@ -1,10 +1,16 @@
 package au.com.shiftyjelly.pocketcasts.home
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -18,6 +24,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.MaterialTheme
+import au.com.shiftyjelly.pocketcasts.component.LocalTvTopBarVisibility
+import au.com.shiftyjelly.pocketcasts.component.TvTopBarVisibility
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.playlists.TvPlaylistsScreen
 import au.com.shiftyjelly.pocketcasts.podcasts.TvYourPodcastsScreen
@@ -34,53 +42,57 @@ fun TvScaffold(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     var isProfileModalVisible by rememberSaveable { mutableStateOf(false) }
+    val topBarVisibility = remember { TvTopBarVisibility() }
 
-    TvScaffoldContent(
-        tabs = uiState.tabs,
-        selectedTabIndex = uiState.selectedTabIndex,
-        profile = uiState.profile,
-        onTabSelect = viewModel::selectTab,
-        onProfileClick = { isProfileModalVisible = true },
-        modifier = modifier,
-    ) { tab ->
-        val navigateToHome = { viewModel.selectTab(TvTab.entries.indexOf(TvTab.Home)) }
-        when (tab) {
-            is TvTab.Home -> TvHomeScreen()
-
-            is TvTab.YourPodcasts -> TvYourPodcastsScreen(
-                onNavigateToHome = navigateToHome,
-            )
-
-            is TvTab.Playlists -> TvPlaylistsScreen()
-
-            is TvTab.UpNext -> TvUpNextScreen(
-                onNavigateToHome = navigateToHome,
-            )
-
-            else -> TvTabPlaceholder(tab = tab)
-        }
-    }
-
-    if (isProfileModalVisible) {
-        TvProfileModal(
+    CompositionLocalProvider(LocalTvTopBarVisibility provides topBarVisibility) {
+        TvScaffoldContent(
+            tabs = uiState.tabs,
+            selectedTabIndex = uiState.selectedTabIndex,
             profile = uiState.profile,
-            onDismissRequest = { isProfileModalVisible = false },
-            onLogIn = {
-                isProfileModalVisible = false
-                onLogIn()
-            },
-            onCreateAccount = {
-                isProfileModalVisible = false
-                onCreateAccount()
-            },
-            // TODO: wire up the Starred Episodes and Listening History destinations.
-            onStarredEpisodes = {},
-            onListeningHistory = {},
-            onLogOut = {
-                isProfileModalVisible = false
-                viewModel.signOut()
-            },
-        )
+            isTopBarVisible = topBarVisibility.isVisible,
+            onTabSelect = viewModel::selectTab,
+            onProfileClick = { isProfileModalVisible = true },
+            modifier = modifier,
+        ) { tab ->
+            val navigateToHome = { viewModel.selectTab(TvTab.entries.indexOf(TvTab.Home)) }
+            when (tab) {
+                is TvTab.Home -> TvHomeScreen()
+
+                is TvTab.YourPodcasts -> TvYourPodcastsScreen(
+                    onNavigateToHome = navigateToHome,
+                )
+
+                is TvTab.Playlists -> TvPlaylistsScreen()
+
+                is TvTab.UpNext -> TvUpNextScreen(
+                    onNavigateToHome = navigateToHome,
+                )
+
+                else -> TvTabPlaceholder(tab = tab)
+            }
+        }
+
+        if (isProfileModalVisible) {
+            TvProfileModal(
+                profile = uiState.profile,
+                onDismissRequest = { isProfileModalVisible = false },
+                onLogIn = {
+                    isProfileModalVisible = false
+                    onLogIn()
+                },
+                onCreateAccount = {
+                    isProfileModalVisible = false
+                    onCreateAccount()
+                },
+                // TODO: wire up the Starred Episodes and Listening History destinations.
+                onStarredEpisodes = {},
+                onListeningHistory = {},
+                onLogOut = {
+                    isProfileModalVisible = false
+                    viewModel.signOut()
+                },
+            )
+        }
     }
 }
 
@@ -89,6 +101,7 @@ private fun TvScaffoldContent(
     tabs: List<TvTab>,
     selectedTabIndex: Int,
     profile: TvProfileState,
+    isTopBarVisible: Boolean,
     onTabSelect: (Int) -> Unit,
     onProfileClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -106,13 +119,19 @@ private fun TvScaffoldContent(
                 ),
             ),
     ) {
-        TvTopBar(
-            tabs = tabs,
-            selectedTabIndex = selectedTabIndex,
-            profile = profile,
-            onTabSelect = onTabSelect,
-            onProfileClick = onProfileClick,
-        )
+        AnimatedVisibility(
+            visible = isTopBarVisible,
+            enter = fadeIn() + expandVertically(),
+            exit = shrinkVertically() + fadeOut(),
+        ) {
+            TvTopBar(
+                tabs = tabs,
+                selectedTabIndex = selectedTabIndex,
+                profile = profile,
+                onTabSelect = onTabSelect,
+                onProfileClick = onProfileClick,
+            )
+        }
         Box(modifier = Modifier.weight(1f)) {
             val currentTab = tabs.getOrElse(selectedTabIndex) { tabs.first() }
             tabContent(currentTab)
@@ -130,6 +149,7 @@ private fun TvScaffoldPreview() {
                 tabs = TvTab.entries,
                 selectedTabIndex = selectedIndex,
                 profile = TvProfileState.SignedOut,
+                isTopBarVisible = true,
                 onTabSelect = { selectedIndex = it },
                 onProfileClick = {},
             ) { tab ->

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
@@ -46,7 +46,7 @@ fun TvScaffold(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     var isProfileModalVisible by rememberSaveable { mutableStateOf(false) }
     val topBarVisibility = remember { TvTopBarVisibility() }
-    var didFocusTopBar by remember { mutableStateOf(false) }
+    var didFocusTopBar by rememberSaveable { mutableStateOf(false) }
 
     CompositionLocalProvider(LocalTvTopBarVisibility provides topBarVisibility) {
         TvScaffoldContent(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
@@ -3,7 +3,6 @@ package au.com.shiftyjelly.pocketcasts.home
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.FastOutSlowInEasing
-import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -22,12 +21,8 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.layout.onSizeChanged
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.MaterialTheme
@@ -36,7 +31,8 @@ import au.com.shiftyjelly.pocketcasts.component.TvTopBarVisibility
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.playlists.TvPlaylistsScreen
 import au.com.shiftyjelly.pocketcasts.podcasts.TvYourPodcastsScreen
-import au.com.shiftyjelly.pocketcasts.theme.TvColors
+import au.com.shiftyjelly.pocketcasts.theme.TvScreenBackgroundBrush
+import au.com.shiftyjelly.pocketcasts.theme.TvTopBarHeight
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.upnext.TvUpNextScreen
 
@@ -65,6 +61,9 @@ fun TvScaffold(
             modifier = modifier,
         ) { tab ->
             val navigateToHome = { viewModel.selectTab(TvTab.entries.indexOf(TvTab.Home)) }
+            // Tabs without a detail screen sit below the bar; the detail-bearing tabs pad their own
+            // content so their overlays can fill the full height.
+            val belowTopBar = Modifier.fillMaxSize().padding(top = TvTopBarHeight)
             when (tab) {
                 is TvTab.Home -> TvHomeScreen()
 
@@ -74,11 +73,13 @@ fun TvScaffold(
 
                 is TvTab.Playlists -> TvPlaylistsScreen()
 
-                is TvTab.UpNext -> TvUpNextScreen(
-                    onNavigateToHome = navigateToHome,
-                )
+                is TvTab.UpNext -> Box(modifier = belowTopBar) {
+                    TvUpNextScreen(onNavigateToHome = navigateToHome)
+                }
 
-                else -> TvTabPlaceholder(tab = tab)
+                else -> Box(modifier = belowTopBar) {
+                    TvTabPlaceholder(tab = tab)
+                }
             }
         }
 
@@ -119,34 +120,19 @@ private fun TvScaffoldContent(
     onSelectedTabFocus: () -> Unit = {},
     tabContent: @Composable (TvTab) -> Unit,
 ) {
-    val density = LocalDensity.current
-    var topBarHeight by remember { mutableStateOf(DEFAULT_TOP_BAR_HEIGHT) }
-    val contentTopPadding by animateDpAsState(
-        targetValue = if (isTopBarVisible) topBarHeight else HIDDEN_TOP_BAR_PADDING,
-        animationSpec = tween(durationMillis = TOP_BAR_ANIMATION_MILLIS, easing = FastOutSlowInEasing),
-        label = "TvTopBarPadding",
-    )
-
     Box(
         modifier = modifier
             .fillMaxSize()
-            .background(
-                Brush.horizontalGradient(
-                    colors = listOf(
-                        TvColors.DarkGray,
-                        TvColors.Dark,
-                    ),
-                ),
-            ),
+            .background(TvScreenBackgroundBrush),
     ) {
         val currentTab = tabs.getOrElse(selectedTabIndex) { tabs.first() }
+        // Tab content fills the whole area; top-level content reserves TvTopBarHeight for the bar,
+        // while detail overlays fill the full height under the hidden bar.
         Crossfade(
             targetState = currentTab,
             animationSpec = tween(durationMillis = TAB_CONTENT_ANIMATION_MILLIS, easing = FastOutSlowInEasing),
             label = "TvTabContent",
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(top = contentTopPadding),
+            modifier = Modifier.fillMaxSize(),
         ) { tab ->
             tabContent(tab)
         }
@@ -165,13 +151,7 @@ private fun TvScaffoldContent(
                 onProfileClick = onProfileClick,
                 autoFocusSelectedTab = autoFocusSelectedTab,
                 onSelectedTabFocus = onSelectedTabFocus,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .onSizeChanged { size ->
-                        if (size.height > 0) {
-                            topBarHeight = with(density) { size.height.toDp() }
-                        }
-                    },
+                modifier = Modifier.fillMaxWidth(),
             )
         }
     }
@@ -179,8 +159,6 @@ private fun TvScaffoldContent(
 
 private const val TOP_BAR_ANIMATION_MILLIS = 300
 private const val TAB_CONTENT_ANIMATION_MILLIS = 300
-private val DEFAULT_TOP_BAR_HEIGHT = 82.dp
-private val HIDDEN_TOP_BAR_PADDING = 32.dp
 
 @Preview(device = Devices.TV_1080p)
 @Composable
@@ -196,7 +174,9 @@ private fun TvScaffoldPreview() {
                 onTabSelect = { selectedIndex = it },
                 onProfileClick = {},
             ) { tab ->
-                TvTabPlaceholder(tab = tab)
+                Box(modifier = Modifier.fillMaxSize().padding(top = TvTopBarHeight)) {
+                    TvTabPlaceholder(tab = tab)
+                }
             }
         }
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
@@ -122,7 +122,7 @@ private fun TvScaffoldContent(
     val density = LocalDensity.current
     var topBarHeight by remember { mutableStateOf(DEFAULT_TOP_BAR_HEIGHT) }
     val contentTopPadding by animateDpAsState(
-        targetValue = if (isTopBarVisible) topBarHeight else 0.dp,
+        targetValue = if (isTopBarVisible) topBarHeight else HIDDEN_TOP_BAR_PADDING,
         animationSpec = tween(durationMillis = TOP_BAR_ANIMATION_MILLIS, easing = FastOutSlowInEasing),
         label = "TvTopBarPadding",
     )
@@ -180,6 +180,7 @@ private fun TvScaffoldContent(
 private const val TOP_BAR_ANIMATION_MILLIS = 300
 private const val TAB_CONTENT_ANIMATION_MILLIS = 300
 private val DEFAULT_TOP_BAR_HEIGHT = 82.dp
+private val HIDDEN_TOP_BAR_PADDING = 32.dp
 
 @Preview(device = Devices.TV_1080p)
 @Composable

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
@@ -1,14 +1,17 @@
 package au.com.shiftyjelly.pocketcasts.home
 
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.expandVertically
+import androidx.compose.animation.Crossfade
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
@@ -17,10 +20,14 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.MaterialTheme
@@ -112,7 +119,15 @@ private fun TvScaffoldContent(
     onSelectedTabFocus: () -> Unit = {},
     tabContent: @Composable (TvTab) -> Unit,
 ) {
-    Column(
+    val density = LocalDensity.current
+    var topBarHeight by remember { mutableStateOf(DEFAULT_TOP_BAR_HEIGHT) }
+    val contentTopPadding by animateDpAsState(
+        targetValue = if (isTopBarVisible) topBarHeight else 0.dp,
+        animationSpec = tween(durationMillis = TOP_BAR_ANIMATION_MILLIS, easing = FastOutSlowInEasing),
+        label = "TvTopBarPadding",
+    )
+
+    Box(
         modifier = modifier
             .fillMaxSize()
             .background(
@@ -124,10 +139,23 @@ private fun TvScaffoldContent(
                 ),
             ),
     ) {
+        val currentTab = tabs.getOrElse(selectedTabIndex) { tabs.first() }
+        Crossfade(
+            targetState = currentTab,
+            animationSpec = tween(durationMillis = TAB_CONTENT_ANIMATION_MILLIS, easing = FastOutSlowInEasing),
+            label = "TvTabContent",
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(top = contentTopPadding),
+        ) { tab ->
+            tabContent(tab)
+        }
+
         AnimatedVisibility(
             visible = isTopBarVisible,
-            enter = fadeIn() + expandVertically(),
-            exit = shrinkVertically() + fadeOut(),
+            enter = fadeIn(tween(durationMillis = TOP_BAR_ANIMATION_MILLIS, easing = FastOutSlowInEasing)),
+            exit = fadeOut(tween(durationMillis = TOP_BAR_ANIMATION_MILLIS, easing = FastOutSlowInEasing)),
+            modifier = Modifier.align(Alignment.TopCenter),
         ) {
             TvTopBar(
                 tabs = tabs,
@@ -137,14 +165,21 @@ private fun TvScaffoldContent(
                 onProfileClick = onProfileClick,
                 autoFocusSelectedTab = autoFocusSelectedTab,
                 onSelectedTabFocus = onSelectedTabFocus,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .onSizeChanged { size ->
+                        if (size.height > 0) {
+                            topBarHeight = with(density) { size.height.toDp() }
+                        }
+                    },
             )
-        }
-        Box(modifier = Modifier.weight(1f)) {
-            val currentTab = tabs.getOrElse(selectedTabIndex) { tabs.first() }
-            tabContent(currentTab)
         }
     }
 }
+
+private const val TOP_BAR_ANIMATION_MILLIS = 300
+private const val TAB_CONTENT_ANIMATION_MILLIS = 300
+private val DEFAULT_TOP_BAR_HEIGHT = 82.dp
 
 @Preview(device = Devices.TV_1080p)
 @Composable

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
@@ -43,6 +43,7 @@ fun TvScaffold(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     var isProfileModalVisible by rememberSaveable { mutableStateOf(false) }
     val topBarVisibility = remember { TvTopBarVisibility() }
+    var didFocusTopBar by remember { mutableStateOf(false) }
 
     CompositionLocalProvider(LocalTvTopBarVisibility provides topBarVisibility) {
         TvScaffoldContent(
@@ -50,6 +51,8 @@ fun TvScaffold(
             selectedTabIndex = uiState.selectedTabIndex,
             profile = uiState.profile,
             isTopBarVisible = topBarVisibility.isVisible,
+            autoFocusSelectedTab = !didFocusTopBar,
+            onSelectedTabFocus = { didFocusTopBar = true },
             onTabSelect = viewModel::selectTab,
             onProfileClick = { isProfileModalVisible = true },
             modifier = modifier,
@@ -105,6 +108,8 @@ private fun TvScaffoldContent(
     onTabSelect: (Int) -> Unit,
     onProfileClick: () -> Unit,
     modifier: Modifier = Modifier,
+    autoFocusSelectedTab: Boolean = true,
+    onSelectedTabFocus: () -> Unit = {},
     tabContent: @Composable (TvTab) -> Unit,
 ) {
     Column(
@@ -130,6 +135,8 @@ private fun TvScaffoldContent(
                 profile = profile,
                 onTabSelect = onTabSelect,
                 onProfileClick = onProfileClick,
+                autoFocusSelectedTab = autoFocusSelectedTab,
+                onSelectedTabFocus = onSelectedTabFocus,
             )
         }
         Box(modifier = Modifier.weight(1f)) {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvTabBar.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvTabBar.kt
@@ -54,7 +54,9 @@ fun TvTabBar(
     val currentOnSelectedTabFocus by rememberUpdatedState(onSelectedTabFocus)
     LaunchedEffect(autoFocusSelectedTab) {
         if (autoFocusSelectedTab) {
-            focusRequester.requestFocus()
+            runCatching { focusRequester.requestFocus() }
+            // Always report the request so the once-only flag flips even if the requester was
+            // detached, otherwise it would re-arm and retry on every re-entry.
             currentOnSelectedTabFocus()
         }
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvTabBar.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvTabBar.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -46,9 +47,17 @@ fun TvTabBar(
     selectedTabIndex: Int,
     onTabSelect: (Int) -> Unit,
     modifier: Modifier = Modifier,
+    autoFocusSelectedTab: Boolean = true,
+    onSelectedTabFocus: () -> Unit = {},
 ) {
     val focusRequester = remember { FocusRequester() }
-    LaunchedEffect(Unit) { focusRequester.requestFocus() }
+    val currentOnSelectedTabFocus by rememberUpdatedState(onSelectedTabFocus)
+    LaunchedEffect(autoFocusSelectedTab) {
+        if (autoFocusSelectedTab) {
+            focusRequester.requestFocus()
+            currentOnSelectedTabFocus()
+        }
+    }
 
     Box(
         modifier = modifier

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvTopBar.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvTopBar.kt
@@ -44,6 +44,8 @@ fun TvTopBar(
     onTabSelect: (Int) -> Unit,
     onProfileClick: () -> Unit,
     modifier: Modifier = Modifier,
+    autoFocusSelectedTab: Boolean = true,
+    onSelectedTabFocus: () -> Unit = {},
 ) {
     Row(
         modifier = modifier
@@ -60,6 +62,8 @@ fun TvTopBar(
             tabs = tabs,
             selectedTabIndex = selectedTabIndex,
             onTabSelect = onTabSelect,
+            autoFocusSelectedTab = autoFocusSelectedTab,
+            onSelectedTabFocus = onSelectedTabFocus,
         )
         Spacer(modifier = Modifier.weight(1f))
         Image(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsScreen.kt
@@ -47,6 +47,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.Button
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.component.HideTvTopBar
 import au.com.shiftyjelly.pocketcasts.component.TvEmptyState
 import au.com.shiftyjelly.pocketcasts.component.TvPlaylistCard
 import au.com.shiftyjelly.pocketcasts.component.TvPlaylistCardColors
@@ -79,6 +80,7 @@ fun TvPlaylistsScreen(
     val stateHolder = rememberSaveableStateHolder()
     val playlist = openedPlaylist
     if (playlist != null) {
+        HideTvTopBar()
         BackHandler {
             openedPlaylist = null
         }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsScreen.kt
@@ -1,6 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.playlists
 
-import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
@@ -28,7 +27,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -47,10 +45,11 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.Button
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
-import au.com.shiftyjelly.pocketcasts.component.HideTvTopBar
+import au.com.shiftyjelly.pocketcasts.component.TvDetailOverlay
 import au.com.shiftyjelly.pocketcasts.component.TvEmptyState
 import au.com.shiftyjelly.pocketcasts.component.TvPlaylistCard
 import au.com.shiftyjelly.pocketcasts.component.TvPlaylistCardColors
+import au.com.shiftyjelly.pocketcasts.component.tvFocusInactiveWhen
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.loading.LoadingView
 import au.com.shiftyjelly.pocketcasts.models.to.PlaylistIcon
@@ -63,6 +62,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.playlist.SmartPlaylistPreview
 import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
 import au.com.shiftyjelly.pocketcasts.theme.TvColors
 import au.com.shiftyjelly.pocketcasts.theme.TvTextStyles
+import au.com.shiftyjelly.pocketcasts.theme.TvTopBarHeight
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -77,43 +77,41 @@ fun TvPlaylistsScreen(
     var isDownloadModalVisible by rememberSaveable { mutableStateOf(false) }
     var openedPlaylist by rememberSaveable(stateSaver = OpenedPlaylistSaver) { mutableStateOf<OpenedPlaylist?>(null) }
 
-    val stateHolder = rememberSaveableStateHolder()
     val playlist = openedPlaylist
-    if (playlist != null) {
-        HideTvTopBar()
-        BackHandler {
-            openedPlaylist = null
-        }
-        stateHolder.SaveableStateProvider("details-${playlist.uuid}") {
-            TvPlaylistDetailsScreen(
-                playlistUuid = playlist.uuid,
-                playlistType = playlist.type,
-                onClose = { openedPlaylist = null },
-                modifier = modifier,
-            )
-        }
-    } else {
-        stateHolder.SaveableStateProvider("grid") {
-            TvPlaylistsContent(
-                uiState = uiState,
-                getArtworkUuidsFlow = viewModel::getArtworkUuidsFlow,
-                getEpisodeCountFlow = viewModel::getEpisodeCountFlow,
-                refreshArtworkUuids = viewModel::refreshArtworkUuids,
-                refreshEpisodeCount = viewModel::refreshEpisodeCount,
-                findPodcastTint = viewModel::findPodcastTint,
-                onCreatePlaylist = { isDownloadModalVisible = true },
-                onOpenPlaylist = { preview ->
-                    isDownloadModalVisible = false
-                    openedPlaylist = OpenedPlaylist(preview.uuid, preview.type)
-                },
-                modifier = modifier,
-            )
+    Box(modifier = modifier.fillMaxSize()) {
+        TvPlaylistsContent(
+            uiState = uiState,
+            getArtworkUuidsFlow = viewModel::getArtworkUuidsFlow,
+            getEpisodeCountFlow = viewModel::getEpisodeCountFlow,
+            refreshArtworkUuids = viewModel::refreshArtworkUuids,
+            refreshEpisodeCount = viewModel::refreshEpisodeCount,
+            findPodcastTint = viewModel::findPodcastTint,
+            onCreatePlaylist = { isDownloadModalVisible = true },
+            onOpenPlaylist = { preview ->
+                isDownloadModalVisible = false
+                openedPlaylist = OpenedPlaylist(preview.uuid, preview.type)
+            },
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(top = TvTopBarHeight)
+                .tvFocusInactiveWhen(playlist != null),
+        )
 
-            if (isDownloadModalVisible) {
-                TvDownloadAppModal(
-                    onDismissRequest = { isDownloadModalVisible = false },
-                )
-            }
+        if (isDownloadModalVisible) {
+            TvDownloadAppModal(
+                onDismissRequest = { isDownloadModalVisible = false },
+            )
+        }
+
+        TvDetailOverlay(
+            target = playlist,
+            onBack = { openedPlaylist = null },
+        ) { openPlaylist ->
+            TvPlaylistDetailsScreen(
+                playlistUuid = openPlaylist.uuid,
+                playlistType = openPlaylist.type,
+                onClose = { openedPlaylist = null },
+            )
         }
     }
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsScreen.kt
@@ -76,6 +76,7 @@ fun TvPlaylistsScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     var isDownloadModalVisible by rememberSaveable { mutableStateOf(false) }
     var openedPlaylist by rememberSaveable(stateSaver = OpenedPlaylistSaver) { mutableStateOf<OpenedPlaylist?>(null) }
+    var restoreFocusTrigger by remember { mutableIntStateOf(0) }
 
     val playlist = openedPlaylist
     Box(modifier = modifier.fillMaxSize()) {
@@ -95,6 +96,7 @@ fun TvPlaylistsScreen(
                 .fillMaxSize()
                 .padding(top = TvTopBarHeight)
                 .tvFocusInactiveWhen(playlist != null),
+            restoreFocusTrigger = restoreFocusTrigger,
         )
 
         if (isDownloadModalVisible) {
@@ -106,6 +108,7 @@ fun TvPlaylistsScreen(
         TvDetailOverlay(
             target = playlist,
             onBack = { openedPlaylist = null },
+            onHide = { restoreFocusTrigger++ },
         ) { openPlaylist ->
             TvPlaylistDetailsScreen(
                 playlistUuid = openPlaylist.uuid,
@@ -138,6 +141,7 @@ private fun TvPlaylistsContent(
     onCreatePlaylist: () -> Unit,
     onOpenPlaylist: (PlaylistPreview) -> Unit,
     modifier: Modifier = Modifier,
+    restoreFocusTrigger: Int = 0,
 ) {
     AnimatedContent(
         targetState = uiState,
@@ -169,6 +173,7 @@ private fun TvPlaylistsContent(
                     findPodcastTint = findPodcastTint,
                     onOpenPlaylist = onOpenPlaylist,
                     modifier = Modifier.fillMaxSize(),
+                    restoreFocusTrigger = restoreFocusTrigger,
                 )
             }
         }
@@ -185,6 +190,7 @@ private fun TvPlaylistsGrid(
     findPodcastTint: suspend (String) -> Int?,
     onOpenPlaylist: (PlaylistPreview) -> Unit,
     modifier: Modifier = Modifier,
+    restoreFocusTrigger: Int = 0,
 ) {
     Column(modifier = modifier.padding(horizontal = 32.dp)) {
         Text(
@@ -195,6 +201,13 @@ private fun TvPlaylistsGrid(
         )
         var lastFocusedIndex by rememberSaveable(playlists) { mutableIntStateOf(0) }
         val focusRequesters = remember(playlists) { List(playlists.size) { FocusRequester() } }
+        val gridFocusRequester = remember { FocusRequester() }
+
+        LaunchedEffect(restoreFocusTrigger) {
+            if (restoreFocusTrigger > 0) {
+                runCatching { gridFocusRequester.requestFocus() }
+            }
+        }
 
         LazyVerticalGrid(
             columns = GridCells.Fixed(3),
@@ -202,6 +215,7 @@ private fun TvPlaylistsGrid(
             verticalArrangement = Arrangement.spacedBy(32.dp),
             contentPadding = PaddingValues(bottom = 32.dp),
             modifier = Modifier
+                .focusRequester(gridFocusRequester)
                 .focusGroup()
                 .focusProperties {
                     onEnter = {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsScreen.kt
@@ -203,8 +203,13 @@ private fun TvPlaylistsGrid(
         val focusRequesters = remember(playlists) { List(playlists.size) { FocusRequester() } }
         val gridFocusRequester = remember { FocusRequester() }
 
+        var isInitialComposition by remember { mutableStateOf(true) }
         LaunchedEffect(restoreFocusTrigger) {
-            if (restoreFocusTrigger > 0) {
+            // Only restore on an actual trigger change, not when a fresh grid mounts with a
+            // non-zero trigger inherited from a hoisted state holder.
+            if (isInitialComposition) {
+                isInitialComposition = false
+            } else {
                 runCatching { gridFocusRequester.requestFocus() }
             }
         }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
@@ -112,7 +112,7 @@ private fun TvPlaylistDetailsContent(
                     horizontalArrangement = Arrangement.spacedBy(80.dp),
                     modifier = Modifier
                         .fillMaxSize()
-                        .padding(start = 32.dp, top = 16.dp, end = 56.dp),
+                        .padding(start = 32.dp, top = 16.dp, end = 32.dp),
                 ) {
                     PlaylistInfo(
                         playlist = uiState.playlist,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvFolderDetailScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvFolderDetailScreen.kt
@@ -41,6 +41,7 @@ fun TvFolderDetailScreen(
     onOpenPodcast: (String) -> Unit,
     onClose: () -> Unit,
     modifier: Modifier = Modifier,
+    restoreFocusTrigger: Int = 0,
 ) {
     var uiState by remember(folderUuid) { mutableStateOf<TvFolderDetailUiState>(TvFolderDetailUiState.Loading) }
     val currentGetFolderPodcasts by rememberUpdatedState(getFolderPodcasts)
@@ -55,6 +56,7 @@ fun TvFolderDetailScreen(
         onOpenPodcast = onOpenPodcast,
         onClose = onClose,
         modifier = modifier,
+        restoreFocusTrigger = restoreFocusTrigger,
     )
 }
 
@@ -65,6 +67,7 @@ private fun TvFolderDetailContent(
     onOpenPodcast: (String) -> Unit,
     onClose: () -> Unit,
     modifier: Modifier = Modifier,
+    restoreFocusTrigger: Int = 0,
 ) {
     AnimatedContent(
         targetState = uiState,
@@ -95,6 +98,7 @@ private fun TvFolderDetailContent(
                 title = folderName,
                 itemKeys = state.podcasts.map(Podcast::uuid),
                 autoFocusFirstItem = true,
+                restoreFocusTrigger = restoreFocusTrigger,
                 modifier = Modifier.fillMaxSize(),
             ) { index, itemModifier ->
                 val podcast = state.podcasts[index]

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
@@ -132,7 +132,7 @@ private fun TvPodcastDetailsContent(
                     horizontalArrangement = Arrangement.spacedBy(80.dp),
                     modifier = Modifier
                         .fillMaxSize()
-                        .padding(start = 32.dp, top = 16.dp, end = 56.dp),
+                        .padding(start = 32.dp, top = 16.dp, end = 32.dp),
                 ) {
                     PodcastInfo(
                         podcast = uiState.podcast,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsScreen.kt
@@ -1,6 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.podcasts
 
-import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
@@ -10,6 +9,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -24,11 +24,12 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.MaterialTheme
-import au.com.shiftyjelly.pocketcasts.component.HideTvTopBar
+import au.com.shiftyjelly.pocketcasts.component.TvDetailOverlay
 import au.com.shiftyjelly.pocketcasts.component.TvEmptyState
 import au.com.shiftyjelly.pocketcasts.component.TvFolderCard
 import au.com.shiftyjelly.pocketcasts.component.TvPodcastGridScaffold
 import au.com.shiftyjelly.pocketcasts.component.TvPodcastTile
+import au.com.shiftyjelly.pocketcasts.component.tvFocusInactiveWhen
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.loading.LoadingView
 import au.com.shiftyjelly.pocketcasts.models.entity.Folder
@@ -37,6 +38,7 @@ import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
 import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
 import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImage
 import au.com.shiftyjelly.pocketcasts.theme.TvColors
+import au.com.shiftyjelly.pocketcasts.theme.TvTopBarHeight
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import java.util.Date
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -53,37 +55,37 @@ fun TvYourPodcastsScreen(
 
     val podcastUuid = openedPodcastUuid
     val folder = openedFolder
-    when {
-        podcastUuid != null -> {
-            HideTvTopBar()
-            BackHandler { openedPodcastUuid = null }
-            TvPodcastDetailsScreen(
-                podcastUuid = podcastUuid,
-                onClose = { openedPodcastUuid = null },
-                modifier = modifier,
-            )
-        }
-
-        folder != null -> {
-            HideTvTopBar()
-            BackHandler { openedFolder = null }
+    Box(modifier = modifier.fillMaxSize()) {
+        TvYourPodcastsContent(
+            uiState = uiState,
+            onNavigateToHome = onNavigateToHome,
+            onOpenFolder = { openedFolder = OpenedFolder(it.uuid, it.name) },
+            onOpenPodcast = { openedPodcastUuid = it },
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(top = TvTopBarHeight)
+                .tvFocusInactiveWhen(folder != null || podcastUuid != null),
+        )
+        TvDetailOverlay(
+            target = folder,
+            onBack = { openedFolder = null },
+            modifier = Modifier.tvFocusInactiveWhen(podcastUuid != null),
+        ) { openFolder ->
             TvFolderDetailScreen(
-                folderUuid = folder.uuid,
-                folderName = folder.name,
+                folderUuid = openFolder.uuid,
+                folderName = openFolder.name,
                 getFolderPodcasts = viewModel::folderPodcasts,
                 onOpenPodcast = { openedPodcastUuid = it },
                 onClose = { openedFolder = null },
-                modifier = modifier,
             )
         }
-
-        else -> {
-            TvYourPodcastsContent(
-                uiState = uiState,
-                onNavigateToHome = onNavigateToHome,
-                onOpenFolder = { openedFolder = OpenedFolder(it.uuid, it.name) },
-                onOpenPodcast = { openedPodcastUuid = it },
-                modifier = modifier,
+        TvDetailOverlay(
+            target = podcastUuid,
+            onBack = { openedPodcastUuid = null },
+        ) { uuid ->
+            TvPodcastDetailsScreen(
+                podcastUuid = uuid,
+                onClose = { openedPodcastUuid = null },
             )
         }
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsScreen.kt
@@ -12,7 +12,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
@@ -52,6 +54,8 @@ fun TvYourPodcastsScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     var openedFolder by rememberSaveable(stateSaver = OpenedFolderSaver) { mutableStateOf<OpenedFolder?>(null) }
     var openedPodcastUuid by rememberSaveable { mutableStateOf<String?>(null) }
+    var gridRestoreTrigger by remember { mutableIntStateOf(0) }
+    var folderRestoreTrigger by remember { mutableIntStateOf(0) }
 
     val podcastUuid = openedPodcastUuid
     val folder = openedFolder
@@ -65,11 +69,13 @@ fun TvYourPodcastsScreen(
                 .fillMaxSize()
                 .padding(top = TvTopBarHeight)
                 .tvFocusInactiveWhen(folder != null || podcastUuid != null),
+            restoreFocusTrigger = gridRestoreTrigger,
         )
         TvDetailOverlay(
             target = folder,
             onBack = { openedFolder = null },
             modifier = Modifier.tvFocusInactiveWhen(podcastUuid != null),
+            onHide = { gridRestoreTrigger++ },
         ) { openFolder ->
             TvFolderDetailScreen(
                 folderUuid = openFolder.uuid,
@@ -77,11 +83,13 @@ fun TvYourPodcastsScreen(
                 getFolderPodcasts = viewModel::folderPodcasts,
                 onOpenPodcast = { openedPodcastUuid = it },
                 onClose = { openedFolder = null },
+                restoreFocusTrigger = folderRestoreTrigger,
             )
         }
         TvDetailOverlay(
             target = podcastUuid,
             onBack = { openedPodcastUuid = null },
+            onHide = { if (openedFolder != null) folderRestoreTrigger++ else gridRestoreTrigger++ },
         ) { uuid ->
             TvPodcastDetailsScreen(
                 podcastUuid = uuid,
@@ -105,6 +113,7 @@ private fun TvYourPodcastsContent(
     onOpenFolder: (Folder) -> Unit,
     onOpenPodcast: (String) -> Unit,
     modifier: Modifier = Modifier,
+    restoreFocusTrigger: Int = 0,
 ) {
     AnimatedContent(
         targetState = uiState,
@@ -135,6 +144,7 @@ private fun TvYourPodcastsContent(
                 onOpenFolder = onOpenFolder,
                 onOpenPodcast = onOpenPodcast,
                 modifier = Modifier.fillMaxSize(),
+                restoreFocusTrigger = restoreFocusTrigger,
             )
         }
     }
@@ -146,11 +156,13 @@ private fun TvYourPodcastsGrid(
     onOpenFolder: (Folder) -> Unit,
     onOpenPodcast: (String) -> Unit,
     modifier: Modifier = Modifier,
+    restoreFocusTrigger: Int = 0,
 ) {
     TvPodcastGridScaffold(
         title = stringResource(LR.string.tv_tab_your_podcasts),
         itemKeys = items.map(FolderItem::uuid),
         modifier = modifier,
+        restoreFocusTrigger = restoreFocusTrigger,
     ) { index, itemModifier ->
         when (val item = items[index]) {
             is FolderItem.Podcast -> TvPodcastTile(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.MaterialTheme
+import au.com.shiftyjelly.pocketcasts.component.HideTvTopBar
 import au.com.shiftyjelly.pocketcasts.component.TvEmptyState
 import au.com.shiftyjelly.pocketcasts.component.TvFolderCard
 import au.com.shiftyjelly.pocketcasts.component.TvPodcastGridScaffold
@@ -54,6 +55,7 @@ fun TvYourPodcastsScreen(
     val folder = openedFolder
     when {
         podcastUuid != null -> {
+            HideTvTopBar()
             BackHandler { openedPodcastUuid = null }
             TvPodcastDetailsScreen(
                 podcastUuid = podcastUuid,
@@ -63,6 +65,7 @@ fun TvYourPodcastsScreen(
         }
 
         folder != null -> {
+            HideTvTopBar()
             BackHandler { openedFolder = null }
             TvFolderDetailScreen(
                 folderUuid = folder.uuid,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvColors.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvColors.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.theme
 
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 
 object TvColors {
@@ -15,3 +16,8 @@ object TvColors {
     val BgActive20 = Color(0x33FBFBFC)
     val Divider = Color(0xFF4A4D51)
 }
+
+// Shared screen background so detail overlays fully occlude the content fading underneath them.
+val TvScreenBackgroundBrush: Brush = Brush.horizontalGradient(
+    colors = listOf(TvColors.DarkGray, TvColors.Dark),
+)

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvDimensions.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvDimensions.kt
@@ -3,3 +3,9 @@ package au.com.shiftyjelly.pocketcasts.theme
 import androidx.compose.ui.unit.dp
 
 val TvDetailsArtworkSize = 180.dp
+
+// The top bar is a fixed-height row, so top-level tab content reserves this much space to sit below it.
+val TvTopBarHeight = 82.dp
+
+// Breathing room detail screens keep at the top now that they fill the height under a hidden top bar.
+val TvDetailTopInset = 32.dp

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/component/TvTopBarVisibilityTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/component/TvTopBarVisibilityTest.kt
@@ -1,0 +1,45 @@
+package au.com.shiftyjelly.pocketcasts.component
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TvTopBarVisibilityTest {
+
+    private val visibility = TvTopBarVisibility()
+
+    @Test
+    fun `top bar is visible initially`() {
+        assertTrue(visibility.isVisible)
+    }
+
+    @Test
+    fun `entering a detail hides the top bar`() {
+        visibility.enterDetail()
+        assertFalse(visibility.isVisible)
+    }
+
+    @Test
+    fun `exiting the only detail shows the top bar again`() {
+        visibility.enterDetail()
+        visibility.exitDetail()
+        assertTrue(visibility.isVisible)
+    }
+
+    @Test
+    fun `nested details keep the bar hidden until the outer one exits`() {
+        visibility.enterDetail()
+        visibility.enterDetail()
+        visibility.exitDetail()
+        assertFalse(visibility.isVisible)
+
+        visibility.exitDetail()
+        assertTrue(visibility.isVisible)
+    }
+
+    @Test
+    fun `an unbalanced exit cannot hide the bar permanently`() {
+        visibility.exitDetail()
+        assertTrue(visibility.isVisible)
+    }
+}


### PR DESCRIPTION
## Description

On Android TV the top bar (profile + tab row + logo) was shown on every screen, including nested detail screens. On the Apple TV app the tab bar is hidden on pushed detail screens. This brings Android TV to parity: the top bar is hidden on the nested detail screens so they use the full height, and it reappears when you back out.

Detail screens that now hide the top bar:
- Podcast details (opened from Home, Your Podcasts, or a folder)
- Folder details
- Playlist details

### How it works
- A small `TvTopBarVisibility` state holder (counter-based) is provided through a `CompositionLocal` (`LocalTvTopBarVisibility`) in `TvScaffold`, mirroring the existing `TvToast`/`LocalTvToastHostState` pattern in the module.
- Each nested detail is rendered through `TvDetailOverlay`: the parent grid/list **stays composed** and the detail **fades in over the top** of it as an opaque, full-height layer. The overlay drives `HideTvTopBar()` (so the bar fades out under it) and owns the Back handler, so the detail composables stay unchanged and reusable — analogous to iOS driving this from the navigation stack rather than from inside the detail views.
- The layer behind the overlay is deactivated for focus (`tvFocusInactiveWhen`) so the D-pad can't reach the hidden grid. In Your Podcasts a folder and a podcast detail stack as two overlays (the folder stays composed underneath the podcast).

### Addressing review feedback (@geekygecko)
1. **"It should open as a completely new page… faded in over the top, rather than transitioning the previous page."** The detail is now a separate full-height layer that fades in over the still-composed parent. The parent no longer reflows: the animated top-bar/content padding was removed in favour of a static top inset, so opening a detail doesn't shove the content around — it just fades the new page in on top.
2. **"The previous page scrolls to the top when you return — preserve the scroll position."** Because the parent is never removed from composition, its `LazyGrid`/`LazyList` state survives, so backing out lands you exactly where you left off. On close the overlay also fires an `onHide` callback that re-requests the previously focused tile (reusing each grid/row's existing `onEnter`/`lastFocusedKey` restoration), so **focus returns to the tile you opened** instead of jumping to the top bar.

### Layout tweak
While in here, evened out the horizontal padding on the two-pane detail screens (podcast + playlist details): they were `start = 32.dp, end = 56.dp`; both are now `32.dp`, matching the app's horizontal rhythm.

Fixes POC-792 https://linear.app/a8c/issue/POC-792/hide-top-bar-on-nested-destinations-like-playlist-details-and-podcast

## Testing Instructions

1. Launch the TV app and sign in (so Your Podcasts / Playlists have content).
2. On **Home**, **Your Podcasts**, and **Playlists** confirm the top bar is visible.
3. Scroll a tab **down** a few rows, then open a **podcast** (from Home or Your Podcasts), a **folder**, and a **playlist**. In each detail screen the top bar should be hidden, the content should fill the height (with a small top margin), and the detail should **fade in over the top** without the underlying page shifting.
4. Press **Back** — the top bar fades back in and the top-level grid/list is shown **at the same scroll position you left it**, not reset to the top.
5. Switch between tabs and confirm the content **crossfades**.
6. Confirm the **Up Next** tab (which has no detail screen) always keeps the top bar.

## Screenshots or Screencast
<img width="1920" height="1080" alt="Screenshot_20260805_140909" src="https://github.com/user-attachments/assets/673ff8d3-2225-4c9e-8d35-9a2d92d106b9" />


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml` <!-- no new strings -->
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) the Event Horizon schema to reflect any new or changed analytics. <!-- no analytics changes -->

#### I have tested any UI changes...
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
