### PR TITLE
[TV] Align Android TV UI with the Figma design-system tokens

### DIFF
--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvDropdownMenu.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvDropdownMenu.kt
@@ -87,7 +87,7 @@ internal fun TvDropdownMenuSurface(
         if (title != null) {
             Text(
                 text = title,
-                style = TvTextStyles.PlaylistCardCaption,
+                style = TvTextStyles.Caption2,
                 color = TvColors.TextSecondary,
                 modifier = Modifier.padding(start = 16.dp, top = 4.dp, bottom = 8.dp),
             )
@@ -116,9 +116,9 @@ fun TvDropdownMenuItem(
         onClick = onClick,
         colors = ButtonDefaults.colors(
             containerColor = Color.Transparent,
-            contentColor = Color.White,
-            focusedContainerColor = TvColors.LightGray,
-            focusedContentColor = TvColors.Dark,
+            contentColor = TvColors.TextPrimary,
+            focusedContainerColor = TvColors.BackgroundActive,
+            focusedContentColor = TvColors.TextPrimaryActive,
         ),
         border = TvButtonDefaults.borderlessButtonBorder(),
         modifier = modifier

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEmptyState.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEmptyState.kt
@@ -52,8 +52,8 @@ fun TvEmptyState(
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
             Text(
                 text = title,
-                style = TvTextStyles.ScreenTitle,
-                color = Color.White,
+                style = TvTextStyles.Title3,
+                color = TvColors.TextPrimary,
                 textAlign = TextAlign.Center,
             )
             Spacer(modifier = Modifier.height(12.dp))
@@ -71,7 +71,7 @@ fun TvEmptyState(
                     colors = TvButtonDefaults.filledButtonColors(),
                     modifier = if (autoFocusAction) Modifier.focusRequester(focusRequester) else Modifier,
                 ) {
-                    Text(actionLabel, style = TvTextStyles.ModalButtonLabel)
+                    Text(actionLabel, style = TvTextStyles.Caption1)
                 }
             }
         }
@@ -83,7 +83,7 @@ fun TvEmptyState(
 private fun TvEmptyStatePreview() {
     AppTheme(themeType = Theme.ThemeType.EXTRA_DARK) {
         MaterialTheme {
-            Box(modifier = Modifier.fillMaxSize().background(TvColors.Dark)) {
+            Box(modifier = Modifier.fillMaxSize().background(TvColors.BackgroundSunken)) {
                 TvEmptyState(
                     title = "Nothing here yet",
                     subtitle = "Content will show up here once it's available.",

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEmptyState.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEmptyState.kt
@@ -15,7 +15,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionsModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionsModal.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -176,7 +177,7 @@ private fun TvEpisodeActionButton(
     ) {
         Text(
             text = text,
-            style = TvTextStyles.ModalButtonLabel,
+            style = TvTextStyles.Caption1.copy(textAlign = TextAlign.Center),
             modifier = Modifier.fillMaxWidth(),
         )
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeInfoModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeInfoModal.kt
@@ -181,14 +181,14 @@ private fun EpisodeDescriptionPane(
 
             is ShowNotes.Loaded -> Text(
                 text = remember(showNotes.html) { AnnotatedString.fromHtml(showNotes.html) },
-                style = TvTextStyles.FeaturedTileDescription,
+                style = TvTextStyles.Body,
                 color = TvColors.TextPrimary,
                 modifier = Modifier.fillMaxWidth(),
             )
 
             is ShowNotes.Unavailable -> Text(
                 text = stringResource(LR.string.error_loading_show_notes),
-                style = TvTextStyles.FeaturedTileDescription,
+                style = TvTextStyles.Body,
                 color = TvColors.TextSecondary,
             )
         }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeInfoModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeInfoModal.kt
@@ -125,7 +125,7 @@ private fun EpisodeHeader(
             if (!podcastTitle.isNullOrBlank()) {
                 Text(
                     text = podcastTitle,
-                    style = TvTextStyles.Caption1,
+                    style = TvTextStyles.Caption2,
                     color = TvColors.TextSecondary,
                 )
             }
@@ -138,7 +138,7 @@ private fun EpisodeHeader(
             )
             Text(
                 text = remember(episode.publishedDate, episode.durationMs) { episode.metadataLine(context) },
-                style = TvTextStyles.Caption1,
+                style = TvTextStyles.Caption2,
                 color = TvColors.TextSecondary,
             )
         }
@@ -181,14 +181,14 @@ private fun EpisodeDescriptionPane(
 
             is ShowNotes.Loaded -> Text(
                 text = remember(showNotes.html) { AnnotatedString.fromHtml(showNotes.html) },
-                style = TvTextStyles.Body,
-                color = TvColors.TextPrimary,
+                style = TvTextStyles.Caption2,
+                color = TvColors.TextSecondary,
                 modifier = Modifier.fillMaxWidth(),
             )
 
             is ShowNotes.Unavailable -> Text(
                 text = stringResource(LR.string.error_loading_show_notes),
-                style = TvTextStyles.Body,
+                style = TvTextStyles.Caption2,
                 color = TvColors.TextSecondary,
             )
         }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeInfoModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeInfoModal.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
@@ -93,9 +92,9 @@ private fun ColumnScope.TvEpisodeInfoModalContent(
     EpisodeHeader(episode = episode, podcastTitle = podcastTitle, context = context)
     Text(
         text = stringResource(LR.string.tv_episode_details),
-        style = TvTextStyles.EpisodeRowTitle,
+        style = TvTextStyles.Callout,
         fontWeight = FontWeight.SemiBold,
-        color = Color.White,
+        color = TvColors.TextPrimary,
         modifier = Modifier.fillMaxWidth(),
     )
     EpisodeDescriptionPane(
@@ -126,20 +125,20 @@ private fun EpisodeHeader(
             if (!podcastTitle.isNullOrBlank()) {
                 Text(
                     text = podcastTitle,
-                    style = TvTextStyles.Caption,
+                    style = TvTextStyles.Caption1,
                     color = TvColors.TextSecondary,
                 )
             }
             Text(
                 text = episode.title,
-                style = TvTextStyles.PlaylistCardTitle,
-                color = Color.White,
+                style = TvTextStyles.Headline,
+                color = TvColors.TextPrimary,
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis,
             )
             Text(
                 text = remember(episode.publishedDate, episode.durationMs) { episode.metadataLine(context) },
-                style = TvTextStyles.Caption,
+                style = TvTextStyles.Caption1,
                 color = TvColors.TextSecondary,
             )
         }
@@ -178,12 +177,12 @@ private fun EpisodeDescriptionPane(
             .then(if (isScrollable) Modifier.verticalScroll(scrollState) else Modifier),
     ) {
         when (showNotes) {
-            is ShowNotes.Loading -> LoadingView(color = Color.White)
+            is ShowNotes.Loading -> LoadingView(color = TvColors.TextPrimary)
 
             is ShowNotes.Loaded -> Text(
                 text = remember(showNotes.html) { AnnotatedString.fromHtml(showNotes.html) },
                 style = TvTextStyles.FeaturedTileDescription,
-                color = Color.White,
+                color = TvColors.TextPrimary,
                 modifier = Modifier.fillMaxWidth(),
             )
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeListControls.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeListControls.kt
@@ -45,7 +45,7 @@ fun TvArchivedFilterButton(
         ) {
             Text(
                 text = stringResource(if (isShowingArchived) LR.string.show_archived else LR.string.podcast_hide_archived),
-                style = TvTextStyles.PlaylistCardCaption,
+                style = TvTextStyles.Caption2,
             )
             Icon(
                 painter = painterResource(IR.drawable.ic_chevron_small_up),

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeRow.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeRow.kt
@@ -53,7 +53,7 @@ fun TvEpisodeRow(
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     val isFocused by interactionSource.collectIsFocusedAsState()
-    val titleColor = if (isFocused) TvColors.Dark else Color.White
+    val titleColor = if (isFocused) TvColors.TextPrimaryActive else TvColors.TextPrimary
     val captionColor = if (isFocused) TvColors.TextSecondaryActive else TvColors.TextSecondary
 
     TvTile(
@@ -61,8 +61,8 @@ fun TvEpisodeRow(
         scale = CardDefaults.scale(focusedScale = 1.02f),
         shape = CardDefaults.shape(RoundedCornerShape(8.dp)),
         colors = CardDefaults.colors(
-            containerColor = TvColors.DarkGray,
-            focusedContainerColor = TvColors.LightGray,
+            containerColor = TvColors.BackgroundBase,
+            focusedContainerColor = TvColors.BackgroundActive,
         ),
         interactionSource = interactionSource,
         modifier = modifier.alpha(if (episode.isArchived && !isFocused) 0.3f else 1f),
@@ -90,13 +90,13 @@ fun TvEpisodeRow(
                     }
                     Text(
                         text = episode.rememberPublishedDateText(dateFormatter),
-                        style = TvTextStyles.PlaylistCardCaption,
+                        style = TvTextStyles.Caption2,
                         color = captionColor,
                     )
                 }
                 Text(
                     text = episode.title,
-                    style = TvTextStyles.EpisodeRowTitle,
+                    style = TvTextStyles.Callout,
                     color = titleColor,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,
@@ -107,7 +107,7 @@ fun TvEpisodeRow(
                 ) {
                     Text(
                         text = episode.rememberPlaybackTimeText(),
-                        style = TvTextStyles.PlaylistCardCaption,
+                        style = TvTextStyles.Caption2,
                         color = captionColor,
                     )
                     if (episode.isInProgress && episode.duration > 0.0) {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvFeaturedTile.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvFeaturedTile.kt
@@ -87,9 +87,9 @@ fun TvFeaturedTile(
                         Brush.horizontalGradient(
                             colorStops = arrayOf(
                                 0f to Color.Transparent,
-                                0.2f to TvColors.Dark.copy(alpha = 0.7f),
-                                0.45f to TvColors.Dark,
-                                1f to TvColors.Dark,
+                                0.2f to TvColors.BackgroundSunken.copy(alpha = 0.7f),
+                                0.45f to TvColors.BackgroundSunken,
+                                1f to TvColors.BackgroundSunken,
                             ),
                         ),
                     ),
@@ -176,7 +176,7 @@ fun TvFeaturedTile(
 private fun TvFeaturedTilePreview() {
     AppTheme(themeType = Theme.ThemeType.EXTRA_DARK) {
         MaterialTheme {
-            Box(modifier = Modifier.background(TvColors.Dark)) {
+            Box(modifier = Modifier.background(TvColors.BackgroundSunken)) {
                 TvFeaturedTile(
                     artworkUrl = "",
                     isSponsored = true,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvFeaturedTile.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvFeaturedTile.kt
@@ -119,7 +119,7 @@ fun TvFeaturedTile(
                         Text(
                             text = sponsoredLabel ?: stringResource(LR.string.sponsored),
                             style = TvTextStyles.FeaturedTileSponsoredLabel,
-                            color = Color.White.copy(alpha = 0.7f),
+                            color = TvColors.TextPrimary70,
                         )
                     }
 
@@ -128,7 +128,7 @@ fun TvFeaturedTile(
                     Text(
                         text = title,
                         style = TvTextStyles.FeaturedTileTitle,
-                        color = Color.White,
+                        color = TvColors.TextPrimary,
                     )
 
                     Spacer(modifier = Modifier.height(7.dp))
@@ -136,7 +136,7 @@ fun TvFeaturedTile(
                     Text(
                         text = description,
                         style = TvTextStyles.FeaturedTileDescription,
-                        color = Color.White.copy(alpha = 0.7f),
+                        color = TvColors.TextPrimary70,
                         maxLines = 2,
                         overflow = TextOverflow.Ellipsis,
                     )

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvFeaturedTile.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvFeaturedTile.kt
@@ -118,7 +118,7 @@ fun TvFeaturedTile(
                     if (isSponsored) {
                         Text(
                             text = sponsoredLabel ?: stringResource(LR.string.sponsored),
-                            style = TvTextStyles.Body,
+                            style = TvTextStyles.Caption2,
                             color = TvColors.TextPrimary70,
                         )
                     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvFeaturedTile.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvFeaturedTile.kt
@@ -118,7 +118,7 @@ fun TvFeaturedTile(
                     if (isSponsored) {
                         Text(
                             text = sponsoredLabel ?: stringResource(LR.string.sponsored),
-                            style = TvTextStyles.FeaturedTileSponsoredLabel,
+                            style = TvTextStyles.Body,
                             color = TvColors.TextPrimary70,
                         )
                     }
@@ -127,7 +127,7 @@ fun TvFeaturedTile(
 
                     Text(
                         text = title,
-                        style = TvTextStyles.FeaturedTileTitle,
+                        style = TvTextStyles.Title2,
                         color = TvColors.TextPrimary,
                     )
 
@@ -135,7 +135,7 @@ fun TvFeaturedTile(
 
                     Text(
                         text = description,
-                        style = TvTextStyles.FeaturedTileDescription,
+                        style = TvTextStyles.Body,
                         color = TvColors.TextPrimary70,
                         maxLines = 2,
                         overflow = TextOverflow.Ellipsis,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvFeaturedTile.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvFeaturedTile.kt
@@ -127,7 +127,7 @@ fun TvFeaturedTile(
 
                     Text(
                         text = title,
-                        style = TvTextStyles.Title2,
+                        style = TvTextStyles.Headline,
                         color = TvColors.TextPrimary,
                     )
 
@@ -135,7 +135,7 @@ fun TvFeaturedTile(
 
                     Text(
                         text = description,
-                        style = TvTextStyles.Body,
+                        style = TvTextStyles.Caption2,
                         color = TvColors.TextPrimary70,
                         maxLines = 2,
                         overflow = TextOverflow.Ellipsis,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvFolderCard.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvFolderCard.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
@@ -81,7 +82,7 @@ fun TvFolderCard(
 
             Text(
                 text = folder.name,
-                style = TvTextStyles.FolderCardTitle,
+                style = TvTextStyles.Caption2.copy(textAlign = TextAlign.Center),
                 color = Color.White,
                 maxLines = 1,
                 softWrap = false,
@@ -105,7 +106,7 @@ private const val TITLE_VERTICAL_PADDING_RATIO = 0.064f
 private fun TvFolderCardPreview() {
     AppTheme(themeType = Theme.ThemeType.EXTRA_DARK) {
         MaterialTheme {
-            Box(modifier = Modifier.background(TvColors.Dark).padding(32.dp)) {
+            Box(modifier = Modifier.background(TvColors.BackgroundSunken).padding(32.dp)) {
                 TvFolderCard(
                     folder = Folder(
                         uuid = "folder",

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvFolderCard.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvFolderCard.kt
@@ -83,7 +83,7 @@ fun TvFolderCard(
             Text(
                 text = folder.name,
                 style = TvTextStyles.Caption2.copy(textAlign = TextAlign.Center),
-                color = Color.White,
+                color = TvColors.TextPrimary,
                 maxLines = 1,
                 softWrap = false,
                 overflow = TextOverflow.Ellipsis,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvFolderCard.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvFolderCard.kt
@@ -15,7 +15,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Devices

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvModal.kt
@@ -116,8 +116,8 @@ private fun rememberIsBlurBehindEnabled(): State<Boolean> {
 private val DefaultModalWidth = 400.dp
 private val DefaultContentPadding = PaddingValues(horizontal = 53.dp, vertical = 40.dp)
 private val ModalShape = RoundedCornerShape(28.dp)
-private val TranslucentContainerColor = TvColors.Dark.copy(alpha = 0.6f)
-internal val TvOverlayContainerColor = TvColors.Dark.copy(alpha = 0.94f)
+private val TranslucentContainerColor = TvColors.BackgroundSunken.copy(alpha = 0.6f)
+internal val TvOverlayContainerColor = TvColors.BackgroundSunken.copy(alpha = 0.94f)
 internal val TvOverlayBorderColor = Color.White.copy(alpha = 0.12f)
 private val HighlightBrush = Brush.verticalGradient(
     colors = listOf(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPlaylistCard.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPlaylistCard.kt
@@ -59,12 +59,12 @@ fun TvPlaylistCard(
     val isFocused by interactionSource.collectIsFocusedAsState()
 
     val backgroundColor by animateColorAsState(
-        targetValue = if (isFocused) TvColors.LightGray else cardColor,
+        targetValue = if (isFocused) TvColors.BackgroundActive else cardColor,
         animationSpec = tween(durationMillis = 200),
         label = "PlaylistCardBackground",
     )
     val titleColor by animateColorAsState(
-        targetValue = if (isFocused) TvColors.Dark else Color.White,
+        targetValue = if (isFocused) TvColors.TextPrimaryActive else Color.White,
         animationSpec = tween(durationMillis = 200),
         label = "PlaylistCardTitleColor",
     )
@@ -106,7 +106,7 @@ fun TvPlaylistCard(
             ) {
                 Text(
                     text = title,
-                    style = TvTextStyles.PlaylistCardTitle,
+                    style = TvTextStyles.Headline,
                     color = titleColor,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,
@@ -115,7 +115,7 @@ fun TvPlaylistCard(
                     Spacer(modifier = Modifier.height(4.dp))
                     Text(
                         text = stringResource(LR.string.smart_playlist),
-                        style = TvTextStyles.PlaylistCardCaption,
+                        style = TvTextStyles.Caption2,
                         color = captionColor,
                     )
                 }
@@ -123,7 +123,7 @@ fun TvPlaylistCard(
                 if (episodeCount != null) {
                     Text(
                         text = pluralStringResource(LR.plurals.episode_count, episodeCount, episodeCount),
-                        style = TvTextStyles.PlaylistCardCaption,
+                        style = TvTextStyles.Caption2,
                         color = captionColor,
                     )
                 }
@@ -223,7 +223,7 @@ private fun PlaylistCover(
 private fun TvPlaylistCardPreview() {
     AppTheme(themeType = Theme.ThemeType.EXTRA_DARK) {
         MaterialTheme {
-            Box(modifier = Modifier.background(TvColors.Dark).padding(32.dp)) {
+            Box(modifier = Modifier.background(TvColors.BackgroundSunken).padding(32.dp)) {
                 TvPlaylistCard(
                     title = "New Releases",
                     isSmartPlaylist = true,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPlaylistCard.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPlaylistCard.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -96,7 +97,7 @@ fun TvPlaylistCard(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(172.dp)
+                .aspectRatio(568f / 258f)
                 .background(backgroundColor),
         ) {
             Column(
@@ -106,7 +107,7 @@ fun TvPlaylistCard(
             ) {
                 Text(
                     text = title,
-                    style = TvTextStyles.Headline,
+                    style = TvTextStyles.Callout,
                     color = titleColor,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPlaylistCard.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPlaylistCard.kt
@@ -64,7 +64,7 @@ fun TvPlaylistCard(
         label = "PlaylistCardBackground",
     )
     val titleColor by animateColorAsState(
-        targetValue = if (isFocused) TvColors.TextPrimaryActive else Color.White,
+        targetValue = if (isFocused) TvColors.TextPrimaryActive else TvColors.TextPrimary,
         animationSpec = tween(durationMillis = 200),
         label = "PlaylistCardTitleColor",
     )

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastGridScaffold.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastGridScaffold.kt
@@ -21,9 +21,9 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.theme.TvColors
 import au.com.shiftyjelly.pocketcasts.theme.TvTextStyles
 import kotlinx.coroutines.flow.first
 
@@ -39,8 +39,8 @@ internal fun TvPodcastGridScaffold(
     Column(modifier = modifier) {
         Text(
             text = title,
-            style = TvTextStyles.ScreenTitle,
-            color = Color.White,
+            style = TvTextStyles.Title3,
+            color = TvColors.TextPrimary,
             modifier = Modifier.padding(start = 32.dp, top = 8.dp, bottom = 10.dp),
         )
         val gridState = rememberLazyGridState()

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastInfoModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastInfoModal.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
@@ -126,14 +125,14 @@ private fun InfoRow(
     Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
         Text(
             text = label,
-            style = TvTextStyles.PlaylistCardCaption,
+            style = TvTextStyles.Caption2,
             color = TvColors.TextSecondary,
         )
         Text(
             text = value,
-            style = TvTextStyles.PlaylistCardCaption,
+            style = TvTextStyles.Caption2,
             fontWeight = FontWeight.Medium,
-            color = Color.White,
+            color = TvColors.TextPrimary,
             maxLines = 2,
             overflow = TextOverflow.Ellipsis,
         )
@@ -174,20 +173,20 @@ private fun PodcastDescriptionPane(
         if (podcast.author.isNotBlank()) {
             Text(
                 text = podcast.author,
-                style = TvTextStyles.PlaylistCardCaption,
+                style = TvTextStyles.Caption2,
                 color = TvColors.TextSecondary,
             )
         }
         Text(
             text = podcast.title,
-            style = TvTextStyles.ScreenTitle,
-            color = Color.White,
+            style = TvTextStyles.Title3,
+            color = TvColors.TextPrimary,
         )
         if (podcast.podcastDescription.isNotBlank()) {
             Text(
                 text = podcast.podcastDescription,
                 style = TvTextStyles.FeaturedTileDescription,
-                color = Color.White,
+                color = TvColors.TextPrimary,
             )
         }
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastInfoModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastInfoModal.kt
@@ -179,14 +179,14 @@ private fun PodcastDescriptionPane(
         }
         Text(
             text = podcast.title,
-            style = TvTextStyles.Title3,
+            style = TvTextStyles.Headline,
             color = TvColors.TextPrimary,
         )
         if (podcast.podcastDescription.isNotBlank()) {
             Text(
                 text = podcast.podcastDescription,
-                style = TvTextStyles.Body,
-                color = TvColors.TextPrimary,
+                style = TvTextStyles.Caption2,
+                color = TvColors.TextSecondary,
             )
         }
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastInfoModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastInfoModal.kt
@@ -185,7 +185,7 @@ private fun PodcastDescriptionPane(
         if (podcast.podcastDescription.isNotBlank()) {
             Text(
                 text = podcast.podcastDescription,
-                style = TvTextStyles.FeaturedTileDescription,
+                style = TvTextStyles.Body,
                 color = TvColors.TextPrimary,
             )
         }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastTile.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastTile.kt
@@ -46,7 +46,7 @@ object TvPodcastTileDefaults {
 private fun TvPodcastTilePreview() {
     AppTheme(themeType = Theme.ThemeType.EXTRA_DARK) {
         MaterialTheme {
-            Box(modifier = Modifier.background(TvColors.Dark)) {
+            Box(modifier = Modifier.background(TvColors.BackgroundSunken)) {
                 TvPodcastTile(
                     artworkUrl = "",
                     podcastTitle = "Sample Podcast",

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvRow.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvRow.kt
@@ -69,7 +69,7 @@ fun <T> TvRow(
             color = TvColors.TextPrimary,
             style = TextStyle(
                 fontSize = titleSize.sp,
-                fontWeight = FontWeight(510),
+                fontWeight = FontWeight(500),
                 platformStyle = PlatformTextStyle(includeFontPadding = false),
             ),
             modifier = Modifier

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvRow.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvRow.kt
@@ -66,7 +66,7 @@ fun <T> TvRow(
     ) {
         Text(
             text = title,
-            color = Color.White,
+            color = TvColors.TextPrimary,
             style = TextStyle(
                 fontSize = titleSize.sp,
                 fontWeight = FontWeight(510),
@@ -117,7 +117,7 @@ fun <T> TvRow(
 private fun TvRowPreview() {
     AppTheme(themeType = Theme.ThemeType.EXTRA_DARK) {
         MaterialTheme {
-            Box(modifier = Modifier.background(TvColors.Dark)) {
+            Box(modifier = Modifier.background(TvColors.BackgroundSunken)) {
                 TvRow(
                     title = "Recently Played",
                     items = (1..8).toList(),

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvTile.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvTile.kt
@@ -35,8 +35,8 @@ fun TvTile(
     scale: CardScale = CardDefaults.scale(focusedScale = 1.1f),
     shape: CardShape = CardDefaults.shape(),
     colors: CardColors = CardDefaults.colors(
-        containerColor = TvColors.DarkGray,
-        focusedContainerColor = TvColors.Gray,
+        containerColor = TvColors.BackgroundBase,
+        focusedContainerColor = TvColors.BackgroundOverlay,
     ),
     border: CardBorder = CardDefaults.border(
         border = Border.None,
@@ -70,7 +70,7 @@ private fun TvTilePreview() {
                 Box(
                     modifier = Modifier
                         .size(160.dp, 100.dp)
-                        .background(TvColors.DarkGray)
+                        .background(TvColors.BackgroundBase)
                         .padding(12.dp),
                     contentAlignment = Alignment.BottomStart,
                 ) {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvTileButtonState.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvTileButtonState.kt
@@ -14,7 +14,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.nativeKeyCode
@@ -112,8 +111,8 @@ fun Modifier.tvTileButtonNavigation(
 
 @Composable
 fun tileButtonColors(isSelected: Boolean): ButtonColors = ButtonDefaults.colors(
-    containerColor = if (isSelected) Color.White else TvColors.TextPrimary20,
-    contentColor = if (isSelected) Color.Black else TvColors.TextSecondary,
-    focusedContainerColor = TvColors.TextPrimary20,
+    containerColor = if (isSelected) TvColors.BackgroundActive else TvColors.BackgroundActive50,
+    contentColor = if (isSelected) TvColors.TextPrimaryActive else TvColors.TextSecondary,
+    focusedContainerColor = TvColors.BackgroundActive50,
     focusedContentColor = TvColors.TextSecondary,
 )

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvTileButtonState.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvTileButtonState.kt
@@ -111,8 +111,8 @@ fun Modifier.tvTileButtonNavigation(
 
 @Composable
 fun tileButtonColors(isSelected: Boolean): ButtonColors = ButtonDefaults.colors(
-    containerColor = if (isSelected) TvColors.BackgroundActive else TvColors.BackgroundActive50,
+    containerColor = if (isSelected) TvColors.BackgroundActive else TvColors.BackgroundActive20,
     contentColor = if (isSelected) TvColors.TextPrimaryActive else TvColors.TextSecondary,
-    focusedContainerColor = TvColors.BackgroundActive50,
+    focusedContainerColor = TvColors.BackgroundActive20,
     focusedContentColor = TvColors.TextSecondary,
 )

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvToast.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvToast.kt
@@ -21,7 +21,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.semantics
@@ -30,6 +29,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.theme.TvColors
 import au.com.shiftyjelly.pocketcasts.theme.TvTextStyles
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import kotlinx.coroutines.delay
@@ -96,7 +96,7 @@ private fun TvToastContent(
 ) {
     Text(
         text = message,
-        color = Color.White,
+        color = TvColors.TextPrimary,
         style = TvTextStyles.ModalBody,
         modifier = modifier
             .semantics { liveRegion = LiveRegionMode.Polite }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvToast.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvToast.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -97,7 +98,7 @@ private fun TvToastContent(
     Text(
         text = message,
         color = TvColors.TextPrimary,
-        style = TvTextStyles.ModalBody,
+        style = TvTextStyles.Body.copy(textAlign = TextAlign.Center),
         modifier = modifier
             .semantics { liveRegion = LiveRegionMode.Polite }
             .widthIn(max = ToastMaxWidth)

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvVideoTile.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvVideoTile.kt
@@ -118,14 +118,14 @@ fun TvVideoTile(
                             Column {
                                 Text(
                                     text = podcastTitle,
-                                    style = TvTextStyles.VideoTilePodcastTitle,
+                                    style = TvTextStyles.Caption1,
                                     color = TvColors.TextSecondary,
                                     maxLines = 1,
                                     overflow = TextOverflow.Ellipsis,
                                 )
                                 Text(
                                     text = episodeTitle,
-                                    style = TvTextStyles.VideoTileEpisodeTitle,
+                                    style = TvTextStyles.Caption1,
                                     color = TvColors.TextPrimary,
                                     maxLines = 1,
                                     overflow = TextOverflow.Ellipsis,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvVideoTile.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvVideoTile.kt
@@ -144,7 +144,7 @@ fun TvVideoTile(
 private fun TvVideoTilePreview() {
     AppTheme(themeType = Theme.ThemeType.EXTRA_DARK) {
         MaterialTheme {
-            Box(modifier = Modifier.background(TvColors.Dark)) {
+            Box(modifier = Modifier.background(TvColors.BackgroundSunken)) {
                 TvVideoTile(
                     thumbnailUrl = "",
                     podcastArtworkUrl = "",

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvVideoTile.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvVideoTile.kt
@@ -126,7 +126,7 @@ fun TvVideoTile(
                                 Text(
                                     text = episodeTitle,
                                     style = TvTextStyles.VideoTileEpisodeTitle,
-                                    color = Color.White,
+                                    color = TvColors.TextPrimary,
                                     maxLines = 1,
                                     overflow = TextOverflow.Ellipsis,
                                 )

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeScreen.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.onFocusChanged
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
@@ -90,7 +89,7 @@ private fun TvHomeContent(
     restoreFocusTrigger: Int = 0,
 ) {
     when (uiState) {
-        is TvHomeUiState.Loading -> LoadingView(color = Color.White, modifier = modifier)
+        is TvHomeUiState.Loading -> LoadingView(color = TvColors.TextPrimary, modifier = modifier)
 
         is TvHomeUiState.Error -> TvHomeError(onRetry = onRetry, modifier = modifier)
 
@@ -119,7 +118,7 @@ private fun TvHomeError(
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
             Text(
                 text = stringResource(LR.string.error_generic_message),
-                color = Color.White,
+                color = TvColors.TextPrimary,
                 style = MaterialTheme.typography.bodyLarge,
             )
             Spacer(modifier = Modifier.height(24.dp))
@@ -232,7 +231,7 @@ private fun TvHomeRows(
 private fun TvHomeContentPreview() {
     AppTheme(themeType = Theme.ThemeType.EXTRA_DARK) {
         MaterialTheme {
-            Box(modifier = Modifier.background(TvColors.Dark)) {
+            Box(modifier = Modifier.background(TvColors.BackgroundSunken)) {
                 TvHomeContent(
                     uiState = TvHomeUiState.Ready(
                         rows = listOf(
@@ -273,7 +272,7 @@ private fun TvHomeContentPreview() {
 private fun TvHomeErrorPreview() {
     AppTheme(themeType = Theme.ThemeType.EXTRA_DARK) {
         MaterialTheme {
-            Box(modifier = Modifier.background(TvColors.Dark)) {
+            Box(modifier = Modifier.background(TvColors.BackgroundSunken)) {
                 TvHomeContent(
                     uiState = TvHomeUiState.Error,
                     onRetry = {},

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvProfileModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvProfileModal.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.Button
@@ -82,7 +83,7 @@ private fun ColumnScope.TvProfileModalContent(
                 Text(
                     text = profile.email,
                     color = TvColors.TextPrimary,
-                    style = TvTextStyles.ModalEmail,
+                    style = TvTextStyles.Headline.copy(textAlign = TextAlign.Center),
                     modifier = Modifier.padding(bottom = 16.dp),
                 )
             }
@@ -121,7 +122,7 @@ private fun ColumnScope.TvProfileModalContent(
             BuildConfig.VERSION_CODE.toString(),
         ),
         color = TvColors.TextSecondary,
-        style = TvTextStyles.ModalFootnote,
+        style = TvTextStyles.Caption1,
         modifier = Modifier.padding(top = 8.dp),
     )
 }
@@ -148,7 +149,7 @@ private fun TvProfileModalAvatar(email: String?, modifier: Modifier = Modifier) 
 private fun TvProfileModalAvatarPlaceholder(modifier: Modifier = Modifier) {
     Box(
         contentAlignment = Alignment.Center,
-        modifier = modifier.background(TvColors.Gray, CircleShape),
+        modifier = modifier.background(TvColors.BackgroundOverlay, CircleShape),
     ) {
         Icon(
             painter = painterResource(IR.drawable.ic_profile),
@@ -174,7 +175,7 @@ private fun TvProfileModalButton(
     ) {
         Text(
             text = text,
-            style = TvTextStyles.ModalButtonLabel,
+            style = TvTextStyles.Caption1.copy(textAlign = TextAlign.Center),
             modifier = Modifier.fillMaxWidth(),
         )
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvTabBar.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvTabBar.kt
@@ -63,7 +63,7 @@ fun TvTabBar(
 
     Box(
         modifier = modifier
-            .background(TvColors.Dark, RoundedCornerShape(percent = 50))
+            .background(TvColors.BackgroundSunken, RoundedCornerShape(percent = 50))
             .padding(3.dp),
     ) {
         TabRow(
@@ -75,8 +75,8 @@ fun TvTabBar(
                     TabRowDefaults.PillIndicator(
                         currentTabPosition = currentTabPosition,
                         doesTabRowHaveFocus = doesTabRowHaveFocus,
-                        activeColor = Color.White,
-                        inactiveColor = Color.White,
+                        activeColor = TvColors.BackgroundActive,
+                        inactiveColor = TvColors.BackgroundActive,
                     )
                 }
             },
@@ -90,11 +90,11 @@ fun TvTabBar(
                         .padding(horizontal = 21.dp)
                         .then(if (index == selectedTabIndex) Modifier.focusRequester(focusRequester) else Modifier),
                     colors = TabDefaults.pillIndicatorTabColors(
-                        contentColor = Color.White,
-                        selectedContentColor = TvColors.Dark,
-                        focusedContentColor = Color.White,
-                        focusedSelectedContentColor = TvColors.Dark,
-                        inactiveContentColor = Color.White,
+                        contentColor = TvColors.TextPrimary,
+                        selectedContentColor = TvColors.TextPrimaryActive,
+                        focusedContentColor = TvColors.TextPrimary,
+                        focusedSelectedContentColor = TvColors.TextPrimaryActive,
+                        inactiveContentColor = TvColors.TextPrimary,
                     ),
                 ) {
                     Box(
@@ -106,7 +106,7 @@ fun TvTabBar(
                                 Text(
                                     text = stringResource(tab.labelRes),
                                     color = LocalContentColor.current,
-                                    style = TvTextStyles.TabLabel,
+                                    style = TvTextStyles.Caption1,
                                 )
                             }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvTabBar.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvTabBar.kt
@@ -129,7 +129,7 @@ fun TvTabBar(
                                     Text(
                                         text = stringResource(tab.labelRes),
                                         color = LocalContentColor.current,
-                                        style = TvTextStyles.TabLabel,
+                                        style = TvTextStyles.Caption1,
                                     )
                                 }
                             }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvTabPlaceholder.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvTabPlaceholder.kt
@@ -109,7 +109,7 @@ fun TvTabPlaceholder(
 private fun TvTabPlaceholderPreview() {
     AppTheme(themeType = Theme.ThemeType.EXTRA_DARK) {
         MaterialTheme {
-            Box(modifier = Modifier.background(TvColors.Dark)) {
+            Box(modifier = Modifier.background(TvColors.BackgroundSunken)) {
                 TvTabPlaceholder(tab = TvTab.Home)
             }
         }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvTopBar.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvTopBar.kt
@@ -82,7 +82,7 @@ private fun TvProfileButton(
 ) {
     IconButton(
         onClick = onClick,
-        colors = TvButtonDefaults.iconButtonColors(containerColor = TvColors.Gray),
+        colors = TvButtonDefaults.iconButtonColors(containerColor = TvColors.BackgroundOverlay),
         // The avatar image covers the focused container color, so show focus with a border as well.
         border = IconButtonDefaults.border(
             focusedBorder = Border(BorderStroke(2.dp, Color.White), inset = 2.dp, shape = CircleShape),

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/createaccount/TvCreateAccountModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/createaccount/TvCreateAccountModal.kt
@@ -64,8 +64,8 @@ private fun Header(modifier: Modifier = Modifier) {
     ) {
         Text(
             text = stringResource(LR.string.tv_create_account_modal_title),
-            color = Color.White,
-            style = TvTextStyles.ModalTitle,
+            color = TvColors.TextPrimary,
+            style = TvTextStyles.Headline.copy(textAlign = TextAlign.Center),
             textAlign = TextAlign.Start,
         )
         Text(
@@ -112,7 +112,7 @@ private fun LoadingContent(modifier: Modifier = Modifier) {
             .focusRequester(focusRequester)
             .focusable(),
     ) {
-        LoadingView(color = Color.White)
+        LoadingView(color = TvColors.TextPrimary)
     }
 
     LaunchedEffect(Unit) {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/createaccount/TvCreateAccountModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/createaccount/TvCreateAccountModal.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -65,7 +64,7 @@ private fun Header(modifier: Modifier = Modifier) {
         Text(
             text = stringResource(LR.string.tv_create_account_modal_title),
             color = TvColors.TextPrimary,
-            style = TvTextStyles.Headline.copy(textAlign = TextAlign.Center),
+            style = TvTextStyles.Headline,
             textAlign = TextAlign.Start,
         )
         Text(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/createaccount/TvCreateAccountModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/createaccount/TvCreateAccountModal.kt
@@ -135,7 +135,7 @@ private fun ErrorContent(
         Text(
             text = stringResource(LR.string.error_generic_message),
             color = TvColors.TextSecondary,
-            style = TvTextStyles.Title3.copy(textAlign = TextAlign.Center),
+            style = TvTextStyles.Body.copy(textAlign = TextAlign.Center),
         )
         Spacer(modifier = Modifier.height(24.dp))
         Button(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/createaccount/TvCreateAccountModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/createaccount/TvCreateAccountModal.kt
@@ -71,8 +71,7 @@ private fun Header(modifier: Modifier = Modifier) {
         Text(
             text = stringResource(LR.string.tv_create_account_modal_subtitle),
             color = TvColors.TextSecondary,
-            style = TvTextStyles.ModalBody,
-            textAlign = TextAlign.Start,
+            style = TvTextStyles.Body,
         )
     }
 }
@@ -136,7 +135,7 @@ private fun ErrorContent(
         Text(
             text = stringResource(LR.string.error_generic_message),
             color = TvColors.TextSecondary,
-            style = TvTextStyles.SignInSubtitle,
+            style = TvTextStyles.Title3.copy(textAlign = TextAlign.Center),
         )
         Spacer(modifier = Modifier.height(24.dp))
         Button(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/createaccount/TvCreateAccountScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/createaccount/TvCreateAccountScreen.kt
@@ -70,7 +70,7 @@ fun TvCreateAccountScreen(
             Text(
                 text = stringResource(LR.string.tv_create_account_subtitle),
                 color = TvColors.TextSecondary,
-                style = TvTextStyles.Title3.copy(textAlign = TextAlign.Center),
+                style = TvTextStyles.Body.copy(textAlign = TextAlign.Center),
             )
             Spacer(modifier = Modifier.height(24.dp))
             Box(
@@ -88,7 +88,7 @@ fun TvCreateAccountScreen(
             Text(
                 text = stringResource(LR.string.tv_create_account_come_back),
                 color = TvColors.TextSecondary,
-                style = TvTextStyles.Title3.copy(textAlign = TextAlign.Center),
+                style = TvTextStyles.Body.copy(textAlign = TextAlign.Center),
             )
             Spacer(modifier = Modifier.height(24.dp))
             Button(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/createaccount/TvCreateAccountScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/createaccount/TvCreateAccountScreen.kt
@@ -49,7 +49,7 @@ fun TvCreateAccountScreen(
         contentAlignment = Alignment.Center,
         modifier = modifier
             .fillMaxSize()
-            .background(TvColors.Dark),
+            .background(TvColors.BackgroundSunken),
     ) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
@@ -62,7 +62,7 @@ fun TvCreateAccountScreen(
             Spacer(modifier = Modifier.height(16.dp))
             Text(
                 text = stringResource(LR.string.tv_create_account_title),
-                color = Color.White,
+                color = TvColors.TextPrimary,
                 style = TvTextStyles.WelcomeTitle,
             )
             Spacer(modifier = Modifier.height(8.dp))

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/createaccount/TvCreateAccountScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/createaccount/TvCreateAccountScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -63,13 +64,13 @@ fun TvCreateAccountScreen(
             Text(
                 text = stringResource(LR.string.tv_create_account_title),
                 color = TvColors.TextPrimary,
-                style = TvTextStyles.WelcomeTitle,
+                style = TvTextStyles.Title1.copy(textAlign = TextAlign.Center),
             )
             Spacer(modifier = Modifier.height(8.dp))
             Text(
                 text = stringResource(LR.string.tv_create_account_subtitle),
                 color = TvColors.TextSecondary,
-                style = TvTextStyles.SignInSubtitle,
+                style = TvTextStyles.Title3.copy(textAlign = TextAlign.Center),
             )
             Spacer(modifier = Modifier.height(24.dp))
             Box(
@@ -87,7 +88,7 @@ fun TvCreateAccountScreen(
             Text(
                 text = stringResource(LR.string.tv_create_account_come_back),
                 color = TvColors.TextSecondary,
-                style = TvTextStyles.SignInSubtitle,
+                style = TvTextStyles.Title3.copy(textAlign = TextAlign.Center),
             )
             Spacer(modifier = Modifier.height(24.dp))
             Button(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInQrContent.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInQrContent.kt
@@ -102,7 +102,7 @@ private fun StepRow(number: Int, text: String, modifier: Modifier = Modifier) {
         Text(
             text = text,
             color = TvColors.TextPrimary,
-            style = TvTextStyles.Title3.copy(textAlign = TextAlign.Center),
+            style = TvTextStyles.Body.copy(textAlign = TextAlign.Center),
         )
     }
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInQrContent.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInQrContent.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.tv.material3.Text
@@ -101,7 +102,7 @@ private fun StepRow(number: Int, text: String, modifier: Modifier = Modifier) {
         Text(
             text = text,
             color = TvColors.TextPrimary,
-            style = TvTextStyles.SignInSubtitle,
+            style = TvTextStyles.Title3.copy(textAlign = TextAlign.Center),
         )
     }
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInQrContent.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInQrContent.kt
@@ -89,7 +89,7 @@ private fun StepRow(number: Int, text: String, modifier: Modifier = Modifier) {
             contentAlignment = Alignment.Center,
             modifier = Modifier
                 .size(28.dp)
-                .background(TvColors.BackgroundActive50, CircleShape),
+                .background(TvColors.BackgroundActive20, CircleShape),
         ) {
             Text(
                 text = number.toString(),
@@ -117,7 +117,7 @@ private fun CodeRow(userCode: List<String>, modifier: Modifier = Modifier) {
                 contentAlignment = Alignment.Center,
                 modifier = Modifier
                     .size(44.dp)
-                    .background(TvColors.BackgroundActive50, CircleShape),
+                    .background(TvColors.BackgroundActive20, CircleShape),
             ) {
                 Text(
                     text = character,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInQrContent.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInQrContent.kt
@@ -89,7 +89,7 @@ private fun StepRow(number: Int, text: String, modifier: Modifier = Modifier) {
             contentAlignment = Alignment.Center,
             modifier = Modifier
                 .size(28.dp)
-                .background(TvColors.BgActive20, CircleShape),
+                .background(TvColors.BackgroundActive50, CircleShape),
         ) {
             Text(
                 text = number.toString(),
@@ -100,7 +100,7 @@ private fun StepRow(number: Int, text: String, modifier: Modifier = Modifier) {
         }
         Text(
             text = text,
-            color = Color.White,
+            color = TvColors.TextPrimary,
             style = TvTextStyles.SignInSubtitle,
         )
     }
@@ -117,7 +117,7 @@ private fun CodeRow(userCode: List<String>, modifier: Modifier = Modifier) {
                 contentAlignment = Alignment.Center,
                 modifier = Modifier
                     .size(44.dp)
-                    .background(TvColors.BgActive20, CircleShape),
+                    .background(TvColors.BackgroundActive50, CircleShape),
             ) {
                 Text(
                     text = character,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInQrContent.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInQrContent.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.tv.material3.Text
@@ -102,7 +101,7 @@ private fun StepRow(number: Int, text: String, modifier: Modifier = Modifier) {
         Text(
             text = text,
             color = TvColors.TextPrimary,
-            style = TvTextStyles.Body.copy(textAlign = TextAlign.Center),
+            style = TvTextStyles.Body,
         )
     }
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInScreen.kt
@@ -77,7 +77,7 @@ private fun TvSignInLoading(modifier: Modifier = Modifier) {
         contentAlignment = Alignment.Center,
         modifier = modifier
             .fillMaxSize()
-            .background(TvColors.Dark)
+            .background(TvColors.BackgroundSunken)
             .focusRequester(focusRequester)
             .focusable(),
     ) {
@@ -90,7 +90,7 @@ private fun TvSignInLoading(modifier: Modifier = Modifier) {
             Spacer(modifier = Modifier.height(16.dp))
             Text(
                 text = stringResource(LR.string.tv_onboarding_sign_in_title),
-                color = Color.White,
+                color = TvColors.TextPrimary,
                 style = TvTextStyles.WelcomeTitle,
             )
         }
@@ -112,7 +112,7 @@ private fun TvSignInError(
         contentAlignment = Alignment.Center,
         modifier = modifier
             .fillMaxSize()
-            .background(TvColors.Dark),
+            .background(TvColors.BackgroundSunken),
     ) {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
             Image(
@@ -156,7 +156,7 @@ private fun TvSignInContent(
         contentAlignment = Alignment.Center,
         modifier = modifier
             .fillMaxSize()
-            .background(TvColors.Dark)
+            .background(TvColors.BackgroundSunken)
             .focusRequester(focusRequester)
             .focusable(),
     ) {
@@ -166,7 +166,7 @@ private fun TvSignInContent(
         ) {
             Text(
                 text = stringResource(LR.string.tv_sign_in_title),
-                color = Color.White,
+                color = TvColors.TextPrimary,
                 style = TvTextStyles.WelcomeTitle,
             )
             TvSignInQrContent(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInScreen.kt
@@ -125,7 +125,7 @@ private fun TvSignInError(
             Text(
                 text = stringResource(LR.string.error_generic_message),
                 color = TvColors.TextSecondary,
-                style = TvTextStyles.Title3.copy(textAlign = TextAlign.Center),
+                style = TvTextStyles.Body.copy(textAlign = TextAlign.Center),
             )
             Spacer(modifier = Modifier.height(24.dp))
             Button(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -91,7 +92,7 @@ private fun TvSignInLoading(modifier: Modifier = Modifier) {
             Text(
                 text = stringResource(LR.string.tv_onboarding_sign_in_title),
                 color = TvColors.TextPrimary,
-                style = TvTextStyles.WelcomeTitle,
+                style = TvTextStyles.Title1.copy(textAlign = TextAlign.Center),
             )
         }
     }
@@ -124,7 +125,7 @@ private fun TvSignInError(
             Text(
                 text = stringResource(LR.string.error_generic_message),
                 color = TvColors.TextSecondary,
-                style = TvTextStyles.SignInSubtitle,
+                style = TvTextStyles.Title3.copy(textAlign = TextAlign.Center),
             )
             Spacer(modifier = Modifier.height(24.dp))
             Button(
@@ -167,7 +168,7 @@ private fun TvSignInContent(
             Text(
                 text = stringResource(LR.string.tv_sign_in_title),
                 color = TvColors.TextPrimary,
-                style = TvTextStyles.WelcomeTitle,
+                style = TvTextStyles.Title1.copy(textAlign = TextAlign.Center),
             )
             TvSignInQrContent(
                 userCode = userCode,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSyncingScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSyncingScreen.kt
@@ -80,7 +80,7 @@ private fun TvSyncingScreenContent(modifier: Modifier = Modifier) {
     Box(
         modifier = modifier
             .fillMaxSize()
-            .background(TvColors.Dark),
+            .background(TvColors.BackgroundSunken),
     ) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
@@ -95,7 +95,7 @@ private fun TvSyncingScreenContent(modifier: Modifier = Modifier) {
             Spacer(modifier = Modifier.height(16.dp))
             Text(
                 text = stringResource(LR.string.tv_onboarding_welcome_back),
-                color = Color.White,
+                color = TvColors.TextPrimary,
                 style = TvTextStyles.WelcomeTitle,
             )
             Spacer(modifier = Modifier.height(8.dp))

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSyncingScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSyncingScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -96,13 +97,13 @@ private fun TvSyncingScreenContent(modifier: Modifier = Modifier) {
             Text(
                 text = stringResource(LR.string.tv_onboarding_welcome_back),
                 color = TvColors.TextPrimary,
-                style = TvTextStyles.WelcomeTitle,
+                style = TvTextStyles.Title1.copy(textAlign = TextAlign.Center),
             )
             Spacer(modifier = Modifier.height(8.dp))
             Text(
                 text = stringResource(LR.string.tv_onboarding_syncing_subtitle),
                 color = TvColors.TextSecondary,
-                style = TvTextStyles.WelcomeSubtitle,
+                style = TvTextStyles.Headline.copy(textAlign = TextAlign.Center),
             )
             Spacer(modifier = Modifier.height(40.dp))
             TvSyncingCoverRow(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSyncingScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSyncingScreen.kt
@@ -28,7 +28,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/welcome/TvWelcomeScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/welcome/TvWelcomeScreen.kt
@@ -49,7 +49,7 @@ fun TvWelcomeScreen(
     Box(
         modifier = modifier
             .fillMaxSize()
-            .background(TvColors.Dark),
+            .background(TvColors.BackgroundSunken),
     ) {
         TvAnimatedPodcastGrid(
             modifier = Modifier
@@ -63,10 +63,10 @@ fun TvWelcomeScreen(
                 .background(
                     Brush.verticalGradient(
                         colorStops = arrayOf(
-                            0f to TvColors.Dark.copy(alpha = 0.5f),
-                            0.15f to TvColors.Dark.copy(alpha = 0.5f),
-                            0.40f to TvColors.Dark,
-                            1f to TvColors.Dark,
+                            0f to TvColors.BackgroundSunken.copy(alpha = 0.5f),
+                            0.15f to TvColors.BackgroundSunken.copy(alpha = 0.5f),
+                            0.40f to TvColors.BackgroundSunken,
+                            1f to TvColors.BackgroundSunken,
                         ),
                     ),
                 ),
@@ -87,7 +87,7 @@ fun TvWelcomeScreen(
             Spacer(modifier = Modifier.height(16.dp))
             Text(
                 text = stringResource(LR.string.tv_onboarding_welcome_tv),
-                color = Color.White,
+                color = TvColors.TextPrimary,
                 style = TvTextStyles.WelcomeTitle,
             )
             Spacer(modifier = Modifier.height(8.dp))

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/welcome/TvWelcomeScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/welcome/TvWelcomeScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/welcome/TvWelcomeScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/welcome/TvWelcomeScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -88,13 +89,13 @@ fun TvWelcomeScreen(
             Text(
                 text = stringResource(LR.string.tv_onboarding_welcome_tv),
                 color = TvColors.TextPrimary,
-                style = TvTextStyles.WelcomeTitle,
+                style = TvTextStyles.Title1.copy(textAlign = TextAlign.Center),
             )
             Spacer(modifier = Modifier.height(8.dp))
             Text(
                 text = stringResource(LR.string.tv_onboarding_subtitle),
                 color = TvColors.TextSecondary,
-                style = TvTextStyles.WelcomeSubtitle,
+                style = TvTextStyles.Headline.copy(textAlign = TextAlign.Center),
             )
             Spacer(modifier = Modifier.height(32.dp))
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvDownloadAppModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvDownloadAppModal.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.Button
@@ -54,8 +55,8 @@ private fun ColumnScope.TvDownloadAppModalContent(
 
     Text(
         text = stringResource(LR.string.tv_playlists_download_title),
-        color = Color.White,
-        style = TvTextStyles.ModalTitle,
+        color = TvColors.TextPrimary,
+        style = TvTextStyles.Headline.copy(textAlign = TextAlign.Center),
     )
     Text(
         text = stringResource(LR.string.tv_playlists_download_subtitle),
@@ -83,7 +84,7 @@ private fun ColumnScope.TvDownloadAppModalContent(
             .padding(top = 16.dp)
             .focusRequester(focusRequester),
     ) {
-        Text(stringResource(LR.string.done), style = TvTextStyles.ModalButtonLabel)
+        Text(stringResource(LR.string.done), style = TvTextStyles.Caption1)
     }
 }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvDownloadAppModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvDownloadAppModal.kt
@@ -61,7 +61,7 @@ private fun ColumnScope.TvDownloadAppModalContent(
     Text(
         text = stringResource(LR.string.tv_playlists_download_subtitle),
         color = TvColors.TextSecondary,
-        style = TvTextStyles.ModalBody,
+        style = TvTextStyles.Body.copy(textAlign = TextAlign.Center),
     )
     Image(
         painter = rememberQrPainter(content = DOWNLOAD_URL, size = QrCodeSize),
@@ -75,7 +75,7 @@ private fun ColumnScope.TvDownloadAppModalContent(
     Text(
         text = DOWNLOAD_URL_LABEL,
         color = TvColors.TextSecondary,
-        style = TvTextStyles.ModalBody,
+        style = TvTextStyles.Body.copy(textAlign = TextAlign.Center),
     )
     Button(
         onClick = onDone,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsScreen.kt
@@ -156,7 +156,7 @@ private fun TvPlaylistsContent(
         modifier = modifier,
     ) { state ->
         when (state) {
-            is TvPlaylistsUiState.Loading -> LoadingView(color = Color.White, modifier = Modifier.fillMaxSize())
+            is TvPlaylistsUiState.Loading -> LoadingView(color = TvColors.TextPrimary, modifier = Modifier.fillMaxSize())
 
             is TvPlaylistsUiState.Loaded -> if (state.playlists.isEmpty()) {
                 TvPlaylistsEmpty(
@@ -195,8 +195,8 @@ private fun TvPlaylistsGrid(
     Column(modifier = modifier.padding(horizontal = 32.dp)) {
         Text(
             text = stringResource(LR.string.playlists),
-            style = TvTextStyles.ScreenTitle,
-            color = Color.White,
+            style = TvTextStyles.Title3,
+            color = TvColors.TextPrimary,
             modifier = Modifier.padding(top = 8.dp, bottom = 26.dp),
         )
         var lastFocusedIndex by rememberSaveable(playlists) { mutableIntStateOf(0) }
@@ -310,7 +310,7 @@ private fun TvPlaylistsEmpty(
 private fun TvPlaylistsGridPreview() {
     AppTheme(themeType = Theme.ThemeType.EXTRA_DARK) {
         MaterialTheme {
-            Box(modifier = Modifier.background(TvColors.Dark)) {
+            Box(modifier = Modifier.background(TvColors.BackgroundSunken)) {
                 TvPlaylistsContent(
                     uiState = TvPlaylistsUiState.Loaded(
                         playlists = List(5) { index -> previewPlaylist(index) },
@@ -333,7 +333,7 @@ private fun TvPlaylistsGridPreview() {
 private fun TvPlaylistsEmptyPreview() {
     AppTheme(themeType = Theme.ThemeType.EXTRA_DARK) {
         MaterialTheme {
-            Box(modifier = Modifier.background(TvColors.Dark)) {
+            Box(modifier = Modifier.background(TvColors.BackgroundSunken)) {
                 TvPlaylistsContent(
                     uiState = TvPlaylistsUiState.Loaded(playlists = emptyList()),
                     getArtworkUuidsFlow = { MutableStateFlow(null) },

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsScreen.kt
@@ -34,7 +34,6 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Devices

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsScreen.kt
@@ -215,9 +215,9 @@ private fun TvPlaylistsGrid(
 
         LazyVerticalGrid(
             columns = GridCells.Fixed(3),
-            horizontalArrangement = Arrangement.spacedBy(32.dp),
-            verticalArrangement = Arrangement.spacedBy(32.dp),
-            contentPadding = PaddingValues(bottom = 32.dp),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            contentPadding = PaddingValues(top = 16.dp, bottom = 32.dp),
             modifier = Modifier
                 .focusRequester(gridFocusRequester)
                 .focusGroup()

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
@@ -117,7 +117,7 @@ private fun TvPlaylistDetailsContent(
     Box(modifier = modifier.fillMaxSize()) {
         when (uiState) {
             is TvPlaylistDetailsUiState.Loading, TvPlaylistDetailsUiState.NotFound -> {
-                LoadingView(color = Color.White, modifier = Modifier.fillMaxSize())
+                LoadingView(color = TvColors.TextPrimary, modifier = Modifier.fillMaxSize())
             }
 
             is TvPlaylistDetailsUiState.Loaded -> {
@@ -299,8 +299,8 @@ private fun NoEpisodes(
         ) {
             Text(
                 text = stringResource(LR.string.tv_playlist_empty_title),
-                style = TvTextStyles.ScreenTitle,
-                color = Color.White,
+                style = TvTextStyles.Title3,
+                color = TvColors.TextPrimary,
                 textAlign = TextAlign.Center,
             )
             Text(
@@ -339,17 +339,17 @@ private fun PlaylistInfo(
                     Playlist.Type.Manual -> stringResource(LR.string.playlist)
                     Playlist.Type.Smart -> stringResource(LR.string.smart_playlist)
                 },
-                style = TvTextStyles.PlaylistCardCaption,
+                style = TvTextStyles.Caption2,
                 color = TvColors.TextSecondary,
             )
             Text(
                 text = playlist.title,
-                style = TvTextStyles.ScreenTitle,
-                color = Color.White,
+                style = TvTextStyles.Title3,
+                color = TvColors.TextPrimary,
             )
             Text(
                 text = episodeSummaryText(episodes),
-                style = TvTextStyles.PlaylistCardCaption,
+                style = TvTextStyles.Caption2,
                 color = TvColors.TextSecondary,
             )
         }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvFolderDetailScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvFolderDetailScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvFolderDetailScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvFolderDetailScreen.kt
@@ -83,7 +83,7 @@ private fun TvFolderDetailContent(
         modifier = modifier,
     ) { state ->
         when (state) {
-            is TvFolderDetailUiState.Loading -> LoadingView(color = Color.White, modifier = Modifier.fillMaxSize())
+            is TvFolderDetailUiState.Loading -> LoadingView(color = TvColors.TextPrimary, modifier = Modifier.fillMaxSize())
 
             is TvFolderDetailUiState.Empty -> TvEmptyState(
                 title = stringResource(LR.string.podcasts_empty_folder),
@@ -129,7 +129,7 @@ private sealed interface TvFolderDetailUiState {
 private fun TvFolderDetailPreview() {
     AppTheme(themeType = Theme.ThemeType.EXTRA_DARK) {
         MaterialTheme {
-            Box(modifier = Modifier.background(TvColors.Dark)) {
+            Box(modifier = Modifier.background(TvColors.BackgroundSunken)) {
                 TvFolderDetailContent(
                     folderName = "Tech & Science",
                     uiState = TvFolderDetailUiState.Loaded(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
@@ -120,7 +120,7 @@ private fun TvPodcastDetailsContent(
     Box(modifier = modifier.fillMaxSize()) {
         when (uiState) {
             is TvPodcastDetailsUiState.Loading, TvPodcastDetailsUiState.NotFound -> {
-                LoadingView(color = Color.White, modifier = Modifier.fillMaxSize())
+                LoadingView(color = TvColors.TextPrimary, modifier = Modifier.fillMaxSize())
             }
 
             is TvPodcastDetailsUiState.Loaded -> {
@@ -217,19 +217,19 @@ private fun PodcastInfo(
             if (podcast.author.isNotBlank()) {
                 Text(
                     text = podcast.author,
-                    style = TvTextStyles.Caption,
+                    style = TvTextStyles.Caption1,
                     color = TvColors.TextSecondary,
                 )
             }
             Text(
                 text = podcast.title,
-                style = TvTextStyles.ScreenTitle,
-                color = Color.White,
+                style = TvTextStyles.Title3,
+                color = TvColors.TextPrimary,
             )
             if (podcast.podcastDescription.isNotBlank()) {
                 Text(
                     text = podcast.podcastDescription,
-                    style = TvTextStyles.Caption,
+                    style = TvTextStyles.Caption1,
                     color = TvColors.TextSecondary,
                     maxLines = 3,
                     overflow = TextOverflow.Ellipsis,
@@ -283,8 +283,8 @@ private fun EpisodeList(
         ) {
             Text(
                 text = stringResource(LR.string.search_results_all_episodes),
-                style = TvTextStyles.ScreenTitle,
-                color = Color.White,
+                style = TvTextStyles.Title3,
+                color = TvColors.TextPrimary,
                 modifier = Modifier.weight(1f),
             )
             TvArchivedFilterButton(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsScreen.kt
@@ -129,7 +129,7 @@ private fun TvYourPodcastsContent(
         modifier = modifier,
     ) { state ->
         when (state) {
-            is TvYourPodcastsUiState.Loading -> LoadingView(color = Color.White, modifier = Modifier.fillMaxSize())
+            is TvYourPodcastsUiState.Loading -> LoadingView(color = TvColors.TextPrimary, modifier = Modifier.fillMaxSize())
 
             is TvYourPodcastsUiState.Empty -> TvEmptyState(
                 title = stringResource(LR.string.tv_your_podcasts_empty_title),
@@ -190,7 +190,7 @@ private const val FOLDER_COVER_COUNT = 4
 private fun TvYourPodcastsGridPreview() {
     AppTheme(themeType = Theme.ThemeType.EXTRA_DARK) {
         MaterialTheme {
-            Box(modifier = Modifier.background(TvColors.Dark)) {
+            Box(modifier = Modifier.background(TvColors.BackgroundSunken)) {
                 TvYourPodcastsContent(
                     uiState = TvYourPodcastsUiState.Loaded(
                         items = buildList {
@@ -228,7 +228,7 @@ private fun TvYourPodcastsGridPreview() {
 private fun TvYourPodcastsEmptyPreview() {
     AppTheme(themeType = Theme.ThemeType.EXTRA_DARK) {
         MaterialTheme {
-            Box(modifier = Modifier.background(TvColors.Dark)) {
+            Box(modifier = Modifier.background(TvColors.BackgroundSunken)) {
                 TvYourPodcastsContent(
                     uiState = TvYourPodcastsUiState.Empty,
                     onNavigateToHome = {},

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvButtonDefaults.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvButtonDefaults.kt
@@ -12,26 +12,26 @@ object TvButtonDefaults {
 
     @Composable
     fun filledButtonColors(): ButtonColors = ButtonDefaults.colors(
-        containerColor = TvColors.TextPrimary20,
+        containerColor = TvColors.BackgroundActive50,
         contentColor = TvColors.TextPrimary,
-        focusedContainerColor = TvColors.BgActive,
-        focusedContentColor = TvColors.Dark,
+        focusedContainerColor = TvColors.BackgroundActive,
+        focusedContentColor = TvColors.TextPrimaryActive,
     )
 
     @Composable
     fun prominentButtonColors(): ButtonColors = ButtonDefaults.colors(
-        containerColor = Color.White,
-        contentColor = TvColors.Dark,
-        focusedContainerColor = Color.White,
-        focusedContentColor = TvColors.Dark,
+        containerColor = TvColors.BackgroundActive,
+        contentColor = TvColors.TextPrimaryActive,
+        focusedContainerColor = TvColors.BackgroundActive,
+        focusedContentColor = TvColors.TextPrimaryActive,
     )
 
     @Composable
     fun borderlessButtonColors(): ButtonColors = ButtonDefaults.colors(
         containerColor = Color.Transparent,
         contentColor = TvColors.TextSecondary,
-        focusedContainerColor = Color.White.copy(alpha = 0.1f),
-        focusedContentColor = Color.White,
+        focusedContainerColor = TvColors.BackgroundActive.copy(alpha = 0.1f),
+        focusedContentColor = TvColors.TextPrimary,
     )
 
     @Composable
@@ -41,10 +41,10 @@ object TvButtonDefaults {
     )
 
     @Composable
-    fun iconButtonColors(containerColor: Color = TvColors.BgActive20) = IconButtonDefaults.colors(
+    fun iconButtonColors(containerColor: Color = TvColors.BackgroundActive50) = IconButtonDefaults.colors(
         containerColor = containerColor,
-        contentColor = Color.White,
-        focusedContainerColor = Color.White,
-        focusedContentColor = TvColors.Dark,
+        contentColor = TvColors.TextPrimary,
+        focusedContainerColor = TvColors.BackgroundActive,
+        focusedContentColor = TvColors.TextPrimaryActive,
     )
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvButtonDefaults.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvButtonDefaults.kt
@@ -12,7 +12,7 @@ object TvButtonDefaults {
 
     @Composable
     fun filledButtonColors(): ButtonColors = ButtonDefaults.colors(
-        containerColor = TvColors.BackgroundActive50,
+        containerColor = TvColors.BackgroundActive20,
         contentColor = TvColors.TextPrimary,
         focusedContainerColor = TvColors.BackgroundActive,
         focusedContentColor = TvColors.TextPrimaryActive,
@@ -41,7 +41,7 @@ object TvButtonDefaults {
     )
 
     @Composable
-    fun iconButtonColors(containerColor: Color = TvColors.BackgroundActive50) = IconButtonDefaults.colors(
+    fun iconButtonColors(containerColor: Color = TvColors.BackgroundActive20) = IconButtonDefaults.colors(
         containerColor = containerColor,
         contentColor = TvColors.TextPrimary,
         focusedContainerColor = TvColors.BackgroundActive,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvColors.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvColors.kt
@@ -34,5 +34,5 @@ object TvColors {
 
 // Shared screen background so detail overlays fully occlude the content fading underneath them.
 val TvScreenBackgroundBrush: Brush = Brush.horizontalGradient(
-    colors = listOf(TvColors.DarkGray, TvColors.Dark),
+    colors = listOf(TvColors.BackgroundBase, TvColors.BackgroundSunken),
 )

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvColors.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvColors.kt
@@ -3,6 +3,11 @@ package au.com.shiftyjelly.pocketcasts.theme
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 
+/**
+ * The Figma design-system colour tokens for TV. The full palette is defined even where a token has
+ * no call site yet, so it stays complete against Figma. `*Active` variants are the values used on
+ * the light active/focused surface.
+ */
 object TvColors {
     val TextPrimary = Color(0xFFFBFBFC)
     val TextSecondary = Color(0xFFB0B3B8)

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvColors.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvColors.kt
@@ -20,6 +20,7 @@ object TvColors {
     val BackgroundOverlay = Color(0xFF323538)
     val BackgroundActive = Color(0xFFFBFBFC)
     val BackgroundActive50 = Color(0x80FBFBFC)
+    val BackgroundActive20 = Color(0x33FBFBFC)
 }
 
 // Shared screen background so detail overlays fully occlude the content fading underneath them.

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvColors.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvColors.kt
@@ -4,17 +4,32 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 
 object TvColors {
+    val TextPrimary = Color(0xFFFBFBFC)
+    val TextSecondary = Color(0xFFB0B3B8)
+    val TextTertiary = Color(0xFF7A7D82)
+    val TextDisabled = Color(0xFF4A4D51)
+    val TextPrimaryActive = Color(0xFF161718)
+    val TextSecondaryActive = Color(0xFF3D4044)
+    val TextTertiaryActive = Color(0xFF7A7D82)
+    val TextDisabledActive = Color(0xFFB0B3B8)
+    val TextPrimary70 = Color(0xB3FBFBFC)
+
+    val BackgroundSunken = Color(0xFF161718)
+    val BackgroundSurface = Color(0xFF1F2123)
+    val BackgroundBase = Color(0xFF292B2E)
+    val BackgroundOverlay = Color(0xFF323538)
+    val BackgroundActive = Color(0xFFFBFBFC)
+    val BackgroundActive50 = Color(0x80FBFBFC)
+
+    val Divider = Color(0xFF4A4D51)
+
     val Dark = Color(0xFF161718)
     val DarkGray = Color(0xFF292B2E)
     val Gray = Color(0xFF3C3E42)
     val LightGray = Color(0xFFD4D6DB)
-    val TextPrimary = Color(0xFFFBFBFC)
     val TextPrimary20 = Color(0x33FBFBFC)
-    val TextSecondary = Color(0xFFB0B3B8)
-    val TextSecondaryActive = Color(0xFF3D4044)
     val BgActive = Color(0xFFD4D6DB)
     val BgActive20 = Color(0x33FBFBFC)
-    val Divider = Color(0xFF4A4D51)
 }
 
 // Shared screen background so detail overlays fully occlude the content fading underneath them.

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvColors.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvColors.kt
@@ -20,16 +20,6 @@ object TvColors {
     val BackgroundOverlay = Color(0xFF323538)
     val BackgroundActive = Color(0xFFFBFBFC)
     val BackgroundActive50 = Color(0x80FBFBFC)
-
-    val Divider = Color(0xFF4A4D51)
-
-    val Dark = Color(0xFF161718)
-    val DarkGray = Color(0xFF292B2E)
-    val Gray = Color(0xFF3C3E42)
-    val LightGray = Color(0xFFD4D6DB)
-    val TextPrimary20 = Color(0x33FBFBFC)
-    val BgActive = Color(0xFFD4D6DB)
-    val BgActive20 = Color(0x33FBFBFC)
 }
 
 // Shared screen background so detail overlays fully occlude the content fading underneath them.

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvTextStyles.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvTextStyles.kt
@@ -7,15 +7,15 @@ import androidx.compose.ui.unit.sp
 
 /**
  * The Figma type ramp for TV. Sizes are the Figma px values divided by 1.5 (the 1920x1080 → dp
- * convention), hence the fractional `sp`. Figma's SF Pro family is not ported (no such resource in
- * this module), so the tokens use the system default at [FontWeight] 510. The full ramp is defined
- * even where a step has no call site yet, so the palette stays complete.
+ * convention), hence the fractional `sp`. Figma's Google Sans family is not ported (no such resource
+ * in this module), so the tokens use the system default at [FontWeight] 500 (400 for [Subtitle1]).
+ * The full ramp is defined even where a step has no call site yet, so the palette stays complete.
  */
 object TvTextStyles {
     val Title1 = TextStyle(
         fontSize = 50.67.sp,
         lineHeight = 64.sp,
-        fontWeight = FontWeight(510),
+        fontWeight = FontWeight(500),
         letterSpacing = 0.sp,
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
@@ -23,7 +23,7 @@ object TvTextStyles {
     val Title2 = TextStyle(
         fontSize = 38.sp,
         lineHeight = 44.sp,
-        fontWeight = FontWeight(510),
+        fontWeight = FontWeight(500),
         letterSpacing = 0.sp,
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
@@ -31,7 +31,7 @@ object TvTextStyles {
     val Title3 = TextStyle(
         fontSize = 32.sp,
         lineHeight = 37.33.sp,
-        fontWeight = FontWeight(510),
+        fontWeight = FontWeight(500),
         letterSpacing = 0.sp,
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
@@ -39,7 +39,7 @@ object TvTextStyles {
     val Headline = TextStyle(
         fontSize = 25.33.sp,
         lineHeight = 30.67.sp,
-        fontWeight = FontWeight(510),
+        fontWeight = FontWeight(500),
         letterSpacing = 0.sp,
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
@@ -55,15 +55,15 @@ object TvTextStyles {
     val Callout = TextStyle(
         fontSize = 19.33.sp,
         lineHeight = 24.sp,
-        fontWeight = FontWeight(510),
+        fontWeight = FontWeight(500),
         letterSpacing = 0.sp,
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 
     val Body = TextStyle(
-        fontSize = 19.33.sp,
-        lineHeight = 24.sp,
-        fontWeight = FontWeight(400),
+        fontSize = 16.67.sp,
+        lineHeight = 21.33.sp,
+        fontWeight = FontWeight(500),
         letterSpacing = 0.sp,
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
@@ -71,7 +71,7 @@ object TvTextStyles {
     val Caption1 = TextStyle(
         fontSize = 16.67.sp,
         lineHeight = 21.33.sp,
-        fontWeight = FontWeight(510),
+        fontWeight = FontWeight(500),
         letterSpacing = 0.sp,
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
@@ -79,7 +79,7 @@ object TvTextStyles {
     val Caption2 = TextStyle(
         fontSize = 15.33.sp,
         lineHeight = 20.sp,
-        fontWeight = FontWeight(510),
+        fontWeight = FontWeight(500),
         letterSpacing = 0.sp,
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvTextStyles.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvTextStyles.kt
@@ -7,6 +7,62 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.sp
 
 object TvTextStyles {
+    val Title1 = TextStyle(
+        fontSize = 50.67.sp,
+        lineHeight = 64.sp,
+        fontWeight = FontWeight(510),
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    val Title2 = TextStyle(
+        fontSize = 38.sp,
+        lineHeight = 44.sp,
+        fontWeight = FontWeight(510),
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    val Title3 = TextStyle(
+        fontSize = 32.sp,
+        lineHeight = 37.33.sp,
+        fontWeight = FontWeight(510),
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    val Headline = TextStyle(
+        fontSize = 25.33.sp,
+        lineHeight = 30.67.sp,
+        fontWeight = FontWeight(510),
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    val Subtitle1 = TextStyle(
+        fontSize = 25.33.sp,
+        lineHeight = 30.67.sp,
+        fontWeight = FontWeight(400),
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    val Callout = TextStyle(
+        fontSize = 19.33.sp,
+        lineHeight = 24.sp,
+        fontWeight = FontWeight(510),
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    val Caption1 = TextStyle(
+        fontSize = 16.67.sp,
+        lineHeight = 21.33.sp,
+        fontWeight = FontWeight(510),
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+    val Caption2 = TextStyle(
+        fontSize = 15.33.sp,
+        lineHeight = 20.sp,
+        fontWeight = FontWeight(510),
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
     val TabLabel = TextStyle(
         fontSize = 17.sp,
         fontWeight = FontWeight(510),

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvTextStyles.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvTextStyles.kt
@@ -5,11 +5,18 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 
+/**
+ * The Figma type ramp for TV. Sizes are the Figma px values divided by 1.5 (the 1920x1080 → dp
+ * convention), hence the fractional `sp`. Figma's SF Pro family is not ported (no such resource in
+ * this module), so the tokens use the system default at [FontWeight] 510. The full ramp is defined
+ * even where a step has no call site yet, so the palette stays complete.
+ */
 object TvTextStyles {
     val Title1 = TextStyle(
         fontSize = 50.67.sp,
         lineHeight = 64.sp,
         fontWeight = FontWeight(510),
+        letterSpacing = 0.sp,
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 
@@ -17,6 +24,7 @@ object TvTextStyles {
         fontSize = 38.sp,
         lineHeight = 44.sp,
         fontWeight = FontWeight(510),
+        letterSpacing = 0.sp,
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 
@@ -24,6 +32,7 @@ object TvTextStyles {
         fontSize = 32.sp,
         lineHeight = 37.33.sp,
         fontWeight = FontWeight(510),
+        letterSpacing = 0.sp,
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 
@@ -31,6 +40,7 @@ object TvTextStyles {
         fontSize = 25.33.sp,
         lineHeight = 30.67.sp,
         fontWeight = FontWeight(510),
+        letterSpacing = 0.sp,
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 
@@ -38,6 +48,7 @@ object TvTextStyles {
         fontSize = 25.33.sp,
         lineHeight = 30.67.sp,
         fontWeight = FontWeight(400),
+        letterSpacing = 0.sp,
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 
@@ -45,6 +56,7 @@ object TvTextStyles {
         fontSize = 19.33.sp,
         lineHeight = 24.sp,
         fontWeight = FontWeight(510),
+        letterSpacing = 0.sp,
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 
@@ -52,6 +64,7 @@ object TvTextStyles {
         fontSize = 19.33.sp,
         lineHeight = 24.sp,
         fontWeight = FontWeight(400),
+        letterSpacing = 0.sp,
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 
@@ -59,6 +72,7 @@ object TvTextStyles {
         fontSize = 16.67.sp,
         lineHeight = 21.33.sp,
         fontWeight = FontWeight(510),
+        letterSpacing = 0.sp,
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 
@@ -66,6 +80,7 @@ object TvTextStyles {
         fontSize = 15.33.sp,
         lineHeight = 20.sp,
         fontWeight = FontWeight(510),
+        letterSpacing = 0.sp,
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvTextStyles.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvTextStyles.kt
@@ -63,15 +63,6 @@ object TvTextStyles {
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 
-    val TabLabel = TextStyle(
-        fontSize = 17.sp,
-        fontWeight = FontWeight(510),
-        lineHeight = 21.sp,
-        letterSpacing = 0.sp,
-        textAlign = TextAlign.Center,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
     val VideoTilePodcastTitle = TextStyle(
         fontSize = 12.sp,
         platformStyle = PlatformTextStyle(includeFontPadding = false),
@@ -80,45 +71,6 @@ object TvTextStyles {
     val VideoTileEpisodeTitle = TextStyle(
         fontSize = 13.sp,
         fontWeight = FontWeight.SemiBold,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    val ScreenTitle = TextStyle(
-        fontSize = 28.sp,
-        fontWeight = FontWeight.SemiBold,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    val PlaylistCardTitle = TextStyle(
-        fontSize = 24.sp,
-        fontWeight = FontWeight.SemiBold,
-        lineHeight = 28.sp,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    val PlaylistCardCaption = TextStyle(
-        fontSize = 15.sp,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    val Caption = TextStyle(
-        fontSize = 17.sp,
-        fontWeight = FontWeight(510),
-        lineHeight = 21.sp,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    val FolderCardTitle = TextStyle(
-        fontSize = 14.sp,
-        fontWeight = FontWeight.SemiBold,
-        textAlign = TextAlign.Center,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    val EpisodeRowTitle = TextStyle(
-        fontSize = 19.sp,
-        fontWeight = FontWeight.Medium,
-        lineHeight = 24.sp,
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 
@@ -156,41 +108,9 @@ object TvTextStyles {
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 
-    val ModalTitle = TextStyle(
-        fontSize = 24.sp,
-        fontWeight = FontWeight.SemiBold,
-        lineHeight = 28.sp,
-        textAlign = TextAlign.Center,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
     val ModalBody = TextStyle(
         fontSize = 16.sp,
         lineHeight = 20.sp,
-        textAlign = TextAlign.Center,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    val ModalEmail = TextStyle(
-        fontSize = 25.sp,
-        fontWeight = FontWeight(510),
-        lineHeight = 31.sp,
-        textAlign = TextAlign.Center,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    val ModalButtonLabel = TextStyle(
-        fontSize = 17.sp,
-        fontWeight = FontWeight(510),
-        lineHeight = 21.sp,
-        textAlign = TextAlign.Center,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    val ModalFootnote = TextStyle(
-        fontSize = 17.sp,
-        fontWeight = FontWeight(510),
-        lineHeight = 21.sp,
         textAlign = TextAlign.Center,
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvTextStyles.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvTextStyles.kt
@@ -3,7 +3,6 @@ package au.com.shiftyjelly.pocketcasts.theme
 import androidx.compose.ui.text.PlatformTextStyle
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.sp
 
 object TvTextStyles {
@@ -49,6 +48,13 @@ object TvTextStyles {
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 
+    val Body = TextStyle(
+        fontSize = 19.33.sp,
+        lineHeight = 24.sp,
+        fontWeight = FontWeight(400),
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
     val Caption1 = TextStyle(
         fontSize = 16.67.sp,
         lineHeight = 21.33.sp,
@@ -60,67 +66,6 @@ object TvTextStyles {
         fontSize = 15.33.sp,
         lineHeight = 20.sp,
         fontWeight = FontWeight(510),
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    val VideoTilePodcastTitle = TextStyle(
-        fontSize = 12.sp,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    val VideoTileEpisodeTitle = TextStyle(
-        fontSize = 13.sp,
-        fontWeight = FontWeight.SemiBold,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    val FeaturedTileSponsoredLabel = TextStyle(
-        fontSize = 14.sp,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    val FeaturedTileTitle = TextStyle(
-        fontSize = 24.sp,
-        fontWeight = FontWeight.Bold,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    val FeaturedTileDescription = TextStyle(
-        fontSize = 16.sp,
-        lineHeight = 20.sp,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    val WelcomeTitle = TextStyle(
-        fontSize = 27.sp,
-        fontWeight = FontWeight.Medium,
-        lineHeight = 27.sp,
-        letterSpacing = (-0.25).sp,
-        textAlign = TextAlign.Center,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    val SignInSubtitle = TextStyle(
-        fontSize = 12.sp,
-        fontWeight = FontWeight.Medium,
-        lineHeight = 18.sp,
-        textAlign = TextAlign.Center,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    val ModalBody = TextStyle(
-        fontSize = 16.sp,
-        lineHeight = 20.sp,
-        textAlign = TextAlign.Center,
-        platformStyle = PlatformTextStyle(includeFontPadding = false),
-    )
-
-    val WelcomeSubtitle = TextStyle(
-        fontSize = 16.sp,
-        fontWeight = FontWeight.Medium,
-        lineHeight = 16.sp,
-        letterSpacing = (-0.04).sp,
-        textAlign = TextAlign.Center,
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     )
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextScreen.kt
@@ -129,10 +129,10 @@ private fun UpNextList(
         modifier = modifier
             .fillMaxHeight()
             .fillMaxWidth(ROW_WIDTH_FRACTION)
-            .padding(start = 32.dp, top = 16.dp),
+            .padding(start = 32.dp, top = 8.dp),
     ) {
         UpNextHeader(episodes = episodes)
-        Spacer(Modifier.height(24.dp))
+        Spacer(Modifier.height(26.dp))
         LazyColumn(
             state = listState,
             verticalArrangement = Arrangement.spacedBy(12.dp),

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -23,21 +22,19 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.tv.material3.Button
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.component.TvEmptyState
 import au.com.shiftyjelly.pocketcasts.component.TvEpisodeActionContext
 import au.com.shiftyjelly.pocketcasts.component.TvEpisodeActionsModal
 import au.com.shiftyjelly.pocketcasts.component.TvEpisodeInfoModal
@@ -49,7 +46,6 @@ import au.com.shiftyjelly.pocketcasts.localization.helper.RelativeDateFormatter
 import au.com.shiftyjelly.pocketcasts.localization.helper.TimeHelper
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.podcasts.TvPodcastDetailsScreen
-import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
 import au.com.shiftyjelly.pocketcasts.theme.TvColors
 import au.com.shiftyjelly.pocketcasts.theme.TvTextStyles
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
@@ -220,34 +216,13 @@ private fun UpNextEmpty(
     onNavigateToHome: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Box(
-        contentAlignment = Alignment.Center,
+    TvEmptyState(
+        title = stringResource(LR.string.tv_up_next_empty_title),
+        subtitle = stringResource(LR.string.tv_up_next_empty_subtitle),
+        actionLabel = stringResource(LR.string.tv_up_next_empty_action_title),
+        onAction = onNavigateToHome,
         modifier = modifier,
-    ) {
-        Column(horizontalAlignment = Alignment.CenterHorizontally) {
-            Text(
-                text = stringResource(LR.string.tv_up_next_empty_title),
-                style = TvTextStyles.Title3,
-                color = TvColors.TextPrimary,
-                textAlign = TextAlign.Center,
-            )
-            Spacer(modifier = Modifier.height(12.dp))
-            Text(
-                text = stringResource(LR.string.tv_up_next_empty_subtitle),
-                style = MaterialTheme.typography.bodyLarge,
-                color = TvColors.TextSecondary,
-                textAlign = TextAlign.Center,
-                modifier = Modifier.widthIn(max = 400.dp),
-            )
-            Spacer(modifier = Modifier.height(32.dp))
-            Button(
-                onClick = onNavigateToHome,
-                colors = TvButtonDefaults.filledButtonColors(),
-            ) {
-                Text(stringResource(LR.string.tv_up_next_empty_action_title))
-            }
-        }
-    }
+    )
 }
 
 private const val ROW_WIDTH_FRACTION = 0.75f

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextScreen.kt
@@ -97,7 +97,7 @@ private fun TvUpNextContent(
     Box(modifier = modifier.fillMaxSize()) {
         when (uiState) {
             is TvUpNextUiState.Loading -> {
-                LoadingView(color = Color.White, modifier = Modifier.fillMaxSize())
+                LoadingView(color = TvColors.TextPrimary, modifier = Modifier.fillMaxSize())
             }
 
             is TvUpNextUiState.Empty -> {
@@ -193,12 +193,12 @@ private fun UpNextHeader(
     ) {
         Text(
             text = stringResource(LR.string.up_next),
-            style = TvTextStyles.ScreenTitle,
-            color = Color.White,
+            style = TvTextStyles.Title3,
+            color = TvColors.TextPrimary,
         )
         Text(
             text = episodeSummaryText(episodes),
-            style = TvTextStyles.PlaylistCardCaption,
+            style = TvTextStyles.Caption2,
             color = TvColors.TextSecondary,
         )
     }
@@ -227,8 +227,8 @@ private fun UpNextEmpty(
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
             Text(
                 text = stringResource(LR.string.tv_up_next_empty_title),
-                style = TvTextStyles.ScreenTitle,
-                color = Color.White,
+                style = TvTextStyles.Title3,
+                color = TvColors.TextPrimary,
                 textAlign = TextAlign.Center,
             )
             Spacer(modifier = Modifier.height(12.dp))
@@ -257,7 +257,7 @@ private const val ROW_WIDTH_FRACTION = 0.75f
 private fun TvUpNextLoadedPreview() {
     AppTheme(themeType = Theme.ThemeType.EXTRA_DARK) {
         MaterialTheme {
-            Box(modifier = Modifier.background(TvColors.Dark)) {
+            Box(modifier = Modifier.background(TvColors.BackgroundSunken)) {
                 TvUpNextContent(
                     uiState = TvUpNextUiState.Loaded(
                         episodes = List(4) { index ->
@@ -283,7 +283,7 @@ private fun TvUpNextLoadedPreview() {
 private fun TvUpNextEmptyPreview() {
     AppTheme(themeType = Theme.ThemeType.EXTRA_DARK) {
         MaterialTheme {
-            Box(modifier = Modifier.background(TvColors.Dark)) {
+            Box(modifier = Modifier.background(TvColors.BackgroundSunken)) {
                 TvUpNextContent(
                     uiState = TvUpNextUiState.Empty,
                     onNavigateToHome = {},

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource


### PR DESCRIPTION
## Description

Aligns the Android TV UI with the Figma design system by extracting reusable **color** and **text-style** tokens and re-pointing every TV screen/component to them.

- **`TvColors`** now defines the full Figma palette: `TextPrimary/Secondary/Tertiary/Disabled` (+ their `*Active` variants) `TextPrimary70`, and backgrounds `BackgroundSunken/Surface/Base/Overlay/Active` (+ `BackgroundActive50/20`).
- **`TvTextStyles`** gains the Figma type ramp `Title1…Caption2` (+ `Body`) (Figma px ÷ 1.5 per the TV module convention; system font kept, `FontWeight(510)`).
- ~40 files re-pointed to the new tokens; legacy tokens (`Dark`, `DarkGray`, `Gray`, `LightGray`, `TextPrimary20`, `BgActive`, `BgActive20`, `Divider`) and the now-unused per-component text styles removed.

Where existing styling didn't map cleanly, the closest token was used and the gap logged (see below). Stacked on `feat/tv-deep-destination-top-bar` (base of this PR).

### Decisions / discrepancies for design review

- **Color changes:** `Gray` #3C3E42 → `BackgroundOverlay` #323538; focus/active backgrounds `#D4D6DB` → `BackgroundActive` #FBFBFC (`bg-active`).
- **Resting translucent button backgrounds kept at 20%** (`BackgroundActive20`) — Figma only defines `bg-active-50`; 50% would make the white label low-contrast. Needs a design call.
- **All per-component text styles eliminated** — the styles previously kept below the ramp were re-pointed to their confirmed Figma style names (`Caption1`, `Body`, `Title1`, `Title2`, `Headline`); a `Body` token (19.33sp / 400) was added to the ramp. `TvTextStyles` now contains only ramp tokens.

A full discrepancy list is in the PR comments.

## Testing Instructions

1. Build & run the TV app on an Android TV device/emulator.
2. Navigate Home, Your Podcasts, Playlists, Up Next; open podcast/playlist detail screens, the episode-actions and episode-info modals, and the profile modal.
3. Verify tab bar, tiles, rows, buttons, and modals render correctly and that **focus states** stay legible (focused rows/cards/tabs show a white background with dark text).
4. Sign-out onboarding (welcome, QR sign-in, create-account) screens render correctly.

## Screenshots or Screencast

https://github.com/user-attachments/assets/ef9ddbb7-271d-4cd0-9e93-39bf97fcf2ed



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml` _(no string changes)_
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) the Event Horizon schema to reflect any new or changed analytics. _(no analytics changes)_

#### I have tested any UI changes...
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack

