### PR TITLE
[TV] Add a Now Playing tab with basic playback

### DIFF
--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -288,6 +288,8 @@
     <string name="tv_up_next_empty_title">Nothing queued up</string>
     <string name="tv_up_next_empty_subtitle">Add episodes to Up Next and they’ll play in order, back to back</string>
     <string name="tv_up_next_empty_action_title">Add episodes</string>
+    <string name="tv_nothing_playing_title">Nothing playing</string>
+    <string name="tv_nothing_playing_subtitle">Play an episode and it’ll show up here.</string>
     <string name="tv_your_podcasts_empty_title">Time to fill this up</string>
     <string name="tv_your_podcasts_empty_subtitle">Followed podcasts show up here, ready to play.</string>
     <string name="tv_your_podcasts_empty_action_title">Discover podcasts</string>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -2203,7 +2203,8 @@ open class PlaybackManager @Inject constructor(
         if (playingStream) {
             if (!Util.isCarUiMode(application) &&
                 !Util.isWearOs(application) &&
-                // The watch handles these warnings before this is called
+                // The watch handles these warnings before this is called; TV has no data-warning UI
+                !Util.isTv(application) &&
                 settings.warnOnMeteredNetwork.value &&
                 episode.uuid != lastWarnedPlayedEpisodeUuid &&
                 !Network.isUnmeteredConnection(application) &&

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -2202,8 +2202,8 @@ open class PlaybackManager @Inject constructor(
         episodeSubscription?.dispose()
         if (playingStream) {
             if (!Util.isCarUiMode(application) &&
+                // The watch handles these warnings before this is called
                 !Util.isWearOs(application) &&
-                // The watch handles these warnings before this is called; TV has no data-warning UI
                 !Util.isTv(application) &&
                 settings.warnOnMeteredNetwork.value &&
                 episode.uuid != lastWarnedPlayedEpisodeUuid &&

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -2202,7 +2202,7 @@ open class PlaybackManager @Inject constructor(
         episodeSubscription?.dispose()
         if (playingStream) {
             if (!Util.isCarUiMode(application) &&
-                // The watch handles these warnings before this is called
+                // The watch shows this warning before playback starts, and TV has no warning UI.
                 !Util.isWearOs(application) &&
                 !Util.isTv(application) &&
                 settings.warnOnMeteredNetwork.value &&

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/extensions/Context.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/extensions/Context.kt
@@ -8,11 +8,15 @@ import android.content.ContextWrapper
 import android.content.res.Configuration
 import android.view.accessibility.AccessibilityManager
 import androidx.appcompat.app.AppCompatActivity
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 
 fun Context.getLaunchActivityPendingIntent(): PendingIntent {
     // TV builds declare only a LEANBACK_LAUNCHER activity, which getLaunchIntentForPackage does not resolve.
     val intent = packageManager.getLaunchIntentForPackage(packageName)
         ?: packageManager.getLeanbackLaunchIntentForPackage(packageName)
+    if (intent == null) {
+        LogBuffer.e(LogBuffer.TAG_CRASH, "Could not resolve a launch intent for $packageName; content intent will be inert")
+    }
     return PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
 }
 

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/extensions/Context.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/extensions/Context.kt
@@ -10,7 +10,9 @@ import android.view.accessibility.AccessibilityManager
 import androidx.appcompat.app.AppCompatActivity
 
 fun Context.getLaunchActivityPendingIntent(): PendingIntent {
+    // TV builds declare only a LEANBACK_LAUNCHER activity, which getLaunchIntentForPackage does not resolve.
     val intent = packageManager.getLaunchIntentForPackage(packageName)
+        ?: packageManager.getLeanbackLaunchIntentForPackage(packageName)
     return PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
 }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvApplication.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvApplication.kt
@@ -3,7 +3,7 @@ package au.com.shiftyjelly.pocketcasts
 import android.app.Application
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
-import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.utils.TimberDebugTree
 import dagger.hilt.android.HiltAndroidApp
 import javax.inject.Inject
@@ -20,7 +20,7 @@ class TvApplication :
 
     @Inject lateinit var workerFactory: HiltWorkerFactory
 
-    @Inject lateinit var upNextQueue: UpNextQueue
+    @Inject lateinit var playbackManager: PlaybackManager
 
     private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
@@ -29,10 +29,10 @@ class TvApplication :
         if (BuildConfig.DEBUG) {
             Timber.plant(TimberDebugTree())
         }
-        // The only setupBlocking() call on TV; there is no PlaybackManager.setup() here,
-        // so calling it again would double-subscribe the queue's sync pipeline.
+        // setup() subscribes the Up Next queue's sync pipeline itself, so there must be no
+        // separate UpNextQueue.setupBlocking() call on TV.
         applicationScope.launch {
-            upNextQueue.setupBlocking()
+            playbackManager.setup()
         }
     }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionsModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionsModal.kt
@@ -246,7 +246,10 @@ private fun TvEpisodeActionsModalPreviewContent(
     actionContext: TvEpisodeActionContext,
 ) {
     TvTheme {
-        CompositionLocalProvider(LocalTvToastHostState provides remember { TvToastHostState() }) {
+        CompositionLocalProvider(
+            LocalTvToastHostState provides remember { TvToastHostState() },
+            LocalOpenNowPlaying provides {},
+        ) {
             TvModalSurface(contentPadding = ContentPadding) {
                 TvEpisodeActionsModalContent(
                     episode = episode,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionsModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionsModal.kt
@@ -68,8 +68,10 @@ private fun ColumnScope.TvEpisodeActionsModalContent(
     }
 
     val toastHostState = LocalTvToastHostState.current
+    val openNowPlaying = LocalOpenNowPlaying.current
     val source = actionContext.source
 
+    val play = stringResource(LR.string.play)
     val episodeDetails = stringResource(LR.string.tv_episode_details)
     val goToPodcast = stringResource(LR.string.go_to_podcast)
     val playNext = stringResource(LR.string.add_to_up_next_top)
@@ -96,6 +98,12 @@ private fun ColumnScope.TvEpisodeActionsModalContent(
 
     val buttons = tvEpisodeActionTypes(actionContext, showGoToPodcast = onGoToPodcast != null).map { button ->
         when (button) {
+            TvEpisodeActionType.Play -> play to {
+                actions.play(episode, source)
+                onDismissRequest()
+                openNowPlaying()
+            }
+
             TvEpisodeActionType.Details -> episodeDetails to onShowEpisodeDetails
 
             TvEpisodeActionType.GoToPodcast -> goToPodcast to {
@@ -136,6 +144,7 @@ private fun ColumnScope.TvEpisodeActionsModalContent(
 }
 
 internal enum class TvEpisodeActionType {
+    Play,
     Details,
     GoToPodcast,
     PlayNext,
@@ -149,12 +158,17 @@ internal fun tvEpisodeActionTypes(
     actionContext: TvEpisodeActionContext,
     showGoToPodcast: Boolean,
 ): List<TvEpisodeActionType> = buildList {
+    if (actionContext != TvEpisodeActionContext.NowPlaying) {
+        add(TvEpisodeActionType.Play)
+    }
     add(TvEpisodeActionType.Details)
     if (showGoToPodcast) {
         add(TvEpisodeActionType.GoToPodcast)
     }
-    add(TvEpisodeActionType.PlayNext)
-    add(TvEpisodeActionType.PlayLast)
+    if (actionContext != TvEpisodeActionContext.NowPlaying) {
+        add(TvEpisodeActionType.PlayNext)
+        add(TvEpisodeActionType.PlayLast)
+    }
     if (actionContext == TvEpisodeActionContext.UpNext) {
         add(TvEpisodeActionType.RemoveFromUpNext)
     } else {
@@ -248,6 +262,7 @@ private fun TvEpisodeActionsModalPreviewContent(
 }
 
 private object NoOpTvEpisodeActions : TvEpisodeActions {
+    override fun play(episode: PodcastEpisode, source: SourceView) = Unit
     override fun playNext(episode: PodcastEpisode, source: SourceView) = Unit
     override fun playLast(episode: PodcastEpisode, source: SourceView) = Unit
     override fun markAsPlayed(episode: PodcastEpisode) = Unit

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionsViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionsViewModel.kt
@@ -20,9 +20,11 @@ enum class TvEpisodeActionContext(val source: SourceView) {
     PodcastDetails(SourceView.PODCAST_SCREEN),
     Playlist(SourceView.FILTERS),
     UpNext(SourceView.UP_NEXT),
+    NowPlaying(SourceView.PLAYER),
 }
 
 interface TvEpisodeActions {
+    fun play(episode: PodcastEpisode, source: SourceView)
     fun playNext(episode: PodcastEpisode, source: SourceView)
     fun playLast(episode: PodcastEpisode, source: SourceView)
     fun markAsPlayed(episode: PodcastEpisode)
@@ -41,6 +43,10 @@ class TvEpisodeActionsViewModel @Inject constructor(
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel(),
     TvEpisodeActions {
+
+    override fun play(episode: PodcastEpisode, source: SourceView) = launchWrite {
+        playbackManager.playNowSuspend(episode = episode, sourceView = source)
+    }
 
     override fun playNext(episode: PodcastEpisode, source: SourceView) = launchWrite {
         playbackManager.playNext(episode = episode, source = source)

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvNowPlayingOpener.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvNowPlayingOpener.kt
@@ -1,0 +1,5 @@
+package au.com.shiftyjelly.pocketcasts.component
+
+import androidx.compose.runtime.staticCompositionLocalOf
+
+val LocalOpenNowPlaying = staticCompositionLocalOf<() -> Unit> { {} }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvNowPlayingOpener.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvNowPlayingOpener.kt
@@ -2,4 +2,6 @@ package au.com.shiftyjelly.pocketcasts.component
 
 import androidx.compose.runtime.staticCompositionLocalOf
 
-val LocalOpenNowPlaying = staticCompositionLocalOf<() -> Unit> { {} }
+val LocalOpenNowPlaying = staticCompositionLocalOf<() -> Unit> {
+    error("LocalOpenNowPlaying was not provided")
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeScreen.kt
@@ -62,6 +62,11 @@ fun TvHomeScreen(
     val toastHostState = LocalTvToastHostState.current
     val playFailedMessage = stringResource(LR.string.error_generic_message)
     LaunchedEffect(Unit) {
+        viewModel.playStarted.collect {
+            openNowPlaying()
+        }
+    }
+    LaunchedEffect(Unit) {
         viewModel.playFailures.collect {
             toastHostState.show(playFailedMessage)
         }
@@ -71,10 +76,7 @@ fun TvHomeScreen(
             uiState = uiState,
             onRetry = viewModel::load,
             onOpenPodcast = { openedPodcastUuid = it },
-            onPlayEpisode = { episode ->
-                viewModel.playEpisode(episode)
-                openNowPlaying()
-            },
+            onPlayEpisode = viewModel::playEpisode,
             modifier = Modifier
                 .fillMaxSize()
                 .padding(top = TvTopBarHeight)

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeScreen.kt
@@ -32,6 +32,7 @@ import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.OutlinedButton
 import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.component.LocalOpenNowPlaying
+import au.com.shiftyjelly.pocketcasts.component.LocalTvToastHostState
 import au.com.shiftyjelly.pocketcasts.component.TvDetailOverlay
 import au.com.shiftyjelly.pocketcasts.component.TvFeaturedTile
 import au.com.shiftyjelly.pocketcasts.component.TvPodcastTile
@@ -58,6 +59,13 @@ fun TvHomeScreen(
 
     val podcastUuid = openedPodcastUuid
     val openNowPlaying = LocalOpenNowPlaying.current
+    val toastHostState = LocalTvToastHostState.current
+    val playFailedMessage = stringResource(LR.string.error_generic_message)
+    LaunchedEffect(Unit) {
+        viewModel.playFailures.collect {
+            toastHostState.show(playFailedMessage)
+        }
+    }
     Box(modifier = modifier.fillMaxSize()) {
         TvHomeContent(
             uiState = uiState,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeScreen.kt
@@ -31,6 +31,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.OutlinedButton
 import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.component.LocalOpenNowPlaying
 import au.com.shiftyjelly.pocketcasts.component.TvDetailOverlay
 import au.com.shiftyjelly.pocketcasts.component.TvFeaturedTile
 import au.com.shiftyjelly.pocketcasts.component.TvPodcastTile
@@ -56,11 +57,16 @@ fun TvHomeScreen(
     var restoreFocusTrigger by remember { mutableIntStateOf(0) }
 
     val podcastUuid = openedPodcastUuid
+    val openNowPlaying = LocalOpenNowPlaying.current
     Box(modifier = modifier.fillMaxSize()) {
         TvHomeContent(
             uiState = uiState,
             onRetry = viewModel::load,
             onOpenPodcast = { openedPodcastUuid = it },
+            onPlayEpisode = { episode ->
+                viewModel.playEpisode(episode)
+                openNowPlaying()
+            },
             modifier = Modifier
                 .fillMaxSize()
                 .padding(top = TvTopBarHeight)
@@ -85,6 +91,7 @@ private fun TvHomeContent(
     uiState: TvHomeUiState,
     onRetry: () -> Unit,
     onOpenPodcast: (String) -> Unit,
+    onPlayEpisode: (TvHomeEpisode) -> Unit,
     modifier: Modifier = Modifier,
     restoreFocusTrigger: Int = 0,
 ) {
@@ -99,6 +106,7 @@ private fun TvHomeContent(
             TvHomeRows(
                 rows = uiState.rows,
                 onOpenPodcast = onOpenPodcast,
+                onPlayEpisode = onPlayEpisode,
                 modifier = modifier,
                 restoreFocusTrigger = restoreFocusTrigger,
             )
@@ -133,6 +141,7 @@ private fun TvHomeError(
 private fun TvHomeRows(
     rows: List<TvHomeRow>,
     onOpenPodcast: (String) -> Unit,
+    onPlayEpisode: (TvHomeEpisode) -> Unit,
     modifier: Modifier = Modifier,
     restoreFocusTrigger: Int = 0,
 ) {
@@ -197,7 +206,7 @@ private fun TvHomeRows(
                             podcastArtworkUrl = episode.podcastArtworkUrl,
                             podcastTitle = episode.podcastTitle,
                             episodeTitle = episode.episodeTitle,
-                            onPlayEpisode = {},
+                            onPlayEpisode = { onPlayEpisode(episode) },
                             onGoToPodcast = { onOpenPodcast(episode.podcastUuid) },
                         )
                     }
@@ -260,6 +269,7 @@ private fun TvHomeContentPreview() {
                 ),
                 onRetry = {},
                 onOpenPodcast = {},
+                onPlayEpisode = {},
             )
         }
     }
@@ -274,6 +284,7 @@ private fun TvHomeErrorPreview() {
                 uiState = TvHomeUiState.Error,
                 onRetry = {},
                 onOpenPodcast = {},
+                onPlayEpisode = {},
             )
         }
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModel.kt
@@ -62,7 +62,10 @@ class TvHomeViewModel @Inject constructor(
     private val _uiState = MutableStateFlow<TvHomeUiState>(TvHomeUiState.Loading)
     val uiState: StateFlow<TvHomeUiState> = _uiState.asStateFlow()
 
-    private val _playFailures = MutableSharedFlow<Unit>()
+    private val _playStarted = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    val playStarted: SharedFlow<Unit> = _playStarted.asSharedFlow()
+
+    private val _playFailures = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
     val playFailures: SharedFlow<Unit> = _playFailures.asSharedFlow()
 
     private var loadJob: Job? = null
@@ -193,15 +196,16 @@ class TvHomeViewModel @Inject constructor(
                     }
                 if (found != null) {
                     playbackManager.playNowSuspend(episode = found, sourceView = SourceView.DISCOVER)
+                    _playStarted.tryEmit(Unit)
                 } else {
                     Timber.e("Episode %s not found to play from TV home", episode.episodeUuid)
-                    _playFailures.emit(Unit)
+                    _playFailures.tryEmit(Unit)
                 }
             } catch (exception: CancellationException) {
                 throw exception
             } catch (exception: Exception) {
                 Timber.e(exception, "Failed to play episode from TV home")
-                _playFailures.emit(Unit)
+                _playFailures.tryEmit(Unit)
             }
         }
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModel.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.home
 import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.db.dao.PodcastDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.UpNextDao
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
@@ -10,8 +11,11 @@ import au.com.shiftyjelly.pocketcasts.models.type.SmartRules
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImage
 import au.com.shiftyjelly.pocketcasts.repositories.lists.ListRepository
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.SmartPlaylistDraft
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverEpisode
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverPodcast
@@ -34,6 +38,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.rx2.asFlow
+import kotlinx.coroutines.rx2.await
 import timber.log.Timber
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -45,6 +50,9 @@ class TvHomeViewModel @Inject constructor(
     private val upNextDao: UpNextDao,
     private val settings: Settings,
     private val syncManager: SyncManager,
+    private val episodeManager: EpisodeManager,
+    private val podcastManager: PodcastManager,
+    private val playbackManager: PlaybackManager,
     @ApplicationContext private val context: Context,
 ) : ViewModel() {
 
@@ -165,6 +173,27 @@ class TvHomeViewModel @Inject constructor(
                         ),
                     )
                 }
+            }
+        }
+    }
+
+    fun playEpisode(episode: TvHomeEpisode) {
+        viewModelScope.launch {
+            try {
+                val found = episodeManager.findByUuid(episode.episodeUuid)
+                    ?: run {
+                        podcastManager.findOrDownloadPodcastRxSingle(episode.podcastUuid).await()
+                        episodeManager.findByUuid(episode.episodeUuid)
+                    }
+                if (found != null) {
+                    playbackManager.playNowSuspend(episode = found, sourceView = SourceView.DISCOVER)
+                } else {
+                    Timber.e("Episode %s not found to play from TV home", episode.episodeUuid)
+                }
+            } catch (exception: CancellationException) {
+                throw exception
+            } catch (exception: Exception) {
+                Timber.e(exception, "Failed to play episode from TV home")
             }
         }
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModel.kt
@@ -31,8 +31,11 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
@@ -58,6 +61,9 @@ class TvHomeViewModel @Inject constructor(
 
     private val _uiState = MutableStateFlow<TvHomeUiState>(TvHomeUiState.Loading)
     val uiState: StateFlow<TvHomeUiState> = _uiState.asStateFlow()
+
+    private val _playFailures = MutableSharedFlow<Unit>()
+    val playFailures: SharedFlow<Unit> = _playFailures.asSharedFlow()
 
     private var loadJob: Job? = null
 
@@ -189,11 +195,13 @@ class TvHomeViewModel @Inject constructor(
                     playbackManager.playNowSuspend(episode = found, sourceView = SourceView.DISCOVER)
                 } else {
                     Timber.e("Episode %s not found to play from TV home", episode.episodeUuid)
+                    _playFailures.emit(Unit)
                 }
             } catch (exception: CancellationException) {
                 throw exception
             } catch (exception: Exception) {
                 Timber.e(exception, "Failed to play episode from TV home")
+                _playFailures.emit(Unit)
             }
         }
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
@@ -54,11 +54,11 @@ fun TvScaffold(
             isTopBarVisible = topBarVisibility.isVisible,
             autoFocusSelectedTab = !didFocusTopBar,
             onSelectedTabFocus = { didFocusTopBar = true },
-            onTabSelect = viewModel::selectTab,
+            onTabSelect = { index -> uiState.tabs.getOrNull(index)?.let(viewModel::selectTab) },
             onProfileClick = { isProfileModalVisible = true },
             modifier = modifier,
         ) { tab ->
-            val navigateToHome = { viewModel.selectTab(TvTab.entries.indexOf(TvTab.Home)) }
+            val navigateToHome = { viewModel.selectTab(TvTab.Home) }
             // Tabs without a detail screen sit below the bar; the detail-bearing tabs pad their own
             // content so their overlays can fill the full height.
             val belowTopBar = Modifier.fillMaxSize().padding(top = TvTopBarHeight)

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
@@ -47,10 +47,17 @@ fun TvScaffold(
     var isProfileModalVisible by rememberSaveable { mutableStateOf(false) }
     val topBarVisibility = remember { TvTopBarVisibility() }
     var didFocusTopBar by rememberSaveable { mutableStateOf(false) }
+    var nowPlayingOpenTrigger by remember { mutableIntStateOf(0) }
+    val openNowPlaying: () -> Unit = remember(viewModel) {
+        {
+            viewModel.openNowPlaying()
+            nowPlayingOpenTrigger++
+        }
+    }
 
     CompositionLocalProvider(
         LocalTvTopBarVisibility provides topBarVisibility,
-        LocalOpenNowPlaying provides viewModel::openNowPlaying,
+        LocalOpenNowPlaying provides openNowPlaying,
     ) {
         TvScaffoldContent(
             tabs = uiState.tabs,
@@ -59,7 +66,7 @@ fun TvScaffold(
             isTopBarVisible = topBarVisibility.isVisible,
             autoFocusSelectedTab = !didFocusTopBar,
             onSelectedTabFocus = { didFocusTopBar = true },
-            onTabSelect = { index -> uiState.tabs.getOrNull(index)?.let(viewModel::selectTab) },
+            onTabSelect = viewModel::selectTab,
             onProfileClick = { isProfileModalVisible = true },
             modifier = modifier,
         ) { tab ->
@@ -80,7 +87,7 @@ fun TvScaffold(
                     TvUpNextScreen(onNavigateToHome = navigateToHome)
                 }
 
-                is TvTab.NowPlaying -> TvNowPlayingScreen()
+                is TvTab.NowPlaying -> TvNowPlayingScreen(openTrigger = nowPlayingOpenTrigger)
 
                 else -> Box(modifier = belowTopBar) {
                     TvTabPlaceholder(tab = tab)
@@ -118,7 +125,7 @@ private fun TvScaffoldContent(
     selectedTabIndex: Int,
     profile: TvProfileState,
     isTopBarVisible: Boolean,
-    onTabSelect: (Int) -> Unit,
+    onTabSelect: (TvTab) -> Unit,
     onProfileClick: () -> Unit,
     modifier: Modifier = Modifier,
     autoFocusSelectedTab: Boolean = true,
@@ -152,7 +159,9 @@ private fun TvScaffoldContent(
                 tabs = tabs,
                 selectedTabIndex = selectedTabIndex,
                 profile = profile,
-                onTabSelect = onTabSelect,
+                // Resolve against the same list this frame rendered, so a click during a tab-list
+                // change cannot land on the wrong tab.
+                onTabSelect = { index -> tabs.getOrNull(index)?.let(onTabSelect) },
                 onProfileClick = onProfileClick,
                 autoFocusSelectedTab = autoFocusSelectedTab,
                 onSelectedTabFocus = onSelectedTabFocus,
@@ -175,7 +184,7 @@ private fun TvScaffoldPreview() {
             selectedTabIndex = selectedIndex,
             profile = TvProfileState.SignedOut,
             isTopBarVisible = true,
-            onTabSelect = { selectedIndex = it },
+            onTabSelect = { selectedIndex = TvTab.entries.indexOf(it) },
             onProfileClick = {},
         ) { tab ->
             Box(modifier = Modifier.fillMaxSize().padding(top = TvTopBarHeight)) {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
@@ -28,6 +28,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import au.com.shiftyjelly.pocketcasts.component.LocalOpenNowPlaying
 import au.com.shiftyjelly.pocketcasts.component.LocalTvTopBarVisibility
 import au.com.shiftyjelly.pocketcasts.component.TvTopBarVisibility
+import au.com.shiftyjelly.pocketcasts.nowplaying.TvNowPlayingScreen
 import au.com.shiftyjelly.pocketcasts.playlists.TvPlaylistsScreen
 import au.com.shiftyjelly.pocketcasts.podcasts.TvYourPodcastsScreen
 import au.com.shiftyjelly.pocketcasts.theme.TvScreenBackgroundBrush
@@ -78,6 +79,8 @@ fun TvScaffold(
                 is TvTab.UpNext -> Box(modifier = belowTopBar) {
                     TvUpNextScreen(onNavigateToHome = navigateToHome)
                 }
+
+                is TvTab.NowPlaying -> TvNowPlayingScreen()
 
                 else -> Box(modifier = belowTopBar) {
                     TvTabPlaceholder(tab = tab)

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import au.com.shiftyjelly.pocketcasts.component.LocalOpenNowPlaying
 import au.com.shiftyjelly.pocketcasts.component.LocalTvTopBarVisibility
 import au.com.shiftyjelly.pocketcasts.component.TvTopBarVisibility
 import au.com.shiftyjelly.pocketcasts.playlists.TvPlaylistsScreen
@@ -46,7 +47,10 @@ fun TvScaffold(
     val topBarVisibility = remember { TvTopBarVisibility() }
     var didFocusTopBar by rememberSaveable { mutableStateOf(false) }
 
-    CompositionLocalProvider(LocalTvTopBarVisibility provides topBarVisibility) {
+    CompositionLocalProvider(
+        LocalTvTopBarVisibility provides topBarVisibility,
+        LocalOpenNowPlaying provides viewModel::openNowPlaying,
+    ) {
         TvScaffoldContent(
             tabs = uiState.tabs,
             selectedTabIndex = uiState.selectedTabIndex,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffoldViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffoldViewModel.kt
@@ -3,30 +3,56 @@ package au.com.shiftyjelly.pocketcasts.home
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.auth.TvSignOutManager
+import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.rx2.asFlow
+import kotlinx.coroutines.withTimeoutOrNull
 
 @HiltViewModel
 class TvScaffoldViewModel @Inject constructor(
     private val syncManager: SyncManager,
     private val signOutManager: TvSignOutManager,
+    upNextQueue: UpNextQueue,
 ) : ViewModel() {
-    private val selectedTabIndex = MutableStateFlow(0)
+    private val selectedTab = MutableStateFlow<TvTab>(TvTab.Home)
+
+    private val hasCurrentEpisode = upNextQueue.changesObservable.asFlow()
+        .map { state -> state is UpNextQueue.State.Loaded }
+        .onStart { emit(false) }
+        .distinctUntilChanged()
+
+    init {
+        viewModelScope.launch {
+            hasCurrentEpisode.collect { hasEpisode ->
+                if (!hasEpisode && selectedTab.value == TvTab.NowPlaying) {
+                    selectedTab.value = TvTab.Home
+                }
+            }
+        }
+    }
 
     val uiState: StateFlow<TvScaffoldUiState> = combine(
-        selectedTabIndex,
+        selectedTab,
+        hasCurrentEpisode,
         syncManager.isLoggedInObservable.asFlow(),
         syncManager.emailFlow(),
-    ) { tabIndex, isLoggedIn, email ->
+    ) { tab, hasEpisode, isLoggedIn, email ->
         TvScaffoldUiState(
-            selectedTabIndex = tabIndex,
+            tabs = TvTab.tabs(showNowPlaying = hasEpisode || tab == TvTab.NowPlaying),
+            selectedTab = tab,
             profile = profileState(isLoggedIn, email),
         )
     }.stateIn(
@@ -35,8 +61,19 @@ class TvScaffoldViewModel @Inject constructor(
         initialValue = TvScaffoldUiState(profile = currentProfileState()),
     )
 
-    fun selectTab(index: Int) {
-        selectedTabIndex.value = index
+    fun selectTab(tab: TvTab) {
+        selectedTab.value = tab
+    }
+
+    fun openNowPlaying() {
+        viewModelScope.launch {
+            val hasEpisode = withTimeoutOrNull(OPEN_NOW_PLAYING_TIMEOUT) {
+                hasCurrentEpisode.first { it }
+            }
+            if (hasEpisode == true) {
+                selectedTab.value = TvTab.NowPlaying
+            }
+        }
     }
 
     fun signOut() {
@@ -50,13 +87,19 @@ class TvScaffoldViewModel @Inject constructor(
     } else {
         TvProfileState.SignedOut
     }
+
+    private companion object {
+        val OPEN_NOW_PLAYING_TIMEOUT = 5.seconds
+    }
 }
 
 data class TvScaffoldUiState(
     val tabs: List<TvTab> = TvTab.entries,
-    val selectedTabIndex: Int = 0,
+    val selectedTab: TvTab = TvTab.Home,
     val profile: TvProfileState = TvProfileState.SignedOut,
-)
+) {
+    val selectedTabIndex: Int get() = tabs.indexOf(selectedTab).coerceAtLeast(0)
+}
 
 sealed interface TvProfileState {
     data object SignedOut : TvProfileState

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffoldViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffoldViewModel.kt
@@ -7,19 +7,14 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
-import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.rx2.asFlow
-import kotlinx.coroutines.withTimeoutOrNull
 
 @HiltViewModel
 class TvScaffoldViewModel @Inject constructor(
@@ -31,8 +26,7 @@ class TvScaffoldViewModel @Inject constructor(
 
     private val hasCurrentEpisode = upNextQueue.changesObservable.asFlow()
         .map { state -> state is UpNextQueue.State.Loaded }
-        .onStart { emit(false) }
-        .distinctUntilChanged()
+        .stateIn(viewModelScope, SharingStarted.Eagerly, false)
 
     init {
         viewModelScope.launch {
@@ -66,14 +60,7 @@ class TvScaffoldViewModel @Inject constructor(
     }
 
     fun openNowPlaying() {
-        viewModelScope.launch {
-            val hasEpisode = withTimeoutOrNull(OPEN_NOW_PLAYING_TIMEOUT) {
-                hasCurrentEpisode.first { it }
-            }
-            if (hasEpisode == true) {
-                selectedTab.value = TvTab.NowPlaying
-            }
-        }
+        selectedTab.value = TvTab.NowPlaying
     }
 
     fun signOut() {
@@ -86,10 +73,6 @@ class TvScaffoldViewModel @Inject constructor(
         TvProfileState.SignedIn(email = email?.takeIf(String::isNotBlank))
     } else {
         TvProfileState.SignedOut
-    }
-
-    private companion object {
-        val OPEN_NOW_PLAYING_TIMEOUT = 5.seconds
     }
 }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvTab.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvTab.kt
@@ -29,12 +29,12 @@ sealed class TvTab(@StringRes val contentDescriptionRes: Int) {
     data object Search : IconTab(contentDescriptionRes = LR.string.search, iconRes = IR.drawable.ic_search)
 
     companion object {
-        val entries: List<TvTab> = listOf(Home, YourPodcasts, Playlists, UpNext, Search)
+        // Built lazily: referencing the nested objects while the TvTab class hierarchy is still
+        // initializing (e.g. TvTab.Home being the first member touched) would capture them as null.
+        val entries: List<TvTab> by lazy { listOf(Home, YourPodcasts, Playlists, UpNext, Search) }
 
-        fun tabs(showNowPlaying: Boolean): List<TvTab> = if (showNowPlaying) {
-            listOf(Home, YourPodcasts, Playlists, UpNext, NowPlaying, Search)
-        } else {
-            entries
-        }
+        private val entriesWithNowPlaying: List<TvTab> by lazy { listOf(Home, YourPodcasts, Playlists, UpNext, NowPlaying, Search) }
+
+        fun tabs(showNowPlaying: Boolean): List<TvTab> = if (showNowPlaying) entriesWithNowPlaying else entries
     }
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvTab.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvTab.kt
@@ -25,9 +25,16 @@ sealed class TvTab(@StringRes val contentDescriptionRes: Int) {
     data object YourPodcasts : TextTab(labelRes = LR.string.tv_tab_your_podcasts)
     data object Playlists : TextTab(labelRes = LR.string.playlists)
     data object UpNext : TextTab(labelRes = LR.string.up_next)
+    data object NowPlaying : TextTab(labelRes = LR.string.player_tab_playing_wide)
     data object Search : IconTab(contentDescriptionRes = LR.string.search, iconRes = IR.drawable.ic_search)
 
     companion object {
         val entries: List<TvTab> = listOf(Home, YourPodcasts, Playlists, UpNext, Search)
+
+        fun tabs(showNowPlaying: Boolean): List<TvTab> = if (showNowPlaying) {
+            listOf(Home, YourPodcasts, Playlists, UpNext, NowPlaying, Search)
+        } else {
+            entries
+        }
     }
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
@@ -10,9 +10,14 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -33,10 +38,15 @@ import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.component.TvArtworkImage
 import au.com.shiftyjelly.pocketcasts.component.TvEmptyState
+import au.com.shiftyjelly.pocketcasts.component.TvEpisodeActionContext
+import au.com.shiftyjelly.pocketcasts.component.TvEpisodeActionsModal
+import au.com.shiftyjelly.pocketcasts.component.TvEpisodeInfoModal
+import au.com.shiftyjelly.pocketcasts.component.TvMoreButton
 import au.com.shiftyjelly.pocketcasts.compose.loading.LoadingView
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
+import au.com.shiftyjelly.pocketcasts.podcasts.TvPodcastDetailsScreen
 import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImage
 import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
 import au.com.shiftyjelly.pocketcasts.theme.TvTheme
@@ -53,6 +63,18 @@ fun TvNowPlayingScreen(
     viewModel: TvNowPlayingViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    var openedPodcastUuid by rememberSaveable { mutableStateOf<String?>(null) }
+
+    val podcastUuid = openedPodcastUuid
+    if (podcastUuid != null) {
+        BackHandler { openedPodcastUuid = null }
+        TvPodcastDetailsScreen(
+            podcastUuid = podcastUuid,
+            onClose = { openedPodcastUuid = null },
+            modifier = modifier,
+        )
+        return
+    }
 
     when (val state = uiState) {
         is TvNowPlayingUiState.Empty -> TvEmptyState(
@@ -68,6 +90,7 @@ fun TvNowPlayingScreen(
             onPlayPause = viewModel::playPause,
             onSkipBackward = viewModel::skipBackward,
             onSkipForward = viewModel::skipForward,
+            onOpenPodcast = { openedPodcastUuid = it },
             modifier = modifier,
         )
     }
@@ -79,8 +102,13 @@ private fun TvNowPlayingContent(
     onPlayPause: () -> Unit,
     onSkipBackward: () -> Unit,
     onSkipForward: () -> Unit,
+    onOpenPodcast: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    var isActionsModalVisible by remember { mutableStateOf(false) }
+    var isDetailsModalVisible by remember { mutableStateOf(false) }
+    val episode = state.episode
+
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -126,8 +154,34 @@ private fun TvNowPlayingContent(
             onPlayPause = onPlayPause,
             onSkipBackward = onSkipBackward,
             onSkipForward = onSkipForward,
+            onOpenActions = if (episode is PodcastEpisode) {
+                { isActionsModalVisible = true }
+            } else {
+                null
+            },
             modifier = Modifier.fillMaxWidth(),
         )
+    }
+
+    if (episode is PodcastEpisode) {
+        if (isActionsModalVisible) {
+            TvEpisodeActionsModal(
+                episode = episode,
+                actionContext = TvEpisodeActionContext.NowPlaying,
+                onDismissRequest = { isActionsModalVisible = false },
+                onShowEpisodeDetails = {
+                    isDetailsModalVisible = true
+                    isActionsModalVisible = false
+                },
+                onGoToPodcast = { onOpenPodcast(episode.podcastUuid) },
+            )
+        }
+        if (isDetailsModalVisible) {
+            TvEpisodeInfoModal(
+                episode = episode,
+                onDismissRequest = { isDetailsModalVisible = false },
+            )
+        }
     }
 }
 
@@ -176,6 +230,7 @@ private fun PlayerControls(
     onPlayPause: () -> Unit,
     onSkipBackward: () -> Unit,
     onSkipForward: () -> Unit,
+    onOpenActions: (() -> Unit)?,
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -198,6 +253,9 @@ private fun PlayerControls(
             contentDescription = stringResource(LR.string.skip_forward),
             onClick = onSkipForward,
         )
+        if (onOpenActions != null) {
+            TvMoreButton(onClick = onOpenActions)
+        }
     }
 }
 
@@ -278,6 +336,7 @@ private fun TvNowPlayingContentPreview() {
             onPlayPause = {},
             onSkipBackward = {},
             onSkipForward = {},
+            onOpenPodcast = {},
         )
     }
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
@@ -1,0 +1,279 @@
+package au.com.shiftyjelly.pocketcasts.nowplaying
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.tv.material3.Icon
+import androidx.tv.material3.IconButton
+import androidx.tv.material3.LocalContentColor
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.component.TvArtworkImage
+import au.com.shiftyjelly.pocketcasts.component.TvEmptyState
+import au.com.shiftyjelly.pocketcasts.compose.loading.LoadingView
+import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
+import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImage
+import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
+import au.com.shiftyjelly.pocketcasts.theme.TvTheme
+import au.com.shiftyjelly.pocketcasts.theme.TvTopBarHeight
+import au.com.shiftyjelly.pocketcasts.theme.tvColors
+import au.com.shiftyjelly.pocketcasts.theme.tvTypography
+import java.util.Date
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+fun TvNowPlayingScreen(
+    modifier: Modifier = Modifier,
+    viewModel: TvNowPlayingViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    when (val state = uiState) {
+        is TvNowPlayingUiState.Empty -> TvEmptyState(
+            title = stringResource(LR.string.tv_nothing_playing_title),
+            subtitle = stringResource(LR.string.tv_nothing_playing_subtitle),
+            modifier = modifier
+                .fillMaxSize()
+                .padding(top = TvTopBarHeight),
+        )
+
+        is TvNowPlayingUiState.Loaded -> TvNowPlayingContent(
+            state = state,
+            onPlayPause = viewModel::playPause,
+            onSkipBackward = viewModel::skipBackward,
+            onSkipForward = viewModel::skipForward,
+            modifier = modifier,
+        )
+    }
+}
+
+@Composable
+private fun TvNowPlayingContent(
+    state: TvNowPlayingUiState.Loaded,
+    onPlayPause: () -> Unit,
+    onSkipBackward: () -> Unit,
+    onSkipForward: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(top = TvTopBarHeight)
+            .padding(horizontal = 80.dp, vertical = 24.dp),
+    ) {
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth(),
+        ) {
+            EpisodeArtworkWithTitles(state = state)
+        }
+        Spacer(modifier = Modifier.height(24.dp))
+        state.errorMessage?.takeIf { state.isError }?.let { errorMessage ->
+            Text(
+                text = errorMessage,
+                style = MaterialTheme.tvTypography.caption1,
+                color = MaterialTheme.tvColors.textSecondary,
+                textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 16.dp),
+            )
+        }
+        TvSeekBar(
+            positionMs = state.positionMs,
+            durationMs = state.durationMs,
+            bufferedMs = state.bufferedMs,
+            onSeekBack = onSkipBackward,
+            onSeekForward = onSkipForward,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        PlayerControls(
+            isPlaying = state.isPlaying,
+            isBuffering = state.isBuffering,
+            onPlayPause = onPlayPause,
+            onSkipBackward = onSkipBackward,
+            onSkipForward = onSkipForward,
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}
+
+@Composable
+private fun EpisodeArtworkWithTitles(
+    state: TvNowPlayingUiState.Loaded,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier,
+    ) {
+        TvArtworkImage(
+            model = state.episode.artworkModel(),
+            modifier = Modifier
+                .size(280.dp)
+                .clip(RoundedCornerShape(8.dp)),
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+        Text(
+            text = state.episode.title,
+            style = MaterialTheme.tvTypography.title3,
+            color = MaterialTheme.tvColors.textPrimary,
+            textAlign = TextAlign.Center,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+        )
+        state.podcastTitle?.let { podcastTitle ->
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = podcastTitle,
+                style = MaterialTheme.tvTypography.caption1,
+                color = MaterialTheme.tvColors.textSecondary,
+                textAlign = TextAlign.Center,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}
+
+@Composable
+private fun PlayerControls(
+    isPlaying: Boolean,
+    isBuffering: Boolean,
+    onPlayPause: () -> Unit,
+    onSkipBackward: () -> Unit,
+    onSkipForward: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(24.dp, Alignment.CenterHorizontally),
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier,
+    ) {
+        PlayerControlButton(
+            iconRes = IR.drawable.wear_skip_back,
+            contentDescription = stringResource(LR.string.skip_back),
+            onClick = onSkipBackward,
+        )
+        PlayPauseButton(
+            isPlaying = isPlaying,
+            isBuffering = isBuffering,
+            onClick = onPlayPause,
+        )
+        PlayerControlButton(
+            iconRes = IR.drawable.wear_skip_foreward,
+            contentDescription = stringResource(LR.string.skip_forward),
+            onClick = onSkipForward,
+        )
+    }
+}
+
+@Composable
+private fun PlayPauseButton(
+    isPlaying: Boolean,
+    isBuffering: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    IconButton(
+        onClick = onClick,
+        colors = TvButtonDefaults.iconButtonColors(),
+        modifier = modifier.size(64.dp),
+    ) {
+        if (isBuffering) {
+            LoadingView(color = LocalContentColor.current)
+        } else {
+            Icon(
+                painter = painterResource(if (isPlaying) IR.drawable.button_pause else IR.drawable.button_play),
+                contentDescription = stringResource(if (isPlaying) LR.string.pause else LR.string.play),
+                modifier = Modifier.size(36.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun PlayerControlButton(
+    iconRes: Int,
+    contentDescription: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    buttonSize: Dp = 56.dp,
+    iconSize: Dp = 24.dp,
+) {
+    IconButton(
+        onClick = onClick,
+        colors = TvButtonDefaults.iconButtonColors(),
+        modifier = modifier.size(buttonSize),
+    ) {
+        Icon(
+            painter = painterResource(iconRes),
+            contentDescription = contentDescription,
+            modifier = Modifier.size(iconSize),
+        )
+    }
+}
+
+private fun BaseEpisode.artworkModel(): Any? = when (this) {
+    is PodcastEpisode -> PodcastImage.getArtworkUrl(size = null, uuid = podcastUuid, isWearOS = false)
+    is UserEpisode -> artworkUrl
+}
+
+@Preview(device = Devices.TV_1080p)
+@Composable
+private fun TvNowPlayingContentPreview() {
+    TvTheme {
+        TvNowPlayingContent(
+            state = TvNowPlayingUiState.Loaded(
+                episode = PodcastEpisode(
+                    uuid = "episode-uuid",
+                    title = "Episode title that might be quite long and wrap onto two lines",
+                    podcastUuid = "podcast-uuid",
+                    publishedDate = Date(0),
+                ),
+                podcastTitle = "Podcast title",
+                isPlaying = true,
+                isBuffering = false,
+                isError = false,
+                errorMessage = null,
+                positionMs = 600_000,
+                durationMs = 3_600_000,
+                bufferedMs = 1_200_000,
+                isVideo = false,
+                player = null,
+            ),
+            onPlayPause = {},
+            onSkipBackward = {},
+            onSkipForward = {},
+        )
+    }
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
@@ -93,7 +93,11 @@ private fun TvNowPlayingContent(
                 .weight(1f)
                 .fillMaxWidth(),
         ) {
-            EpisodeArtworkWithTitles(state = state)
+            if (state.isVideo) {
+                TvVideoSurface(player = state.player)
+            } else {
+                EpisodeArtworkWithTitles(state = state)
+            }
         }
         Spacer(modifier = Modifier.height(24.dp))
         state.errorMessage?.takeIf { state.isError }?.let { errorMessage ->

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
@@ -71,14 +71,20 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 fun TvNowPlayingScreen(
+    openTrigger: Int,
     modifier: Modifier = Modifier,
     viewModel: TvNowPlayingViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     var openedPodcastUuid by rememberSaveable { mutableStateOf<String?>(null) }
 
+    LaunchedEffect(openTrigger) {
+        openedPodcastUuid = null
+    }
+
     val podcastUuid = openedPodcastUuid
     if (podcastUuid != null) {
+        HideTvTopBar()
         BackHandler { openedPodcastUuid = null }
         TvPodcastDetailsScreen(
             podcastUuid = podcastUuid,
@@ -140,20 +146,15 @@ private fun TvNowPlayingContent(
         modifier = modifier
             .fillMaxSize()
             .onPreviewKeyEvent { event ->
-                when {
-                    event.type != KeyEventType.KeyDown || event.key == Key.Back -> false
-
-                    !isChromeVisible -> {
-                        isChromeVisible = true
-                        interactionTick++
-                        true
-                    }
-
-                    else -> {
-                        interactionTick++
-                        false
-                    }
+                if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
+                interactionTick++
+                val revealsChrome = !isChromeVisible
+                if (revealsChrome) {
+                    isChromeVisible = true
                 }
+                // Only navigation presses are swallowed by the reveal; media and back keys keep
+                // their effect even while the chrome is hidden.
+                revealsChrome && event.key in chromeRevealConsumedKeys
             }
             .padding(top = TvTopBarHeight)
             .padding(horizontal = 80.dp, vertical = 24.dp),
@@ -167,12 +168,12 @@ private fun TvNowPlayingContent(
             if (state.isVideo) {
                 TvVideoSurface(player = state.player)
             } else {
-                EpisodeArtworkWithTitles(state = state)
+                EpisodeArtworkWithTitles(episode = episode, podcastTitle = state.podcastTitle)
             }
         }
         Spacer(modifier = Modifier.height(24.dp))
         Column(modifier = Modifier.graphicsLayer { alpha = chromeAlpha }) {
-            state.errorMessage?.takeIf { state.isError }?.let { errorMessage ->
+            state.errorMessage?.let { errorMessage ->
                 Text(
                     text = errorMessage,
                     style = MaterialTheme.tvTypography.caption1,
@@ -232,7 +233,8 @@ private fun TvNowPlayingContent(
 
 @Composable
 private fun EpisodeArtworkWithTitles(
-    state: TvNowPlayingUiState.Loaded,
+    episode: BaseEpisode,
+    podcastTitle: String?,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -240,21 +242,21 @@ private fun EpisodeArtworkWithTitles(
         modifier = modifier,
     ) {
         TvArtworkImage(
-            model = state.episode.artworkModel(),
+            model = episode.artworkModel(),
             modifier = Modifier
                 .size(280.dp)
                 .clip(RoundedCornerShape(8.dp)),
         )
         Spacer(modifier = Modifier.height(24.dp))
         Text(
-            text = state.episode.title,
+            text = episode.title,
             style = MaterialTheme.tvTypography.title3,
             color = MaterialTheme.tvColors.textPrimary,
             textAlign = TextAlign.Center,
             maxLines = 2,
             overflow = TextOverflow.Ellipsis,
         )
-        state.podcastTitle?.let { podcastTitle ->
+        podcastTitle?.let { podcastTitle ->
             Spacer(modifier = Modifier.height(8.dp))
             Text(
                 text = podcastTitle,
@@ -352,8 +354,17 @@ private fun PlayerControlButton(
 
 private val CHROME_HIDE_DELAY = 4.seconds
 
+private val chromeRevealConsumedKeys = setOf(
+    Key.DirectionUp,
+    Key.DirectionDown,
+    Key.DirectionLeft,
+    Key.DirectionRight,
+    Key.DirectionCenter,
+    Key.Enter,
+)
+
 private fun BaseEpisode.artworkModel(): Any? = when (this) {
-    is PodcastEpisode -> PodcastImage.getArtworkUrl(size = null, uuid = podcastUuid, isWearOS = false)
+    is PodcastEpisode -> PodcastImage.getMediumArtworkUrl(podcastUuid)
     is UserEpisode -> artworkUrl
 }
 
@@ -372,7 +383,6 @@ private fun TvNowPlayingContentPreview() {
                 podcastTitle = "Podcast title",
                 isPlaying = true,
                 isBuffering = false,
-                isError = false,
                 errorMessage = null,
                 positionMs = 600_000,
                 durationMs = 3_600_000,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
@@ -1,5 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.nowplaying
 
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -10,10 +12,11 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -21,6 +24,12 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -36,6 +45,7 @@ import androidx.tv.material3.IconButton
 import androidx.tv.material3.LocalContentColor
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.component.HideTvTopBar
 import au.com.shiftyjelly.pocketcasts.component.TvArtworkImage
 import au.com.shiftyjelly.pocketcasts.component.TvEmptyState
 import au.com.shiftyjelly.pocketcasts.component.TvEpisodeActionContext
@@ -54,6 +64,8 @@ import au.com.shiftyjelly.pocketcasts.theme.TvTopBarHeight
 import au.com.shiftyjelly.pocketcasts.theme.tvColors
 import au.com.shiftyjelly.pocketcasts.theme.tvTypography
 import java.util.Date
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.delay
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -107,11 +119,42 @@ private fun TvNowPlayingContent(
 ) {
     var isActionsModalVisible by remember { mutableStateOf(false) }
     var isDetailsModalVisible by remember { mutableStateOf(false) }
+    var isChromeVisible by remember { mutableStateOf(true) }
+    var interactionTick by remember { mutableIntStateOf(0) }
     val episode = state.episode
+
+    LaunchedEffect(state.isVideo, state.isPlaying, isActionsModalVisible, isDetailsModalVisible, interactionTick) {
+        if (state.isVideo && state.isPlaying && !isActionsModalVisible && !isDetailsModalVisible) {
+            delay(CHROME_HIDE_DELAY)
+            isChromeVisible = false
+        } else {
+            isChromeVisible = true
+        }
+    }
+    if (!isChromeVisible) {
+        HideTvTopBar()
+    }
+    val chromeAlpha by animateFloatAsState(if (isChromeVisible) 1f else 0f, label = "TvNowPlayingChromeAlpha")
 
     Column(
         modifier = modifier
             .fillMaxSize()
+            .onPreviewKeyEvent { event ->
+                when {
+                    event.type != KeyEventType.KeyDown || event.key == Key.Back -> false
+
+                    !isChromeVisible -> {
+                        isChromeVisible = true
+                        interactionTick++
+                        true
+                    }
+
+                    else -> {
+                        interactionTick++
+                        false
+                    }
+                }
+            }
             .padding(top = TvTopBarHeight)
             .padding(horizontal = 80.dp, vertical = 24.dp),
     ) {
@@ -128,39 +171,41 @@ private fun TvNowPlayingContent(
             }
         }
         Spacer(modifier = Modifier.height(24.dp))
-        state.errorMessage?.takeIf { state.isError }?.let { errorMessage ->
-            Text(
-                text = errorMessage,
-                style = MaterialTheme.tvTypography.caption1,
-                color = MaterialTheme.tvColors.textSecondary,
-                textAlign = TextAlign.Center,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(bottom = 16.dp),
+        Column(modifier = Modifier.graphicsLayer { alpha = chromeAlpha }) {
+            state.errorMessage?.takeIf { state.isError }?.let { errorMessage ->
+                Text(
+                    text = errorMessage,
+                    style = MaterialTheme.tvTypography.caption1,
+                    color = MaterialTheme.tvColors.textSecondary,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(bottom = 16.dp),
+                )
+            }
+            TvSeekBar(
+                positionMs = state.positionMs,
+                durationMs = state.durationMs,
+                bufferedMs = state.bufferedMs,
+                onSeekBack = onSkipBackward,
+                onSeekForward = onSkipForward,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            PlayerControls(
+                isPlaying = state.isPlaying,
+                isBuffering = state.isBuffering,
+                onPlayPause = onPlayPause,
+                onSkipBackward = onSkipBackward,
+                onSkipForward = onSkipForward,
+                onOpenActions = if (episode is PodcastEpisode) {
+                    { isActionsModalVisible = true }
+                } else {
+                    null
+                },
+                modifier = Modifier.fillMaxWidth(),
             )
         }
-        TvSeekBar(
-            positionMs = state.positionMs,
-            durationMs = state.durationMs,
-            bufferedMs = state.bufferedMs,
-            onSeekBack = onSkipBackward,
-            onSeekForward = onSkipForward,
-            modifier = Modifier.fillMaxWidth(),
-        )
-        Spacer(modifier = Modifier.height(16.dp))
-        PlayerControls(
-            isPlaying = state.isPlaying,
-            isBuffering = state.isBuffering,
-            onPlayPause = onPlayPause,
-            onSkipBackward = onSkipBackward,
-            onSkipForward = onSkipForward,
-            onOpenActions = if (episode is PodcastEpisode) {
-                { isActionsModalVisible = true }
-            } else {
-                null
-            },
-            modifier = Modifier.fillMaxWidth(),
-        )
     }
 
     if (episode is PodcastEpisode) {
@@ -304,6 +349,8 @@ private fun PlayerControlButton(
         )
     }
 }
+
+private val CHROME_HIDE_DELAY = 4.seconds
 
 private fun BaseEpisode.artworkModel(): Any? = when (this) {
     is PodcastEpisode -> PodcastImage.getArtworkUrl(size = null, uuid = podcastUuid, isWearOS = false)

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
@@ -23,8 +23,8 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
@@ -78,8 +78,13 @@ fun TvNowPlayingScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     var openedPodcastUuid by rememberSaveable { mutableStateOf<String?>(null) }
 
+    // Skip the first composition so a restored openedPodcastUuid is not cleared.
+    var lastHandledOpenTrigger by remember { mutableIntStateOf(openTrigger) }
     LaunchedEffect(openTrigger) {
-        openedPodcastUuid = null
+        if (openTrigger != lastHandledOpenTrigger) {
+            lastHandledOpenTrigger = openTrigger
+            openedPodcastUuid = null
+        }
     }
 
     val podcastUuid = openedPodcastUuid
@@ -172,7 +177,7 @@ private fun TvNowPlayingContent(
             }
         }
         Spacer(modifier = Modifier.height(24.dp))
-        Column(modifier = Modifier.graphicsLayer { alpha = chromeAlpha }) {
+        Column(modifier = Modifier.alpha(chromeAlpha)) {
             state.errorMessage?.let { errorMessage ->
                 Text(
                     text = errorMessage,
@@ -188,8 +193,8 @@ private fun TvNowPlayingContent(
                 positionMs = state.positionMs,
                 durationMs = state.durationMs,
                 bufferedMs = state.bufferedMs,
-                onSeekBack = onSkipBackward,
-                onSeekForward = onSkipForward,
+                onSkipBack = onSkipBackward,
+                onSkipForward = onSkipForward,
                 modifier = Modifier.fillMaxWidth(),
             )
             Spacer(modifier = Modifier.height(16.dp))

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingViewModel.kt
@@ -31,17 +31,20 @@ class TvNowPlayingViewModel @Inject constructor(
         playbackManager.videoRenderingEnabled,
     ) { playbackState, queueState, player, streamVideoState, videoRenderingEnabled ->
         if (queueState is UpNextQueue.State.Loaded) {
+            val episode = queueState.episode
+            // The queue and playback relays update at different times during an episode switch, so
+            // fall back to the entity's progress until the playback state refers to this episode.
+            val isPlaybackStateCurrent = playbackState.episodeUuid == episode.uuid
             TvNowPlayingUiState.Loaded(
-                episode = queueState.episode,
+                episode = episode,
                 podcastTitle = queueState.podcast?.title,
                 isPlaying = playbackState.isPlaying,
                 isBuffering = playbackState.isBuffering,
-                isError = playbackState.isError,
-                errorMessage = playbackState.lastErrorMessage,
-                positionMs = playbackState.positionMs,
-                durationMs = playbackState.durationMs,
-                bufferedMs = playbackState.bufferedMs,
-                isVideo = isVideo(queueState.episode, streamVideoState, videoRenderingEnabled),
+                errorMessage = playbackState.lastErrorMessage.takeIf { playbackState.isError },
+                positionMs = if (isPlaybackStateCurrent) playbackState.positionMs else episode.playedUpToMs,
+                durationMs = if (isPlaybackStateCurrent) playbackState.durationMs else episode.durationMs,
+                bufferedMs = if (isPlaybackStateCurrent) playbackState.bufferedMs else 0,
+                isVideo = isVideo(episode, streamVideoState, videoRenderingEnabled),
                 player = player,
             )
         } else {
@@ -58,11 +61,17 @@ class TvNowPlayingViewModel @Inject constructor(
     }
 
     fun skipForward() {
-        playbackManager.skipForward(sourceView = SourceView.PLAYER, jumpAmountSeconds = settings.skipForwardInSecs.value)
+        playbackManager.skipForward(
+            sourceView = SourceView.PLAYER,
+            jumpAmountSeconds = settings.skipForwardInSecs.value,
+        )
     }
 
     fun skipBackward() {
-        playbackManager.skipBackward(sourceView = SourceView.PLAYER, jumpAmountSeconds = settings.skipBackInSecs.value)
+        playbackManager.skipBackward(
+            sourceView = SourceView.PLAYER,
+            jumpAmountSeconds = settings.skipBackInSecs.value,
+        )
     }
 
     private fun isVideo(
@@ -84,7 +93,6 @@ sealed interface TvNowPlayingUiState {
         val podcastTitle: String?,
         val isPlaying: Boolean,
         val isBuffering: Boolean,
-        val isError: Boolean,
         val errorMessage: String?,
         val positionMs: Int,
         val durationMs: Int,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingViewModel.kt
@@ -1,0 +1,95 @@
+package au.com.shiftyjelly.pocketcasts.nowplaying
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.playback.Player
+import au.com.shiftyjelly.pocketcasts.repositories.playback.StreamVideoState
+import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.rx2.asFlow
+
+@HiltViewModel
+class TvNowPlayingViewModel @Inject constructor(
+    private val playbackManager: PlaybackManager,
+    private val settings: Settings,
+) : ViewModel() {
+
+    val uiState: StateFlow<TvNowPlayingUiState> = combine(
+        playbackManager.playbackStateFlow,
+        playbackManager.upNextQueue.changesObservable.asFlow(),
+        playbackManager.playerFlow,
+        playbackManager.streamVideoState,
+        playbackManager.videoRenderingEnabled,
+    ) { playbackState, queueState, player, streamVideoState, videoRenderingEnabled ->
+        if (queueState is UpNextQueue.State.Loaded) {
+            TvNowPlayingUiState.Loaded(
+                episode = queueState.episode,
+                podcastTitle = queueState.podcast?.title,
+                isPlaying = playbackState.isPlaying,
+                isBuffering = playbackState.isBuffering,
+                isError = playbackState.isError,
+                errorMessage = playbackState.lastErrorMessage,
+                positionMs = playbackState.positionMs,
+                durationMs = playbackState.durationMs,
+                bufferedMs = playbackState.bufferedMs,
+                isVideo = isVideo(queueState.episode, streamVideoState, videoRenderingEnabled),
+                player = player,
+            )
+        } else {
+            TvNowPlayingUiState.Empty
+        }
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5_000),
+        initialValue = TvNowPlayingUiState.Empty,
+    )
+
+    fun playPause() {
+        playbackManager.playPause(sourceView = SourceView.PLAYER)
+    }
+
+    fun skipForward() {
+        playbackManager.skipForward(sourceView = SourceView.PLAYER, jumpAmountSeconds = settings.skipForwardInSecs.value)
+    }
+
+    fun skipBackward() {
+        playbackManager.skipBackward(sourceView = SourceView.PLAYER, jumpAmountSeconds = settings.skipBackInSecs.value)
+    }
+
+    private fun isVideo(
+        episode: BaseEpisode,
+        streamVideoState: StreamVideoState,
+        videoRenderingEnabled: Boolean,
+    ) = videoRenderingEnabled && when (streamVideoState) {
+        StreamVideoState.HasVideo -> true
+        StreamVideoState.Unknown, StreamVideoState.AudioOnly -> false
+        StreamVideoState.NotVideo -> episode.isVideo
+    }
+}
+
+sealed interface TvNowPlayingUiState {
+    data object Empty : TvNowPlayingUiState
+
+    data class Loaded(
+        val episode: BaseEpisode,
+        val podcastTitle: String?,
+        val isPlaying: Boolean,
+        val isBuffering: Boolean,
+        val isError: Boolean,
+        val errorMessage: String?,
+        val positionMs: Int,
+        val durationMs: Int,
+        val bufferedMs: Int,
+        val isVideo: Boolean,
+        val player: Player?,
+    ) : TvNowPlayingUiState
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvSeekBar.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvSeekBar.kt
@@ -91,7 +91,7 @@ fun TvSeekBar(
                     modifier = Modifier
                         .fillMaxWidth(buffered)
                         .fillMaxHeight()
-                        .background(MaterialTheme.tvColors.backgroundActive20),
+                        .background(MaterialTheme.tvColors.backgroundActive50),
                 )
                 Box(
                     modifier = Modifier

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvSeekBar.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvSeekBar.kt
@@ -29,6 +29,9 @@ import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.type
+import androidx.compose.ui.semantics.ProgressBarRangeInfo
+import androidx.compose.ui.semantics.progressBarRangeInfo
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.MaterialTheme
@@ -43,8 +46,8 @@ fun TvSeekBar(
     positionMs: Int,
     durationMs: Int,
     bufferedMs: Int,
-    onSeekBack: () -> Unit,
-    onSeekForward: () -> Unit,
+    onSkipBack: () -> Unit,
+    onSkipForward: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var isFocused by remember { mutableStateOf(false) }
@@ -60,17 +63,20 @@ fun TvSeekBar(
                 .fillMaxWidth()
                 .height(12.dp)
                 .onFocusChanged { isFocused = it.isFocused }
+                .semantics {
+                    progressBarRangeInfo = ProgressBarRangeInfo(progress, 0f..1f)
+                }
                 .onKeyEvent { event ->
                     when {
-                        event.type != KeyEventType.KeyDown -> false
+                        event.type != KeyEventType.KeyDown || !hasDuration -> false
 
                         event.key == Key.DirectionLeft -> {
-                            onSeekBack()
+                            onSkipBack()
                             true
                         }
 
                         event.key == Key.DirectionRight -> {
-                            onSeekForward()
+                            onSkipForward()
                             true
                         }
 
@@ -143,8 +149,8 @@ private fun TvSeekBarPreview() {
             positionMs = 600_000,
             durationMs = 3_600_000,
             bufferedMs = 1_200_000,
-            onSeekBack = {},
-            onSeekForward = {},
+            onSkipBack = {},
+            onSkipForward = {},
         )
     }
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvSeekBar.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvSeekBar.kt
@@ -1,0 +1,150 @@
+package au.com.shiftyjelly.pocketcasts.nowplaying
+
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.localization.helper.TimeHelper
+import au.com.shiftyjelly.pocketcasts.theme.TvTheme
+import au.com.shiftyjelly.pocketcasts.theme.tvColors
+import au.com.shiftyjelly.pocketcasts.theme.tvTypography
+
+@Composable
+fun TvSeekBar(
+    positionMs: Int,
+    durationMs: Int,
+    bufferedMs: Int,
+    onSeekBack: () -> Unit,
+    onSeekForward: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var isFocused by remember { mutableStateOf(false) }
+    val hasDuration = durationMs > 0
+    val progress = if (hasDuration) (positionMs.toFloat() / durationMs).coerceIn(0f, 1f) else 0f
+    val buffered = if (hasDuration) (bufferedMs.toFloat() / durationMs).coerceIn(0f, 1f) else 0f
+    val trackHeight by animateDpAsState(if (isFocused) 8.dp else 4.dp, label = "TvSeekBarTrackHeight")
+
+    Column(modifier = modifier) {
+        BoxWithConstraints(
+            contentAlignment = Alignment.CenterStart,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(12.dp)
+                .onFocusChanged { isFocused = it.isFocused }
+                .onKeyEvent { event ->
+                    when {
+                        event.type != KeyEventType.KeyDown -> false
+
+                        event.key == Key.DirectionLeft -> {
+                            onSeekBack()
+                            true
+                        }
+
+                        event.key == Key.DirectionRight -> {
+                            onSeekForward()
+                            true
+                        }
+
+                        else -> false
+                    }
+                }
+                .focusable(),
+        ) {
+            val thumbSize = 12.dp
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(trackHeight)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.tvColors.backgroundActive20),
+            ) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth(buffered)
+                        .fillMaxHeight()
+                        .background(MaterialTheme.tvColors.backgroundActive20),
+                )
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth(progress)
+                        .fillMaxHeight()
+                        .background(MaterialTheme.tvColors.backgroundActive),
+                )
+            }
+            if (isFocused) {
+                Box(
+                    modifier = Modifier
+                        .offset(x = (maxWidth - thumbSize) * progress)
+                        .size(thumbSize)
+                        .clip(CircleShape)
+                        .background(MaterialTheme.tvColors.backgroundActive),
+                )
+            }
+        }
+        Row(
+            horizontalArrangement = Arrangement.SpaceBetween,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 8.dp),
+        ) {
+            SeekBarLabel(text = TimeHelper.formattedSeconds(positionMs / 1000.0))
+            SeekBarLabel(text = if (hasDuration) TimeHelper.formattedSeconds(durationMs / 1000.0) else "-")
+        }
+    }
+}
+
+@Composable
+private fun SeekBarLabel(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = text,
+        style = MaterialTheme.tvTypography.caption2,
+        color = MaterialTheme.tvColors.textSecondary,
+        modifier = modifier,
+    )
+}
+
+@Preview(widthDp = 600)
+@Composable
+private fun TvSeekBarPreview() {
+    TvTheme {
+        TvSeekBar(
+            positionMs = 600_000,
+            durationMs = 3_600_000,
+            bufferedMs = 1_200_000,
+            onSeekBack = {},
+            onSeekForward = {},
+        )
+    }
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvVideoSurface.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvVideoSurface.kt
@@ -1,0 +1,133 @@
+package au.com.shiftyjelly.pocketcasts.nowplaying
+
+import android.content.Context
+import android.view.SurfaceHolder
+import android.view.SurfaceView
+import android.widget.FrameLayout
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.AndroidView
+import au.com.shiftyjelly.pocketcasts.repositories.playback.Player
+import au.com.shiftyjelly.pocketcasts.repositories.playback.SimplePlayer
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
+
+@Composable
+fun TvVideoSurface(
+    player: Player?,
+    modifier: Modifier = Modifier,
+) {
+    var aspectRatio by remember { mutableFloatStateOf(DEFAULT_ASPECT_RATIO) }
+    AndroidView(
+        factory = { context -> TvVideoView(context) },
+        update = { view ->
+            view.onAspectRatioChanged = { ratio -> aspectRatio = ratio }
+            view.player = player
+            view.connectWithDelay()
+        },
+        onRelease = { view -> view.releaseSurface() },
+        modifier = modifier.aspectRatio(aspectRatio),
+    )
+}
+
+private const val DEFAULT_ASPECT_RATIO = 1.78f
+
+// The surface handling mirrors the mobile player's VideoView. That view lives in the player
+// feature module whose Hilt graph cannot be linked into the TV app, hence this local copy.
+private class TvVideoView(
+    context: Context,
+) : FrameLayout(context),
+    SurfaceHolder.Callback,
+    SimplePlayer.VideoChangedListener {
+
+    var player: Player? = null
+    var onAspectRatioChanged: ((Float) -> Unit)? = null
+
+    private var isSurfaceCreated = false
+    private var isSurfaceConnectionPending = false
+    private var isSurfaceConnected = false
+
+    private val surfaceView = SurfaceView(context).also { view ->
+        addView(view, LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT))
+        view.holder.addCallback(this)
+    }
+
+    override fun onDetachedFromWindow() {
+        releaseSurface()
+        super.onDetachedFromWindow()
+    }
+
+    fun releaseSurface() {
+        (player as? SimplePlayer)?.setDisplay(null)
+        isSurfaceConnected = false
+        isSurfaceConnectionPending = false
+    }
+
+    fun connectWithDelay() {
+        if (isSurfaceConnected) {
+            return
+        }
+        isSurfaceConnectionPending = true
+
+        // The delay prevents the race condition where the surface gets destroyed immediately
+        // after creation while a screen transition is still running.
+        postDelayed({
+            if (isSurfaceConnectionPending) {
+                try {
+                    connect()
+                } catch (e: Exception) {
+                    LogBuffer.e(TAG, "Failed to connect video surface", e)
+                }
+            }
+            isSurfaceConnectionPending = false
+        }, SURFACE_CONNECT_DELAY_MS)
+    }
+
+    private fun connect() {
+        if (!isSurfaceCreated || isSurfaceConnected || !isSurfaceConnectionPending) {
+            return
+        }
+
+        val player = this.player as? SimplePlayer
+        if (player == null || !player.supportsVideo() || player.isRemote || player.isPip) {
+            return
+        }
+
+        player.setVideoSizeChangedListener(this)
+        if (player.setDisplay(surfaceView)) {
+            isSurfaceConnected = true
+        }
+    }
+
+    override fun videoSizeChanged(width: Int, height: Int, pixelWidthHeightRatio: Float) {
+        val videoAspectRatio = if (height == 0 || width == 0) 1f else width * pixelWidthHeightRatio / height
+        onAspectRatioChanged?.invoke(videoAspectRatio)
+    }
+
+    override fun videoNeedsReset() {
+        isSurfaceConnected = false
+    }
+
+    override fun surfaceCreated(holder: SurfaceHolder) {
+        isSurfaceCreated = true
+        isSurfaceConnected = false
+        connectWithDelay()
+    }
+
+    override fun surfaceDestroyed(holder: SurfaceHolder) {
+        isSurfaceCreated = false
+        isSurfaceConnected = false
+        isSurfaceConnectionPending = false
+    }
+
+    override fun surfaceChanged(holder: SurfaceHolder, format: Int, width: Int, height: Int) = Unit
+
+    companion object {
+        private const val SURFACE_CONNECT_DELAY_MS = 300L
+        private const val TAG = "TvVideoView"
+    }
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvVideoSurface.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvVideoSurface.kt
@@ -68,7 +68,7 @@ private class TvVideoView(
     }
 
     fun connectWithDelay() {
-        if (isSurfaceConnected) {
+        if (isSurfaceConnected || isSurfaceConnectionPending) {
             return
         }
         isSurfaceConnectionPending = true

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextScreen.kt
@@ -33,6 +33,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.component.LocalOpenNowPlaying
 import au.com.shiftyjelly.pocketcasts.component.TvEmptyState
 import au.com.shiftyjelly.pocketcasts.component.TvEpisodeActionContext
 import au.com.shiftyjelly.pocketcasts.component.TvEpisodeActionsModal
@@ -72,10 +73,15 @@ fun TvUpNextScreen(
             modifier = modifier,
         )
     } else {
+        val openNowPlaying = LocalOpenNowPlaying.current
         TvUpNextContent(
             uiState = uiState,
             onNavigateToHome = onNavigateToHome,
             onOpenPodcast = { openedPodcastUuid = it },
+            onPlayEpisode = { episode ->
+                viewModel.play(episode)
+                openNowPlaying()
+            },
             modifier = modifier,
         )
     }
@@ -86,6 +92,7 @@ private fun TvUpNextContent(
     uiState: TvUpNextUiState,
     onNavigateToHome: () -> Unit,
     onOpenPodcast: (String) -> Unit,
+    onPlayEpisode: (PodcastEpisode) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Box(modifier = modifier.fillMaxSize()) {
@@ -105,6 +112,7 @@ private fun TvUpNextContent(
                 UpNextList(
                     episodes = uiState.episodes,
                     onOpenPodcast = onOpenPodcast,
+                    onPlayEpisode = onPlayEpisode,
                 )
             }
         }
@@ -115,6 +123,7 @@ private fun TvUpNextContent(
 private fun UpNextList(
     episodes: List<PodcastEpisode>,
     onOpenPodcast: (String) -> Unit,
+    onPlayEpisode: (PodcastEpisode) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
@@ -145,7 +154,7 @@ private fun UpNextList(
                 TvEpisodeListItem(
                     episode = episode,
                     dateFormatter = dateFormatter,
-                    onClick = {},
+                    onClick = { onPlayEpisode(episode) },
                     onOpenActions = {
                         focus.watchForRemoval(episodes, index)
                         actionsEpisode = episode
@@ -244,6 +253,7 @@ private fun TvUpNextLoadedPreview() {
                 ),
                 onNavigateToHome = {},
                 onOpenPodcast = {},
+                onPlayEpisode = {},
             )
         }
     }
@@ -258,6 +268,7 @@ private fun TvUpNextEmptyPreview() {
                 uiState = TvUpNextUiState.Empty,
                 onNavigateToHome = {},
                 onOpenPodcast = {},
+                onPlayEpisode = {},
             )
         }
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextViewModel.kt
@@ -14,12 +14,15 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.WhileSubscribed
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.rx2.asFlow
+import timber.log.Timber
 
 @HiltViewModel
 class TvUpNextViewModel @Inject constructor(
@@ -52,7 +55,15 @@ class TvUpNextViewModel @Inject constructor(
     }
 
     fun play(episode: PodcastEpisode) {
-        playbackManager.playNow(episode, sourceView = SourceView.UP_NEXT)
+        viewModelScope.launch {
+            try {
+                playbackManager.playNowSuspend(episode = episode, sourceView = SourceView.UP_NEXT)
+            } catch (exception: CancellationException) {
+                throw exception
+            } catch (exception: Exception) {
+                Timber.e(exception, "Failed to play episode from TV up next")
+            }
+        }
     }
 }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextViewModel.kt
@@ -3,7 +3,9 @@ package au.com.shiftyjelly.pocketcasts.upnext
 import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.UpNextSyncWorker
@@ -24,6 +26,7 @@ class TvUpNextViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
     private val syncManager: SyncManager,
     private val upNextQueue: UpNextQueue,
+    private val playbackManager: PlaybackManager,
 ) : ViewModel() {
 
     val uiState: StateFlow<TvUpNextUiState> = upNextQueue.changesObservable.asFlow()
@@ -46,6 +49,10 @@ class TvUpNextViewModel @Inject constructor(
 
     fun onShown() {
         UpNextSyncWorker.enqueue(syncManager, context)
+    }
+
+    fun play(episode: PodcastEpisode) {
+        playbackManager.playNow(episode, sourceView = SourceView.UP_NEXT)
     }
 }
 

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/TvScaffoldViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/TvScaffoldViewModelTest.kt
@@ -5,12 +5,18 @@ import au.com.shiftyjelly.pocketcasts.auth.TvSignOutManager
 import au.com.shiftyjelly.pocketcasts.home.TvProfileState
 import au.com.shiftyjelly.pocketcasts.home.TvScaffoldViewModel
 import au.com.shiftyjelly.pocketcasts.home.TvTab
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import com.jakewharton.rxrelay2.BehaviorRelay
+import io.reactivex.subjects.BehaviorSubject
+import java.util.Date
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Rule
@@ -36,36 +42,123 @@ class TvScaffoldViewModelTest {
     }
     private val signOutManager = mock<TvSignOutManager>()
 
+    private val queueChanges = BehaviorSubject.create<UpNextQueue.State>()
+    private val upNextQueue = mock<UpNextQueue> {
+        on { changesObservable } doReturn queueChanges
+    }
+
+    private val loadedQueue = UpNextQueue.State.Loaded(
+        episode = PodcastEpisode(uuid = "episode", publishedDate = Date(0)),
+        podcast = null,
+        queue = emptyList(),
+    )
+
     private val viewModel by lazy {
-        TvScaffoldViewModel(syncManager, signOutManager)
+        TvScaffoldViewModel(syncManager, signOutManager, upNextQueue)
     }
 
     @Test
-    fun `initial state has all tabs with first tab selected`() = runTest {
+    fun `initial state has the default tabs with home selected`() = runTest {
         viewModel.uiState.test {
             val state = awaitItem()
             assertEquals(TvTab.entries, state.tabs)
+            assertEquals(TvTab.Home, state.selectedTab)
             assertEquals(0, state.selectedTabIndex)
         }
     }
 
     @Test
-    fun `selectTab updates selected index`() = runTest {
+    fun `selectTab updates the selected tab`() = runTest {
         viewModel.uiState.test {
-            assertEquals(0, awaitItem().selectedTabIndex)
+            assertEquals(TvTab.Home, awaitItem().selectedTab)
 
-            viewModel.selectTab(2)
-            assertEquals(2, awaitItem().selectedTabIndex)
+            viewModel.selectTab(TvTab.Playlists)
+            val state = awaitItem()
+            assertEquals(TvTab.Playlists, state.selectedTab)
+            assertEquals(2, state.selectedTabIndex)
         }
     }
 
     @Test
-    fun `selectTab to same index does not emit new state`() = runTest {
+    fun `selectTab with the same tab does not emit new state`() = runTest {
         viewModel.uiState.test {
-            assertEquals(0, awaitItem().selectedTabIndex)
+            assertEquals(TvTab.Home, awaitItem().selectedTab)
 
-            viewModel.selectTab(0)
+            viewModel.selectTab(TvTab.Home)
             expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `now playing tab appears between up next and search when the queue loads`() = runTest {
+        viewModel.uiState.test {
+            assertEquals(TvTab.entries, awaitItem().tabs)
+
+            queueChanges.onNext(loadedQueue)
+
+            assertEquals(
+                listOf(TvTab.Home, TvTab.YourPodcasts, TvTab.Playlists, TvTab.UpNext, TvTab.NowPlaying, TvTab.Search),
+                awaitItem().tabs,
+            )
+        }
+    }
+
+    @Test
+    fun `now playing tab hides when the queue empties`() = runTest {
+        queueChanges.onNext(loadedQueue)
+
+        viewModel.uiState.test {
+            assertEquals(true, awaitItem().tabs.contains(TvTab.NowPlaying))
+
+            queueChanges.onNext(UpNextQueue.State.Empty)
+
+            assertEquals(TvTab.entries, awaitItem().tabs)
+        }
+    }
+
+    @Test
+    fun `openNowPlaying selects the now playing tab once the queue loads`() = runTest {
+        viewModel.uiState.test {
+            assertEquals(TvTab.Home, awaitItem().selectedTab)
+
+            viewModel.openNowPlaying()
+            queueChanges.onNext(loadedQueue)
+
+            val state = expectMostRecentItem()
+            assertEquals(TvTab.NowPlaying, state.selectedTab)
+            assertEquals(4, state.selectedTabIndex)
+        }
+    }
+
+    @Test
+    fun `openNowPlaying does nothing when playback never starts`() = runTest {
+        viewModel.uiState.test {
+            assertEquals(TvTab.Home, awaitItem().selectedTab)
+
+            viewModel.openNowPlaying()
+            advanceTimeBy(6.seconds)
+            queueChanges.onNext(loadedQueue)
+
+            val state = expectMostRecentItem()
+            assertEquals(TvTab.Home, state.selectedTab)
+        }
+    }
+
+    @Test
+    fun `redirects to home when the queue empties while on now playing`() = runTest {
+        queueChanges.onNext(loadedQueue)
+
+        viewModel.uiState.test {
+            awaitItem()
+
+            viewModel.selectTab(TvTab.NowPlaying)
+            assertEquals(TvTab.NowPlaying, awaitItem().selectedTab)
+
+            queueChanges.onNext(UpNextQueue.State.Empty)
+
+            val state = expectMostRecentItem()
+            assertEquals(TvTab.Home, state.selectedTab)
+            assertEquals(TvTab.entries, state.tabs)
         }
     }
 

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/TvScaffoldViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/TvScaffoldViewModelTest.kt
@@ -12,11 +12,9 @@ import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import com.jakewharton.rxrelay2.BehaviorRelay
 import io.reactivex.subjects.BehaviorSubject
 import java.util.Date
-import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Rule
@@ -117,7 +115,20 @@ class TvScaffoldViewModelTest {
     }
 
     @Test
-    fun `openNowPlaying selects the now playing tab once the queue loads`() = runTest {
+    fun `openNowPlaying selects the now playing tab immediately`() = runTest {
+        viewModel.uiState.test {
+            assertEquals(TvTab.Home, awaitItem().selectedTab)
+
+            viewModel.openNowPlaying()
+
+            val state = expectMostRecentItem()
+            assertEquals(TvTab.NowPlaying, state.selectedTab)
+            assertEquals(true, state.tabs.contains(TvTab.NowPlaying))
+        }
+    }
+
+    @Test
+    fun `openNowPlaying keeps the tab selected while the queue loads`() = runTest {
         viewModel.uiState.test {
             assertEquals(TvTab.Home, awaitItem().selectedTab)
 
@@ -127,20 +138,6 @@ class TvScaffoldViewModelTest {
             val state = expectMostRecentItem()
             assertEquals(TvTab.NowPlaying, state.selectedTab)
             assertEquals(4, state.selectedTabIndex)
-        }
-    }
-
-    @Test
-    fun `openNowPlaying does nothing when playback never starts`() = runTest {
-        viewModel.uiState.test {
-            assertEquals(TvTab.Home, awaitItem().selectedTab)
-
-            viewModel.openNowPlaying()
-            advanceTimeBy(6.seconds)
-            queueChanges.onNext(loadedQueue)
-
-            val state = expectMostRecentItem()
-            assertEquals(TvTab.Home, state.selectedTab)
         }
     }
 

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionTypeTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionTypeTest.kt
@@ -12,6 +12,7 @@ class TvEpisodeActionTypeTest {
 
         assertEquals(
             listOf(
+                TvEpisodeActionType.Play,
                 TvEpisodeActionType.Details,
                 TvEpisodeActionType.PlayNext,
                 TvEpisodeActionType.PlayLast,
@@ -28,6 +29,7 @@ class TvEpisodeActionTypeTest {
 
         assertEquals(
             listOf(
+                TvEpisodeActionType.Play,
                 TvEpisodeActionType.Details,
                 TvEpisodeActionType.GoToPodcast,
                 TvEpisodeActionType.PlayNext,
@@ -45,11 +47,27 @@ class TvEpisodeActionTypeTest {
 
         assertEquals(
             listOf(
+                TvEpisodeActionType.Play,
                 TvEpisodeActionType.Details,
                 TvEpisodeActionType.GoToPodcast,
                 TvEpisodeActionType.PlayNext,
                 TvEpisodeActionType.PlayLast,
                 TvEpisodeActionType.RemoveFromUpNext,
+            ),
+            actions,
+        )
+    }
+
+    @Test
+    fun `now playing shows the current episode actions without play or queue actions`() {
+        val actions = tvEpisodeActionTypes(TvEpisodeActionContext.NowPlaying, showGoToPodcast = true)
+
+        assertEquals(
+            listOf(
+                TvEpisodeActionType.Details,
+                TvEpisodeActionType.GoToPodcast,
+                TvEpisodeActionType.TogglePlayed,
+                TvEpisodeActionType.ToggleArchived,
             ),
             actions,
         )

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionsViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionsViewModelTest.kt
@@ -42,6 +42,13 @@ class TvEpisodeActionsViewModelTest {
     )
 
     @Test
+    fun `play starts playback of the episode`() = runTest {
+        viewModel().play(episode, SourceView.UP_NEXT)
+
+        verifyBlocking(playbackManager) { playNowSuspend(episode = episode, sourceView = SourceView.UP_NEXT) }
+    }
+
+    @Test
     fun `playNext adds episode to the top of the queue`() = runTest {
         viewModel().playNext(episode, SourceView.UP_NEXT)
 

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModelTest.kt
@@ -525,6 +525,19 @@ class TvHomeViewModelTest {
     }
 
     @Test
+    fun `playEpisode reports when playback has started`() = runTest {
+        val episode = episode("episode-1", podcastUuid = "podcast-1")
+        whenever(episodeManager.findByUuid("episode-1")).thenReturn(episode)
+        val viewModel = createViewModel()
+
+        viewModel.playStarted.test {
+            viewModel.playEpisode(homeEpisode())
+
+            awaitItem()
+        }
+    }
+
+    @Test
     fun `playEpisode reports a failure when the podcast fetch fails`() = runTest {
         whenever(episodeManager.findByUuid("episode-1")).thenReturn(null)
         whenever(podcastManager.findOrDownloadPodcastRxSingle("podcast-1")).thenReturn(Single.error(RuntimeException("boom")))

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModelTest.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.home
 import android.content.Context
 import android.content.res.Resources
 import app.cash.turbine.test
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.db.dao.PodcastDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.UpNextDao
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
@@ -12,7 +13,10 @@ import au.com.shiftyjelly.pocketcasts.models.to.PlaylistEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
 import au.com.shiftyjelly.pocketcasts.repositories.lists.ListRepository
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.servers.model.Discover
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverEpisode
@@ -25,6 +29,7 @@ import au.com.shiftyjelly.pocketcasts.servers.model.ListFeed
 import au.com.shiftyjelly.pocketcasts.servers.model.ListType
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import com.jakewharton.rxrelay2.BehaviorRelay
+import io.reactivex.Single
 import java.util.Date
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
@@ -40,6 +45,8 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyBlocking
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -75,6 +82,9 @@ class TvHomeViewModelTest {
     private val settings = mock<Settings> {
         whenever(it.discoverCountryCode).thenReturn(discoverCountryCode)
     }
+    private val episodeManager = mock<EpisodeManager>()
+    private val podcastManager = mock<PodcastManager>()
+    private val playbackManager = mock<PlaybackManager>()
 
     @Test
     fun `all rows load in feed order`() = runTest {
@@ -492,6 +502,45 @@ class TvHomeViewModelTest {
         }
     }
 
+    @Test
+    fun `playEpisode plays an episode that is already in the database`() = runTest {
+        val episode = episode("episode-1", podcastUuid = "podcast-1")
+        whenever(episodeManager.findByUuid("episode-1")).thenReturn(episode)
+
+        createViewModel().playEpisode(homeEpisode())
+
+        verifyBlocking(playbackManager) { playNowSuspend(episode = episode, sourceView = SourceView.DISCOVER) }
+        verify(podcastManager, never()).findOrDownloadPodcastRxSingle(any(), any())
+    }
+
+    @Test
+    fun `playEpisode fetches the podcast before playing an unknown episode`() = runTest {
+        val episode = episode("episode-1", podcastUuid = "podcast-1")
+        whenever(episodeManager.findByUuid("episode-1")).thenReturn(null, episode)
+        whenever(podcastManager.findOrDownloadPodcastRxSingle("podcast-1")).thenReturn(Single.just(Podcast(uuid = "podcast-1")))
+
+        createViewModel().playEpisode(homeEpisode())
+
+        verifyBlocking(playbackManager) { playNowSuspend(episode = episode, sourceView = SourceView.DISCOVER) }
+    }
+
+    @Test
+    fun `playEpisode does not start playback when the podcast fetch fails`() = runTest {
+        whenever(episodeManager.findByUuid("episode-1")).thenReturn(null)
+        whenever(podcastManager.findOrDownloadPodcastRxSingle("podcast-1")).thenReturn(Single.error(RuntimeException("boom")))
+
+        createViewModel().playEpisode(homeEpisode())
+
+        verifyNoInteractions(playbackManager)
+    }
+
+    private fun homeEpisode() = TvHomeEpisode(
+        episodeUuid = "episode-1",
+        episodeTitle = "Episode",
+        podcastUuid = "podcast-1",
+        podcastTitle = "Podcast",
+    )
+
     private fun createViewModel() = TvHomeViewModel(
         listRepository = listRepository,
         playlistManager = playlistManager,
@@ -499,6 +548,9 @@ class TvHomeViewModelTest {
         upNextDao = upNextDao,
         settings = settings,
         syncManager = syncManager,
+        episodeManager = episodeManager,
+        podcastManager = podcastManager,
+        playbackManager = playbackManager,
         context = context,
     )
 

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModelTest.kt
@@ -525,13 +525,17 @@ class TvHomeViewModelTest {
     }
 
     @Test
-    fun `playEpisode does not start playback when the podcast fetch fails`() = runTest {
+    fun `playEpisode reports a failure when the podcast fetch fails`() = runTest {
         whenever(episodeManager.findByUuid("episode-1")).thenReturn(null)
         whenever(podcastManager.findOrDownloadPodcastRxSingle("podcast-1")).thenReturn(Single.error(RuntimeException("boom")))
+        val viewModel = createViewModel()
 
-        createViewModel().playEpisode(homeEpisode())
+        viewModel.playFailures.test {
+            viewModel.playEpisode(homeEpisode())
 
-        verifyNoInteractions(playbackManager)
+            awaitItem()
+            verifyNoInteractions(playbackManager)
+        }
     }
 
     private fun homeEpisode() = TvHomeEpisode(

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingViewModelTest.kt
@@ -1,0 +1,181 @@
+package au.com.shiftyjelly.pocketcasts.nowplaying
+
+import app.cash.turbine.test
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
+import au.com.shiftyjelly.pocketcasts.repositories.playback.Player
+import au.com.shiftyjelly.pocketcasts.repositories.playback.StreamVideoState
+import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
+import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import io.reactivex.subjects.BehaviorSubject
+import java.util.Date
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TvNowPlayingViewModelTest {
+
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
+
+    private val playbackStates = MutableStateFlow(PlaybackState())
+    private val queueChanges = BehaviorSubject.create<UpNextQueue.State>()
+    private val players = MutableStateFlow<Player?>(null)
+    private val streamVideoStates = MutableStateFlow(StreamVideoState.NotVideo)
+    private val videoRenderingEnabledStates = MutableStateFlow(true)
+
+    private val queue = mock<UpNextQueue> {
+        on { changesObservable } doReturn queueChanges
+    }
+    private val playbackManager = mock<PlaybackManager> {
+        on { playbackStateFlow } doReturn playbackStates
+        on { upNextQueue } doReturn queue
+        on { playerFlow } doReturn players
+        on { streamVideoState } doReturn streamVideoStates
+        on { videoRenderingEnabled } doReturn videoRenderingEnabledStates
+    }
+
+    private val skipForwardSetting = mock<UserSetting<Int>> { on { value } doReturn 30 }
+    private val skipBackSetting = mock<UserSetting<Int>> { on { value } doReturn 10 }
+    private val settings = mock<Settings> {
+        on { skipForwardInSecs } doReturn skipForwardSetting
+        on { skipBackInSecs } doReturn skipBackSetting
+    }
+
+    private val audioEpisode = PodcastEpisode(uuid = "audio", publishedDate = Date(0))
+    private val videoEpisode = PodcastEpisode(uuid = "video", publishedDate = Date(0), fileType = "video/mp4")
+
+    private val viewModel by lazy { TvNowPlayingViewModel(playbackManager, settings) }
+
+    @Test
+    fun `an empty queue maps to the empty state`() = runTest {
+        viewModel.uiState.test {
+            assertEquals(TvNowPlayingUiState.Empty, awaitItem())
+
+            queueChanges.onNext(UpNextQueue.State.Empty)
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `a loaded queue maps the playback state`() = runTest {
+        queueChanges.onNext(UpNextQueue.State.Loaded(audioEpisode, Podcast(uuid = "podcast", title = "Podcast"), emptyList()))
+        playbackStates.value = PlaybackState(
+            state = PlaybackState.State.PLAYING,
+            isBuffering = true,
+            positionMs = 1_000,
+            durationMs = 60_000,
+            bufferedMs = 5_000,
+        )
+
+        viewModel.uiState.test {
+            val state = awaitItem() as TvNowPlayingUiState.Loaded
+            assertEquals(audioEpisode, state.episode)
+            assertEquals("Podcast", state.podcastTitle)
+            assertEquals(true, state.isPlaying)
+            assertEquals(true, state.isBuffering)
+            assertEquals(false, state.isError)
+            assertEquals(1_000, state.positionMs)
+            assertEquals(60_000, state.durationMs)
+            assertEquals(5_000, state.bufferedMs)
+            assertEquals(false, state.isVideo)
+        }
+    }
+
+    @Test
+    fun `an error playback state is exposed`() = runTest {
+        queueChanges.onNext(UpNextQueue.State.Loaded(audioEpisode, null, emptyList()))
+        playbackStates.value = PlaybackState(
+            state = PlaybackState.State.ERROR,
+            lastErrorMessage = "Something went wrong",
+        )
+
+        viewModel.uiState.test {
+            val state = awaitItem() as TvNowPlayingUiState.Loaded
+            assertEquals(true, state.isError)
+            assertEquals("Something went wrong", state.errorMessage)
+        }
+    }
+
+    @Test
+    fun `a stream with video is video`() = runTest {
+        queueChanges.onNext(UpNextQueue.State.Loaded(audioEpisode, null, emptyList()))
+        streamVideoStates.value = StreamVideoState.HasVideo
+
+        viewModel.uiState.test {
+            assertEquals(true, (awaitItem() as TvNowPlayingUiState.Loaded).isVideo)
+        }
+    }
+
+    @Test
+    fun `an unknown stream is not video`() = runTest {
+        queueChanges.onNext(UpNextQueue.State.Loaded(videoEpisode, null, emptyList()))
+        streamVideoStates.value = StreamVideoState.Unknown
+
+        viewModel.uiState.test {
+            assertEquals(false, (awaitItem() as TvNowPlayingUiState.Loaded).isVideo)
+        }
+    }
+
+    @Test
+    fun `an audio only stream is not video`() = runTest {
+        queueChanges.onNext(UpNextQueue.State.Loaded(videoEpisode, null, emptyList()))
+        streamVideoStates.value = StreamVideoState.AudioOnly
+
+        viewModel.uiState.test {
+            assertEquals(false, (awaitItem() as TvNowPlayingUiState.Loaded).isVideo)
+        }
+    }
+
+    @Test
+    fun `a video episode without stream video info is video`() = runTest {
+        queueChanges.onNext(UpNextQueue.State.Loaded(videoEpisode, null, emptyList()))
+
+        viewModel.uiState.test {
+            assertEquals(true, (awaitItem() as TvNowPlayingUiState.Loaded).isVideo)
+        }
+    }
+
+    @Test
+    fun `video is disabled when rendering is off`() = runTest {
+        queueChanges.onNext(UpNextQueue.State.Loaded(videoEpisode, null, emptyList()))
+        videoRenderingEnabledStates.value = false
+
+        viewModel.uiState.test {
+            assertEquals(false, (awaitItem() as TvNowPlayingUiState.Loaded).isVideo)
+        }
+    }
+
+    @Test
+    fun `playPause delegates to the playback manager`() = runTest {
+        viewModel.playPause()
+
+        verify(playbackManager).playPause(sourceView = SourceView.PLAYER)
+    }
+
+    @Test
+    fun `skipForward delegates to the playback manager`() = runTest {
+        viewModel.skipForward()
+
+        verify(playbackManager).skipForward(sourceView = SourceView.PLAYER, jumpAmountSeconds = 30)
+    }
+
+    @Test
+    fun `skipBackward delegates to the playback manager`() = runTest {
+        viewModel.skipBackward()
+
+        verify(playbackManager).skipBackward(sourceView = SourceView.PLAYER, jumpAmountSeconds = 10)
+    }
+}

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingViewModelTest.kt
@@ -74,6 +74,7 @@ class TvNowPlayingViewModelTest {
         queueChanges.onNext(UpNextQueue.State.Loaded(audioEpisode, Podcast(uuid = "podcast", title = "Podcast"), emptyList()))
         playbackStates.value = PlaybackState(
             state = PlaybackState.State.PLAYING,
+            episodeUuid = audioEpisode.uuid,
             isBuffering = true,
             positionMs = 1_000,
             durationMs = 60_000,
@@ -86,11 +87,31 @@ class TvNowPlayingViewModelTest {
             assertEquals("Podcast", state.podcastTitle)
             assertEquals(true, state.isPlaying)
             assertEquals(true, state.isBuffering)
-            assertEquals(false, state.isError)
+            assertEquals(null, state.errorMessage)
             assertEquals(1_000, state.positionMs)
             assertEquals(60_000, state.durationMs)
             assertEquals(5_000, state.bufferedMs)
             assertEquals(false, state.isVideo)
+        }
+    }
+
+    @Test
+    fun `playback progress of a different episode falls back to the entity`() = runTest {
+        val episode = PodcastEpisode(uuid = "next", publishedDate = Date(0), playedUpTo = 12.0, duration = 60.0)
+        queueChanges.onNext(UpNextQueue.State.Loaded(episode, null, emptyList()))
+        playbackStates.value = PlaybackState(
+            state = PlaybackState.State.PLAYING,
+            episodeUuid = "previous",
+            positionMs = 55_000,
+            durationMs = 55_000,
+            bufferedMs = 55_000,
+        )
+
+        viewModel.uiState.test {
+            val state = awaitItem() as TvNowPlayingUiState.Loaded
+            assertEquals(12_000, state.positionMs)
+            assertEquals(60_000, state.durationMs)
+            assertEquals(0, state.bufferedMs)
         }
     }
 
@@ -104,7 +125,6 @@ class TvNowPlayingViewModelTest {
 
         viewModel.uiState.test {
             val state = awaitItem() as TvNowPlayingUiState.Loaded
-            assertEquals(true, state.isError)
             assertEquals("Something went wrong", state.errorMessage)
         }
     }

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextViewModelTest.kt
@@ -19,7 +19,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyBlocking
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class TvUpNextViewModelTest {
@@ -132,7 +132,7 @@ class TvUpNextViewModelTest {
 
         createViewModel().play(episode)
 
-        verify(playbackManager).playNow(episode, sourceView = SourceView.UP_NEXT)
+        verifyBlocking(playbackManager) { playNowSuspend(episode = episode, sourceView = SourceView.UP_NEXT) }
     }
 
     private fun createViewModel() = TvUpNextViewModel(

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextViewModelTest.kt
@@ -2,8 +2,10 @@ package au.com.shiftyjelly.pocketcasts.upnext
 
 import android.content.Context
 import app.cash.turbine.test
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
@@ -17,6 +19,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class TvUpNextViewModelTest {
@@ -30,6 +33,7 @@ class TvUpNextViewModelTest {
     }
     private val syncManager = mock<SyncManager>()
     private val context = mock<Context>()
+    private val playbackManager = mock<PlaybackManager>()
 
     private val currentEpisode = episode("current")
 
@@ -122,10 +126,20 @@ class TvUpNextViewModelTest {
         }
     }
 
+    @Test
+    fun `play starts playback of the episode`() = runTest {
+        val episode = episode("episode")
+
+        createViewModel().play(episode)
+
+        verify(playbackManager).playNow(episode, sourceView = SourceView.UP_NEXT)
+    }
+
     private fun createViewModel() = TvUpNextViewModel(
         context = context,
         syncManager = syncManager,
         upNextQueue = upNextQueue,
+        playbackManager = playbackManager,
     )
 
     private fun episode(uuid: String) = PodcastEpisode(uuid = uuid, publishedDate = Date(0))


### PR DESCRIPTION
## Description

Adds a **Now Playing** tab to the Android TV app's top bar and wires up real playback for the first time, mirroring the Apple TV app's behavior. Scope agreed for this PR: basic playback screen (play/pause, seek, skip), video + audio (audio shows static artwork), and Up Next queue interactions — analytics and everything else the tvOS player has is deliberately left for follow-ups.

** IMPORTANT **
Please note that the UI is not final, figma (Ftk3KwnfqaK4g57yCN63p0-fi-2639_2612) shows apple tv's built-in player interface. Screenshots attached to the linear ticket is different, so this needs to be clarified with design team and make amends when necessary.

**What's in it:**
- The TV app now calls `PlaybackManager.setup()` (it previously only seeded the Up Next queue and every Play button was a no-op).
- A dynamic **Now Playing** tab between Up Next and Search, mirroring tvOS: it only exists while there is a current episode, and auto-redirects to Home if the queue empties while selected. Tab selection is now keyed on the tab (not its index) so the list can change shape safely.
- A **playback screen**: static artwork + titles for audio, an aspect-fitted video surface for video episodes, a focusable seek bar (DPAD left/right seeks by the user's skip amounts), skip back/forward and play/pause buttons with a buffering spinner, and error text. During video playback the controls and top bar auto-hide after 4s; any navigation press reveals them (media keys keep their function).
- **Current-episode actions** on the player (`…` button): details, go to podcast, mark played/unplayed, archive/unarchive — the tvOS player ellipsis set, reusing `TvEpisodeActionsModal` with a new `NowPlaying` context.
- **Entry points that start playback**: Up Next row click, a new *Play* action in the episode actions modal (all contexts), and the Home screen video-tile play buttons (discover episodes are fetched via `findOrDownloadPodcastRxSingle` first; failures show a toast). Starting playback switches to the Now Playing tab via a `LocalOpenNowPlaying` composition local.
- **Shared-module fixes** needed to make playback work on TV: the metered-network stream warning is skipped on TV (it has no warning UI — same exclusion as Auto/Wear), and `getLaunchActivityPendingIntent` falls back to the leanback launch intent (the compat media session path would otherwise NPE on release TV builds, which only declare a `LEANBACK_LAUNCHER` activity).

**Notable decisions:**
- `VideoView` from `modules/features/player` can't be reused: depending on that module drags the whole phone player/sharing/transcripts Hilt graph into the TV app (unresolvable bindings + APK bloat). The TV module has a small self-contained `TvVideoView` that mirrors its surface handling against `SimplePlayer`.
- The video-vs-audio decision duplicates the small `streamVideoState`/`videoRenderingEnabled` mapping from `PlayerViewModel`; extracting a shared helper next to `StreamVideoState` is a follow-up to avoid touching the mobile player in this PR.
- Known limitation: debug/prototype TV builds resolve the `MEDIA3_SESSION` flag to true but TV declares no `PlaybackService`, so no system media session exists there (remote media keys don't control playback outside the app's own controls). Release builds take the `MediaSessionCompat` path, which works after the leanback fix. A proper TV media session is a follow-up.

Fixes PCDROID-709 https://linear.app/a8c/issue/PCDROID-706/basic-playback-capability

## Testing Instructions

1. Install the TV app on an Android TV device/emulator and sign in to an account with episodes in Up Next.
2. Open the **Up Next** tab and click an episode row — playback starts and the app switches to a new **Now Playing** tab (between Up Next and Search).
3. On the player: toggle play/pause, use the skip back/forward buttons, focus the seek bar and press DPAD left/right to seek. Check position/duration labels and the buffered fill.
4. Open the `…` menu: check details, go to podcast (top bar hides on the details screen; Back returns to the player), mark played/unplayed, archive.
5. Play a **video** episode (e.g. from the Home "Made for TV" row): video renders; after ~4s of playback the controls and top bar fade out; any DPAD press brings them back (and is not swallowed by hidden controls' actions).
6. Play an **audio** episode: static artwork with episode/podcast titles is shown.
7. From Home and podcast/playlist episode action modals, use the new **Play** action — playback starts and the Now Playing tab opens.
8. Let an episode finish — playback advances to the next queued episode and the screen follows. Clear the queue (or finish the last episode): the tab disappears and, if you were on it, you land on Home.
9. Kill and relaunch the app with a non-empty queue: the Now Playing tab is present, showing the paused current episode.

## Screenshots or Screencast 
<img width="1920" height="1080" alt="Screenshot_20260806_213306" src="https://github.com/user-attachments/assets/8a9bc018-32ff-4e3a-98ff-cac123eca23f" />


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
