### PR TITLE
[TV] Search screen: system on-screen keyboard + browse categories

### DIFF
--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -252,6 +252,7 @@
     <string name="tv_row_recommendations">Recommendations</string>
     <string name="tv_row_because_you_liked">Because you liked Podcast</string>
     <string name="tv_home_keep_listening">Keep Listening</string>
+    <string name="tv_search_browse_categories">Browse categories</string>
     <string name="tv_profile_starred_episodes">Starred Episodes</string>
     <string name="tv_sign_in_title">Log in to Pocket Casts</string>
     <string name="tv_sign_in_step_scan">Scan the QR code or go to %1$s</string>

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvCategoryTile.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvCategoryTile.kt
@@ -1,0 +1,84 @@
+package au.com.shiftyjelly.pocketcasts.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
+import au.com.shiftyjelly.pocketcasts.theme.TvTheme
+import au.com.shiftyjelly.pocketcasts.theme.tvColors
+import au.com.shiftyjelly.pocketcasts.theme.tvTypography
+import coil3.compose.AsyncImage
+
+@Composable
+fun TvCategoryTile(
+    category: DiscoverCategory,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var isFocused by remember { mutableStateOf(false) }
+    val contentColor = if (isFocused) MaterialTheme.tvColors.textPrimary else MaterialTheme.tvColors.textSecondary
+
+    TvTile(
+        onClick = onClick,
+        modifier = modifier
+            .width(280.dp)
+            .height(128.dp)
+            .onFocusChanged { isFocused = it.isFocused },
+    ) {
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            AsyncImage(
+                model = category.icon,
+                contentDescription = null,
+                colorFilter = ColorFilter.tint(contentColor),
+                modifier = Modifier.size(40.dp),
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = category.name,
+                style = MaterialTheme.tvTypography.headline,
+                color = contentColor,
+            )
+        }
+    }
+}
+
+@Preview(device = Devices.TV_1080p)
+@Composable
+private fun TvCategoryTilePreview() {
+    TvTheme {
+        Column(
+            modifier = Modifier
+                .background(MaterialTheme.tvColors.backgroundSunken)
+                .padding(48.dp),
+        ) {
+            TvCategoryTile(
+                category = DiscoverCategory(id = 1, name = "Comedy", icon = "", source = ""),
+                onClick = {},
+            )
+        }
+    }
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvCategoryTile.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvCategoryTile.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.tv.material3.CardDefaults
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
@@ -40,6 +41,10 @@ fun TvCategoryTile(
 
     TvTile(
         onClick = onClick,
+        colors = CardDefaults.colors(
+            containerColor = MaterialTheme.tvColors.backgroundOverlay,
+            focusedContainerColor = MaterialTheme.tvColors.backgroundOverlay,
+        ),
         modifier = modifier
             .width(280.dp)
             .height(128.dp)
@@ -54,12 +59,12 @@ fun TvCategoryTile(
                 model = category.icon,
                 contentDescription = null,
                 colorFilter = ColorFilter.tint(contentColor),
-                modifier = Modifier.size(40.dp),
+                modifier = Modifier.size(28.dp),
             )
-            Spacer(modifier = Modifier.height(12.dp))
+            Spacer(modifier = Modifier.height(10.dp))
             Text(
                 text = category.name,
-                style = MaterialTheme.tvTypography.headline,
+                style = MaterialTheme.tvTypography.body,
                 color = contentColor,
             )
         }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvCategoryTile.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvCategoryTile.kt
@@ -1,6 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.component
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -11,13 +13,11 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -36,7 +36,8 @@ fun TvCategoryTile(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    var isFocused by remember { mutableStateOf(false) }
+    val interactionSource = remember { MutableInteractionSource() }
+    val isFocused by interactionSource.collectIsFocusedAsState()
     val contentColor = if (isFocused) MaterialTheme.tvColors.textPrimary else MaterialTheme.tvColors.textSecondary
 
     TvTile(
@@ -45,10 +46,10 @@ fun TvCategoryTile(
             containerColor = MaterialTheme.tvColors.backgroundOverlay,
             focusedContainerColor = MaterialTheme.tvColors.backgroundOverlay,
         ),
+        interactionSource = interactionSource,
         modifier = modifier
             .width(280.dp)
-            .height(128.dp)
-            .onFocusChanged { isFocused = it.isFocused },
+            .height(128.dp),
     ) {
         Column(
             modifier = Modifier.fillMaxSize(),
@@ -66,6 +67,9 @@ fun TvCategoryTile(
                 text = category.name,
                 style = MaterialTheme.tvTypography.body,
                 color = contentColor,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.padding(horizontal = 12.dp),
             )
         }
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
@@ -32,6 +32,7 @@ import au.com.shiftyjelly.pocketcasts.component.TvTopBarVisibility
 import au.com.shiftyjelly.pocketcasts.nowplaying.TvNowPlayingScreen
 import au.com.shiftyjelly.pocketcasts.playlists.TvPlaylistsScreen
 import au.com.shiftyjelly.pocketcasts.podcasts.TvYourPodcastsScreen
+import au.com.shiftyjelly.pocketcasts.search.TvSearchScreen
 import au.com.shiftyjelly.pocketcasts.theme.TvScreenBackgroundBrush
 import au.com.shiftyjelly.pocketcasts.theme.TvTheme
 import au.com.shiftyjelly.pocketcasts.theme.TvTopBarHeight
@@ -105,8 +106,8 @@ fun TvScaffold(
                     onConsumeOpenRequest = { isNowPlayingOpenRequested = false },
                 )
 
-                else -> Box(modifier = belowTopBar) {
-                    TvTabPlaceholder(tab = tab)
+                is TvTab.Search -> Box(modifier = belowTopBar) {
+                    TvSearchScreen()
                 }
             }
         }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchField.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchField.kt
@@ -34,7 +34,7 @@ internal fun TvSearchField(
     modifier: Modifier = Modifier,
 ) {
     val scrollState = rememberScrollState()
-    LaunchedEffect(query) { scrollState.scrollTo(scrollState.maxValue) }
+    LaunchedEffect(scrollState.maxValue) { scrollState.scrollTo(scrollState.maxValue) }
 
     Row(
         verticalAlignment = Alignment.CenterVertically,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchField.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchField.kt
@@ -1,0 +1,92 @@
+package au.com.shiftyjelly.pocketcasts.search
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.tv.material3.Icon
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.theme.TvTheme
+import au.com.shiftyjelly.pocketcasts.theme.tvColors
+import au.com.shiftyjelly.pocketcasts.theme.tvTypography
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+internal fun TvSearchField(
+    query: String,
+    modifier: Modifier = Modifier,
+) {
+    val scrollState = rememberScrollState()
+    LaunchedEffect(query) { scrollState.scrollTo(scrollState.maxValue) }
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier,
+    ) {
+        Icon(
+            painter = painterResource(IR.drawable.ic_search),
+            contentDescription = null,
+            tint = MaterialTheme.tvColors.textSecondary,
+            modifier = Modifier.size(40.dp),
+        )
+        Spacer(modifier = Modifier.width(20.dp))
+        if (query.isEmpty()) {
+            Text(
+                text = stringResource(LR.string.search),
+                style = MaterialTheme.tvTypography.title2,
+                color = MaterialTheme.tvColors.textSecondary,
+            )
+        } else {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.horizontalScroll(scrollState),
+            ) {
+                Text(
+                    text = query,
+                    style = MaterialTheme.tvTypography.title2,
+                    color = MaterialTheme.tvColors.textPrimary,
+                    maxLines = 1,
+                    softWrap = false,
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+                Box(
+                    modifier = Modifier
+                        .width(3.dp)
+                        .height(36.dp)
+                        .background(MaterialTheme.tvColors.textPrimary),
+                )
+            }
+        }
+    }
+}
+
+@Preview(device = Devices.TV_1080p)
+@Composable
+private fun TvSearchFieldPreview() {
+    TvTheme {
+        Box(
+            modifier = Modifier
+                .background(MaterialTheme.tvColors.backgroundSunken)
+                .padding(48.dp),
+        ) {
+            TvSearchField(query = "huberman")
+        }
+    }
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchField.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchField.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.search
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
@@ -8,15 +9,29 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -25,9 +40,12 @@ import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.tv.material3.CardDefaults
 import androidx.tv.material3.Icon
+import androidx.tv.material3.LocalContentColor
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.component.TvTile
 import au.com.shiftyjelly.pocketcasts.theme.TvTheme
 import au.com.shiftyjelly.pocketcasts.theme.tvColors
 import au.com.shiftyjelly.pocketcasts.theme.tvTypography
@@ -39,51 +57,140 @@ internal fun TvSearchField(
     query: String,
     onQueryChange: (String) -> Unit,
     modifier: Modifier = Modifier,
-    autoFocus: Boolean = false,
 ) {
-    val focusRequester = remember { FocusRequester() }
+    var editing by remember { mutableStateOf(false) }
+    var restoreRestFocus by remember { mutableStateOf(false) }
+    val fieldFocusRequester = remember { FocusRequester() }
+    val restFocusRequester = remember { FocusRequester() }
+    val focusManager = LocalFocusManager.current
     val keyboardController = LocalSoftwareKeyboardController.current
-    if (autoFocus) {
-        LaunchedEffect(Unit) {
-            runCatching { focusRequester.requestFocus() }
+
+    LaunchedEffect(editing) {
+        if (editing) {
+            runCatching { fieldFocusRequester.requestFocus() }
             keyboardController?.show()
+        } else {
+            keyboardController?.hide()
+            if (restoreRestFocus) {
+                runCatching { restFocusRequester.requestFocus() }
+                restoreRestFocus = false
+            }
         }
     }
 
-    BasicTextField(
-        value = query,
-        onValueChange = onQueryChange,
-        singleLine = true,
-        textStyle = MaterialTheme.tvTypography.title2.copy(color = MaterialTheme.tvColors.textPrimary),
-        cursorBrush = SolidColor(MaterialTheme.tvColors.textPrimary),
-        keyboardOptions = KeyboardOptions(
-            capitalization = KeyboardCapitalization.None,
-            autoCorrectEnabled = false,
-            imeAction = ImeAction.Search,
-        ),
-        modifier = modifier.focusRequester(focusRequester),
-        decorationBox = { innerTextField ->
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Icon(
-                    painter = painterResource(IR.drawable.ic_search),
-                    contentDescription = null,
-                    tint = MaterialTheme.tvColors.textSecondary,
-                    modifier = Modifier.size(40.dp),
-                )
-                Spacer(modifier = Modifier.width(20.dp))
-                Box(contentAlignment = Alignment.CenterStart) {
-                    if (query.isEmpty()) {
-                        Text(
-                            text = stringResource(LR.string.search),
-                            style = MaterialTheme.tvTypography.title2,
-                            color = MaterialTheme.tvColors.textSecondary,
-                        )
+    if (editing) {
+        var hasFocused by remember { mutableStateOf(false) }
+
+        BackHandler(enabled = true) {
+            editing = false
+            restoreRestFocus = true
+        }
+
+        BasicTextField(
+            value = query,
+            onValueChange = onQueryChange,
+            singleLine = true,
+            textStyle = MaterialTheme.tvTypography.title3.copy(color = MaterialTheme.tvColors.textPrimary),
+            cursorBrush = SolidColor(MaterialTheme.tvColors.textPrimary),
+            keyboardOptions = KeyboardOptions(
+                capitalization = KeyboardCapitalization.None,
+                autoCorrectEnabled = false,
+                imeAction = ImeAction.Search,
+            ),
+            keyboardActions = KeyboardActions(
+                onSearch = {
+                    editing = false
+                    restoreRestFocus = true
+                },
+            ),
+            modifier = modifier
+                .focusRequester(fieldFocusRequester)
+                .onFocusChanged {
+                    if (it.isFocused) {
+                        hasFocused = true
+                    } else if (hasFocused) {
+                        editing = false
                     }
-                    innerTextField()
                 }
+                .onPreviewKeyEvent { event ->
+                    when {
+                        event.type == KeyEventType.KeyDown && event.key == Key.DirectionDown -> {
+                            focusManager.moveFocus(FocusDirection.Down)
+                            true
+                        }
+
+                        event.type == KeyEventType.KeyDown && event.key == Key.DirectionUp -> {
+                            focusManager.moveFocus(FocusDirection.Up)
+                            true
+                        }
+
+                        else -> false
+                    }
+                },
+            decorationBox = { innerTextField ->
+                TvSearchFieldContent(
+                    query = query,
+                    contentColor = MaterialTheme.tvColors.textPrimary,
+                    innerTextField = innerTextField,
+                )
+            },
+        )
+    } else {
+        TvTile(
+            onClick = { editing = true },
+            scale = CardDefaults.scale(focusedScale = 1f),
+            shape = CardDefaults.shape(shape = RectangleShape),
+            colors = CardDefaults.colors(
+                containerColor = Color.Transparent,
+                contentColor = MaterialTheme.tvColors.textSecondary,
+                focusedContainerColor = Color.Transparent,
+                focusedContentColor = MaterialTheme.tvColors.textPrimary,
+                pressedContainerColor = Color.Transparent,
+            ),
+            modifier = modifier.focusRequester(restFocusRequester),
+        ) {
+            TvSearchFieldContent(query = query, contentColor = LocalContentColor.current)
+        }
+    }
+}
+
+@Composable
+private fun TvSearchFieldContent(
+    query: String,
+    contentColor: Color,
+    modifier: Modifier = Modifier,
+    innerTextField: (@Composable () -> Unit)? = null,
+) {
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            painter = painterResource(IR.drawable.ic_search),
+            contentDescription = null,
+            tint = contentColor,
+            modifier = Modifier.size(32.dp),
+        )
+        Spacer(modifier = Modifier.width(16.dp))
+        Box(contentAlignment = Alignment.CenterStart) {
+            if (query.isEmpty()) {
+                Text(
+                    text = stringResource(LR.string.search),
+                    style = MaterialTheme.tvTypography.title3,
+                    color = MaterialTheme.tvColors.textSecondary,
+                )
             }
-        },
-    )
+            if (innerTextField != null) {
+                innerTextField()
+            } else if (query.isNotEmpty()) {
+                Text(
+                    text = query,
+                    style = MaterialTheme.tvTypography.title3,
+                    color = MaterialTheme.tvColors.textPrimary,
+                )
+            }
+        }
+    }
 }
 
 @Preview(device = Devices.TV_1080p)
@@ -95,7 +202,7 @@ private fun TvSearchFieldPreview() {
                 .background(MaterialTheme.tvColors.backgroundSunken)
                 .padding(48.dp),
         ) {
-            TvSearchField(query = "huberman", onQueryChange = {})
+            TvSearchField(query = "", onQueryChange = {})
         }
     }
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchField.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchField.kt
@@ -1,21 +1,27 @@
 package au.com.shiftyjelly.pocketcasts.search
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -31,50 +37,53 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 @Composable
 internal fun TvSearchField(
     query: String,
+    onQueryChange: (String) -> Unit,
     modifier: Modifier = Modifier,
+    autoFocus: Boolean = false,
 ) {
-    val scrollState = rememberScrollState()
-    LaunchedEffect(scrollState.maxValue) { scrollState.scrollTo(scrollState.maxValue) }
-
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = modifier,
-    ) {
-        Icon(
-            painter = painterResource(IR.drawable.ic_search),
-            contentDescription = null,
-            tint = MaterialTheme.tvColors.textSecondary,
-            modifier = Modifier.size(40.dp),
-        )
-        Spacer(modifier = Modifier.width(20.dp))
-        if (query.isEmpty()) {
-            Text(
-                text = stringResource(LR.string.search),
-                style = MaterialTheme.tvTypography.title2,
-                color = MaterialTheme.tvColors.textSecondary,
-            )
-        } else {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.horizontalScroll(scrollState),
-            ) {
-                Text(
-                    text = query,
-                    style = MaterialTheme.tvTypography.title2,
-                    color = MaterialTheme.tvColors.textPrimary,
-                    maxLines = 1,
-                    softWrap = false,
-                )
-                Spacer(modifier = Modifier.width(4.dp))
-                Box(
-                    modifier = Modifier
-                        .width(3.dp)
-                        .height(36.dp)
-                        .background(MaterialTheme.tvColors.textPrimary),
-                )
-            }
+    val focusRequester = remember { FocusRequester() }
+    val keyboardController = LocalSoftwareKeyboardController.current
+    if (autoFocus) {
+        LaunchedEffect(Unit) {
+            runCatching { focusRequester.requestFocus() }
+            keyboardController?.show()
         }
     }
+
+    BasicTextField(
+        value = query,
+        onValueChange = onQueryChange,
+        singleLine = true,
+        textStyle = MaterialTheme.tvTypography.title2.copy(color = MaterialTheme.tvColors.textPrimary),
+        cursorBrush = SolidColor(MaterialTheme.tvColors.textPrimary),
+        keyboardOptions = KeyboardOptions(
+            capitalization = KeyboardCapitalization.None,
+            autoCorrectEnabled = false,
+            imeAction = ImeAction.Search,
+        ),
+        modifier = modifier.focusRequester(focusRequester),
+        decorationBox = { innerTextField ->
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    painter = painterResource(IR.drawable.ic_search),
+                    contentDescription = null,
+                    tint = MaterialTheme.tvColors.textSecondary,
+                    modifier = Modifier.size(40.dp),
+                )
+                Spacer(modifier = Modifier.width(20.dp))
+                Box(contentAlignment = Alignment.CenterStart) {
+                    if (query.isEmpty()) {
+                        Text(
+                            text = stringResource(LR.string.search),
+                            style = MaterialTheme.tvTypography.title2,
+                            color = MaterialTheme.tvColors.textSecondary,
+                        )
+                    }
+                    innerTextField()
+                }
+            }
+        },
+    )
 }
 
 @Preview(device = Devices.TV_1080p)
@@ -86,7 +95,7 @@ private fun TvSearchFieldPreview() {
                 .background(MaterialTheme.tvColors.backgroundSunken)
                 .padding(48.dp),
         ) {
-            TvSearchField(query = "huberman")
+            TvSearchField(query = "huberman", onQueryChange = {})
         }
     }
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
@@ -42,9 +42,7 @@ fun TvSearchScreen(
     TvSearchContent(
         query = query,
         categories = categories,
-        onCharacter = { query += it },
-        onSpace = { query += ' ' },
-        onDelete = { query = query.dropLast(1) },
+        onQueryChange = { query = it },
         modifier = modifier,
     )
 }
@@ -53,9 +51,7 @@ fun TvSearchScreen(
 private fun TvSearchContent(
     query: String,
     categories: List<DiscoverCategory>,
-    onCharacter: (Char) -> Unit,
-    onSpace: () -> Unit,
-    onDelete: () -> Unit,
+    onQueryChange: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -65,19 +61,15 @@ private fun TvSearchContent(
     ) {
         Column(modifier = Modifier.padding(horizontal = 48.dp)) {
             Spacer(modifier = Modifier.height(40.dp))
-            TvSearchField(query = query)
-            Spacer(modifier = Modifier.height(40.dp))
-            TvSearchKeyboard(
-                onCharacter = onCharacter,
-                onSpace = onSpace,
-                onDelete = onDelete,
-                onSubmit = {},
+            TvSearchField(
+                query = query,
+                onQueryChange = onQueryChange,
                 autoFocus = true,
             )
+            Spacer(modifier = Modifier.height(24.dp))
         }
 
         if (categories.isNotEmpty()) {
-            Spacer(modifier = Modifier.height(24.dp))
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -111,9 +103,7 @@ private fun TvSearchScreenPreview() {
                     DiscoverCategory(id = 2, name = "True Crime", icon = "", source = ""),
                     DiscoverCategory(id = 3, name = "Fiction", icon = "", source = ""),
                 ),
-                onCharacter = {},
-                onSpace = {},
-                onDelete = {},
+                onQueryChange = {},
             )
         }
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
@@ -1,0 +1,55 @@
+package au.com.shiftyjelly.pocketcasts.search
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.tv.material3.MaterialTheme
+import au.com.shiftyjelly.pocketcasts.theme.TvTheme
+import au.com.shiftyjelly.pocketcasts.theme.tvColors
+
+@Composable
+fun TvSearchScreen(
+    modifier: Modifier = Modifier,
+) {
+    var query by rememberSaveable { mutableStateOf("") }
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = 48.dp),
+    ) {
+        Spacer(modifier = Modifier.height(40.dp))
+        TvSearchField(query = query)
+        Spacer(modifier = Modifier.height(40.dp))
+        TvSearchKeyboard(
+            onCharacter = { query += it },
+            onSpace = { query += ' ' },
+            onDelete = { query = query.dropLast(1) },
+            onSubmit = {},
+            autoFocus = true,
+        )
+    }
+}
+
+@Preview(device = Devices.TV_1080p)
+@Composable
+private fun TvSearchScreenPreview() {
+    TvTheme {
+        Box(modifier = Modifier.fillMaxSize().background(MaterialTheme.tvColors.backgroundSunken)) {
+            TvSearchScreen()
+        }
+    }
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
@@ -3,44 +3,99 @@ package au.com.shiftyjelly.pocketcasts.search
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.MaterialTheme
+import au.com.shiftyjelly.pocketcasts.component.TvCategoryTile
+import au.com.shiftyjelly.pocketcasts.component.TvRow
+import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
 import au.com.shiftyjelly.pocketcasts.theme.TvTheme
 import au.com.shiftyjelly.pocketcasts.theme.tvColors
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 fun TvSearchScreen(
     modifier: Modifier = Modifier,
+    viewModel: TvSearchViewModel = hiltViewModel(),
 ) {
     var query by rememberSaveable { mutableStateOf("") }
+    val categories by viewModel.categories.collectAsStateWithLifecycle()
 
+    TvSearchContent(
+        query = query,
+        categories = categories,
+        onCharacter = { query += it },
+        onSpace = { query += ' ' },
+        onDelete = { query = query.dropLast(1) },
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun TvSearchContent(
+    query: String,
+    categories: List<DiscoverCategory>,
+    onCharacter: (Char) -> Unit,
+    onSpace: () -> Unit,
+    onDelete: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
     Column(
         modifier = modifier
             .fillMaxSize()
-            .padding(horizontal = 48.dp),
+            .verticalScroll(rememberScrollState()),
     ) {
-        Spacer(modifier = Modifier.height(40.dp))
-        TvSearchField(query = query)
-        Spacer(modifier = Modifier.height(40.dp))
-        TvSearchKeyboard(
-            onCharacter = { query += it },
-            onSpace = { query += ' ' },
-            onDelete = { query = query.dropLast(1) },
-            onSubmit = {},
-            autoFocus = true,
-        )
+        Column(modifier = Modifier.padding(horizontal = 48.dp)) {
+            Spacer(modifier = Modifier.height(40.dp))
+            TvSearchField(query = query)
+            Spacer(modifier = Modifier.height(40.dp))
+            TvSearchKeyboard(
+                onCharacter = onCharacter,
+                onSpace = onSpace,
+                onDelete = onDelete,
+                onSubmit = {},
+                autoFocus = true,
+            )
+        }
+
+        if (categories.isNotEmpty()) {
+            Spacer(modifier = Modifier.height(24.dp))
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 48.dp)
+                    .height(1.dp)
+                    .background(MaterialTheme.tvColors.overlayBorder),
+            )
+            Spacer(modifier = Modifier.height(24.dp))
+            TvRow(
+                title = stringResource(LR.string.tv_search_browse_categories),
+                items = categories,
+                contentPadding = PaddingValues(horizontal = 48.dp),
+                key = { it.id },
+            ) { category ->
+                TvCategoryTile(category = category, onClick = {})
+            }
+            Spacer(modifier = Modifier.height(40.dp))
+        }
     }
 }
 
@@ -49,7 +104,17 @@ fun TvSearchScreen(
 private fun TvSearchScreenPreview() {
     TvTheme {
         Box(modifier = Modifier.fillMaxSize().background(MaterialTheme.tvColors.backgroundSunken)) {
-            TvSearchScreen()
+            TvSearchContent(
+                query = "",
+                categories = listOf(
+                    DiscoverCategory(id = 1, name = "Comedy", icon = "", source = ""),
+                    DiscoverCategory(id = 2, name = "True Crime", icon = "", source = ""),
+                    DiscoverCategory(id = 3, name = "Fiction", icon = "", source = ""),
+                ),
+                onCharacter = {},
+                onSpace = {},
+                onDelete = {},
+            )
         }
     }
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
@@ -64,7 +64,6 @@ private fun TvSearchContent(
             TvSearchField(
                 query = query,
                 onQueryChange = onQueryChange,
-                autoFocus = true,
             )
             Spacer(modifier = Modifier.height(24.dp))
         }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
@@ -1,0 +1,41 @@
+package au.com.shiftyjelly.pocketcasts.search
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.lists.ListRepository
+import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+@HiltViewModel
+class TvSearchViewModel @Inject constructor(
+    private val listRepository: ListRepository,
+) : ViewModel() {
+
+    private val _categories = MutableStateFlow<List<DiscoverCategory>>(emptyList())
+    val categories: StateFlow<List<DiscoverCategory>> = _categories.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            _categories.value = try {
+                listRepository.getCategoriesList(CATEGORIES_URL)
+            } catch (exception: CancellationException) {
+                throw exception
+            } catch (exception: Exception) {
+                Timber.e(exception, "Failed to load TV browse categories")
+                emptyList()
+            }
+        }
+    }
+
+    companion object {
+        private const val CATEGORIES_URL = "${Settings.SERVER_STATIC_URL}/discover/json/categories_v2.json"
+    }
+}

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModelTest.kt
@@ -1,0 +1,45 @@
+package au.com.shiftyjelly.pocketcasts.search
+
+import au.com.shiftyjelly.pocketcasts.repositories.lists.ListRepository
+import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
+import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TvSearchViewModelTest {
+
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
+
+    private val listRepository = mock<ListRepository>()
+
+    @Test
+    fun `exposes the loaded browse categories`() = runTest {
+        whenever(listRepository.getCategoriesList(any())).thenReturn(
+            listOf(category(1, "Comedy"), category(2, "True Crime")),
+        )
+
+        val viewModel = TvSearchViewModel(listRepository)
+
+        assertEquals(listOf("Comedy", "True Crime"), viewModel.categories.value.map { it.name })
+    }
+
+    @Test
+    fun `categories are empty when loading fails`() = runTest {
+        whenever(listRepository.getCategoriesList(any())).thenThrow(RuntimeException("Network error"))
+
+        val viewModel = TvSearchViewModel(listRepository)
+
+        assertTrue(viewModel.categories.value.isEmpty())
+    }
+
+    private fun category(id: Int, name: String) = DiscoverCategory(id = id, name = name, icon = "", source = "")
+}


### PR DESCRIPTION
## Description

The Android TV **search screen**: an editable query field backed by Android TV's **default system on-screen keyboard** (the leanback IME, per [Manage on-screen keyboards](https://developer.android.com/training/tv/get-started/onscreen-keyboard)), plus a **Browse categories** row.

> **Design decision:** we prototyped a bespoke tvOS-style on-screen keyboard, but design compared it against the platform keyboard and chose the **system keyboard** (autocomplete, dictation, physical-keyboard handling for free). This PR now integrates the system keyboard directly; the custom-keyboard spike (previously #5718) has been dropped, so this PR is based on `main`.

### Search field + keyboard
- **`search/TvSearchField.kt`** — an editable `BasicTextField` (search icon + placeholder + cursor) with `ImeAction.Search`, single line. It auto-focuses and shows the system keyboard on entry, so text comes from the leanback IME (or a connected physical keyboard).
- **`search/TvSearchScreen.kt`** — holds the query state and drives it from the field's `onValueChange`; split into a stateful screen (`hiltViewModel`) and a preview-friendly stateless `TvSearchContent`. Wrapped in `verticalScroll` so the categories row is reachable by D-pad.
- **`home/TvScaffold.kt`** — the `TvTab.Search` tab renders `TvSearchScreen`.

### Browse categories (new, display-only)
Modeled on the Apple TV category tiles.
- **`component/TvCategoryTile.kt`** — a `TvTile`-based rounded card with a centered tinted icon (`category.icon`, rendered as a monochrome mask — same treatment as the mobile category pills) over the category name; icon/label swap `textSecondary`→`textPrimary` on focus.
- **`search/TvSearchViewModel.kt`** — `@HiltViewModel`, loads the category list and exposes `categories: StateFlow<List<DiscoverCategory>>` (empty on failure). + unit tests.
- A **1dp horizontal divider** separates the field from a `TvRow(title = "Browse categories")` of `TvCategoryTile`s (shown only once categories load).

> **Note on the category source:** the TV discover feed (`tv/content_v3.json`) does not currently carry a `categories` row, so the view model fetches the canonical categories endpoint directly (`${SERVER_STATIC_URL}/discover/json/categories_v2.json` — the same list the mobile discover feed references). When the TV feed gains a categories row this can switch to feed-driven.

**Scope:** display-only — category tiles have **no click navigation and no analytics** (both intentionally deferred). Autocomplete suggestions and search results are follow-ups (`ImprovedSearchManager` is already reachable from `tv/`).

Fixes POC-799 https://linear.app/a8c/issue/POC-799/search-skeleton-ui
Figma: Ftk3KwnfqaK4g57yCN63p0-fi-2595_2028
Conversation: p1786523963874079-slack-C0ATWH7BNH3

## Testing Instructions

1. Open the **Search** tab. The field auto-focuses and the **system on-screen keyboard** appears; below the divider, the **Browse categories** row loads (Arts, Business, Comedy, …).
2. Type with the remote (D-pad) or a physical keyboard — characters land in the field, with the system keyboard's autocomplete suggestions.
3. D-pad **Down** off the keyboard into the categories row; tiles focus-highlight (icon/label brighten, card lifts). Pressing a tile does nothing (display-only, by design).
4. `./gradlew :tv:testDebugUnitTest` passes.

## Screenshots or Screencast

| Search in focus | Browse category in focus |
| --- | --- |
| <img width="1920" height="1080" alt="Screenshot_20260812_133212" src="https://github.com/user-attachments/assets/2d735722-a55d-427a-9d4a-10b6f0a17f40" /> | <img width="1920" height="1080" alt="Screenshot_20260812_133227" src="https://github.com/user-attachments/assets/19677bc0-0f6a-43a3-ab75-598d4f4f5cc6" /> |


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md 
- [x] Ensure the linter passes (`./gradlew spotlessApply`)
- [x] I have considered whether it makes sense to add tests for my changes 
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) the Event Horizon schema to reflect any new or changed analytics.