### PR TITLE
Skip background video decoding to fix stuttering at high playback speeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 8.19
 -----
+*   Bug Fixes
+    *   Fix audio stuttering when playing video episodes at high speed in the background
+        ([#5707](https://github.com/Automattic/pocket-casts-android/pull/5707))
 
 
 8.18

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ShiftyRenderersFactory.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ShiftyRenderersFactory.kt
@@ -102,6 +102,9 @@ class ShiftyRenderersFactory(
     }
 
     companion object {
+        // The platform's ~250ms minimum PCM buffer underruns under transient load and (since media3 1.8.0)
+        // flips playback into STATE_BUFFERING. 500ms matches the media3 1.11.0 default and can be dropped
+        // once we bump to it. https://github.com/androidx/media/issues/3210
         private const val MIN_PCM_BUFFER_DURATION_US = 500_000
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ShiftyRenderersFactory.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ShiftyRenderersFactory.kt
@@ -9,7 +9,9 @@ import androidx.media3.exoplayer.Renderer
 import androidx.media3.exoplayer.analytics.AnalyticsListener
 import androidx.media3.exoplayer.audio.AudioRendererEventListener
 import androidx.media3.exoplayer.audio.AudioSink
+import androidx.media3.exoplayer.audio.AudioTrackAudioOutputProvider
 import androidx.media3.exoplayer.audio.DefaultAudioSink
+import androidx.media3.exoplayer.audio.DefaultAudioTrackBufferSizeProvider
 import androidx.media3.exoplayer.mediacodec.MediaCodecSelector
 import au.com.shiftyjelly.pocketcasts.models.type.TrimMode
 import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.FingerprintPcmTap
@@ -57,6 +59,15 @@ class ShiftyRenderersFactory(
             .setAudioProcessorChain(processorChain!!)
             .setEnableFloatOutput(enableFloatOutput)
             .setEnableAudioOutputPlaybackParameters(enableAudioOutputPlaybackParameters)
+            .setAudioOutputProvider(
+                AudioTrackAudioOutputProvider.Builder(context)
+                    .setAudioTrackBufferSizeProvider(
+                        DefaultAudioTrackBufferSizeProvider.Builder()
+                            .setMinPcmBufferDurationUs(MIN_PCM_BUFFER_DURATION_US)
+                            .build(),
+                    )
+                    .build(),
+            )
             .build()
         return if (fingerprintPcmTap != null) FingerprintTapAudioSink(sink, fingerprintPcmTap) else sink
     }
@@ -88,5 +99,9 @@ class ShiftyRenderersFactory(
 
     override fun onAudioSessionIdChanged(eventTime: AnalyticsListener.EventTime, audioSessionId: Int) {
         customAudio.setupVolumeBoost(audioSessionId)
+    }
+
+    companion object {
+        private const val MIN_PCM_BUFFER_DURATION_US = 500_000
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -67,6 +67,8 @@ class SimplePlayer(
 
     private var videoChangedListener: VideoChangedListener? = null
 
+    private var hasVideoSurface = false
+
     @Volatile
     private var prepared = false
 
@@ -201,7 +203,8 @@ class SimplePlayer(
     private fun prepare() {
         val trackSelector = DefaultTrackSelector(context)
         this.trackSelector = trackSelector
-        applyAudioOnly()
+        hasVideoSurface = false
+        applyVideoTrackSelection()
 
         val minBufferMillis = if (isStreaming) bufferTimeMinMillis else DefaultLoadControl.DEFAULT_MIN_BUFFER_MS
         val maxBufferMillis = if (isStreaming) bufferTimeMaxMillis else DefaultLoadControl.DEFAULT_MAX_BUFFER_MS
@@ -305,24 +308,35 @@ class SimplePlayer(
     private fun updateVideoState() {
         val player = player ?: return
         if (player.playbackState == Player.STATE_READY) {
-            onVideoTrackChanged(player.currentTracks.isTypeSelected(C.TRACK_TYPE_VIDEO))
+            onVideoTrackChanged(player.currentTracks.containsType(C.TRACK_TYPE_VIDEO) && !settings.audioOnly.value)
         }
     }
 
     override fun updateAudioOnly() {
-        applyAudioOnly()
+        Handler(Looper.getMainLooper()).post {
+            applyVideoTrackSelection()
+            updateVideoState()
+        }
     }
 
     @OptIn(UnstableApi::class)
-    private fun applyAudioOnly() {
+    private fun applyVideoTrackSelection() {
         val trackSelector = trackSelector ?: return
         trackSelector.parameters = trackSelector.buildUponParameters()
-            .setTrackTypeDisabled(C.TRACK_TYPE_VIDEO, settings.audioOnly.value)
+            .setTrackTypeDisabled(C.TRACK_TYPE_VIDEO, shouldDisableVideoTrack(settings.audioOnly.value, hasVideoSurface, episodeLocation.isHlsStream))
             .build()
     }
 
     private fun addVideoListener(player: ExoPlayer) {
         player.addListener(object : Player.Listener {
+            override fun onSurfaceSizeChanged(width: Int, height: Int) {
+                val attached = width != 0 || height != 0
+                if (attached != hasVideoSurface) {
+                    hasVideoSurface = attached
+                    applyVideoTrackSelection()
+                }
+            }
+
             override fun onVideoSizeChanged(videoSize: VideoSize) {
                 videoWidth = videoSize.width
                 videoHeight = videoSize.height
@@ -388,6 +402,10 @@ class SimplePlayer(
         }
         player.playbackParameters = PlaybackParameters(playbackEffects.playbackSpeed.toFloat(), 1f)
     }
+}
+
+internal fun shouldDisableVideoTrack(audioOnly: Boolean, hasVideoSurface: Boolean, isHlsStream: Boolean): Boolean {
+    return audioOnly || (!hasVideoSurface && !isHlsStream)
 }
 
 private class PlayPauseListener(

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -338,16 +338,14 @@ class SimplePlayer(
             }
 
             override fun onVideoSizeChanged(videoSize: VideoSize) {
-                videoWidth = videoSize.width
-                videoHeight = videoSize.height
-
                 // Real video dimensions are definitive proof the stream carries video.
                 if (videoSize.width > 0 && videoSize.height > 0) {
+                    videoWidth = videoSize.width
+                    videoHeight = videoSize.height
                     onVideoTrackChanged(true)
-                }
-
-                videoChangedListener?.let {
-                    Handler(Looper.getMainLooper()).post { it.videoSizeChanged(videoSize.width, videoSize.height, videoSize.pixelWidthHeightRatio) }
+                    videoChangedListener?.let {
+                        Handler(Looper.getMainLooper()).post { it.videoSizeChanged(videoSize.width, videoSize.height, videoSize.pixelWidthHeightRatio) }
+                    }
                 }
             }
         })

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/VideoTrackSelectionTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/VideoTrackSelectionTest.kt
@@ -1,0 +1,29 @@
+package au.com.shiftyjelly.pocketcasts.repositories.playback
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class VideoTrackSelectionTest {
+
+    @Test
+    fun `disables video without a surface for progressive playback`() {
+        assertTrue(shouldDisableVideoTrack(audioOnly = false, hasVideoSurface = false, isHlsStream = false))
+    }
+
+    @Test
+    fun `keeps video when a surface is attached`() {
+        assertFalse(shouldDisableVideoTrack(audioOnly = false, hasVideoSurface = true, isHlsStream = false))
+    }
+
+    @Test
+    fun `audio only setting always disables video`() {
+        assertTrue(shouldDisableVideoTrack(audioOnly = true, hasVideoSurface = true, isHlsStream = false))
+        assertTrue(shouldDisableVideoTrack(audioOnly = true, hasVideoSurface = false, isHlsStream = true))
+    }
+
+    @Test
+    fun `keeps video for hls streams without a surface`() {
+        assertFalse(shouldDisableVideoTrack(audioOnly = false, hasVideoSurface = false, isHlsStream = true))
+    }
+}


### PR DESCRIPTION
## Description

Fixes the long-standing "playback stutters in bursts" reports for video episodes played at high speed (e.g. user-imported YouTube videos at 2–3.3x with trim silence), diagnosed from a user's debug logs.

Conversation: https://pocketcastsbeta.slack.com/archives/C013F9RM6UA/p1785932983069969

**Root cause.** `SimplePlayer` only disables the video track when the global Audio-only setting is on. In every other case ExoPlayer keeps decoding the video track even with no surface attached (background listening, screen off, collapsed player): `MediaCodecVideoRenderer` decodes every frame to a placeholder surface at frame-rate × playback speed and immediately skips it. When the decoder intermittently falls behind (heavy scenes, software-decoded codecs such as AV1 on devices without hardware support, thermal throttling), the resulting AudioTrack underruns surface as rapid ready⇄buffering oscillation — audible stuttering with the position advancing at ~1x while speed is set to 2–3.3x. Seeking back flushes the codecs, which is why users report "going back fixes it for a while". Media3 1.8.0 made underruns flip the player into `STATE_BUFFERING` immediately (androidx/media#3210), which is why reports picked up roughly a year ago. In the user's logs, video user files stuttered at 2.0x while an audio episode at ~3x played clean in the same session.

**Fix.**
- `SimplePlayer` now deselects `TRACK_TYPE_VIDEO` whenever no video surface is attached, tracked via `Player.Listener.onSurfaceSizeChanged` (`(0,0)` is ExoPlayer's detach signal across all paths). The track re-enables as soon as the player screen attaches a surface, so video still renders whenever it is actually visible, including PiP. HLS is exempt because it can mux audio into the video track and already has its own audio-only stream switch. `StreamVideoState` is now reported from track *presence* (minus the Audio-only setting) instead of *selection*, so the player UI still treats the stream as video and can attach the surface — reporting selection would leave the UI on artwork with no way back. `updateAudioOnly()` also re-reports the state (and hops to the main thread, which `player.currentTracks` requires) so toggling the setting off while backgrounded doesn't leave a stale `AudioOnly` state.
- `ShiftyRenderersFactory` raises the minimum AudioTrack PCM buffer from the platform floor (250 ms on many devices) to 500 ms — the same default media3 adopted in 1.11.0 — making the audio pipeline resilient to transient load even when video *is* rendering (androidx/media#3210, androidx/media#718).

Side benefit: background playback of video episodes no longer burns a full-rate video decode, which should be a noticeable battery win.

Follow-up worth considering: bumping media3 to 1.11.0 (released this week) brings the upstream fixes for the same issue (100 ms not-ready grace period, fixed 500 ms buffer default, operating-rate reset fix).

## Testing Instructions

_I did not notice any meaningful difference pre/post fix when playing the scenario on my Pixel 6 test device besides the CPU usage drop post-fix. Playback never stuttered pre-fix either._

To download youtube videos, you can use https://ytdlnis.org/download

1. Import a video file via Profile > Files (or play any video episode) and set playback speed to 2–3x with trim silence on Max.
2. Play it, open the full player: video renders as before.
3. Background the app / lock the screen: audio continues; video decoding stops (verifiable via `adb shell top` — CPU drops substantially, or in a systrace no video MediaCodec activity).
4. Return to the player: video resumes rendering after a brief keyframe join.
5. Toggle Settings > General > Audio only on and off while playing in foreground and background: artwork/video switch correctly in all combinations.
6. Verify HLS video episodes still play and switch video/audio as before.
7. Verify PiP from both entry points renders video: fullscreen video -> PiP button, and the player shelf PiP action (the fullscreen `VideoFragment` uses media3 `PlayerView`, which attaches its surface via `setPlayer` independently of the inline `VideoView`'s `isPip` guard, so the video track stays enabled in PiP).

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

#### I have tested any UI changes...
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack


