### PR TITLE
[TV] Wire up Play all episodes on the playlist details screen

### DIFF
--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -266,8 +266,8 @@
     <string name="tv_playlists_download_title">Create playlists on your phone</string>
     <string name="tv_playlists_download_subtitle">They’ll be waiting here when you’re done. Scan to get the app</string>
     <string name="tv_playlist_play_all">Play all episodes</string>
-    <string name="tv_playlist_play_all_clear_up_next_title">This will clear your Up Next</string>
-    <string name="tv_playlist_play_all_clear_up_next_message">We can save your current Up Next as a playlist</string>
+    <string name="tv_playlist_play_all_clear_up_next_title">This will clear your Up\u00A0Next</string>
+    <string name="tv_playlist_play_all_clear_up_next_message">We can save your current Up Next as a\u00A0playlist</string>
     <string name="tv_playlist_play_all_save_and_play">Save and play</string>
     <string name="tv_playlist_play_all_play_without_saving">Play without saving</string>
     <plurals name="tv_playlist_all_archived">

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -266,6 +266,10 @@
     <string name="tv_playlists_download_title">Create playlists on your phone</string>
     <string name="tv_playlists_download_subtitle">They’ll be waiting here when you’re done. Scan to get the app</string>
     <string name="tv_playlist_play_all">Play all episodes</string>
+    <string name="tv_playlist_play_all_clear_up_next_title">This will clear your Up Next</string>
+    <string name="tv_playlist_play_all_clear_up_next_message">We can save your current Up Next as a playlist</string>
+    <string name="tv_playlist_play_all_save_and_play">Save and play</string>
+    <string name="tv_playlist_play_all_play_without_saving">Play without saving</string>
     <plurals name="tv_playlist_all_archived">
         <item quantity="one">The only episode of this playlist has been archived.</item>
         <item quantity="other">All %1$d episodes of this playlist have been archived.</item>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayAllHandler.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayAllHandler.kt
@@ -30,6 +30,10 @@ class PlayAllHandler @AssistedInject constructor(
         return handlePlayAllAction(episodes, PlaylistEpisode::toPodcastEpisode)
     }
 
+    suspend fun handlePlayAllEpisodes(episodes: List<BaseEpisode>): PlayAllResponse {
+        return handlePlayAllAction(episodes) { it }
+    }
+
     private suspend fun <T> handlePlayAllAction(
         episodes: List<T>,
         toBaseEpisode: (T) -> BaseEpisode?,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayAllHandler.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayAllHandler.kt
@@ -82,13 +82,15 @@ class PlayAllHandler @AssistedInject constructor(
         return playlistEpisodes.isNotEmpty()
     }
 
-    suspend fun playAllPendingEpisodes() {
-        val episodes = pendingEpisodes?.episodesToPlay ?: return
+    suspend fun playAllPendingEpisodes(): Boolean {
+        val episodes = pendingEpisodes?.episodesToPlay ?: return false
 
         withContext(Dispatchers.Default) {
             playbackManager.upNextQueue.removeAll()
             playbackManager.playEpisodes(episodes, source)
         }
+        pendingEpisodes = null
+        return true
     }
 
     private suspend fun appendToQueueAndPlay(episodes: List<BaseEpisode>) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayAllHandler.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayAllHandler.kt
@@ -58,8 +58,8 @@ class PlayAllHandler @AssistedInject constructor(
         }
     }
 
-    suspend fun saveUpNextAsPlaylist(upNextTranslation: String) {
-        val episodes = pendingEpisodes?.episodeInQueue ?: return
+    suspend fun saveUpNextAsPlaylist(upNextTranslation: String): Boolean {
+        val episodes = pendingEpisodes?.episodeInQueue ?: return false
         val baseName = buildString {
             append(upNextTranslation)
             runCatching {
@@ -79,6 +79,7 @@ class PlayAllHandler @AssistedInject constructor(
             val name = if (index == 0) baseName else "$baseName (${index + 1})"
             playlistManager.createManualPlaylistWithEpisodes(name, episodes)
         }
+        return playlistEpisodes.isNotEmpty()
     }
 
     suspend fun playAllPendingEpisodes() {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
@@ -4,6 +4,7 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
@@ -47,6 +48,7 @@ import au.com.shiftyjelly.pocketcasts.component.TvEpisodeInfoModal
 import au.com.shiftyjelly.pocketcasts.component.TvEpisodeListItem
 import au.com.shiftyjelly.pocketcasts.component.TvModal
 import au.com.shiftyjelly.pocketcasts.component.TvModalButton
+import au.com.shiftyjelly.pocketcasts.component.TvModalSurface
 import au.com.shiftyjelly.pocketcasts.component.TvSortButton
 import au.com.shiftyjelly.pocketcasts.component.rememberTvEpisodeListFocus
 import au.com.shiftyjelly.pocketcasts.compose.components.PlaylistArtwork
@@ -82,12 +84,13 @@ fun TvPlaylistDetailsScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     var openedPodcastUuid by rememberSaveable { mutableStateOf<String?>(null) }
-    var isReplaceUpNextConfirmationVisible by remember { mutableStateOf(false) }
+    var isReplaceUpNextConfirmationVisible by rememberSaveable { mutableStateOf(false) }
 
     val openNowPlaying = LocalOpenNowPlaying.current
     val toastHostState = LocalTvToastHostState.current
     val upNextName = stringResource(LR.string.up_next)
     val savedToast = stringResource(LR.string.up_next_as_playlist_saved)
+    val noEpisodesToast = stringResource(LR.string.play_all_no_episodes_message)
 
     LaunchedEffect(uiState, onClose) {
         if (uiState is TvPlaylistDetailsUiState.NotFound) {
@@ -101,6 +104,7 @@ fun TvPlaylistDetailsScreen(
                 TvPlaylistDetailsEvent.OpenNowPlaying -> openNowPlaying()
                 TvPlaylistDetailsEvent.ShowReplaceUpNextConfirmation -> isReplaceUpNextConfirmationVisible = true
                 TvPlaylistDetailsEvent.ShowUpNextSavedToast -> toastHostState.show(savedToast)
+                TvPlaylistDetailsEvent.ShowNoEpisodesToPlay -> toastHostState.show(noEpisodesToast)
             }
         }
     }
@@ -407,37 +411,50 @@ private fun TvPlayAllReplaceUpNextModal(
     onSaveAndPlay: () -> Unit,
     onCancel: () -> Unit,
 ) {
+    TvModal(onDismissRequest = onCancel) {
+        TvPlayAllReplaceUpNextContent(
+            onPlayWithoutSaving = onPlayWithoutSaving,
+            onSaveAndPlay = onSaveAndPlay,
+            onCancel = onCancel,
+        )
+    }
+}
+
+@Composable
+private fun ColumnScope.TvPlayAllReplaceUpNextContent(
+    onPlayWithoutSaving: () -> Unit,
+    onSaveAndPlay: () -> Unit,
+    onCancel: () -> Unit,
+) {
     val focusRequester = remember { FocusRequester() }
     LaunchedEffect(Unit) {
         focusRequester.requestFocus()
     }
-    TvModal(onDismissRequest = onCancel) {
-        Text(
-            text = stringResource(LR.string.tv_playlist_play_all_clear_up_next_title),
-            color = MaterialTheme.tvColors.textPrimary,
-            style = MaterialTheme.tvTypography.headline.copy(textAlign = TextAlign.Center),
-            modifier = Modifier.fillMaxWidth(),
-        )
-        Text(
-            text = stringResource(LR.string.tv_playlist_play_all_clear_up_next_message),
-            color = MaterialTheme.tvColors.textSecondary,
-            style = MaterialTheme.tvTypography.caption1.copy(textAlign = TextAlign.Center),
-            modifier = Modifier.fillMaxWidth(),
-        )
-        TvModalButton(
-            text = stringResource(LR.string.tv_playlist_play_all_play_without_saving),
-            onClick = onPlayWithoutSaving,
-            modifier = Modifier.focusRequester(focusRequester),
-        )
-        TvModalButton(
-            text = stringResource(LR.string.tv_playlist_play_all_save_and_play),
-            onClick = onSaveAndPlay,
-        )
-        TvModalButton(
-            text = stringResource(LR.string.cancel),
-            onClick = onCancel,
-        )
-    }
+    Text(
+        text = stringResource(LR.string.tv_playlist_play_all_clear_up_next_title),
+        color = MaterialTheme.tvColors.textPrimary,
+        style = MaterialTheme.tvTypography.headline.copy(textAlign = TextAlign.Center),
+        modifier = Modifier.fillMaxWidth(),
+    )
+    Text(
+        text = stringResource(LR.string.tv_playlist_play_all_clear_up_next_message),
+        color = MaterialTheme.tvColors.textSecondary,
+        style = MaterialTheme.tvTypography.caption1.copy(textAlign = TextAlign.Center),
+        modifier = Modifier.fillMaxWidth(),
+    )
+    TvModalButton(
+        text = stringResource(LR.string.tv_playlist_play_all_play_without_saving),
+        onClick = onPlayWithoutSaving,
+    )
+    TvModalButton(
+        text = stringResource(LR.string.tv_playlist_play_all_save_and_play),
+        onClick = onSaveAndPlay,
+    )
+    TvModalButton(
+        text = stringResource(LR.string.cancel),
+        onClick = onCancel,
+        modifier = Modifier.focusRequester(focusRequester),
+    )
 }
 
 @Composable
@@ -506,5 +523,19 @@ private fun TvPlaylistDetailsLoadedPreview() {
             onOpenPodcast = {},
             onPlayAll = {},
         )
+    }
+}
+
+@Preview
+@Composable
+private fun TvPlayAllReplaceUpNextPreview() {
+    TvTheme {
+        TvModalSurface {
+            TvPlayAllReplaceUpNextContent(
+                onPlayWithoutSaving = {},
+                onSaveAndPlay = {},
+                onCancel = {},
+            )
+        }
     }
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
@@ -38,11 +38,15 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.Button
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.component.LocalOpenNowPlaying
+import au.com.shiftyjelly.pocketcasts.component.LocalTvToastHostState
 import au.com.shiftyjelly.pocketcasts.component.TvArchivedFilterButton
 import au.com.shiftyjelly.pocketcasts.component.TvEpisodeActionContext
 import au.com.shiftyjelly.pocketcasts.component.TvEpisodeActionsModal
 import au.com.shiftyjelly.pocketcasts.component.TvEpisodeInfoModal
 import au.com.shiftyjelly.pocketcasts.component.TvEpisodeListItem
+import au.com.shiftyjelly.pocketcasts.component.TvModal
+import au.com.shiftyjelly.pocketcasts.component.TvModalButton
 import au.com.shiftyjelly.pocketcasts.component.TvSortButton
 import au.com.shiftyjelly.pocketcasts.component.rememberTvEpisodeListFocus
 import au.com.shiftyjelly.pocketcasts.compose.components.PlaylistArtwork
@@ -78,10 +82,25 @@ fun TvPlaylistDetailsScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     var openedPodcastUuid by rememberSaveable { mutableStateOf<String?>(null) }
+    var isReplaceUpNextConfirmationVisible by remember { mutableStateOf(false) }
+
+    val openNowPlaying = LocalOpenNowPlaying.current
+    val toastHostState = LocalTvToastHostState.current
+    val upNextName = stringResource(LR.string.up_next)
+    val savedToast = stringResource(LR.string.up_next_as_playlist_saved)
 
     LaunchedEffect(uiState, onClose) {
         if (uiState is TvPlaylistDetailsUiState.NotFound) {
             onClose()
+        }
+    }
+
+    LaunchedEffect(viewModel) {
+        viewModel.events.collect { event ->
+            when (event) {
+                TvPlaylistDetailsEvent.OpenNowPlaying -> openNowPlaying()
+                TvPlaylistDetailsEvent.ShowReplaceUpNextConfirmation -> isReplaceUpNextConfirmationVisible = true
+            }
         }
     }
 
@@ -99,7 +118,23 @@ fun TvPlaylistDetailsScreen(
             onChangeSortType = viewModel::changeSortType,
             onToggleArchiveFilter = viewModel::toggleArchiveFilter,
             onOpenPodcast = { openedPodcastUuid = it },
+            onPlayAll = viewModel::playAll,
             modifier = modifier,
+        )
+    }
+
+    if (isReplaceUpNextConfirmationVisible) {
+        TvPlayAllReplaceUpNextModal(
+            onPlayWithoutSaving = {
+                isReplaceUpNextConfirmationVisible = false
+                viewModel.replaceUpNextAndPlay(saveUpNext = false, upNextName = upNextName)
+            },
+            onSaveAndPlay = {
+                isReplaceUpNextConfirmationVisible = false
+                toastHostState.show(savedToast)
+                viewModel.replaceUpNextAndPlay(saveUpNext = true, upNextName = upNextName)
+            },
+            onCancel = { isReplaceUpNextConfirmationVisible = false },
         )
     }
 }
@@ -110,6 +145,7 @@ private fun TvPlaylistDetailsContent(
     onChangeSortType: (PlaylistEpisodeSortType) -> Unit,
     onToggleArchiveFilter: () -> Unit,
     onOpenPodcast: (String) -> Unit,
+    onPlayAll: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Box(modifier = modifier.fillMaxSize()) {
@@ -129,6 +165,7 @@ private fun TvPlaylistDetailsContent(
                     PlaylistInfo(
                         playlist = uiState.playlist,
                         episodes = uiState.episodes,
+                        onPlayAll = onPlayAll,
                         playAllFocusRequester = playAllFocusRequester,
                         modifier = Modifier.width(InfoPaneWidth),
                     )
@@ -319,6 +356,7 @@ private fun NoEpisodes(
 private fun PlaylistInfo(
     playlist: Playlist,
     episodes: List<PodcastEpisode>,
+    onPlayAll: () -> Unit,
     playAllFocusRequester: FocusRequester,
     modifier: Modifier = Modifier,
 ) {
@@ -353,13 +391,52 @@ private fun PlaylistInfo(
         }
         if (episodes.isNotEmpty()) {
             Button(
-                onClick = {},
+                onClick = onPlayAll,
                 colors = TvButtonDefaults.filledButtonColors(),
                 modifier = Modifier.focusRequester(playAllFocusRequester),
             ) {
                 Text(stringResource(LR.string.tv_playlist_play_all))
             }
         }
+    }
+}
+
+@Composable
+private fun TvPlayAllReplaceUpNextModal(
+    onPlayWithoutSaving: () -> Unit,
+    onSaveAndPlay: () -> Unit,
+    onCancel: () -> Unit,
+) {
+    val focusRequester = remember { FocusRequester() }
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+    TvModal(onDismissRequest = onCancel) {
+        Text(
+            text = stringResource(LR.string.tv_playlist_play_all_clear_up_next_title),
+            color = MaterialTheme.tvColors.textPrimary,
+            style = MaterialTheme.tvTypography.headline.copy(textAlign = TextAlign.Center),
+            modifier = Modifier.fillMaxWidth(),
+        )
+        Text(
+            text = stringResource(LR.string.tv_playlist_play_all_clear_up_next_message),
+            color = MaterialTheme.tvColors.textSecondary,
+            style = MaterialTheme.tvTypography.caption1.copy(textAlign = TextAlign.Center),
+            modifier = Modifier.fillMaxWidth(),
+        )
+        TvModalButton(
+            text = stringResource(LR.string.tv_playlist_play_all_play_without_saving),
+            onClick = onPlayWithoutSaving,
+            modifier = Modifier.focusRequester(focusRequester),
+        )
+        TvModalButton(
+            text = stringResource(LR.string.tv_playlist_play_all_save_and_play),
+            onClick = onSaveAndPlay,
+        )
+        TvModalButton(
+            text = stringResource(LR.string.cancel),
+            onClick = onCancel,
+        )
     }
 }
 
@@ -395,6 +472,7 @@ private fun TvPlaylistDetailsPreview() {
             onChangeSortType = {},
             onToggleArchiveFilter = {},
             onOpenPodcast = {},
+            onPlayAll = {},
         )
     }
 }
@@ -426,6 +504,7 @@ private fun TvPlaylistDetailsLoadedPreview() {
             onChangeSortType = {},
             onToggleArchiveFilter = {},
             onOpenPodcast = {},
+            onPlayAll = {},
         )
     }
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
@@ -100,6 +100,7 @@ fun TvPlaylistDetailsScreen(
             when (event) {
                 TvPlaylistDetailsEvent.OpenNowPlaying -> openNowPlaying()
                 TvPlaylistDetailsEvent.ShowReplaceUpNextConfirmation -> isReplaceUpNextConfirmationVisible = true
+                TvPlaylistDetailsEvent.ShowUpNextSavedToast -> toastHostState.show(savedToast)
             }
         }
     }
@@ -131,7 +132,6 @@ fun TvPlaylistDetailsScreen(
             },
             onSaveAndPlay = {
                 isReplaceUpNextConfirmationVisible = false
-                toastHostState.show(savedToast)
                 viewModel.replaceUpNextAndPlay(saveUpNext = true, upNextName = upNextName)
             },
             onCancel = { isReplaceUpNextConfirmationVisible = false },

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModel.kt
@@ -19,17 +19,18 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.WhileSubscribed
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @HiltViewModel(assistedFactory = TvPlaylistDetailsViewModel.Factory::class)
 class TvPlaylistDetailsViewModel @AssistedInject constructor(
@@ -42,10 +43,11 @@ class TvPlaylistDetailsViewModel @AssistedInject constructor(
 
     private val playAllHandler = playAllHandlerFactory.create(SourceView.FILTERS)
 
-    private val _events = MutableSharedFlow<TvPlaylistDetailsEvent>(extraBufferCapacity = 1)
-    val events: SharedFlow<TvPlaylistDetailsEvent> = _events.asSharedFlow()
+    private val _events = Channel<TvPlaylistDetailsEvent>(Channel.BUFFERED)
+    val events: Flow<TvPlaylistDetailsEvent> = _events.receiveAsFlow()
 
     private var playAllJob: Job? = null
+    private var replaceUpNextJob: Job? = null
 
     private val playlistFlow: Flow<Playlist?> = when (playlistType) {
         Playlist.Type.Manual -> playlistManager.manualPlaylistFlow(playlistUuid, includeArchived = true)
@@ -93,20 +95,28 @@ class TvPlaylistDetailsViewModel @AssistedInject constructor(
         playAllJob = viewModelScope.launch {
             val episodes = (uiState.value as? TvPlaylistDetailsUiState.Loaded)?.episodes.orEmpty()
             when (playAllHandler.handlePlayAllEpisodes(episodes)) {
-                PlayAllResponse.DoNothing -> _events.emit(TvPlaylistDetailsEvent.OpenNowPlaying)
-                PlayAllResponse.ShowWarning -> _events.emit(TvPlaylistDetailsEvent.ShowReplaceUpNextConfirmation)
+                PlayAllResponse.DoNothing -> _events.send(TvPlaylistDetailsEvent.OpenNowPlaying)
+                PlayAllResponse.ShowWarning -> _events.send(TvPlaylistDetailsEvent.ShowReplaceUpNextConfirmation)
                 PlayAllResponse.ShowNoEpisodesToPlay -> Unit
             }
         }
     }
 
     fun replaceUpNextAndPlay(saveUpNext: Boolean, upNextName: String) {
-        viewModelScope.launch {
-            if (saveUpNext) {
-                playAllHandler.saveUpNextAsPlaylist(upNextName)
+        if (replaceUpNextJob?.isActive == true) {
+            return
+        }
+        replaceUpNextJob = viewModelScope.launch {
+            withContext(NonCancellable) {
+                if (saveUpNext) {
+                    playAllHandler.saveUpNextAsPlaylist(upNextName)
+                }
+                playAllHandler.playAllPendingEpisodes()
             }
-            playAllHandler.playAllPendingEpisodes()
-            _events.emit(TvPlaylistDetailsEvent.OpenNowPlaying)
+            if (saveUpNext) {
+                _events.send(TvPlaylistDetailsEvent.ShowUpNextSavedToast)
+            }
+            _events.send(TvPlaylistDetailsEvent.OpenNowPlaying)
         }
     }
 
@@ -120,6 +130,8 @@ sealed interface TvPlaylistDetailsEvent {
     data object OpenNowPlaying : TvPlaylistDetailsEvent
 
     data object ShowReplaceUpNextConfirmation : TvPlaylistDetailsEvent
+
+    data object ShowUpNextSavedToast : TvPlaylistDetailsEvent
 }
 
 sealed interface TvPlaylistDetailsUiState {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModel.kt
@@ -20,14 +20,15 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.WhileSubscribed
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -43,8 +44,8 @@ class TvPlaylistDetailsViewModel @AssistedInject constructor(
 
     private val playAllHandler = playAllHandlerFactory.create(SourceView.FILTERS)
 
-    private val _events = Channel<TvPlaylistDetailsEvent>(Channel.BUFFERED)
-    val events: Flow<TvPlaylistDetailsEvent> = _events.receiveAsFlow()
+    private val _events = MutableSharedFlow<TvPlaylistDetailsEvent>(extraBufferCapacity = 2)
+    val events: SharedFlow<TvPlaylistDetailsEvent> = _events.asSharedFlow()
 
     private var playAllJob: Job? = null
     private var replaceUpNextJob: Job? = null
@@ -95,9 +96,9 @@ class TvPlaylistDetailsViewModel @AssistedInject constructor(
         playAllJob = viewModelScope.launch {
             val episodes = (uiState.value as? TvPlaylistDetailsUiState.Loaded)?.episodes.orEmpty()
             when (playAllHandler.handlePlayAllEpisodes(episodes)) {
-                PlayAllResponse.DoNothing -> _events.send(TvPlaylistDetailsEvent.OpenNowPlaying)
-                PlayAllResponse.ShowWarning -> _events.send(TvPlaylistDetailsEvent.ShowReplaceUpNextConfirmation)
-                PlayAllResponse.ShowNoEpisodesToPlay -> Unit
+                PlayAllResponse.DoNothing -> _events.tryEmit(TvPlaylistDetailsEvent.OpenNowPlaying)
+                PlayAllResponse.ShowWarning -> _events.tryEmit(TvPlaylistDetailsEvent.ShowReplaceUpNextConfirmation)
+                PlayAllResponse.ShowNoEpisodesToPlay -> _events.tryEmit(TvPlaylistDetailsEvent.ShowNoEpisodesToPlay)
             }
         }
     }
@@ -108,15 +109,13 @@ class TvPlaylistDetailsViewModel @AssistedInject constructor(
         }
         replaceUpNextJob = viewModelScope.launch {
             withContext(NonCancellable) {
-                if (saveUpNext) {
-                    playAllHandler.saveUpNextAsPlaylist(upNextName)
+                val saved = saveUpNext && runCatching { playAllHandler.saveUpNextAsPlaylist(upNextName) }.getOrDefault(false)
+                if (saved) {
+                    _events.tryEmit(TvPlaylistDetailsEvent.ShowUpNextSavedToast)
                 }
                 playAllHandler.playAllPendingEpisodes()
             }
-            if (saveUpNext) {
-                _events.send(TvPlaylistDetailsEvent.ShowUpNextSavedToast)
-            }
-            _events.send(TvPlaylistDetailsEvent.OpenNowPlaying)
+            _events.tryEmit(TvPlaylistDetailsEvent.OpenNowPlaying)
         }
     }
 
@@ -132,6 +131,8 @@ sealed interface TvPlaylistDetailsEvent {
     data object ShowReplaceUpNextConfirmation : TvPlaylistDetailsEvent
 
     data object ShowUpNextSavedToast : TvPlaylistDetailsEvent
+
+    data object ShowNoEpisodesToPlay : TvPlaylistDetailsEvent
 }
 
 sealed interface TvPlaylistDetailsUiState {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModel.kt
@@ -18,6 +18,7 @@ import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.Flow
@@ -32,6 +33,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import timber.log.Timber
 
 @HiltViewModel(assistedFactory = TvPlaylistDetailsViewModel.Factory::class)
 class TvPlaylistDetailsViewModel @AssistedInject constructor(
@@ -49,6 +51,8 @@ class TvPlaylistDetailsViewModel @AssistedInject constructor(
 
     private var playAllJob: Job? = null
     private var replaceUpNextJob: Job? = null
+
+    private val isBusy get() = playAllJob?.isActive == true || replaceUpNextJob?.isActive == true
 
     private val playlistFlow: Flow<Playlist?> = when (playlistType) {
         Playlist.Type.Manual -> playlistManager.manualPlaylistFlow(playlistUuid, includeArchived = true)
@@ -90,32 +94,56 @@ class TvPlaylistDetailsViewModel @AssistedInject constructor(
     }
 
     fun playAll() {
-        if (playAllJob?.isActive == true) {
+        if (isBusy) {
             return
         }
         playAllJob = viewModelScope.launch {
-            val episodes = (uiState.value as? TvPlaylistDetailsUiState.Loaded)?.episodes.orEmpty()
-            when (playAllHandler.handlePlayAllEpisodes(episodes)) {
-                PlayAllResponse.DoNothing -> _events.tryEmit(TvPlaylistDetailsEvent.OpenNowPlaying)
-                PlayAllResponse.ShowWarning -> _events.tryEmit(TvPlaylistDetailsEvent.ShowReplaceUpNextConfirmation)
-                PlayAllResponse.ShowNoEpisodesToPlay -> _events.tryEmit(TvPlaylistDetailsEvent.ShowNoEpisodesToPlay)
+            try {
+                val episodes = (uiState.value as? TvPlaylistDetailsUiState.Loaded)?.episodes.orEmpty()
+                when (playAllHandler.handlePlayAllEpisodes(episodes)) {
+                    PlayAllResponse.DoNothing -> _events.tryEmit(TvPlaylistDetailsEvent.OpenNowPlaying)
+                    PlayAllResponse.ShowWarning -> _events.tryEmit(TvPlaylistDetailsEvent.ShowReplaceUpNextConfirmation)
+                    PlayAllResponse.ShowNoEpisodesToPlay -> _events.tryEmit(TvPlaylistDetailsEvent.ShowNoEpisodesToPlay)
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to play all episodes on TV")
             }
         }
     }
 
     fun replaceUpNextAndPlay(saveUpNext: Boolean, upNextName: String) {
-        if (replaceUpNextJob?.isActive == true) {
+        if (isBusy) {
             return
         }
         replaceUpNextJob = viewModelScope.launch {
-            withContext(NonCancellable) {
-                val saved = saveUpNext && runCatching { playAllHandler.saveUpNextAsPlaylist(upNextName) }.getOrDefault(false)
-                if (saved) {
-                    _events.tryEmit(TvPlaylistDetailsEvent.ShowUpNextSavedToast)
+            val played = withContext(NonCancellable) {
+                if (saveUpNext) {
+                    val saved = try {
+                        playAllHandler.saveUpNextAsPlaylist(upNextName)
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        Timber.e(e, "Failed to save Up Next as a playlist on TV")
+                        false
+                    }
+                    if (saved) {
+                        _events.tryEmit(TvPlaylistDetailsEvent.ShowUpNextSavedToast)
+                    }
                 }
-                playAllHandler.playAllPendingEpisodes()
+                try {
+                    playAllHandler.playAllPendingEpisodes()
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    Timber.e(e, "Failed to play the Up Next queue on TV")
+                    false
+                }
             }
-            _events.tryEmit(TvPlaylistDetailsEvent.OpenNowPlaying)
+            if (played) {
+                _events.tryEmit(TvPlaylistDetailsEvent.OpenNowPlaying)
+            }
         }
     }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModel.kt
@@ -2,11 +2,14 @@ package au.com.shiftyjelly.pocketcasts.playlists.details
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.PlaylistEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.toPodcastEpisodes
 import au.com.shiftyjelly.pocketcasts.models.type.PlaylistEpisodeSortType
 import au.com.shiftyjelly.pocketcasts.preferences.TvPreferences
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlayAllHandler
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlayAllResponse
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.Playlist
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
 import dagger.assisted.Assisted
@@ -15,11 +18,15 @@ import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.WhileSubscribed
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -30,7 +37,15 @@ class TvPlaylistDetailsViewModel @AssistedInject constructor(
     @Assisted private val playlistType: Playlist.Type,
     private val playlistManager: PlaylistManager,
     private val preferences: TvPreferences,
+    playAllHandlerFactory: PlayAllHandler.Factory,
 ) : ViewModel() {
+
+    private val playAllHandler = playAllHandlerFactory.create(SourceView.FILTERS)
+
+    private val _events = MutableSharedFlow<TvPlaylistDetailsEvent>(extraBufferCapacity = 1)
+    val events: SharedFlow<TvPlaylistDetailsEvent> = _events.asSharedFlow()
+
+    private var playAllJob: Job? = null
 
     private val playlistFlow: Flow<Playlist?> = when (playlistType) {
         Playlist.Type.Manual -> playlistManager.manualPlaylistFlow(playlistUuid, includeArchived = true)
@@ -71,10 +86,40 @@ class TvPlaylistDetailsViewModel @AssistedInject constructor(
         isShowingArchivedFlow.value = isShowingArchived
     }
 
+    fun playAll() {
+        if (playAllJob?.isActive == true) {
+            return
+        }
+        playAllJob = viewModelScope.launch {
+            val episodes = (uiState.value as? TvPlaylistDetailsUiState.Loaded)?.episodes.orEmpty()
+            when (playAllHandler.handlePlayAllEpisodes(episodes)) {
+                PlayAllResponse.DoNothing -> _events.emit(TvPlaylistDetailsEvent.OpenNowPlaying)
+                PlayAllResponse.ShowWarning -> _events.emit(TvPlaylistDetailsEvent.ShowReplaceUpNextConfirmation)
+                PlayAllResponse.ShowNoEpisodesToPlay -> Unit
+            }
+        }
+    }
+
+    fun replaceUpNextAndPlay(saveUpNext: Boolean, upNextName: String) {
+        viewModelScope.launch {
+            if (saveUpNext) {
+                playAllHandler.saveUpNextAsPlaylist(upNextName)
+            }
+            playAllHandler.playAllPendingEpisodes()
+            _events.emit(TvPlaylistDetailsEvent.OpenNowPlaying)
+        }
+    }
+
     @AssistedFactory
     interface Factory {
         fun create(playlistUuid: String, playlistType: Playlist.Type): TvPlaylistDetailsViewModel
     }
+}
+
+sealed interface TvPlaylistDetailsEvent {
+    data object OpenNowPlaying : TvPlaylistDetailsEvent
+
+    data object ShowReplaceUpNextConfirmation : TvPlaylistDetailsEvent
 }
 
 sealed interface TvPlaylistDetailsUiState {

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModelTest.kt
@@ -193,6 +193,7 @@ class TvPlaylistDetailsViewModelTest {
 
         viewModel.events.test {
             viewModel.replaceUpNextAndPlay(saveUpNext = true, upNextName = "Up Next")
+            assertEquals(TvPlaylistDetailsEvent.ShowUpNextSavedToast, awaitItem())
             assertEquals(TvPlaylistDetailsEvent.OpenNowPlaying, awaitItem())
         }
 

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModelTest.kt
@@ -12,6 +12,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.playlist.Playlist
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import java.util.Date
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.runTest
@@ -21,10 +22,12 @@ import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -189,6 +192,7 @@ class TvPlaylistDetailsViewModelTest {
 
     @Test
     fun `replacing with saving saves the queue before playing`() = runTest {
+        whenever(playAllHandler.saveUpNextAsPlaylist(any())) doReturn true
         val viewModel = createViewModel()
 
         viewModel.events.test {
@@ -200,6 +204,78 @@ class TvPlaylistDetailsViewModelTest {
         inOrder(playAllHandler) {
             verify(playAllHandler).saveUpNextAsPlaylist("Up Next")
             verify(playAllHandler).playAllPendingEpisodes()
+        }
+    }
+
+    @Test
+    fun `replacing with saving does not claim a save when nothing was saved`() = runTest {
+        whenever(playAllHandler.saveUpNextAsPlaylist(any())) doReturn false
+        val viewModel = createViewModel()
+
+        viewModel.events.test {
+            viewModel.replaceUpNextAndPlay(saveUpNext = true, upNextName = "Up Next")
+            assertEquals(TvPlaylistDetailsEvent.OpenNowPlaying, awaitItem())
+        }
+
+        verify(playAllHandler).playAllPendingEpisodes()
+    }
+
+    @Test
+    fun `replacing with saving still plays when the save fails`() = runTest {
+        whenever(playAllHandler.saveUpNextAsPlaylist(any())) doSuspendableAnswer { throw RuntimeException("boom") }
+        val viewModel = createViewModel()
+
+        viewModel.events.test {
+            viewModel.replaceUpNextAndPlay(saveUpNext = true, upNextName = "Up Next")
+            assertEquals(TvPlaylistDetailsEvent.OpenNowPlaying, awaitItem())
+        }
+
+        verify(playAllHandler).playAllPendingEpisodes()
+    }
+
+    @Test
+    fun `rapid replace requests save the up next only once`() = runTest {
+        val gate = CompletableDeferred<Boolean>()
+        whenever(playAllHandler.saveUpNextAsPlaylist(any())) doSuspendableAnswer { gate.await() }
+        val viewModel = createViewModel()
+
+        viewModel.replaceUpNextAndPlay(saveUpNext = true, upNextName = "Up Next")
+        viewModel.replaceUpNextAndPlay(saveUpNext = true, upNextName = "Up Next")
+        gate.complete(true)
+
+        verify(playAllHandler, times(1)).saveUpNextAsPlaylist("Up Next")
+    }
+
+    @Test
+    fun `play all passes only the visible episodes to the handler`() = runTest {
+        whenever(playAllHandler.handlePlayAllEpisodes(any())) doReturn PlayAllResponse.DoNothing
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            assertEquals(TvPlaylistDetailsUiState.Loading, awaitItem())
+            playlists.emit(playlist(availableEpisode, archivedEpisode))
+            assertEquals(listOf(availableEpisode), (awaitItem() as TvPlaylistDetailsUiState.Loaded).episodes)
+
+            viewModel.playAll()
+        }
+
+        verify(playAllHandler).handlePlayAllEpisodes(listOf(availableEpisode))
+    }
+
+    @Test
+    fun `play all surfaces the no episodes toast when nothing can be played`() = runTest {
+        whenever(playAllHandler.handlePlayAllEpisodes(any())) doReturn PlayAllResponse.ShowNoEpisodesToPlay
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            assertEquals(TvPlaylistDetailsUiState.Loading, awaitItem())
+            playlists.emit(playlist(availableEpisode))
+            assertEquals(listOf(availableEpisode), (awaitItem() as TvPlaylistDetailsUiState.Loaded).episodes)
+
+            viewModel.events.test {
+                viewModel.playAll()
+                assertEquals(TvPlaylistDetailsEvent.ShowNoEpisodesToPlay, awaitItem())
+            }
         }
     }
 

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModelTest.kt
@@ -15,6 +15,7 @@ import java.util.Date
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Rule
@@ -179,6 +180,7 @@ class TvPlaylistDetailsViewModelTest {
 
     @Test
     fun `replacing without saving plays the pending episodes and opens now playing`() = runTest {
+        whenever(playAllHandler.playAllPendingEpisodes()) doReturn true
         val viewModel = createViewModel()
 
         viewModel.events.test {
@@ -193,6 +195,7 @@ class TvPlaylistDetailsViewModelTest {
     @Test
     fun `replacing with saving saves the queue before playing`() = runTest {
         whenever(playAllHandler.saveUpNextAsPlaylist(any())) doReturn true
+        whenever(playAllHandler.playAllPendingEpisodes()) doReturn true
         val viewModel = createViewModel()
 
         viewModel.events.test {
@@ -210,6 +213,7 @@ class TvPlaylistDetailsViewModelTest {
     @Test
     fun `replacing with saving does not claim a save when nothing was saved`() = runTest {
         whenever(playAllHandler.saveUpNextAsPlaylist(any())) doReturn false
+        whenever(playAllHandler.playAllPendingEpisodes()) doReturn true
         val viewModel = createViewModel()
 
         viewModel.events.test {
@@ -223,6 +227,7 @@ class TvPlaylistDetailsViewModelTest {
     @Test
     fun `replacing with saving still plays when the save fails`() = runTest {
         whenever(playAllHandler.saveUpNextAsPlaylist(any())) doSuspendableAnswer { throw RuntimeException("boom") }
+        whenever(playAllHandler.playAllPendingEpisodes()) doReturn true
         val viewModel = createViewModel()
 
         viewModel.events.test {
@@ -242,8 +247,62 @@ class TvPlaylistDetailsViewModelTest {
         viewModel.replaceUpNextAndPlay(saveUpNext = true, upNextName = "Up Next")
         viewModel.replaceUpNextAndPlay(saveUpNext = true, upNextName = "Up Next")
         gate.complete(true)
+        advanceUntilIdle()
 
         verify(playAllHandler, times(1)).saveUpNextAsPlaylist("Up Next")
+    }
+
+    @Test
+    fun `replacing does not open now playing when there is nothing to play`() = runTest {
+        whenever(playAllHandler.playAllPendingEpisodes()) doReturn false
+        val viewModel = createViewModel()
+
+        viewModel.events.test {
+            viewModel.replaceUpNextAndPlay(saveUpNext = false, upNextName = "Up Next")
+            expectNoEvents()
+        }
+
+        verify(playAllHandler).playAllPendingEpisodes()
+    }
+
+    @Test
+    fun `rapid play all requests reach the handler only once`() = runTest {
+        val gate = CompletableDeferred<PlayAllResponse>()
+        whenever(playAllHandler.handlePlayAllEpisodes(any())) doSuspendableAnswer { gate.await() }
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            assertEquals(TvPlaylistDetailsUiState.Loading, awaitItem())
+            playlists.emit(playlist(availableEpisode))
+            assertEquals(listOf(availableEpisode), (awaitItem() as TvPlaylistDetailsUiState.Loaded).episodes)
+
+            viewModel.playAll()
+            viewModel.playAll()
+            gate.complete(PlayAllResponse.DoNothing)
+            advanceUntilIdle()
+        }
+
+        verify(playAllHandler, times(1)).handlePlayAllEpisodes(any())
+    }
+
+    @Test
+    fun `replace is ignored while play all is still running`() = runTest {
+        val gate = CompletableDeferred<PlayAllResponse>()
+        whenever(playAllHandler.handlePlayAllEpisodes(any())) doSuspendableAnswer { gate.await() }
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            assertEquals(TvPlaylistDetailsUiState.Loading, awaitItem())
+            playlists.emit(playlist(availableEpisode))
+            assertEquals(listOf(availableEpisode), (awaitItem() as TvPlaylistDetailsUiState.Loaded).episodes)
+
+            viewModel.playAll()
+            viewModel.replaceUpNextAndPlay(saveUpNext = true, upNextName = "Up Next")
+            gate.complete(PlayAllResponse.ShowWarning)
+            advanceUntilIdle()
+        }
+
+        verify(playAllHandler, never()).saveUpNextAsPlaylist(any())
     }
 
     @Test

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModelTest.kt
@@ -5,6 +5,8 @@ import au.com.shiftyjelly.pocketcasts.models.entity.ManualPlaylistEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.PlaylistEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.TvPreferences
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlayAllHandler
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlayAllResponse
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.ManualPlaylist
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.Playlist
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
@@ -20,8 +22,11 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class TvPlaylistDetailsViewModelTest {
@@ -34,6 +39,11 @@ class TvPlaylistDetailsViewModelTest {
         on { manualPlaylistFlow(any(), anyOrNull(), any()) } doReturn playlists
     }
     private val preferences = mock<TvPreferences>()
+
+    private val playAllHandler = mock<PlayAllHandler>()
+    private val playAllHandlerFactory = mock<PlayAllHandler.Factory> {
+        on { create(any()) } doReturn playAllHandler
+    }
 
     private val availableEpisode = episode(uuid = "episode-1", isArchived = false)
     private val archivedEpisode = episode(uuid = "episode-2", isArchived = true)
@@ -130,11 +140,74 @@ class TvPlaylistDetailsViewModelTest {
         }
     }
 
+    @Test
+    fun `play all opens now playing when the queue does not need replacing`() = runTest {
+        whenever(playAllHandler.handlePlayAllEpisodes(any())) doReturn PlayAllResponse.DoNothing
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            assertEquals(TvPlaylistDetailsUiState.Loading, awaitItem())
+            playlists.emit(playlist(availableEpisode))
+            assertEquals(listOf(availableEpisode), (awaitItem() as TvPlaylistDetailsUiState.Loaded).episodes)
+
+            viewModel.events.test {
+                viewModel.playAll()
+                assertEquals(TvPlaylistDetailsEvent.OpenNowPlaying, awaitItem())
+            }
+        }
+    }
+
+    @Test
+    fun `play all asks for confirmation when the queue would be replaced`() = runTest {
+        whenever(playAllHandler.handlePlayAllEpisodes(any())) doReturn PlayAllResponse.ShowWarning
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            assertEquals(TvPlaylistDetailsUiState.Loading, awaitItem())
+            playlists.emit(playlist(availableEpisode))
+            assertEquals(listOf(availableEpisode), (awaitItem() as TvPlaylistDetailsUiState.Loaded).episodes)
+
+            viewModel.events.test {
+                viewModel.playAll()
+                assertEquals(TvPlaylistDetailsEvent.ShowReplaceUpNextConfirmation, awaitItem())
+            }
+        }
+    }
+
+    @Test
+    fun `replacing without saving plays the pending episodes and opens now playing`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.events.test {
+            viewModel.replaceUpNextAndPlay(saveUpNext = false, upNextName = "Up Next")
+            assertEquals(TvPlaylistDetailsEvent.OpenNowPlaying, awaitItem())
+        }
+
+        verify(playAllHandler, never()).saveUpNextAsPlaylist(any())
+        verify(playAllHandler).playAllPendingEpisodes()
+    }
+
+    @Test
+    fun `replacing with saving saves the queue before playing`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.events.test {
+            viewModel.replaceUpNextAndPlay(saveUpNext = true, upNextName = "Up Next")
+            assertEquals(TvPlaylistDetailsEvent.OpenNowPlaying, awaitItem())
+        }
+
+        inOrder(playAllHandler) {
+            verify(playAllHandler).saveUpNextAsPlaylist("Up Next")
+            verify(playAllHandler).playAllPendingEpisodes()
+        }
+    }
+
     private fun createViewModel(prefs: TvPreferences = preferences) = TvPlaylistDetailsViewModel(
         playlistUuid = "playlist-uuid",
         playlistType = Playlist.Type.Manual,
         playlistManager = playlistManager,
         preferences = prefs,
+        playAllHandlerFactory = playAllHandlerFactory,
     )
 
     private fun playlist(vararg episodes: PodcastEpisode) = ManualPlaylist(


### PR DESCRIPTION
## Description

Wires up the **Play all episodes** action on the Android TV playlist details screen, mirroring the Apple TV (tvOS) implementation. The button already existed on the screen but its `onClick` was an empty stub.

Behaviour is ported from tvOS `PlaylistDetailsViewModel.playAll()` → `PlaybackManager.playIfSafe(playlist:episodeIDs:)`, reusing the existing phone-app `PlayAllHandler` so the Android phone and TV share identical semantics:

- **Up Next is empty, or is already this playlist** → replace/append and start playing immediately, then open Now Playing (no dialog).
- **Up Next is non-empty and different** → show a confirmation modal, matching the three tvOS options:
  - **Play without saving** — clear Up Next and play the playlist.
  - **Save and play** — snapshot the current Up Next into new manual playlists ("Up Next – <date>"), then play. A toast confirms the save once it completes.
  - **Cancel**.

The visible, sort/archive-filtered episode list is what gets played (matching what the user sees).

Fixes PCDROID-711 https://linear.app/a8c/issue/PCDROID-711/play-all-episodes

### Notable implementation points
- New `PlayAllHandler.handlePlayAllEpisodes(List<BaseEpisode>)` overload reuses the existing generic core so the TV screen can pass its `List<PodcastEpisode>` directly — no new play-all logic was written.
- One-shot navigation/toast signals go through a `Channel(BUFFERED).receiveAsFlow()` so an event can't be dropped across an activity-recreation window.
- `playAll()` and `replaceUpNextAndPlay()` are both re-entrancy guarded (a TV remote double-press on "Save and play" would otherwise create duplicate synced playlists), and the destructive queue-replace runs under `NonCancellable`.
- The 3-button confirmation is a `TvModal` (consistent with `TvEpisodeActionsModal`/`TvConfirmationContent`), not the phone's `Switch`-based dialog, because discrete buttons are far more D-pad friendly — the strings and logic remain the iOS ones.
- Analytics are intentionally omitted, consistent with the rest of the TV episode-action work.

## Testing Instructions

1. On Android TV, sign in and open a playlist that has episodes (Playlists tab → a playlist).
2. Focus the left pane and select **Play all episodes**.
   - With an **empty Up Next**: playback starts on the first episode and Now Playing opens.
3. Add some unrelated episodes to Up Next, then select **Play all episodes** again on a different playlist.
   - The **"This will clear your Up Next"** confirmation appears.
   - **Play without saving** → Up Next is replaced, playback starts, Now Playing opens.
   - **Save and play** → your previous Up Next is saved as new manual playlist(s), a toast confirms, then the playlist plays.
   - **Cancel** / Back → nothing changes.
4. Select **Play all episodes** when the playlist is already playing as Up Next → resumes / no-op, no dialog.

## Screenshots or Screencast
<img width="1920" height="1080" alt="Screenshot_20260810_145033" src="https://github.com/user-attachments/assets/1e30242a-3baf-47ab-b956-4031987fd8cc" />


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) the Event Horizon schema to reflect any new or changed analytics

#### I have tested any UI changes...
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
