### PR TITLE
Skip background video decoding to fix stuttering at high playback speeds (cherry-pick to 8.18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 8.19
 -----
+*   Bug Fixes
+    *   Fix audio stuttering when playing video episodes at high speed in the background
+        ([#5707](https://github.com/Automattic/pocket-casts-android/pull/5707))
 
 
 8.18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 8.19
 -----
-*   Bug Fixes
-    *   Fix audio stuttering when playing video episodes at high speed in the background
-        ([#5707](https://github.com/Automattic/pocket-casts-android/pull/5707))
 
 
 8.18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
         ([#5628](https://github.com/Automattic/pocket-casts-android/pull/5628))
     *   Fix the app briefly freezing when showing the default podcast artwork
         ([#5634](https://github.com/Automattic/pocket-casts-android/pull/5634))
+    *   Fix audio stuttering when playing video episodes at high speed in the background
+        ([#5707](https://github.com/Automattic/pocket-casts-android/pull/5707))
 
 8.17
 -----

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ShiftyRenderersFactory.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ShiftyRenderersFactory.kt
@@ -9,7 +9,9 @@ import androidx.media3.exoplayer.Renderer
 import androidx.media3.exoplayer.analytics.AnalyticsListener
 import androidx.media3.exoplayer.audio.AudioRendererEventListener
 import androidx.media3.exoplayer.audio.AudioSink
+import androidx.media3.exoplayer.audio.AudioTrackAudioOutputProvider
 import androidx.media3.exoplayer.audio.DefaultAudioSink
+import androidx.media3.exoplayer.audio.DefaultAudioTrackBufferSizeProvider
 import androidx.media3.exoplayer.mediacodec.MediaCodecSelector
 import au.com.shiftyjelly.pocketcasts.models.type.TrimMode
 import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.FingerprintPcmTap
@@ -57,6 +59,15 @@ class ShiftyRenderersFactory(
             .setAudioProcessorChain(processorChain!!)
             .setEnableFloatOutput(enableFloatOutput)
             .setEnableAudioOutputPlaybackParameters(enableAudioOutputPlaybackParameters)
+            .setAudioOutputProvider(
+                AudioTrackAudioOutputProvider.Builder(context)
+                    .setAudioTrackBufferSizeProvider(
+                        DefaultAudioTrackBufferSizeProvider.Builder()
+                            .setMinPcmBufferDurationUs(MIN_PCM_BUFFER_DURATION_US)
+                            .build(),
+                    )
+                    .build(),
+            )
             .build()
         return if (fingerprintPcmTap != null) FingerprintTapAudioSink(sink, fingerprintPcmTap) else sink
     }
@@ -88,5 +99,12 @@ class ShiftyRenderersFactory(
 
     override fun onAudioSessionIdChanged(eventTime: AnalyticsListener.EventTime, audioSessionId: Int) {
         customAudio.setupVolumeBoost(audioSessionId)
+    }
+
+    companion object {
+        // The platform's ~250ms minimum PCM buffer underruns under transient load and (since media3 1.8.0)
+        // flips playback into STATE_BUFFERING. 500ms matches the media3 1.11.0 default and can be dropped
+        // once we bump to it. https://github.com/androidx/media/issues/3210
+        private const val MIN_PCM_BUFFER_DURATION_US = 500_000
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -67,6 +67,8 @@ class SimplePlayer(
 
     private var videoChangedListener: VideoChangedListener? = null
 
+    private var hasVideoSurface = false
+
     @Volatile
     private var prepared = false
 
@@ -201,7 +203,8 @@ class SimplePlayer(
     private fun prepare() {
         val trackSelector = DefaultTrackSelector(context)
         this.trackSelector = trackSelector
-        applyAudioOnly()
+        hasVideoSurface = false
+        applyVideoTrackSelection()
 
         val minBufferMillis = if (isStreaming) bufferTimeMinMillis else DefaultLoadControl.DEFAULT_MIN_BUFFER_MS
         val maxBufferMillis = if (isStreaming) bufferTimeMaxMillis else DefaultLoadControl.DEFAULT_MAX_BUFFER_MS
@@ -305,35 +308,44 @@ class SimplePlayer(
     private fun updateVideoState() {
         val player = player ?: return
         if (player.playbackState == Player.STATE_READY) {
-            onVideoTrackChanged(player.currentTracks.isTypeSelected(C.TRACK_TYPE_VIDEO))
+            onVideoTrackChanged(player.currentTracks.containsType(C.TRACK_TYPE_VIDEO) && !settings.audioOnly.value)
         }
     }
 
     override fun updateAudioOnly() {
-        applyAudioOnly()
+        Handler(Looper.getMainLooper()).post {
+            applyVideoTrackSelection()
+            updateVideoState()
+        }
     }
 
     @OptIn(UnstableApi::class)
-    private fun applyAudioOnly() {
+    private fun applyVideoTrackSelection() {
         val trackSelector = trackSelector ?: return
         trackSelector.parameters = trackSelector.buildUponParameters()
-            .setTrackTypeDisabled(C.TRACK_TYPE_VIDEO, settings.audioOnly.value)
+            .setTrackTypeDisabled(C.TRACK_TYPE_VIDEO, shouldDisableVideoTrack(settings.audioOnly.value, hasVideoSurface, episodeLocation.isHlsStream))
             .build()
     }
 
     private fun addVideoListener(player: ExoPlayer) {
         player.addListener(object : Player.Listener {
-            override fun onVideoSizeChanged(videoSize: VideoSize) {
-                videoWidth = videoSize.width
-                videoHeight = videoSize.height
+            override fun onSurfaceSizeChanged(width: Int, height: Int) {
+                val attached = width != 0 || height != 0
+                if (attached != hasVideoSurface) {
+                    hasVideoSurface = attached
+                    applyVideoTrackSelection()
+                }
+            }
 
+            override fun onVideoSizeChanged(videoSize: VideoSize) {
                 // Real video dimensions are definitive proof the stream carries video.
                 if (videoSize.width > 0 && videoSize.height > 0) {
+                    videoWidth = videoSize.width
+                    videoHeight = videoSize.height
                     onVideoTrackChanged(true)
-                }
-
-                videoChangedListener?.let {
-                    Handler(Looper.getMainLooper()).post { it.videoSizeChanged(videoSize.width, videoSize.height, videoSize.pixelWidthHeightRatio) }
+                    videoChangedListener?.let {
+                        Handler(Looper.getMainLooper()).post { it.videoSizeChanged(videoSize.width, videoSize.height, videoSize.pixelWidthHeightRatio) }
+                    }
                 }
             }
         })
@@ -388,6 +400,10 @@ class SimplePlayer(
         }
         player.playbackParameters = PlaybackParameters(playbackEffects.playbackSpeed.toFloat(), 1f)
     }
+}
+
+internal fun shouldDisableVideoTrack(audioOnly: Boolean, hasVideoSurface: Boolean, isHlsStream: Boolean): Boolean {
+    return audioOnly || (!hasVideoSurface && !isHlsStream)
 }
 
 private class PlayPauseListener(

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/VideoTrackSelectionTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/VideoTrackSelectionTest.kt
@@ -1,0 +1,29 @@
+package au.com.shiftyjelly.pocketcasts.repositories.playback
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class VideoTrackSelectionTest {
+
+    @Test
+    fun `disables video without a surface for progressive playback`() {
+        assertTrue(shouldDisableVideoTrack(audioOnly = false, hasVideoSurface = false, isHlsStream = false))
+    }
+
+    @Test
+    fun `keeps video when a surface is attached`() {
+        assertFalse(shouldDisableVideoTrack(audioOnly = false, hasVideoSurface = true, isHlsStream = false))
+    }
+
+    @Test
+    fun `audio only setting always disables video`() {
+        assertTrue(shouldDisableVideoTrack(audioOnly = true, hasVideoSurface = true, isHlsStream = false))
+        assertTrue(shouldDisableVideoTrack(audioOnly = true, hasVideoSurface = false, isHlsStream = true))
+    }
+
+    @Test
+    fun `keeps video for hls streams without a surface`() {
+        assertFalse(shouldDisableVideoTrack(audioOnly = false, hasVideoSurface = false, isHlsStream = true))
+    }
+}


### PR DESCRIPTION
## Description

Cherry-pick of #5707 into `release/8.18`.

> **This change was already reviewed and merged on `main`.** This PR exists to land it in the upcoming release. CI and a quick review should still run to confirm the cherry-pick applies cleanly and introduces no issues on the release branch, since `release/8.18` may have diverged from `main`.

- Original PR: https://github.com/Automattic/pocket-casts-android/pull/5707
- Cherry-picked commit: `33b2bacc5c`

## Testing Instructions

See the original PR (https://github.com/Automattic/pocket-casts-android/pull/5707) for full testing steps. In addition, verify the change behaves as described on top of `release/8.18`.