### PR TITLE
[TV] Play video episodes fullscreen

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/video/VideoView.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/video/VideoView.kt
@@ -106,6 +106,8 @@ class VideoView @JvmOverloads constructor(
         isSurfaceConnected = false
     }
 
+    override fun videoFirstFrameRendered() = Unit
+
     override fun surfaceCreated(holder: SurfaceHolder) {
         isSurfaceCreated = true
         isSurfaceConnected = false

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -340,6 +340,12 @@ class SimplePlayer(
                     Handler(Looper.getMainLooper()).post { it.videoSizeChanged(videoSize.width, videoSize.height, videoSize.pixelWidthHeightRatio) }
                 }
             }
+
+            override fun onRenderedFirstFrame() {
+                videoChangedListener?.let {
+                    Handler(Looper.getMainLooper()).post { it.videoFirstFrameRendered() }
+                }
+            }
         })
     }
 
@@ -372,6 +378,7 @@ class SimplePlayer(
     interface VideoChangedListener {
         fun videoSizeChanged(width: Int, height: Int, pixelWidthHeightRatio: Float)
         fun videoNeedsReset()
+        fun videoFirstFrameRendered() = Unit
     }
 
     fun setVideoSizeChangedListener(videoChangedListener: VideoChangedListener) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -70,6 +70,7 @@ class SimplePlayer(
     override val currentAudioLevel: Float get() = renderersFactory?.currentAudioLevel ?: 0f
 
     private var videoChangedListener: VideoChangedListener? = null
+    private val mainHandler = Handler(Looper.getMainLooper())
 
     @Volatile
     private var prepared = false
@@ -337,13 +338,13 @@ class SimplePlayer(
                 }
 
                 videoChangedListener?.let {
-                    Handler(Looper.getMainLooper()).post { it.videoSizeChanged(videoSize.width, videoSize.height, videoSize.pixelWidthHeightRatio) }
+                    mainHandler.post { it.videoSizeChanged(videoSize.width, videoSize.height, videoSize.pixelWidthHeightRatio) }
                 }
             }
 
             override fun onRenderedFirstFrame() {
                 videoChangedListener?.let {
-                    Handler(Looper.getMainLooper()).post { it.videoFirstFrameRendered() }
+                    mainHandler.post { it.videoFirstFrameRendered() }
                 }
             }
         })
@@ -378,7 +379,7 @@ class SimplePlayer(
     interface VideoChangedListener {
         fun videoSizeChanged(width: Int, height: Int, pixelWidthHeightRatio: Float)
         fun videoNeedsReset()
-        fun videoFirstFrameRendered() = Unit
+        fun videoFirstFrameRendered()
     }
 
     fun setVideoSizeChangedListener(videoChangedListener: VideoChangedListener) {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
@@ -238,12 +238,15 @@ private fun TvNowPlayingContent(
     ) {
         Box(
             contentAlignment = Alignment.Center,
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier
+                .fillMaxSize()
+                .then(if (state.isVideo) Modifier.background(Color.Black) else Modifier),
         ) {
             if (state.isVideo) {
                 TvVideoSurface(
                     player = state.player,
                     onFirstFrameRender = { hasRenderedFirstFrame = true },
+                    onVideoReset = { hasRenderedFirstFrame = false },
                 )
             } else {
                 EpisodeArtwork(
@@ -271,6 +274,7 @@ private fun TvNowPlayingContent(
                         isPlaying = state.isPlaying && !state.isBuffering,
                         player = state.player,
                         audioLevel = { state.player?.currentAudioLevel ?: 0f },
+                        showWaveform = false,
                     )
                 }
             }
@@ -287,8 +291,6 @@ private fun TvNowPlayingContent(
             EpisodeTitles(
                 episode = episode,
                 podcastTitle = state.podcastTitle,
-                textAlign = TextAlign.Start,
-                horizontalAlignment = Alignment.Start,
             )
             Spacer(modifier = Modifier.height(16.dp))
             state.errorMessage?.let { errorMessage ->
@@ -367,18 +369,21 @@ private fun EpisodeArtwork(
     player: Player?,
     audioLevel: () -> Float,
     modifier: Modifier = Modifier,
+    showWaveform: Boolean = true,
 ) {
     Box(
         contentAlignment = Alignment.Center,
         modifier = modifier,
     ) {
-        TvNowPlayingWaveform(
-            isPlaying = isPlaying,
-            episodeUuid = episode.uuid,
-            player = player,
-            audioLevel = audioLevel,
-            artworkSize = ArtworkSize,
-        )
+        if (showWaveform) {
+            TvNowPlayingWaveform(
+                isPlaying = isPlaying,
+                episodeUuid = episode.uuid,
+                player = player,
+                audioLevel = audioLevel,
+                artworkSize = ArtworkSize,
+            )
+        }
         TvArtworkImage(
             model = episode.artworkModel(),
             modifier = Modifier
@@ -400,19 +405,17 @@ private fun EpisodeArtwork(
 private fun EpisodeTitles(
     episode: BaseEpisode,
     podcastTitle: String?,
-    textAlign: TextAlign,
-    horizontalAlignment: Alignment.Horizontal,
     modifier: Modifier = Modifier,
 ) {
     Column(
-        horizontalAlignment = horizontalAlignment,
+        horizontalAlignment = Alignment.Start,
         modifier = modifier,
     ) {
         Text(
             text = episode.title,
             style = MaterialTheme.tvTypography.title3,
             color = MaterialTheme.tvColors.textPrimary,
-            textAlign = textAlign,
+            textAlign = TextAlign.Start,
             maxLines = 2,
             overflow = TextOverflow.Ellipsis,
         )
@@ -422,7 +425,7 @@ private fun EpisodeTitles(
                 text = podcastTitle,
                 style = MaterialTheme.tvTypography.caption1,
                 color = MaterialTheme.tvColors.textSecondary,
-                textAlign = textAlign,
+                textAlign = TextAlign.Start,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
             )
@@ -569,17 +572,17 @@ private fun BaseEpisode.artworkModel(): Any? = when (this) {
 @Preview(device = Devices.TV_1080p)
 @Composable
 private fun TvNowPlayingContentPreview() {
-    TvNowPlayingContentPreview(isVideo = false)
+    TvNowPlayingContentPreviewContent(isVideo = false)
 }
 
 @Preview(device = Devices.TV_1080p)
 @Composable
 private fun TvNowPlayingVideoContentPreview() {
-    TvNowPlayingContentPreview(isVideo = true)
+    TvNowPlayingContentPreviewContent(isVideo = true)
 }
 
 @Composable
-private fun TvNowPlayingContentPreview(isVideo: Boolean) {
+private fun TvNowPlayingContentPreviewContent(isVideo: Boolean) {
     TvTheme {
         CompositionLocalProvider(LocalFocusTvTopBar provides {}) {
             TvNowPlayingContent(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
@@ -243,7 +243,7 @@ private fun TvNowPlayingContent(
             if (state.isVideo) {
                 TvVideoSurface(
                     player = state.player,
-                    onFirstFrameRendered = { hasRenderedFirstFrame = true },
+                    onFirstFrameRender = { hasRenderedFirstFrame = true },
                 )
             } else {
                 EpisodeArtwork(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
@@ -296,7 +296,7 @@ private fun TvNowPlayingContent(
                     text = errorMessage,
                     style = MaterialTheme.tvTypography.caption1,
                     color = MaterialTheme.tvColors.textSecondary,
-                    textAlign = TextAlign.Center,
+                    textAlign = TextAlign.Start,
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(bottom = 16.dp),

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
@@ -236,7 +236,10 @@ private fun TvNowPlayingContent(
                 .fillMaxWidth(),
         ) {
             if (state.isVideo) {
-                TvVideoSurface(player = state.player)
+                TvVideoSurface(
+                    player = state.player,
+                    onFirstFrameRendered = {},
+                )
             } else {
                 EpisodeArtworkWithTitles(
                     episode = episode,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
@@ -48,6 +48,8 @@ import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -214,6 +216,9 @@ private fun TvNowPlayingContent(
         }
     }
     val chromeAlpha by animateFloatAsState(if (isChromeVisible) 1f else 0f, label = "TvNowPlayingChromeAlpha")
+    val density = LocalDensity.current
+    var chromeHeight by remember { mutableStateOf(0.dp) }
+    val artworkBottomPadding = chromeHeight * chromeAlpha
 
     Box(
         modifier = modifier
@@ -238,7 +243,9 @@ private fun TvNowPlayingContent(
     ) {
         Box(
             contentAlignment = Alignment.Center,
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(bottom = if (state.isVideo) 0.dp else artworkBottomPadding),
         ) {
             if (state.isVideo) {
                 TvVideoSurface(
@@ -265,7 +272,8 @@ private fun TvNowPlayingContent(
                     contentAlignment = Alignment.Center,
                     modifier = Modifier
                         .fillMaxSize()
-                        .background(TvScreenBackgroundBrush),
+                        .background(TvScreenBackgroundBrush)
+                        .padding(bottom = artworkBottomPadding),
                 ) {
                     EpisodeArtworkWithTitles(
                         episode = episode,
@@ -283,6 +291,7 @@ private fun TvNowPlayingContent(
                 .fillMaxWidth()
                 .graphicsLayer { alpha = chromeAlpha }
                 .then(if (state.isVideo) Modifier.background(ChromeScrimBrush) else Modifier)
+                .onSizeChanged { size -> chromeHeight = with(density) { size.height.toDp() } }
                 .padding(horizontal = 80.dp)
                 .padding(top = if (state.isVideo) ChromeScrimTopInset else 0.dp, bottom = 24.dp),
         ) {
@@ -583,6 +592,17 @@ private fun BaseEpisode.artworkModel(): Any? = when (this) {
 @Preview(device = Devices.TV_1080p)
 @Composable
 private fun TvNowPlayingContentPreview() {
+    TvNowPlayingContentPreview(isVideo = false)
+}
+
+@Preview(device = Devices.TV_1080p)
+@Composable
+private fun TvNowPlayingVideoContentPreview() {
+    TvNowPlayingContentPreview(isVideo = true)
+}
+
+@Composable
+private fun TvNowPlayingContentPreview(isVideo: Boolean) {
     TvTheme {
         CompositionLocalProvider(LocalFocusTvTopBar provides {}) {
             TvNowPlayingContent(
@@ -602,7 +622,7 @@ private fun TvNowPlayingContentPreview() {
                     positionMs = 600_000,
                     durationMs = 3_600_000,
                     bufferedMs = 1_200_000,
-                    isVideo = false,
+                    isVideo = isVideo,
                     player = null,
                     playbackSpeed = 1.0,
                     trimMode = TrimMode.OFF,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
@@ -48,8 +48,6 @@ import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
-import androidx.compose.ui.layout.onSizeChanged
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -216,9 +214,6 @@ private fun TvNowPlayingContent(
         }
     }
     val chromeAlpha by animateFloatAsState(if (isChromeVisible) 1f else 0f, label = "TvNowPlayingChromeAlpha")
-    val density = LocalDensity.current
-    var chromeHeight by remember { mutableStateOf(0.dp) }
-    val artworkBottomPadding = chromeHeight * chromeAlpha
 
     Box(
         modifier = modifier
@@ -243,9 +238,7 @@ private fun TvNowPlayingContent(
     ) {
         Box(
             contentAlignment = Alignment.Center,
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(bottom = if (state.isVideo) 0.dp else artworkBottomPadding),
+            modifier = Modifier.fillMaxSize(),
         ) {
             if (state.isVideo) {
                 TvVideoSurface(
@@ -253,9 +246,8 @@ private fun TvNowPlayingContent(
                     onFirstFrameRendered = { hasRenderedFirstFrame = true },
                 )
             } else {
-                EpisodeArtworkWithTitles(
+                EpisodeArtwork(
                     episode = episode,
-                    podcastTitle = state.podcastTitle,
                     isPlaying = state.isPlaying && !state.isBuffering,
                     player = state.player,
                     audioLevel = { state.player?.currentAudioLevel ?: 0f },
@@ -272,12 +264,10 @@ private fun TvNowPlayingContent(
                     contentAlignment = Alignment.Center,
                     modifier = Modifier
                         .fillMaxSize()
-                        .background(TvScreenBackgroundBrush)
-                        .padding(bottom = artworkBottomPadding),
+                        .background(TvScreenBackgroundBrush),
                 ) {
-                    EpisodeArtworkWithTitles(
+                    EpisodeArtwork(
                         episode = episode,
-                        podcastTitle = state.podcastTitle,
                         isPlaying = state.isPlaying && !state.isBuffering,
                         player = state.player,
                         audioLevel = { state.player?.currentAudioLevel ?: 0f },
@@ -290,20 +280,17 @@ private fun TvNowPlayingContent(
                 .align(Alignment.BottomCenter)
                 .fillMaxWidth()
                 .graphicsLayer { alpha = chromeAlpha }
-                .then(if (state.isVideo) Modifier.background(ChromeScrimBrush) else Modifier)
-                .onSizeChanged { size -> chromeHeight = with(density) { size.height.toDp() } }
+                .background(ChromeScrimBrush)
                 .padding(horizontal = 80.dp)
-                .padding(top = if (state.isVideo) ChromeScrimTopInset else 0.dp, bottom = 24.dp),
+                .padding(top = ChromeScrimTopInset, bottom = 24.dp),
         ) {
-            if (state.isVideo) {
-                EpisodeTitles(
-                    episode = episode,
-                    podcastTitle = state.podcastTitle,
-                    textAlign = TextAlign.Start,
-                    horizontalAlignment = Alignment.Start,
-                )
-                Spacer(modifier = Modifier.height(16.dp))
-            }
+            EpisodeTitles(
+                episode = episode,
+                podcastTitle = state.podcastTitle,
+                textAlign = TextAlign.Start,
+                horizontalAlignment = Alignment.Start,
+            )
+            Spacer(modifier = Modifier.height(16.dp))
             state.errorMessage?.let { errorMessage ->
                 Text(
                     text = errorMessage,
@@ -374,47 +361,37 @@ private fun TvNowPlayingContent(
 }
 
 @Composable
-private fun EpisodeArtworkWithTitles(
+private fun EpisodeArtwork(
     episode: BaseEpisode,
-    podcastTitle: String?,
     isPlaying: Boolean,
     player: Player?,
     audioLevel: () -> Float,
     modifier: Modifier = Modifier,
 ) {
-    Column(
-        horizontalAlignment = Alignment.CenterHorizontally,
+    Box(
+        contentAlignment = Alignment.Center,
         modifier = modifier,
     ) {
-        Box(contentAlignment = Alignment.Center) {
-            TvNowPlayingWaveform(
-                isPlaying = isPlaying,
-                episodeUuid = episode.uuid,
-                player = player,
-                audioLevel = audioLevel,
-                artworkSize = ArtworkSize,
-            )
-            TvArtworkImage(
-                model = episode.artworkModel(),
-                modifier = Modifier
-                    .requiredSize(ArtworkSize * BlurredArtworkScale)
-                    .offset(x = BlurredArtworkOffset, y = BlurredArtworkOffset)
-                    .blur(BlurredArtworkRadius, BlurredEdgeTreatment.Unbounded)
-                    .alpha(0.7f),
-            )
-            TvArtworkImage(
-                model = episode.artworkModel(),
-                modifier = Modifier
-                    .size(ArtworkSize)
-                    .clip(RoundedCornerShape(8.dp)),
-            )
-        }
-        Spacer(modifier = Modifier.height(24.dp))
-        EpisodeTitles(
-            episode = episode,
-            podcastTitle = podcastTitle,
-            textAlign = TextAlign.Center,
-            horizontalAlignment = Alignment.CenterHorizontally,
+        TvNowPlayingWaveform(
+            isPlaying = isPlaying,
+            episodeUuid = episode.uuid,
+            player = player,
+            audioLevel = audioLevel,
+            artworkSize = ArtworkSize,
+        )
+        TvArtworkImage(
+            model = episode.artworkModel(),
+            modifier = Modifier
+                .requiredSize(ArtworkSize * BlurredArtworkScale)
+                .offset(x = BlurredArtworkOffset, y = BlurredArtworkOffset)
+                .blur(BlurredArtworkRadius, BlurredEdgeTreatment.Unbounded)
+                .alpha(0.7f),
+        )
+        TvArtworkImage(
+            model = episode.artworkModel(),
+            modifier = Modifier
+                .size(ArtworkSize)
+                .clip(RoundedCornerShape(8.dp)),
         )
     }
 }
@@ -561,7 +538,7 @@ private fun PlayerControlButton(
     }
 }
 
-private val ArtworkSize = 266.dp
+private val ArtworkSize = 240.dp
 private val BlurredArtworkScale = 1.25f
 private val BlurredArtworkOffset = -ArtworkSize * 0.2f
 private val BlurredArtworkRadius = 66.dp

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
@@ -169,6 +169,8 @@ private fun TvNowPlayingContent(
     var isEffectsMenuVisible by remember { mutableStateOf(false) }
     var isChromeVisible by remember { mutableStateOf(true) }
     var hasRenderedFirstFrame by remember(state.episode.uuid, state.isVideo) { mutableStateOf(false) }
+    val onFirstFrameRender = remember(state.episode.uuid, state.isVideo) { { hasRenderedFirstFrame = true } }
+    val onVideoReset = remember(state.episode.uuid, state.isVideo) { { hasRenderedFirstFrame = false } }
     var interactionTick by remember { mutableIntStateOf(0) }
     var isContentFocused by remember { mutableStateOf(false) }
     var isTopBarRevealRequested by remember { mutableStateOf(false) }
@@ -245,8 +247,8 @@ private fun TvNowPlayingContent(
             if (state.isVideo) {
                 TvVideoSurface(
                     player = state.player,
-                    onFirstFrameRender = { hasRenderedFirstFrame = true },
-                    onVideoReset = { hasRenderedFirstFrame = false },
+                    onFirstFrameRender = onFirstFrameRender,
+                    onVideoReset = onVideoReset,
                 )
             } else {
                 EpisodeArtwork(
@@ -271,9 +273,6 @@ private fun TvNowPlayingContent(
                 ) {
                     EpisodeArtwork(
                         episode = episode,
-                        isPlaying = state.isPlaying && !state.isBuffering,
-                        player = state.player,
-                        audioLevel = { state.player?.currentAudioLevel ?: 0f },
                         showWaveform = false,
                     )
                 }
@@ -365,10 +364,10 @@ private fun TvNowPlayingContent(
 @Composable
 private fun EpisodeArtwork(
     episode: BaseEpisode,
-    isPlaying: Boolean,
-    player: Player?,
-    audioLevel: () -> Float,
     modifier: Modifier = Modifier,
+    isPlaying: Boolean = false,
+    player: Player? = null,
+    audioLevel: () -> Float = { 0f },
     showWaveform: Boolean = true,
 ) {
     Box(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.nowplaying
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -35,6 +36,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
@@ -206,7 +209,7 @@ private fun TvNowPlayingContent(
     }
     val chromeAlpha by animateFloatAsState(if (isChromeVisible) 1f else 0f, label = "TvNowPlayingChromeAlpha")
 
-    Column(
+    Box(
         modifier = modifier
             .fillMaxSize()
             .onFocusChanged { focusState ->
@@ -225,15 +228,11 @@ private fun TvNowPlayingContent(
                 // Only navigation presses are swallowed by the reveal; media keys keep their
                 // effect even while the chrome is hidden and back is revealed via BackHandler.
                 revealsChrome && event.key in chromeRevealConsumedKeys
-            }
-            .padding(top = TvTopBarHeight)
-            .padding(horizontal = 80.dp, vertical = 24.dp),
+            },
     ) {
         Box(
             contentAlignment = Alignment.Center,
-            modifier = Modifier
-                .weight(1f)
-                .fillMaxWidth(),
+            modifier = Modifier.fillMaxSize(),
         ) {
             if (state.isVideo) {
                 TvVideoSurface(
@@ -250,8 +249,24 @@ private fun TvNowPlayingContent(
                 )
             }
         }
-        Spacer(modifier = Modifier.height(24.dp))
-        Column(modifier = Modifier.alpha(chromeAlpha)) {
+        Column(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .fillMaxWidth()
+                .graphicsLayer { alpha = chromeAlpha }
+                .then(if (state.isVideo) Modifier.background(ChromeScrimBrush) else Modifier)
+                .padding(horizontal = 80.dp)
+                .padding(top = if (state.isVideo) ChromeScrimTopInset else 0.dp, bottom = 24.dp),
+        ) {
+            if (state.isVideo) {
+                EpisodeTitles(
+                    episode = episode,
+                    podcastTitle = state.podcastTitle,
+                    textAlign = TextAlign.Start,
+                    horizontalAlignment = Alignment.Start,
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+            }
             state.errorMessage?.let { errorMessage ->
                 Text(
                     text = errorMessage,
@@ -358,11 +373,32 @@ private fun EpisodeArtworkWithTitles(
             )
         }
         Spacer(modifier = Modifier.height(24.dp))
+        EpisodeTitles(
+            episode = episode,
+            podcastTitle = podcastTitle,
+            textAlign = TextAlign.Center,
+            horizontalAlignment = Alignment.CenterHorizontally,
+        )
+    }
+}
+
+@Composable
+private fun EpisodeTitles(
+    episode: BaseEpisode,
+    podcastTitle: String?,
+    textAlign: TextAlign,
+    horizontalAlignment: Alignment.Horizontal,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        horizontalAlignment = horizontalAlignment,
+        modifier = modifier,
+    ) {
         Text(
             text = episode.title,
             style = MaterialTheme.tvTypography.title3,
             color = MaterialTheme.tvColors.textPrimary,
-            textAlign = TextAlign.Center,
+            textAlign = textAlign,
             maxLines = 2,
             overflow = TextOverflow.Ellipsis,
         )
@@ -372,7 +408,7 @@ private fun EpisodeArtworkWithTitles(
                 text = podcastTitle,
                 style = MaterialTheme.tvTypography.caption1,
                 color = MaterialTheme.tvColors.textSecondary,
-                textAlign = TextAlign.Center,
+                textAlign = textAlign,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
             )
@@ -494,6 +530,12 @@ private val BlurredArtworkOffset = -ArtworkSize * 0.2f
 private val BlurredArtworkRadius = 66.dp
 
 private val CHROME_HIDE_DELAY = 4.seconds
+
+private val ChromeScrimTopInset = 48.dp
+private val ChromeScrimBrush = Brush.verticalGradient(
+    0f to Color.Transparent,
+    1f to Color.Black.copy(alpha = 0.8f),
+)
 
 private val chromeRevealConsumedKeys = setOf(
     Key.DirectionUp,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
@@ -1,7 +1,11 @@
 package au.com.shiftyjelly.pocketcasts.nowplaying
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -76,6 +80,7 @@ import au.com.shiftyjelly.pocketcasts.podcasts.TvPodcastDetailsScreen
 import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImage
 import au.com.shiftyjelly.pocketcasts.repositories.playback.Player
 import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
+import au.com.shiftyjelly.pocketcasts.theme.TvScreenBackgroundBrush
 import au.com.shiftyjelly.pocketcasts.theme.TvTheme
 import au.com.shiftyjelly.pocketcasts.theme.TvTopBarHeight
 import au.com.shiftyjelly.pocketcasts.theme.tvColors
@@ -163,6 +168,7 @@ private fun TvNowPlayingContent(
     var isSpeedMenuVisible by remember { mutableStateOf(false) }
     var isEffectsMenuVisible by remember { mutableStateOf(false) }
     var isChromeVisible by remember { mutableStateOf(true) }
+    var hasRenderedFirstFrame by remember(state.episode.uuid, state.isVideo) { mutableStateOf(false) }
     var interactionTick by remember { mutableIntStateOf(0) }
     var isContentFocused by remember { mutableStateOf(false) }
     var isTopBarRevealRequested by remember { mutableStateOf(false) }
@@ -237,7 +243,7 @@ private fun TvNowPlayingContent(
             if (state.isVideo) {
                 TvVideoSurface(
                     player = state.player,
-                    onFirstFrameRendered = {},
+                    onFirstFrameRendered = { hasRenderedFirstFrame = true },
                 )
             } else {
                 EpisodeArtworkWithTitles(
@@ -247,6 +253,28 @@ private fun TvNowPlayingContent(
                     player = state.player,
                     audioLevel = { state.player?.currentAudioLevel ?: 0f },
                 )
+            }
+        }
+        if (state.isVideo) {
+            AnimatedVisibility(
+                visible = !hasRenderedFirstFrame || state.errorMessage != null,
+                enter = fadeIn(tween(VIDEO_OVERLAY_FADE_MILLIS)),
+                exit = fadeOut(tween(VIDEO_OVERLAY_FADE_MILLIS)),
+            ) {
+                Box(
+                    contentAlignment = Alignment.Center,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(TvScreenBackgroundBrush),
+                ) {
+                    EpisodeArtworkWithTitles(
+                        episode = episode,
+                        podcastTitle = state.podcastTitle,
+                        isPlaying = state.isPlaying && !state.isBuffering,
+                        player = state.player,
+                        audioLevel = { state.player?.currentAudioLevel ?: 0f },
+                    )
+                }
             }
         }
         Column(
@@ -530,6 +558,7 @@ private val BlurredArtworkOffset = -ArtworkSize * 0.2f
 private val BlurredArtworkRadius = 66.dp
 
 private val CHROME_HIDE_DELAY = 4.seconds
+private const val VIDEO_OVERLAY_FADE_MILLIS = 200
 
 private val ChromeScrimTopInset = 48.dp
 private val ChromeScrimBrush = Brush.verticalGradient(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvVideoSurface.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvVideoSurface.kt
@@ -19,7 +19,7 @@ import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 @Composable
 fun TvVideoSurface(
     player: Player?,
-    onFirstFrameRendered: () -> Unit,
+    onFirstFrameRender: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var aspectRatio by remember { mutableFloatStateOf(DEFAULT_ASPECT_RATIO) }
@@ -27,7 +27,7 @@ fun TvVideoSurface(
         factory = { context -> TvVideoView(context) },
         update = { view ->
             view.onAspectRatioChanged = { ratio -> aspectRatio = ratio }
-            view.onFirstFrameRendered = onFirstFrameRendered
+            view.onFirstFrameRender = onFirstFrameRender
             view.player = player
             view.connectWithDelay()
         },
@@ -48,7 +48,7 @@ private class TvVideoView(
 
     var player: Player? = null
     var onAspectRatioChanged: ((Float) -> Unit)? = null
-    var onFirstFrameRendered: (() -> Unit)? = null
+    var onFirstFrameRender: (() -> Unit)? = null
 
     private var isSurfaceCreated = false
     private var isSurfaceConnectionPending = false
@@ -116,7 +116,7 @@ private class TvVideoView(
     }
 
     override fun videoFirstFrameRendered() {
-        onFirstFrameRendered?.invoke()
+        onFirstFrameRender?.invoke()
     }
 
     override fun surfaceCreated(holder: SurfaceHolder) {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvVideoSurface.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvVideoSurface.kt
@@ -19,6 +19,7 @@ import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 @Composable
 fun TvVideoSurface(
     player: Player?,
+    onFirstFrameRendered: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var aspectRatio by remember { mutableFloatStateOf(DEFAULT_ASPECT_RATIO) }
@@ -26,6 +27,7 @@ fun TvVideoSurface(
         factory = { context -> TvVideoView(context) },
         update = { view ->
             view.onAspectRatioChanged = { ratio -> aspectRatio = ratio }
+            view.onFirstFrameRendered = onFirstFrameRendered
             view.player = player
             view.connectWithDelay()
         },
@@ -46,6 +48,7 @@ private class TvVideoView(
 
     var player: Player? = null
     var onAspectRatioChanged: ((Float) -> Unit)? = null
+    var onFirstFrameRendered: (() -> Unit)? = null
 
     private var isSurfaceCreated = false
     private var isSurfaceConnectionPending = false
@@ -110,6 +113,10 @@ private class TvVideoView(
 
     override fun videoNeedsReset() {
         isSurfaceConnected = false
+    }
+
+    override fun videoFirstFrameRendered() {
+        onFirstFrameRendered?.invoke()
     }
 
     override fun surfaceCreated(holder: SurfaceHolder) {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvVideoSurface.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvVideoSurface.kt
@@ -30,10 +30,8 @@ fun TvVideoSurface(
             view.onAspectRatioChanged = { ratio -> aspectRatio = ratio }
             view.onFirstFrameRender = onFirstFrameRender
             view.onVideoReset = onVideoReset
-            if (view.player !== player) {
-                view.player = player
-                view.connectWithDelay()
-            }
+            view.player = player
+            view.connectWithDelay()
         },
         onRelease = { view -> view.releaseSurface() },
         modifier = modifier.aspectRatio(aspectRatio),

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvVideoSurface.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvVideoSurface.kt
@@ -20,6 +20,7 @@ import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 fun TvVideoSurface(
     player: Player?,
     onFirstFrameRender: () -> Unit,
+    onVideoReset: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var aspectRatio by remember { mutableFloatStateOf(DEFAULT_ASPECT_RATIO) }
@@ -28,8 +29,11 @@ fun TvVideoSurface(
         update = { view ->
             view.onAspectRatioChanged = { ratio -> aspectRatio = ratio }
             view.onFirstFrameRender = onFirstFrameRender
-            view.player = player
-            view.connectWithDelay()
+            view.onVideoReset = onVideoReset
+            if (view.player !== player) {
+                view.player = player
+                view.connectWithDelay()
+            }
         },
         onRelease = { view -> view.releaseSurface() },
         modifier = modifier.aspectRatio(aspectRatio),
@@ -49,6 +53,7 @@ private class TvVideoView(
     var player: Player? = null
     var onAspectRatioChanged: ((Float) -> Unit)? = null
     var onFirstFrameRender: (() -> Unit)? = null
+    var onVideoReset: (() -> Unit)? = null
 
     private var isSurfaceCreated = false
     private var isSurfaceConnectionPending = false
@@ -113,6 +118,7 @@ private class TvVideoView(
 
     override fun videoNeedsReset() {
         isSurfaceConnected = false
+        post { onVideoReset?.invoke() }
     }
 
     override fun videoFirstFrameRendered() {


### PR DESCRIPTION
## Description

Makes the Android TV **Now Playing** screen render video episodes fullscreen with overlaid controls, and reworks the audio/video layout to match the Apple TV (tvOS) player.

**Fullscreen video**
- Plumbs ExoPlayer's first-rendered-frame event through `SimplePlayer` (new `VideoChangedListener.videoFirstFrameRendered()`, defaulted so the mobile `VideoView` is unaffected) and exposes it from the TV video surface as `onFirstFrameRender`.
- Restructures the screen into a fullscreen `Box` with the video surface behind and the player chrome overlaid at the bottom over a scrim.
- Shows the episode artwork over the video until the first frame renders (or on error), so there's no black flash while the surface connects.
- The artwork is now centered and **stationary** — it no longer shifts up/down as the controls show and hide (the previous coupling made it jump and truncate on open).
- The episode title + podcast name moved **into the bottom chrome** (over the scrim) for both audio and video, so the two branches are now almost identical.
- Reduced the artwork to `240.dp` to better match the tvOS proportion now that the controls overlay the bottom of it.

Stacked on `feat/tv-now-playing-waveform` (#5711) → `feat/tv-now-playing-effects` (#5710) → `feat/tv-now-playing` (#5706). **Base this PR on `feat/tv-now-playing-waveform`; review after the ones below it merge.**

Fixes PCDROID-710 https://linear.app/a8c/issue/PCDROID-710/video-playback

**Please note that the playback controls are not yet final, desing discussion pending**

## Testing Instructions

1. Sign in on the TV app and start an **audio** episode → open Now Playing.
2. Confirm the artwork is centered with the waveform behind it, and the episode/podcast titles sit in the bottom bar with the seekbar and controls.
3. Let playback run ~4s → the chrome auto-hides; confirm the artwork stays put (no downward slide) and the titles fade with the controls.
4. Press a d-pad direction → the chrome (and titles) fade back in over the artwork; the artwork does not move.
5. Start a **video** episode → confirm it plays fullscreen, the artwork placeholder shows only until the first frame renders, and the title/controls overlay the bottom over the scrim.
6. Trigger a playback error → confirm the error text renders left-aligned in the bottom bar.

## Screenshots or Screencast
| With player chrome | Chrome hidden |
| --- | --- |
| <img width="1920" height="1080" alt="Screenshot_20260810_093331" src="https://github.com/user-attachments/assets/c818a030-9476-4c28-a35e-52961335bc46" /> | <img width="1920" height="1080" alt="Screenshot_20260810_093346" src="https://github.com/user-attachments/assets/95c27db7-0a3f-4f8d-871f-ddaf54dfffc3" /> |

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md 
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml` 
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) the Event Horizon schema to reflect any new or changed analytics.

#### I have tested any UI changes...
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
