### PR TITLE
fix: use activity window for status bar icons in dialog fragments

### DIFF
--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/BaseDialogFragment.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/BaseDialogFragment.kt
@@ -70,8 +70,10 @@ open class BaseDialogFragment : BottomSheetDialogFragment() {
 
         view.isClickable = true
 
-        dialog?.window?.let { window ->
+        activity?.window?.let { window ->
             theme.updateWindowStatusBarIcons(window = window, statusBarIconColor = statusBarIconColor)
+        }
+        dialog?.window?.let { window ->
             theme.updateWindowNavigationBarColor(window = window, navigationBarColor = navigationBarColor)
         }
 


### PR DESCRIPTION
## Summary

- `BaseDialogFragment.onViewCreated()` was calling `theme.updateWindowStatusBarIcons()` on `dialog?.window`, but status bar icon appearance is controlled by the **activity's window**, not the dialog's overlay window
- Changed to use `activity?.window` for status bar icons, matching how `BaseAppCompatDialogFragment` already handles this correctly
- Navigation bar color still uses the dialog window (controls the dialog's own nav bar)

Fixes #2127

## Test plan

- [ ] Use a light theme (Light or Rose)
- [ ] Open the full-screen player, then open Up Next — status bar icons should be dark/visible
- [ ] Open Cloud File Bookmarks dialog — status bar icons should be dark/visible
- [ ] Switch to a dark theme and verify status bar icons are light/visible on the same dialogs
- [ ] Dismiss each dialog and verify status bar icons restore to the correct color