### PR TITLE
[TV] Add a custom on-screen keyboard for search

### DIFF
--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -252,6 +252,9 @@
     <string name="tv_row_recommendations">Recommendations</string>
     <string name="tv_row_because_you_liked">Because you liked Podcast</string>
     <string name="tv_home_keep_listening">Keep Listening</string>
+    <string name="tv_search_key_space">Space</string>
+    <string name="tv_search_key_symbols" translatable="false">123</string>
+    <string name="tv_search_key_letters" translatable="false">ABC</string>
     <string name="tv_profile_starred_episodes">Starred Episodes</string>
     <string name="tv_sign_in_title">Log in to Pocket Casts</string>
     <string name="tv_sign_in_step_scan">Scan the QR code or go to %1$s</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -252,6 +252,7 @@
     <string name="tv_row_recommendations">Recommendations</string>
     <string name="tv_row_because_you_liked">Because you liked Podcast</string>
     <string name="tv_home_keep_listening">Keep Listening</string>
+    <string name="tv_search_keyboard">On-screen keyboard</string>
     <string name="tv_search_key_space">Space</string>
     <string name="tv_search_key_symbols" translatable="false">123</string>
     <string name="tv_search_key_letters" translatable="false">ABC</string>

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchKeyboard.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchKeyboard.kt
@@ -177,7 +177,7 @@ internal fun TvSearchKeyboard(
         )
     }
 
-    Box(modifier = modifier) {
+    Box(modifier = modifier, propagateMinConstraints = true) {
         CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
             Row(
                 horizontalArrangement = Arrangement.spacedBy(2.dp),

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchKeyboard.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchKeyboard.kt
@@ -1,0 +1,295 @@
+package au.com.shiftyjelly.pocketcasts.search
+
+import android.view.KeyEvent.KEYCODE_DEL
+import android.view.KeyEvent.KEYCODE_DPAD_CENTER
+import android.view.KeyEvent.KEYCODE_DPAD_LEFT
+import android.view.KeyEvent.KEYCODE_DPAD_RIGHT
+import android.view.KeyEvent.KEYCODE_ENTER
+import android.view.KeyEvent.KEYCODE_NUMPAD_ENTER
+import android.view.KeyEvent.KEYCODE_SPACE
+import androidx.compose.foundation.background
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.nativeKeyCode
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.theme.TvTheme
+import au.com.shiftyjelly.pocketcasts.theme.tvColors
+import au.com.shiftyjelly.pocketcasts.theme.tvTypography
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+sealed interface TvSearchKey {
+    data class Character(val char: Char) : TvSearchKey
+    data object Space : TvSearchKey
+    data object Delete : TvSearchKey
+    data object TogglePage : TvSearchKey
+}
+
+private enum class TvSearchKeyboardPage { Letters, Symbols }
+
+private val LettersKeys: List<TvSearchKey> = buildList {
+    add(TvSearchKey.TogglePage)
+    add(TvSearchKey.Space)
+    ('a'..'z').forEach { add(TvSearchKey.Character(it)) }
+    add(TvSearchKey.Delete)
+}
+
+private val SymbolsKeys: List<TvSearchKey> = buildList {
+    add(TvSearchKey.TogglePage)
+    add(TvSearchKey.Space)
+    ('0'..'9').forEach { add(TvSearchKey.Character(it)) }
+    ".,'-_&@".forEach { add(TvSearchKey.Character(it)) }
+    add(TvSearchKey.Delete)
+}
+
+private val InitialSelectedIndex = LettersKeys.indexOfFirst { it is TvSearchKey.Character }
+
+@Stable
+class TvSearchKeyboardState {
+    private var page by mutableStateOf(TvSearchKeyboardPage.Letters)
+
+    var selectedIndex by mutableIntStateOf(InitialSelectedIndex)
+        private set
+
+    var isFocused by mutableStateOf(false)
+        private set
+
+    private var consumedLastLeftRight = false
+
+    val keys: List<TvSearchKey> get() = if (page == TvSearchKeyboardPage.Letters) LettersKeys else SymbolsKeys
+    val isSymbolsPage: Boolean get() = page == TvSearchKeyboardPage.Symbols
+    val selectedKey: TvSearchKey get() = keys[selectedIndex]
+
+    fun onFocusChanged(focused: Boolean) {
+        isFocused = focused
+    }
+
+    fun togglePage() {
+        page = if (page == TvSearchKeyboardPage.Letters) TvSearchKeyboardPage.Symbols else TvSearchKeyboardPage.Letters
+        if (selectedIndex > keys.lastIndex) {
+            selectedIndex = keys.lastIndex
+        }
+    }
+
+    fun isSelected(index: Int): Boolean = isFocused && selectedIndex == index
+
+    fun handleDpadDirection(keyCode: Int, isKeyDown: Boolean): Boolean {
+        if (keyCode != KEYCODE_DPAD_LEFT && keyCode != KEYCODE_DPAD_RIGHT) return false
+        return if (isKeyDown) {
+            consumedLastLeftRight = when (keyCode) {
+                KEYCODE_DPAD_RIGHT -> (selectedIndex < keys.lastIndex).also { if (it) selectedIndex++ }
+                KEYCODE_DPAD_LEFT -> (selectedIndex > 0).also { if (it) selectedIndex-- }
+                else -> false
+            }
+            consumedLastLeftRight
+        } else {
+            consumedLastLeftRight.also { consumedLastLeftRight = false }
+        }
+    }
+}
+
+@Composable
+fun rememberTvSearchKeyboardState(): TvSearchKeyboardState = remember { TvSearchKeyboardState() }
+
+@Composable
+internal fun TvSearchKeyboard(
+    onCharacter: (Char) -> Unit,
+    onSpace: () -> Unit,
+    onDelete: () -> Unit,
+    onSubmit: () -> Unit,
+    modifier: Modifier = Modifier,
+    state: TvSearchKeyboardState = rememberTvSearchKeyboardState(),
+) {
+    val focusRequester = remember { FocusRequester() }
+    LaunchedEffect(Unit) {
+        withFrameNanos {}
+        runCatching { focusRequester.requestFocus() }
+    }
+
+    fun activate(key: TvSearchKey) {
+        when (key) {
+            is TvSearchKey.Character -> onCharacter(key.char)
+            TvSearchKey.Space -> onSpace()
+            TvSearchKey.Delete -> onDelete()
+            TvSearchKey.TogglePage -> state.togglePage()
+        }
+    }
+
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(2.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier
+            .focusRequester(focusRequester)
+            .onFocusChanged { state.onFocusChanged(it.isFocused) }
+            .onPreviewKeyEvent { event ->
+                val keyCode = event.key.nativeKeyCode
+                val isKeyDown = event.type == KeyEventType.KeyDown
+                when (keyCode) {
+                    KEYCODE_DPAD_LEFT, KEYCODE_DPAD_RIGHT -> state.handleDpadDirection(keyCode, isKeyDown)
+
+                    KEYCODE_DPAD_CENTER -> {
+                        if (isKeyDown) activate(state.selectedKey)
+                        true
+                    }
+
+                    KEYCODE_ENTER, KEYCODE_NUMPAD_ENTER -> {
+                        if (isKeyDown) onSubmit()
+                        true
+                    }
+
+                    KEYCODE_DEL -> {
+                        if (isKeyDown) onDelete()
+                        true
+                    }
+
+                    KEYCODE_SPACE -> {
+                        if (isKeyDown) onSpace()
+                        true
+                    }
+
+                    else -> {
+                        val unicodeChar = event.nativeKeyEvent.getUnicodeChar(event.nativeKeyEvent.metaState)
+                        if (unicodeChar != 0 && !Character.isISOControl(unicodeChar)) {
+                            if (isKeyDown) onCharacter(unicodeChar.toChar())
+                            true
+                        } else {
+                            false
+                        }
+                    }
+                }
+            }
+            .focusable(),
+    ) {
+        state.keys.forEachIndexed { index, key ->
+            TvSearchKeyCap(
+                key = key,
+                selected = state.isSelected(index),
+                isSymbolsPage = state.isSymbolsPage,
+            )
+        }
+    }
+}
+
+@Composable
+private fun TvSearchKeyCap(
+    key: TvSearchKey,
+    selected: Boolean,
+    isSymbolsPage: Boolean,
+) {
+    val hasPersistentBackground = key is TvSearchKey.Space || key is TvSearchKey.TogglePage
+    val background = when {
+        selected -> MaterialTheme.tvColors.backgroundActive
+        hasPersistentBackground -> MaterialTheme.tvColors.backgroundActive20
+        else -> Color.Transparent
+    }
+    val contentColor = if (selected) MaterialTheme.tvColors.textPrimaryActive else MaterialTheme.tvColors.textSecondary
+    val deleteLabel = stringResource(LR.string.delete)
+    val shape = RoundedCornerShape(8.dp)
+    val sizeModifier = when (key) {
+        is TvSearchKey.Character -> Modifier.width(24.dp).height(48.dp).clip(shape).background(background)
+
+        TvSearchKey.Delete -> Modifier.width(42.dp).height(48.dp).clip(shape).background(background)
+
+        TvSearchKey.Space, TvSearchKey.TogglePage ->
+            Modifier.clip(shape).background(background).padding(horizontal = 12.dp, vertical = 6.dp)
+    }
+
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier
+            .scale(if (selected) 1.25f else 1f)
+            .then(sizeModifier),
+    ) {
+        when (key) {
+            is TvSearchKey.Character -> Text(
+                text = key.char.toString(),
+                style = MaterialTheme.tvTypography.subtitle1,
+                color = contentColor,
+            )
+
+            TvSearchKey.Space -> Text(
+                text = stringResource(LR.string.tv_search_key_space),
+                style = MaterialTheme.tvTypography.caption1,
+                color = contentColor,
+            )
+
+            TvSearchKey.Delete -> Text(
+                text = "⌫",
+                style = MaterialTheme.tvTypography.title3,
+                color = contentColor,
+                modifier = Modifier.semantics { contentDescription = deleteLabel },
+            )
+
+            TvSearchKey.TogglePage -> Text(
+                text = stringResource(
+                    if (isSymbolsPage) LR.string.tv_search_key_letters else LR.string.tv_search_key_symbols,
+                ),
+                style = MaterialTheme.tvTypography.caption1,
+                color = contentColor,
+            )
+        }
+    }
+}
+
+@Preview(device = Devices.TV_1080p)
+@Composable
+private fun TvSearchKeyboardPreview() {
+    TvTheme {
+        var query by remember { mutableStateOf("") }
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.tvColors.backgroundSunken)
+                .padding(48.dp),
+        ) {
+            Text(
+                text = query.ifEmpty { "Type with the remote or a keyboard…" },
+                style = MaterialTheme.tvTypography.title2,
+                color = MaterialTheme.tvColors.textPrimary,
+            )
+            Spacer(modifier = Modifier.height(24.dp))
+            TvSearchKeyboard(
+                onCharacter = { query += it },
+                onSpace = { query += ' ' },
+                onDelete = { query = query.dropLast(1) },
+                onSubmit = {},
+            )
+        }
+    }
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchKeyboard.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchKeyboard.kt
@@ -1,8 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.search
 
-import android.view.InputDevice
 import android.view.KeyCharacterMap
-import android.view.KeyEvent
 import android.view.KeyEvent.KEYCODE_DEL
 import android.view.KeyEvent.KEYCODE_DPAD_CENTER
 import android.view.KeyEvent.KEYCODE_DPAD_LEFT
@@ -198,19 +196,8 @@ internal fun TvSearchKeyboard(
                         when (keyCode) {
                             KEYCODE_DPAD_LEFT, KEYCODE_DPAD_RIGHT -> state.handleDpadDirection(keyCode, isKeyDown)
 
-                            KEYCODE_DPAD_CENTER -> {
+                            KEYCODE_DPAD_CENTER, KEYCODE_ENTER, KEYCODE_NUMPAD_ENTER -> {
                                 if (isKeyDown) activate(state.selectedKey)
-                                true
-                            }
-
-                            KEYCODE_ENTER, KEYCODE_NUMPAD_ENTER -> {
-                                if (isKeyDown) {
-                                    if (event.nativeKeyEvent.isFromPhysicalKeyboard()) {
-                                        onSubmit()
-                                    } else {
-                                        activate(state.selectedKey)
-                                    }
-                                }
                                 true
                             }
 
@@ -259,12 +246,6 @@ internal fun TvSearchKeyboard(
             }
         }
     }
-}
-
-private fun KeyEvent.isFromPhysicalKeyboard(): Boolean {
-    val device = device ?: return false
-    return device.keyboardType == InputDevice.KEYBOARD_TYPE_ALPHABETIC &&
-        (source and InputDevice.SOURCE_KEYBOARD) == InputDevice.SOURCE_KEYBOARD
 }
 
 @Composable

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchKeyboard.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchKeyboard.kt
@@ -2,12 +2,14 @@ package au.com.shiftyjelly.pocketcasts.search
 
 import android.view.InputDevice
 import android.view.KeyCharacterMap
+import android.view.KeyEvent
 import android.view.KeyEvent.KEYCODE_DEL
 import android.view.KeyEvent.KEYCODE_DPAD_CENTER
 import android.view.KeyEvent.KEYCODE_DPAD_LEFT
 import android.view.KeyEvent.KEYCODE_DPAD_RIGHT
 import android.view.KeyEvent.KEYCODE_ENTER
 import android.view.KeyEvent.KEYCODE_NUMPAD_ENTER
+import android.view.KeyEvent.KEYCODE_SEARCH
 import android.view.KeyEvent.KEYCODE_SPACE
 import androidx.compose.foundation.background
 import androidx.compose.foundation.focusable
@@ -51,6 +53,8 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.LayoutDirection
@@ -142,7 +146,7 @@ internal fun TvSearchKeyboard(
     onDelete: () -> Unit,
     onSubmit: () -> Unit,
     modifier: Modifier = Modifier,
-    autoFocus: Boolean = true,
+    autoFocus: Boolean = false,
     state: TvSearchKeyboardState = rememberTvSearchKeyboardState(),
 ) {
     val focusRequester = remember { FocusRequester() }
@@ -175,79 +179,92 @@ internal fun TvSearchKeyboard(
         )
     }
 
-    CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
-        Row(
-            horizontalArrangement = Arrangement.spacedBy(2.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = modifier
-                .focusRequester(focusRequester)
-                .onFocusChanged { state.onFocusChanged(it.isFocused) }
-                .semantics {
-                    contentDescription = keyboardDescription
-                    stateDescription = selectedKeyLabel
-                    liveRegion = LiveRegionMode.Polite
-                }
-                .onPreviewKeyEvent { event ->
-                    val keyCode = event.key.nativeKeyCode
-                    val isKeyDown = event.type == KeyEventType.KeyDown
-                    when (keyCode) {
-                        KEYCODE_DPAD_LEFT, KEYCODE_DPAD_RIGHT -> state.handleDpadDirection(keyCode, isKeyDown)
+    Box(modifier = modifier) {
+        CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(2.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier
+                    .focusRequester(focusRequester)
+                    .onFocusChanged { state.onFocusChanged(it.isFocused) }
+                    .semantics(mergeDescendants = true) {
+                        contentDescription = keyboardDescription
+                        stateDescription = selectedKeyLabel
+                        liveRegion = LiveRegionMode.Polite
+                    }
+                    .onPreviewKeyEvent { event ->
+                        val keyCode = event.key.nativeKeyCode
+                        val isKeyDown = event.type == KeyEventType.KeyDown
+                        when (keyCode) {
+                            KEYCODE_DPAD_LEFT, KEYCODE_DPAD_RIGHT -> state.handleDpadDirection(keyCode, isKeyDown)
 
-                        KEYCODE_DPAD_CENTER -> {
-                            if (isKeyDown) activate(state.selectedKey)
-                            true
-                        }
-
-                        KEYCODE_ENTER, KEYCODE_NUMPAD_ENTER -> {
-                            if (isKeyDown) {
-                                if (event.nativeKeyEvent.device?.keyboardType == InputDevice.KEYBOARD_TYPE_ALPHABETIC) {
-                                    onSubmit()
-                                } else {
-                                    activate(state.selectedKey)
-                                }
-                            }
-                            true
-                        }
-
-                        KEYCODE_DEL -> {
-                            if (isKeyDown) onDelete()
-                            true
-                        }
-
-                        KEYCODE_SPACE -> {
-                            if (isKeyDown) onSpace()
-                            true
-                        }
-
-                        else -> {
-                            val nativeEvent = event.nativeKeyEvent
-                            if (nativeEvent.isCtrlPressed || nativeEvent.isMetaPressed) {
-                                return@onPreviewKeyEvent false
-                            }
-                            val unicodeChar = nativeEvent.getUnicodeChar(nativeEvent.metaState)
-                            val isPrintable = unicodeChar != 0 &&
-                                (unicodeChar and KeyCharacterMap.COMBINING_ACCENT) == 0 &&
-                                !Character.isISOControl(unicodeChar)
-                            if (isPrintable) {
-                                if (isKeyDown) onCharacter(unicodeChar.toChar())
+                            KEYCODE_DPAD_CENTER -> {
+                                if (isKeyDown) activate(state.selectedKey)
                                 true
-                            } else {
-                                false
+                            }
+
+                            KEYCODE_ENTER, KEYCODE_NUMPAD_ENTER -> {
+                                if (isKeyDown) {
+                                    if (event.nativeKeyEvent.isFromPhysicalKeyboard()) {
+                                        onSubmit()
+                                    } else {
+                                        activate(state.selectedKey)
+                                    }
+                                }
+                                true
+                            }
+
+                            KEYCODE_SEARCH -> {
+                                if (isKeyDown) onSubmit()
+                                true
+                            }
+
+                            KEYCODE_DEL -> {
+                                if (isKeyDown) onDelete()
+                                true
+                            }
+
+                            KEYCODE_SPACE -> {
+                                if (isKeyDown) onSpace()
+                                true
+                            }
+
+                            else -> {
+                                val nativeEvent = event.nativeKeyEvent
+                                if (nativeEvent.isCtrlPressed || nativeEvent.isMetaPressed) {
+                                    return@onPreviewKeyEvent false
+                                }
+                                val unicodeChar = nativeEvent.getUnicodeChar(nativeEvent.metaState)
+                                val isPrintable = unicodeChar != 0 &&
+                                    (unicodeChar and KeyCharacterMap.COMBINING_ACCENT) == 0 &&
+                                    !Character.isISOControl(unicodeChar)
+                                if (isPrintable) {
+                                    if (isKeyDown) onCharacter(unicodeChar.toChar())
+                                    true
+                                } else {
+                                    false
+                                }
                             }
                         }
                     }
+                    .focusable(),
+            ) {
+                state.keys.forEachIndexed { index, key ->
+                    TvSearchKeyCap(
+                        key = key,
+                        selected = state.isSelected(index),
+                        isSymbolsPage = state.isSymbolsPage,
+                    )
                 }
-                .focusable(),
-        ) {
-            state.keys.forEachIndexed { index, key ->
-                TvSearchKeyCap(
-                    key = key,
-                    selected = state.isSelected(index),
-                    isSymbolsPage = state.isSymbolsPage,
-                )
             }
         }
     }
+}
+
+private fun KeyEvent.isFromPhysicalKeyboard(): Boolean {
+    val device = device ?: return false
+    return device.keyboardType == InputDevice.KEYBOARD_TYPE_ALPHABETIC &&
+        (source and InputDevice.SOURCE_KEYBOARD) == InputDevice.SOURCE_KEYBOARD
 }
 
 @Composable
@@ -269,7 +286,9 @@ private fun TvSearchKeyCap(
 
         TvSearchKey.Delete -> Modifier.width(42.dp).height(48.dp).clip(shape).background(background)
 
-        TvSearchKey.Space, TvSearchKey.TogglePage ->
+        TvSearchKey.Space -> Modifier.width(60.dp).clip(shape).background(background).padding(vertical = 6.dp)
+
+        TvSearchKey.TogglePage ->
             Modifier.clip(shape).background(background).padding(horizontal = 12.dp, vertical = 6.dp)
     }
 
@@ -290,6 +309,9 @@ private fun TvSearchKeyCap(
                 text = stringResource(LR.string.tv_search_key_space),
                 style = MaterialTheme.tvTypography.caption1,
                 color = contentColor,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                textAlign = TextAlign.Center,
             )
 
             TvSearchKey.Delete -> Text(
@@ -331,6 +353,7 @@ private fun TvSearchKeyboardPreview() {
                 onSpace = { query += ' ' },
                 onDelete = { query = query.dropLast(1) },
                 onSubmit = {},
+                autoFocus = true,
             )
         }
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchKeyboard.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchKeyboard.kt
@@ -1,5 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.search
 
+import android.view.InputDevice
+import android.view.KeyCharacterMap
 import android.view.KeyEvent.KEYCODE_DEL
 import android.view.KeyEvent.KEYCODE_DPAD_CENTER
 import android.view.KeyEvent.KEYCODE_DPAD_LEFT
@@ -20,6 +22,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
@@ -41,11 +44,16 @@ import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.nativeKeyCode
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
@@ -54,7 +62,7 @@ import au.com.shiftyjelly.pocketcasts.theme.tvColors
 import au.com.shiftyjelly.pocketcasts.theme.tvTypography
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
-sealed interface TvSearchKey {
+internal sealed interface TvSearchKey {
     data class Character(val char: Char) : TvSearchKey
     data object Space : TvSearchKey
     data object Delete : TvSearchKey
@@ -81,7 +89,7 @@ private val SymbolsKeys: List<TvSearchKey> = buildList {
 private val InitialSelectedIndex = LettersKeys.indexOfFirst { it is TvSearchKey.Character }
 
 @Stable
-class TvSearchKeyboardState {
+internal class TvSearchKeyboardState {
     private var page by mutableStateOf(TvSearchKeyboardPage.Letters)
 
     var selectedIndex by mutableIntStateOf(InitialSelectedIndex)
@@ -125,7 +133,7 @@ class TvSearchKeyboardState {
 }
 
 @Composable
-fun rememberTvSearchKeyboardState(): TvSearchKeyboardState = remember { TvSearchKeyboardState() }
+internal fun rememberTvSearchKeyboardState(): TvSearchKeyboardState = remember { TvSearchKeyboardState() }
 
 @Composable
 internal fun TvSearchKeyboard(
@@ -134,12 +142,15 @@ internal fun TvSearchKeyboard(
     onDelete: () -> Unit,
     onSubmit: () -> Unit,
     modifier: Modifier = Modifier,
+    autoFocus: Boolean = true,
     state: TvSearchKeyboardState = rememberTvSearchKeyboardState(),
 ) {
     val focusRequester = remember { FocusRequester() }
-    LaunchedEffect(Unit) {
-        withFrameNanos {}
-        runCatching { focusRequester.requestFocus() }
+    if (autoFocus) {
+        LaunchedEffect(Unit) {
+            withFrameNanos {}
+            runCatching { focusRequester.requestFocus() }
+        }
     }
 
     fun activate(key: TvSearchKey) {
@@ -151,57 +162,90 @@ internal fun TvSearchKeyboard(
         }
     }
 
-    Row(
-        horizontalArrangement = Arrangement.spacedBy(2.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = modifier
-            .focusRequester(focusRequester)
-            .onFocusChanged { state.onFocusChanged(it.isFocused) }
-            .onPreviewKeyEvent { event ->
-                val keyCode = event.key.nativeKeyCode
-                val isKeyDown = event.type == KeyEventType.KeyDown
-                when (keyCode) {
-                    KEYCODE_DPAD_LEFT, KEYCODE_DPAD_RIGHT -> state.handleDpadDirection(keyCode, isKeyDown)
+    val keyboardDescription = stringResource(LR.string.tv_search_keyboard)
+    val selectedKeyLabel = when (val key = state.selectedKey) {
+        is TvSearchKey.Character -> key.char.toString()
 
-                    KEYCODE_DPAD_CENTER -> {
-                        if (isKeyDown) activate(state.selectedKey)
-                        true
-                    }
+        TvSearchKey.Space -> stringResource(LR.string.tv_search_key_space)
 
-                    KEYCODE_ENTER, KEYCODE_NUMPAD_ENTER -> {
-                        if (isKeyDown) onSubmit()
-                        true
-                    }
+        TvSearchKey.Delete -> stringResource(LR.string.delete)
 
-                    KEYCODE_DEL -> {
-                        if (isKeyDown) onDelete()
-                        true
-                    }
+        TvSearchKey.TogglePage -> stringResource(
+            if (state.isSymbolsPage) LR.string.tv_search_key_letters else LR.string.tv_search_key_symbols,
+        )
+    }
 
-                    KEYCODE_SPACE -> {
-                        if (isKeyDown) onSpace()
-                        true
-                    }
+    CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(2.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = modifier
+                .focusRequester(focusRequester)
+                .onFocusChanged { state.onFocusChanged(it.isFocused) }
+                .semantics {
+                    contentDescription = keyboardDescription
+                    stateDescription = selectedKeyLabel
+                    liveRegion = LiveRegionMode.Polite
+                }
+                .onPreviewKeyEvent { event ->
+                    val keyCode = event.key.nativeKeyCode
+                    val isKeyDown = event.type == KeyEventType.KeyDown
+                    when (keyCode) {
+                        KEYCODE_DPAD_LEFT, KEYCODE_DPAD_RIGHT -> state.handleDpadDirection(keyCode, isKeyDown)
 
-                    else -> {
-                        val unicodeChar = event.nativeKeyEvent.getUnicodeChar(event.nativeKeyEvent.metaState)
-                        if (unicodeChar != 0 && !Character.isISOControl(unicodeChar)) {
-                            if (isKeyDown) onCharacter(unicodeChar.toChar())
+                        KEYCODE_DPAD_CENTER -> {
+                            if (isKeyDown) activate(state.selectedKey)
                             true
-                        } else {
-                            false
+                        }
+
+                        KEYCODE_ENTER, KEYCODE_NUMPAD_ENTER -> {
+                            if (isKeyDown) {
+                                if (event.nativeKeyEvent.device?.keyboardType == InputDevice.KEYBOARD_TYPE_ALPHABETIC) {
+                                    onSubmit()
+                                } else {
+                                    activate(state.selectedKey)
+                                }
+                            }
+                            true
+                        }
+
+                        KEYCODE_DEL -> {
+                            if (isKeyDown) onDelete()
+                            true
+                        }
+
+                        KEYCODE_SPACE -> {
+                            if (isKeyDown) onSpace()
+                            true
+                        }
+
+                        else -> {
+                            val nativeEvent = event.nativeKeyEvent
+                            if (nativeEvent.isCtrlPressed || nativeEvent.isMetaPressed) {
+                                return@onPreviewKeyEvent false
+                            }
+                            val unicodeChar = nativeEvent.getUnicodeChar(nativeEvent.metaState)
+                            val isPrintable = unicodeChar != 0 &&
+                                (unicodeChar and KeyCharacterMap.COMBINING_ACCENT) == 0 &&
+                                !Character.isISOControl(unicodeChar)
+                            if (isPrintable) {
+                                if (isKeyDown) onCharacter(unicodeChar.toChar())
+                                true
+                            } else {
+                                false
+                            }
                         }
                     }
                 }
+                .focusable(),
+        ) {
+            state.keys.forEachIndexed { index, key ->
+                TvSearchKeyCap(
+                    key = key,
+                    selected = state.isSelected(index),
+                    isSymbolsPage = state.isSymbolsPage,
+                )
             }
-            .focusable(),
-    ) {
-        state.keys.forEachIndexed { index, key ->
-            TvSearchKeyCap(
-                key = key,
-                selected = state.isSelected(index),
-                isSymbolsPage = state.isSymbolsPage,
-            )
         }
     }
 }
@@ -219,7 +263,6 @@ private fun TvSearchKeyCap(
         else -> Color.Transparent
     }
     val contentColor = if (selected) MaterialTheme.tvColors.textPrimaryActive else MaterialTheme.tvColors.textSecondary
-    val deleteLabel = stringResource(LR.string.delete)
     val shape = RoundedCornerShape(8.dp)
     val sizeModifier = when (key) {
         is TvSearchKey.Character -> Modifier.width(24.dp).height(48.dp).clip(shape).background(background)
@@ -253,7 +296,6 @@ private fun TvSearchKeyCap(
                 text = "⌫",
                 style = MaterialTheme.tvTypography.title3,
                 color = contentColor,
-                modifier = Modifier.semantics { contentDescription = deleteLabel },
             )
 
             TvSearchKey.TogglePage -> Text(

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/search/TvSearchKeyboardStateTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/search/TvSearchKeyboardStateTest.kt
@@ -1,0 +1,82 @@
+package au.com.shiftyjelly.pocketcasts.search
+
+import android.view.KeyEvent.KEYCODE_DPAD_LEFT
+import android.view.KeyEvent.KEYCODE_DPAD_RIGHT
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TvSearchKeyboardStateTest {
+
+    private val state = TvSearchKeyboardState()
+
+    @Test
+    fun `initial state selects the first letter on the letters page`() {
+        assertFalse(state.isSymbolsPage)
+        assertEquals(TvSearchKey.Character('a'), state.selectedKey)
+    }
+
+    @Test
+    fun `dpad right moves to the next key and consumes the event`() {
+        val consumed = state.handleDpadDirection(KEYCODE_DPAD_RIGHT, isKeyDown = true)
+        assertTrue(consumed)
+        assertEquals(TvSearchKey.Character('b'), state.selectedKey)
+    }
+
+    @Test
+    fun `dpad left walks onto the leading Space and Toggle keys then stops`() {
+        state.handleDpadDirection(KEYCODE_DPAD_LEFT, isKeyDown = true)
+        assertEquals(TvSearchKey.Space, state.selectedKey)
+        state.handleDpadDirection(KEYCODE_DPAD_LEFT, isKeyDown = true)
+        assertEquals(TvSearchKey.TogglePage, state.selectedKey)
+
+        val consumedAtStart = state.handleDpadDirection(KEYCODE_DPAD_LEFT, isKeyDown = true)
+        assertFalse(consumedAtStart)
+        assertEquals(TvSearchKey.TogglePage, state.selectedKey)
+    }
+
+    @Test
+    fun `dpad right stops on the trailing Delete key`() {
+        repeat(40) { state.handleDpadDirection(KEYCODE_DPAD_RIGHT, isKeyDown = true) }
+        assertEquals(TvSearchKey.Delete, state.selectedKey)
+
+        val consumedAtEnd = state.handleDpadDirection(KEYCODE_DPAD_RIGHT, isKeyDown = true)
+        assertFalse(consumedAtEnd)
+        assertEquals(TvSearchKey.Delete, state.selectedKey)
+    }
+
+    @Test
+    fun `key up returns the consumed state then resets`() {
+        state.handleDpadDirection(KEYCODE_DPAD_RIGHT, isKeyDown = true)
+        assertTrue(state.handleDpadDirection(KEYCODE_DPAD_RIGHT, isKeyDown = false))
+        assertFalse(state.handleDpadDirection(KEYCODE_DPAD_RIGHT, isKeyDown = false))
+    }
+
+    @Test
+    fun `toggle page swaps to the symbols page and back`() {
+        state.togglePage()
+        assertTrue(state.isSymbolsPage)
+        assertEquals(TvSearchKey.Character('0'), state.selectedKey)
+
+        state.togglePage()
+        assertFalse(state.isSymbolsPage)
+        assertEquals(TvSearchKey.Character('a'), state.selectedKey)
+    }
+
+    @Test
+    fun `toggle page clamps a high selection onto the shorter symbols page`() {
+        repeat(23) { state.handleDpadDirection(KEYCODE_DPAD_RIGHT, isKeyDown = true) }
+        state.togglePage()
+        assertTrue(state.isSymbolsPage)
+        assertEquals(TvSearchKey.Delete, state.selectedKey)
+    }
+
+    @Test
+    fun `isSelected only reports the selection while focused`() {
+        assertFalse(state.isSelected(state.selectedIndex))
+        state.onFocusChanged(true)
+        assertTrue(state.isSelected(state.selectedIndex))
+        assertFalse(state.isSelected(state.selectedIndex + 1))
+    }
+}

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/search/TvSearchKeyboardStateTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/search/TvSearchKeyboardStateTest.kt
@@ -1,7 +1,9 @@
 package au.com.shiftyjelly.pocketcasts.search
 
+import android.view.KeyEvent.KEYCODE_DPAD_DOWN
 import android.view.KeyEvent.KEYCODE_DPAD_LEFT
 import android.view.KeyEvent.KEYCODE_DPAD_RIGHT
+import android.view.KeyEvent.KEYCODE_DPAD_UP
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -66,10 +68,20 @@ class TvSearchKeyboardStateTest {
 
     @Test
     fun `toggle page clamps a high selection onto the shorter symbols page`() {
-        repeat(23) { state.handleDpadDirection(KEYCODE_DPAD_RIGHT, isKeyDown = true) }
+        assertEquals(29, state.keys.size)
+        repeat(40) { state.handleDpadDirection(KEYCODE_DPAD_RIGHT, isKeyDown = true) }
+        assertEquals(TvSearchKey.Delete, state.selectedKey)
+
         state.togglePage()
         assertTrue(state.isSymbolsPage)
+        assertEquals(20, state.keys.size)
         assertEquals(TvSearchKey.Delete, state.selectedKey)
+    }
+
+    @Test
+    fun `vertical dpad keys are not consumed so navigation can leave the keyboard`() {
+        assertFalse(state.handleDpadDirection(KEYCODE_DPAD_UP, isKeyDown = true))
+        assertFalse(state.handleDpadDirection(KEYCODE_DPAD_DOWN, isKeyDown = true))
     }
 
     @Test


### PR DESCRIPTION
## Description

Adds a **custom, embedded on-screen keyboard** for the (upcoming) Android TV search screen — `TvSearchKeyboard`.

**Why custom:** Android TV ships no reusable embedded keyboard. `androidx.tv.material3` and Leanback have no in-layout keyboard component, and there's no adoptable third-party one; the only system option is the Gboard-for-TV IME, which is a separate popup window that can't be embedded or restyled and doesn't match our design. Every major TV app (YouTube, Netflix, Google TV) rolls its own — so we do too.

**How it works:**
- One focusable element with a virtual `selectedIndex` (built on the existing `component/TvTileButtonState` idiom), not ~30 individually focusable keys — so focus entry is deterministic and there's a single place to handle input.
- **Remote / D-pad:** Left/Right steps the highlighted key, Center activates it. The highlighted key enlarges and inverts to the light treatment.
- **Bluetooth / physical keyboard:** a single `onPreviewKeyEvent` reads hardware keys via `nativeKeyEvent.getUnicodeChar(metaState)`; printable characters, Backspace, Space and Enter are consumed, while D-pad directions pass through (a physical keyboard's arrow keys navigate the keys for free). Because **no editable text field ever holds focus, the system IME can never appear** (no `InputConnection` is created) — this is the whole point.
- Layout: a single horizontal row — `123` · `Space` · `a`–`z` · `⌫` — plus a `123`/`ABC` toggle to a numbers & symbols page (`0`–`9` and `. , ' - _ & @`).
- Exposes plain callbacks (`onCharacter`, `onSpace`, `onDelete`, `onSubmit`) and holds no query state itself, so the consuming screen owns the text.

**Scope:** this PR is the **component only** — it is not yet wired into the Search tab. That (the search screen, query field, autocomplete suggestions and results) is a follow-up. Reviewers can exercise it now through the interactive Compose preview.

Fixes POC-638 https://linear.app/a8c/issue/POC-839/custom-on-screen-keyboard
Figma: Ftk3KwnfqaK4g57yCN63p0-fi-2595_2269

## Testing Instructions

1. Open `tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchKeyboard.kt` and run the `TvSearchKeyboardPreview` in **interactive** Compose preview mode.
2. With the remote/arrow keys: Left/Right moves the highlighted key, Center/Enter types it into the demo query line above the keyboard; `123` toggles the numbers/symbols page (and `ABC` back); `⌫` deletes; `Space` inserts a space.
3. With a physical keyboard: just type — characters, Space and Backspace go straight into the query, and the arrow keys move the highlighted key. No system keyboard appears.
4. `./gradlew :tv:testDebugUnitTest` passes.

> Verified on a 1080p Android TV emulator in a temporary search-screen harness: D-pad navigation + Center typing, hardware-keyboard typing with **no system IME** (`dumpsys input_method` → `mInputShown=false`), and the `123`/`ABC` page toggle.

## Screenshots or Screencast
<img width="555" height="106" alt="SCR-20260811-mkxa" src="https://github.com/user-attachments/assets/62d51cc8-b4db-420c-8ba5-191144b05320" />

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md 
- [x] Ensure the linter passes (`./gradlew spotlessApply`)
- [x] I have considered whether it makes sense to add tests for my changes 
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews 
- [x] I have updated (or requested that someone edit) the Event Horizon schema to reflect any new or changed analytics.
