### PR TITLE
Fix state-loss crash when showing a bottom sheet after the activity is backgrounded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 *   Bug Fixes
     *   Fix audio stuttering when playing video episodes at high speed in the background
         ([#5707](https://github.com/Automattic/pocket-casts-android/pull/5707))
-
+    *   Fix a crash when showing a bottom sheet after the app is sent to the background
+        ([#5709](https://github.com/Automattic/pocket-casts-android/pull/5709))
 
 8.18
 -----

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -53,6 +53,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import androidx.lifecycle.withResumed
 import androidx.mediarouter.media.MediaControlIntent
 import androidx.mediarouter.media.MediaRouteSelector
 import androidx.mediarouter.media.MediaRouter
@@ -1404,6 +1405,14 @@ class MainActivity :
     }
 
     override fun showBottomSheet(fragment: Fragment) {
+        if (supportFragmentManager.isStateSaved) {
+            lifecycleScope.launch { withResumed { commitBottomSheet(fragment) } }
+        } else {
+            commitBottomSheet(fragment)
+        }
+    }
+
+    private fun commitBottomSheet(fragment: Fragment) {
         supportFragmentManager.commitNow {
             bottomSheetTag = fragment::class.java.name
             replace(R.id.frameBottomSheet, fragment, bottomSheetTag)

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -354,7 +354,7 @@ class MainActivity :
         get() = binding.bottomContainer.height - binding.bottomContainer.paddingBottom
 
     private var bottomSheetTag: String? = null
-    private val bottomSheetQueue: MutableList<(() -> Unit)?> = mutableListOf()
+    private var pendingBottomSheetFragment: Fragment? = null
 
     override val coroutineContext: CoroutineContext
         get() = Dispatchers.Default
@@ -1171,9 +1171,9 @@ class MainActivity :
 
             if (viewModel.shouldShowTrialFinished(signinState)) {
                 val trialFinished = TrialFinishedFragment()
-                showBottomSheet(trialFinished)
-
-                settings.setTrialFinishedSeen(true)
+                showBottomSheet(trialFinished) {
+                    settings.setTrialFinishedSeen(true)
+                }
             }
 
             // Result is intentionally ignored; failures are logged internally by sendAuthToDataLayer
@@ -1184,10 +1184,9 @@ class MainActivity :
             lifecycle.repeatOnLifecycle(Lifecycle.State.CREATED) {
                 viewModel.state.collect { state ->
                     if (state.shouldShowWhatsNew) {
-                        showBottomSheet(
-                            fragment = WhatsNewFragment(),
-                        )
-                        viewModel.onWhatsNewShown()
+                        showBottomSheet(WhatsNewFragment()) {
+                            viewModel.onWhatsNewShown()
+                        }
                     }
                 }
             }
@@ -1405,14 +1404,28 @@ class MainActivity :
     }
 
     override fun showBottomSheet(fragment: Fragment) {
+        showBottomSheet(fragment, onShown = {})
+    }
+
+    private fun showBottomSheet(fragment: Fragment, onShown: () -> Unit) {
         if (supportFragmentManager.isStateSaved) {
-            lifecycleScope.launch { withResumed { commitBottomSheet(fragment) } }
+            pendingBottomSheetFragment = fragment
+            lifecycleScope.launch {
+                withResumed {
+                    if (pendingBottomSheetFragment === fragment) {
+                        commitBottomSheet(fragment)
+                        onShown()
+                    }
+                }
+            }
         } else {
             commitBottomSheet(fragment)
+            onShown()
         }
     }
 
     private fun commitBottomSheet(fragment: Fragment) {
+        pendingBottomSheetFragment = null
         supportFragmentManager.commitNow {
             bottomSheetTag = fragment::class.java.name
             replace(R.id.frameBottomSheet, fragment, bottomSheetTag)
@@ -1441,9 +1454,11 @@ class MainActivity :
         }
     }
 
-    override fun isUpNextShowing() = bottomSheetTag == UpNextFragment::class.java.name
+    override fun isUpNextShowing() = isBottomSheetShowing(UpNextFragment::class.java)
 
-    private fun isWhatsNewShowing() = bottomSheetTag == WhatsNewFragment::class.java.name
+    private fun isWhatsNewShowing() = isBottomSheetShowing(WhatsNewFragment::class.java)
+
+    private fun isBottomSheetShowing(fragmentClass: Class<out Fragment>) = bottomSheetTag == fragmentClass.name || pendingBottomSheetFragment?.javaClass == fragmentClass
 
     private fun removeBottomSheetFragment(fragment: Fragment) {
         val tag = fragment::class.java.name
@@ -1453,11 +1468,6 @@ class MainActivity :
 
                 updateStatusBar()
                 bottomSheetTag = null
-
-                if (bottomSheetQueue.isNotEmpty()) {
-                    val next = bottomSheetQueue.removeAt(0)
-                    next?.invoke()
-                }
             }
         }
     }


### PR DESCRIPTION
## Description

Fixes a Sentry-reported crash:

```
java.lang.IllegalStateException: Can not perform this action after onSaveInstanceState
    at androidx.fragment.app.BackStackRecord.commitNow(BackStackRecord.java:317)
    at au.com.shiftyjelly.pocketcasts.ui.MainActivity.showBottomSheet(MainActivity.kt:1407)
    at au.com.shiftyjelly.pocketcasts.ui.MainActivity.showUpNextFragment(MainActivity.kt:1006)
    at au.com.shiftyjelly.pocketcasts.ui.MainActivity.onMiniPlayerVisible(MainActivity.kt:1348)
    at au.com.shiftyjelly.pocketcasts.player.view.PlayerBottomSheet$setUpNext$1.onAnimationEnd(PlayerBottomSheet.java:146)
```
It was a low-hanging fruit with a straightforward fix and low risk, so I went ahead and raised this PR.

Details: https://a8c.sentry.io/issues/3709846273/?project=6711064&query=release%3A%22au.com.shiftyjelly.pocketcasts%408.17%2B9444%22&referrer=release-issue-stream

`showBottomSheet` commits a fragment transaction with `commitNow`, which throws `IllegalStateException` whenever it runs after the activity's state has been saved. The Up Next shortcut path reaches it from `PlayerBottomSheet`'s mini-player slide `onAnimationEnd` listener — a plain `ViewPropertyAnimator` callback with no lifecycle awareness — so if the activity is backgrounded while that animation is still finishing, the commit lands in the illegal window and crashes.

The same hazard applies to the other `showBottomSheet` caller that can fire while the activity is state-saved: `WhatsNewFragment`, shown from a `repeatOnLifecycle(CREATED)` collector.

### Fix

`showBottomSheet` now checks `supportFragmentManager.isStateSaved` (which is exactly the condition `FragmentManager.checkStateLoss()` throws on):

- Not saved → commit immediately, as before (foreground callers are unchanged).
- Saved → defer the transaction with `withResumed { … }` so it runs the moment the activity is resumed again.

This avoids the crash without silently dropping the sheet (no `commitAllowingStateLoss`): the Up Next / What's New sheet is still shown when the user returns. `withResumed` runs the block immediately if already resumed and is cancelled with `lifecycleScope` if the activity is destroyed, so there is no leak or stale dispatch.

## Testing Instructions

Because the crash depends on a fragment commit landing after `onSaveInstanceState`, it is easiest to reproduce with the Up Next shortcut deep link:

1. Start playback so the mini player is present.
2. Trigger the Up Next shortcut deep link (the `showUpNextModal` deep link / app shortcut) so the app launches and the mini player slides in.
3. While the mini-player slide-in animation is still running, immediately background the app (Home).
4. Return to the app.

Expected: no crash; the Up Next bottom sheet is shown on return. Before this change, step 3–4 could throw `IllegalStateException: Can not perform this action after onSaveInstanceState`.

Regression check: open the Up Next sheet normally (tap the mini player up-next affordance) and confirm it still expands immediately, and that What's New still appears on a version upgrade.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) the Event Horizon schema to reflect any new or changed analytics.
