### PR TITLE
[TV] Search: combined search results (podcasts + episodes)

### DIFF
--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -253,6 +253,9 @@
     <string name="tv_row_because_you_liked">Because you liked Podcast</string>
     <string name="tv_home_keep_listening">Keep Listening</string>
     <string name="tv_search_browse_categories">Browse categories</string>
+    <string name="tv_search_searching">Searching…</string>
+    <string name="tv_search_no_results_title">No results</string>
+    <string name="tv_search_no_results_subtitle">Try more general or different keywords.</string>
     <string name="tv_profile_starred_episodes">Starred Episodes</string>
     <string name="tv_sign_in_title">Log in to Pocket Casts</string>
     <string name="tv_sign_in_step_scan">Scan the QR code or go to %1$s</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -253,9 +253,9 @@
     <string name="tv_row_because_you_liked">Because you liked Podcast</string>
     <string name="tv_home_keep_listening">Keep Listening</string>
     <string name="tv_search_browse_categories">Browse categories</string>
-    <string name="tv_search_searching">Searching…</string>
     <string name="tv_search_no_results_title">No results</string>
     <string name="tv_search_no_results_subtitle">Try more general or different keywords.</string>
+    <string name="tv_search_error_subtitle">Check your connection and try again.</string>
     <string name="tv_profile_starred_episodes">Starred Episodes</string>
     <string name="tv_sign_in_title">Log in to Pocket Casts</string>
     <string name="tv_sign_in_step_scan">Scan the QR code or go to %1$s</string>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/ImprovedSearchResultItem.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/ImprovedSearchResultItem.kt
@@ -29,6 +29,7 @@ sealed interface ImprovedSearchResultItem {
         override val uuid: String,
         override val title: String,
         val podcastUuid: String,
+        val podcastTitle: String,
         val publishedDate: Date,
         val duration: Duration,
     ) : ImprovedSearchResultItem

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/search/ImprovedSearchManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/search/ImprovedSearchManagerImpl.kt
@@ -49,6 +49,7 @@ class ImprovedSearchManagerImpl @Inject constructor(
                     uuid = it.uuid,
                     title = it.title,
                     podcastUuid = it.podcastUuid,
+                    podcastTitle = it.podcastTitle,
                     publishedDate = it.publishedDate,
                     duration = it.duration.seconds,
                 )

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/search/ImprovedSearchManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/search/ImprovedSearchManagerImplTest.kt
@@ -62,5 +62,8 @@ class ImprovedSearchManagerImplTest {
             results.map { it.uuid },
         )
         assertTrue(results.none { it is ImprovedSearchResultItem.PodcastItem && it.uuid == "null-title-uuid" })
+
+        val episode = results.filterIsInstance<ImprovedSearchResultItem.EpisodeItem>().single()
+        assertEquals("Business Daily", episode.podcastTitle)
     }
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionsViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionsViewModel.kt
@@ -18,6 +18,7 @@ import timber.log.Timber
 
 enum class TvEpisodeActionContext(val source: SourceView) {
     PodcastDetails(SourceView.PODCAST_SCREEN),
+    SearchResults(SourceView.SEARCH_RESULTS),
     Playlist(SourceView.FILTERS),
     UpNext(SourceView.UP_NEXT),
     NowPlaying(SourceView.PLAYER),

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeListItem.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeListItem.kt
@@ -37,6 +37,27 @@ fun TvEpisodeListItem(
     episodeFocusRequester: FocusRequester? = null,
     leftFocusRequester: FocusRequester? = null,
 ) {
+    TvEpisodeListItemContainer(
+        onOpenActions = onOpenActions,
+        modifier = modifier,
+    ) { rowModifier ->
+        TvEpisodeRow(
+            episode = episode,
+            onClick = onClick,
+            dateFormatter = dateFormatter,
+            modifier = rowModifier
+                .then(if (leftFocusRequester != null) Modifier.focusProperties { left = leftFocusRequester } else Modifier)
+                .then(if (episodeFocusRequester != null) Modifier.focusRequester(episodeFocusRequester) else Modifier),
+        )
+    }
+}
+
+@Composable
+fun TvEpisodeListItemContainer(
+    onOpenActions: () -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable (Modifier) -> Unit,
+) {
     var isItemFocused by remember { mutableStateOf(false) }
     Row(
         verticalAlignment = Alignment.CenterVertically,
@@ -44,15 +65,7 @@ fun TvEpisodeListItem(
             .fillMaxWidth()
             .onFocusChanged { isItemFocused = it.hasFocus },
     ) {
-        TvEpisodeRow(
-            episode = episode,
-            onClick = onClick,
-            dateFormatter = dateFormatter,
-            modifier = Modifier
-                .weight(1f)
-                .then(if (leftFocusRequester != null) Modifier.focusProperties { left = leftFocusRequester } else Modifier)
-                .then(if (episodeFocusRequester != null) Modifier.focusRequester(episodeFocusRequester) else Modifier),
-        )
+        content(Modifier.weight(1f))
         AnimatedVisibility(
             visible = isItemFocused,
             enter = expandHorizontally(tween(MORE_BUTTON_ANIMATION_DURATION_MS), expandFrom = Alignment.Start) +

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvRow.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvRow.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.tv.material3.MaterialTheme
@@ -41,6 +42,25 @@ import au.com.shiftyjelly.pocketcasts.theme.tvColors
 
 private const val TITLE_UNFOCUSED_SIZE = 17f
 private const val TITLE_FOCUSED_SIZE = 21f
+
+@Composable
+fun TvSectionTitle(
+    title: String,
+    modifier: Modifier = Modifier,
+    fontSize: TextUnit = TITLE_UNFOCUSED_SIZE.sp,
+) {
+    Text(
+        text = title,
+        color = MaterialTheme.tvColors.textPrimary,
+        style = TextStyle(
+            fontFamily = GoogleSansFontFamily,
+            fontSize = fontSize,
+            fontWeight = FontWeight(500),
+            platformStyle = PlatformTextStyle(includeFontPadding = false),
+        ),
+        modifier = modifier,
+    )
+}
 
 @Composable
 fun <T> TvRow(
@@ -64,15 +84,9 @@ fun <T> TvRow(
             hasFocus = focusState.hasFocus
         },
     ) {
-        Text(
-            text = title,
-            color = MaterialTheme.tvColors.textPrimary,
-            style = TextStyle(
-                fontFamily = GoogleSansFontFamily,
-                fontSize = titleSize.sp,
-                fontWeight = FontWeight(500),
-                platformStyle = PlatformTextStyle(includeFontPadding = false),
-            ),
+        TvSectionTitle(
+            title = title,
+            fontSize = titleSize.sp,
             modifier = Modifier
                 .padding(contentPadding)
                 .padding(bottom = 17.dp),

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchEpisodeRow.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchEpisodeRow.kt
@@ -1,13 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.search
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.expandHorizontally
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.shrinkHorizontally
-import androidx.compose.animation.slideInHorizontally
-import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -17,7 +9,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -27,6 +18,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextOverflow
@@ -37,7 +30,7 @@ import androidx.tv.material3.CardDefaults
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.component.TvArtworkImage
-import au.com.shiftyjelly.pocketcasts.component.TvMoreButton
+import au.com.shiftyjelly.pocketcasts.component.TvEpisodeListItemContainer
 import au.com.shiftyjelly.pocketcasts.component.TvTile
 import au.com.shiftyjelly.pocketcasts.localization.helper.TimeHelper
 import au.com.shiftyjelly.pocketcasts.models.to.ImprovedSearchResultItem
@@ -48,41 +41,24 @@ import au.com.shiftyjelly.pocketcasts.theme.tvTypography
 import java.util.Date
 import kotlin.time.Duration.Companion.seconds
 
-private const val MORE_BUTTON_ANIMATION_DURATION_MS = 200
-
 @Composable
 internal fun TvSearchEpisodeRow(
     episode: ImprovedSearchResultItem.EpisodeItem,
     onClick: () -> Unit,
     onOpenActions: () -> Unit,
     modifier: Modifier = Modifier,
+    episodeFocusRequester: FocusRequester? = null,
 ) {
-    var isItemFocused by remember { mutableStateOf(false) }
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = modifier
-            .fillMaxWidth()
-            .onFocusChanged { isItemFocused = it.hasFocus },
-    ) {
+    TvEpisodeListItemContainer(
+        onOpenActions = onOpenActions,
+        modifier = modifier,
+    ) { rowModifier ->
         TvSearchEpisodeCard(
             episode = episode,
             onClick = onClick,
-            modifier = Modifier.weight(1f),
+            modifier = rowModifier
+                .then(if (episodeFocusRequester != null) Modifier.focusRequester(episodeFocusRequester) else Modifier),
         )
-        AnimatedVisibility(
-            visible = isItemFocused,
-            enter = expandHorizontally(tween(MORE_BUTTON_ANIMATION_DURATION_MS), expandFrom = Alignment.Start) +
-                slideInHorizontally(tween(MORE_BUTTON_ANIMATION_DURATION_MS), initialOffsetX = { it }) +
-                fadeIn(tween(MORE_BUTTON_ANIMATION_DURATION_MS)),
-            exit = shrinkHorizontally(tween(MORE_BUTTON_ANIMATION_DURATION_MS), shrinkTowards = Alignment.Start) +
-                slideOutHorizontally(tween(MORE_BUTTON_ANIMATION_DURATION_MS), targetOffsetX = { it }) +
-                fadeOut(tween(MORE_BUTTON_ANIMATION_DURATION_MS)),
-        ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Spacer(modifier = Modifier.width(16.dp))
-                TvMoreButton(onClick = onOpenActions)
-            }
-        }
     }
 }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchEpisodeRow.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchEpisodeRow.kt
@@ -1,0 +1,181 @@
+package au.com.shiftyjelly.pocketcasts.search
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandHorizontally
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkHorizontally
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.tv.material3.CardDefaults
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.component.TvArtworkImage
+import au.com.shiftyjelly.pocketcasts.component.TvMoreButton
+import au.com.shiftyjelly.pocketcasts.component.TvTile
+import au.com.shiftyjelly.pocketcasts.localization.helper.TimeHelper
+import au.com.shiftyjelly.pocketcasts.models.to.ImprovedSearchResultItem
+import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImage
+import au.com.shiftyjelly.pocketcasts.theme.TvTheme
+import au.com.shiftyjelly.pocketcasts.theme.tvColors
+import au.com.shiftyjelly.pocketcasts.theme.tvTypography
+import java.util.Date
+import kotlin.time.Duration.Companion.seconds
+
+private const val MORE_BUTTON_ANIMATION_DURATION_MS = 200
+
+@Composable
+internal fun TvSearchEpisodeRow(
+    episode: ImprovedSearchResultItem.EpisodeItem,
+    onClick: () -> Unit,
+    onOpenActions: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var isItemFocused by remember { mutableStateOf(false) }
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier
+            .fillMaxWidth()
+            .onFocusChanged { isItemFocused = it.hasFocus },
+    ) {
+        TvSearchEpisodeCard(
+            episode = episode,
+            onClick = onClick,
+            modifier = Modifier.weight(1f),
+        )
+        AnimatedVisibility(
+            visible = isItemFocused,
+            enter = expandHorizontally(tween(MORE_BUTTON_ANIMATION_DURATION_MS), expandFrom = Alignment.Start) +
+                slideInHorizontally(tween(MORE_BUTTON_ANIMATION_DURATION_MS), initialOffsetX = { it }) +
+                fadeIn(tween(MORE_BUTTON_ANIMATION_DURATION_MS)),
+            exit = shrinkHorizontally(tween(MORE_BUTTON_ANIMATION_DURATION_MS), shrinkTowards = Alignment.Start) +
+                slideOutHorizontally(tween(MORE_BUTTON_ANIMATION_DURATION_MS), targetOffsetX = { it }) +
+                fadeOut(tween(MORE_BUTTON_ANIMATION_DURATION_MS)),
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Spacer(modifier = Modifier.width(16.dp))
+                TvMoreButton(onClick = onOpenActions)
+            }
+        }
+    }
+}
+
+@Composable
+private fun TvSearchEpisodeCard(
+    episode: ImprovedSearchResultItem.EpisodeItem,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var isFocused by remember { mutableStateOf(false) }
+    val textPrimary = if (isFocused) MaterialTheme.tvColors.textPrimaryActive else MaterialTheme.tvColors.textPrimary
+    val textSecondary = if (isFocused) MaterialTheme.tvColors.textSecondaryActive else MaterialTheme.tvColors.textSecondary
+
+    val context = LocalContext.current
+    val duration = remember(episode.duration) {
+        TimeHelper.getTimeDurationShortString(episode.duration.inWholeMilliseconds, context, emptyString = "")
+    }
+
+    TvTile(
+        onClick = onClick,
+        scale = CardDefaults.scale(focusedScale = 1.02f),
+        shape = CardDefaults.shape(shape = RoundedCornerShape(12.dp)),
+        colors = CardDefaults.colors(
+            containerColor = MaterialTheme.tvColors.backgroundSunken,
+            focusedContainerColor = MaterialTheme.tvColors.backgroundActive,
+        ),
+        modifier = modifier.onFocusChanged { isFocused = it.isFocused },
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(24.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            TvArtworkImage(
+                model = PodcastImage.getMediumArtworkUrl(episode.podcastUuid),
+                modifier = Modifier
+                    .size(96.dp)
+                    .clip(RoundedCornerShape(6.dp)),
+            )
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(start = 24.dp),
+            ) {
+                if (episode.podcastTitle.isNotBlank()) {
+                    Text(
+                        text = episode.podcastTitle,
+                        style = MaterialTheme.tvTypography.caption1,
+                        color = textSecondary,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                }
+                Text(
+                    text = episode.title,
+                    style = MaterialTheme.tvTypography.body,
+                    color = textPrimary,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                if (duration.isNotBlank()) {
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = duration,
+                        style = MaterialTheme.tvTypography.caption1,
+                        color = textSecondary,
+                        maxLines = 1,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview(device = Devices.TV_1080p)
+@Composable
+private fun TvSearchEpisodeRowPreview() {
+    TvTheme {
+        Box(modifier = Modifier.background(MaterialTheme.tvColors.backgroundSunken).padding(48.dp)) {
+            TvSearchEpisodeRow(
+                episode = ImprovedSearchResultItem.EpisodeItem(
+                    uuid = "episode-1",
+                    title = "The real cost of sugar and how it shapes the food we eat",
+                    podcastUuid = "podcast-1",
+                    podcastTitle = "Business Daily",
+                    publishedDate = Date(0),
+                    duration = 1440.seconds,
+                ),
+                onClick = {},
+                onOpenActions = {},
+            )
+        }
+    }
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
@@ -10,9 +10,14 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -28,13 +33,30 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.component.LocalOpenNowPlaying
+import au.com.shiftyjelly.pocketcasts.component.LocalTvToastHostState
 import au.com.shiftyjelly.pocketcasts.component.TvCategoryTile
+import au.com.shiftyjelly.pocketcasts.component.TvDetailOverlay
+import au.com.shiftyjelly.pocketcasts.component.TvEmptyState
+import au.com.shiftyjelly.pocketcasts.component.TvEpisodeActionContext
+import au.com.shiftyjelly.pocketcasts.component.TvEpisodeActionsModal
+import au.com.shiftyjelly.pocketcasts.component.TvEpisodeInfoModal
+import au.com.shiftyjelly.pocketcasts.component.TvPodcastTile
+import au.com.shiftyjelly.pocketcasts.component.TvPodcastTileDefaults
 import au.com.shiftyjelly.pocketcasts.component.TvRow
+import au.com.shiftyjelly.pocketcasts.component.tvFocusInactiveWhen
+import au.com.shiftyjelly.pocketcasts.compose.loading.LoadingView
 import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverRow
 import au.com.shiftyjelly.pocketcasts.discover.tvDiscoverRow
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.to.ImprovedSearchResultItem
+import au.com.shiftyjelly.pocketcasts.podcasts.TvPodcastDetailsScreen
+import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImage
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
 import au.com.shiftyjelly.pocketcasts.theme.TvTheme
 import au.com.shiftyjelly.pocketcasts.theme.tvColors
+import au.com.shiftyjelly.pocketcasts.theme.tvTypography
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 private val ContentPadding = PaddingValues(horizontal = 48.dp)
@@ -44,26 +66,88 @@ fun TvSearchScreen(
     modifier: Modifier = Modifier,
     viewModel: TvSearchViewModel = hiltViewModel(),
 ) {
-    var query by rememberSaveable { mutableStateOf("") }
+    val query by viewModel.query.collectAsStateWithLifecycle()
+    val searchState by viewModel.searchState.collectAsStateWithLifecycle()
     val categories by viewModel.categories.collectAsStateWithLifecycle()
     val discoverRows by viewModel.discoverRows.collectAsStateWithLifecycle()
+    val actionsEpisode by viewModel.actionsEpisode.collectAsStateWithLifecycle()
 
-    TvSearchContent(
-        query = query,
-        categories = categories,
-        discoverRows = discoverRows,
-        onQueryChange = { query = it },
-        modifier = modifier,
-    )
+    var openedPodcastUuid by rememberSaveable { mutableStateOf<String?>(null) }
+    var detailsEpisode by remember { mutableStateOf<PodcastEpisode?>(null) }
+    var restoreFocusTrigger by remember { mutableIntStateOf(0) }
+    val podcastUuid = openedPodcastUuid
+
+    val openNowPlaying = LocalOpenNowPlaying.current
+    val toastHostState = LocalTvToastHostState.current
+    val playFailedMessage = stringResource(LR.string.error_generic_message)
+    LaunchedEffect(Unit) {
+        viewModel.playStarted.collect { openNowPlaying() }
+    }
+    LaunchedEffect(Unit) {
+        viewModel.playFailures.collect { toastHostState.show(playFailedMessage) }
+    }
+
+    Box(modifier = modifier.fillMaxSize()) {
+        TvSearchContent(
+            query = query,
+            searchState = searchState,
+            categories = categories,
+            discoverRows = discoverRows,
+            onQueryChange = viewModel::onQueryChange,
+            onOpenPodcast = { openedPodcastUuid = it },
+            onPlayEpisode = viewModel::playEpisode,
+            onOpenEpisodeActions = viewModel::openEpisodeActions,
+            restoreFocusTrigger = restoreFocusTrigger,
+            modifier = Modifier
+                .fillMaxSize()
+                .tvFocusInactiveWhen(podcastUuid != null),
+        )
+        TvDetailOverlay(
+            target = podcastUuid,
+            onBack = { openedPodcastUuid = null },
+            onHide = { restoreFocusTrigger++ },
+        ) { uuid ->
+            TvPodcastDetailsScreen(
+                podcastUuid = uuid,
+                onClose = { openedPodcastUuid = null },
+            )
+        }
+        actionsEpisode?.let { episode ->
+            TvEpisodeActionsModal(
+                episode = episode,
+                actionContext = TvEpisodeActionContext.PodcastDetails,
+                onDismissRequest = viewModel::dismissEpisodeActions,
+                onShowEpisodeDetails = {
+                    detailsEpisode = episode
+                    viewModel.dismissEpisodeActions()
+                },
+                onGoToPodcast = {
+                    viewModel.dismissEpisodeActions()
+                    openedPodcastUuid = episode.podcastUuid
+                },
+            )
+        }
+        detailsEpisode?.let { episode ->
+            TvEpisodeInfoModal(
+                episode = episode,
+                onDismissRequest = { detailsEpisode = null },
+            )
+        }
+    }
 }
 
 @Composable
 private fun TvSearchContent(
     query: String,
+    searchState: TvSearchState,
     categories: List<DiscoverCategory>,
     discoverRows: List<TvDiscoverRow>,
     onQueryChange: (String) -> Unit,
+    onOpenPodcast: (String) -> Unit,
+    onPlayEpisode: (ImprovedSearchResultItem.EpisodeItem) -> Unit,
+    onOpenEpisodeActions: (ImprovedSearchResultItem.EpisodeItem) -> Unit,
     modifier: Modifier = Modifier,
+    restoreFocusTrigger: Int = 0,
 ) {
     val searchFieldFocusRequester = remember { FocusRequester() }
     Column(
@@ -84,45 +168,178 @@ private fun TvSearchContent(
             Spacer(modifier = Modifier.height(24.dp))
         }
 
-        LazyColumn(modifier = Modifier.fillMaxSize()) {
-            if (categories.isNotEmpty()) {
-                item {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(ContentPadding)
-                            .height(1.dp)
-                            .background(MaterialTheme.tvColors.overlayBorder),
-                    )
-                }
-                item {
-                    Spacer(modifier = Modifier.height(24.dp))
-                    TvRow(
-                        title = stringResource(LR.string.tv_search_browse_categories),
-                        items = categories,
-                        contentPadding = ContentPadding,
-                        key = { it.id },
-                    ) { category ->
-                        TvCategoryTile(category = category, onClick = {})
-                    }
-                }
-            }
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
+        ) {
+            when (searchState) {
+                is TvSearchState.Idle -> TvSearchDiscover(
+                    categories = categories,
+                    discoverRows = discoverRows,
+                )
 
-            if (query.isBlank()) {
-                discoverRows.forEach { row ->
-                    item { Spacer(modifier = Modifier.height(24.dp)) }
-                    tvDiscoverRow(
-                        row = row,
-                        onOpenPodcast = {},
-                        onPlayEpisode = {},
-                        contentPadding = ContentPadding,
-                    )
-                }
-            }
+                is TvSearchState.Searching -> LoadingView(
+                    color = MaterialTheme.tvColors.textPrimary,
+                    modifier = Modifier.fillMaxSize(),
+                )
 
-            item { Spacer(modifier = Modifier.height(40.dp)) }
+                is TvSearchState.Error -> TvSearchMessage(
+                    title = stringResource(LR.string.error_generic_message),
+                    subtitle = stringResource(LR.string.tv_search_no_results_subtitle),
+                )
+
+                is TvSearchState.NoResults -> TvSearchMessage(
+                    title = stringResource(LR.string.tv_search_no_results_title),
+                    subtitle = stringResource(LR.string.tv_search_no_results_subtitle),
+                )
+
+                is TvSearchState.Results -> TvSearchResults(
+                    results = searchState,
+                    onOpenPodcast = onOpenPodcast,
+                    onPlayEpisode = onPlayEpisode,
+                    onOpenEpisodeActions = onOpenEpisodeActions,
+                    restoreFocusTrigger = restoreFocusTrigger,
+                )
+            }
         }
     }
+}
+
+@Composable
+private fun TvSearchDiscover(
+    categories: List<DiscoverCategory>,
+    discoverRows: List<TvDiscoverRow>,
+) {
+    LazyColumn(modifier = Modifier.fillMaxSize()) {
+        if (categories.isNotEmpty()) {
+            item {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(ContentPadding)
+                        .height(1.dp)
+                        .background(MaterialTheme.tvColors.overlayBorder),
+                )
+            }
+            item {
+                Spacer(modifier = Modifier.height(24.dp))
+                TvRow(
+                    title = stringResource(LR.string.tv_search_browse_categories),
+                    items = categories,
+                    contentPadding = ContentPadding,
+                    key = { it.id },
+                ) { category ->
+                    TvCategoryTile(category = category, onClick = {})
+                }
+            }
+        }
+
+        discoverRows.forEach { row ->
+            item { Spacer(modifier = Modifier.height(24.dp)) }
+            tvDiscoverRow(
+                row = row,
+                onOpenPodcast = {},
+                onPlayEpisode = {},
+                contentPadding = ContentPadding,
+            )
+        }
+
+        item { Spacer(modifier = Modifier.height(40.dp)) }
+    }
+}
+
+@Composable
+private fun TvSearchResults(
+    results: TvSearchState.Results,
+    onOpenPodcast: (String) -> Unit,
+    onPlayEpisode: (ImprovedSearchResultItem.EpisodeItem) -> Unit,
+    onOpenEpisodeActions: (ImprovedSearchResultItem.EpisodeItem) -> Unit,
+    restoreFocusTrigger: Int,
+) {
+    val podcastsRowFocusRequester = remember { FocusRequester() }
+    var isInitialComposition by remember { mutableStateOf(true) }
+    LaunchedEffect(restoreFocusTrigger) {
+        if (isInitialComposition) {
+            isInitialComposition = false
+        } else {
+            runCatching { podcastsRowFocusRequester.requestFocus() }
+        }
+    }
+
+    LazyColumn(modifier = Modifier.fillMaxSize()) {
+        if (results.podcasts.isNotEmpty()) {
+            tvSearchPodcastsRow(
+                podcasts = results.podcasts,
+                onOpenPodcast = onOpenPodcast,
+                focusRequester = podcastsRowFocusRequester,
+            )
+        }
+        if (results.episodes.isNotEmpty()) {
+            item {
+                Spacer(modifier = Modifier.height(24.dp))
+                TvSearchSectionTitle(stringResource(LR.string.episodes))
+            }
+            items(
+                items = results.episodes,
+                key = ImprovedSearchResultItem.EpisodeItem::uuid,
+            ) { episode ->
+                TvSearchEpisodeRow(
+                    episode = episode,
+                    onClick = { onPlayEpisode(episode) },
+                    onOpenActions = { onOpenEpisodeActions(episode) },
+                    modifier = Modifier.padding(ContentPadding),
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+            }
+        }
+        item { Spacer(modifier = Modifier.height(40.dp)) }
+    }
+}
+
+private fun LazyListScope.tvSearchPodcastsRow(
+    podcasts: List<ImprovedSearchResultItem.PodcastItem>,
+    onOpenPodcast: (String) -> Unit,
+    focusRequester: FocusRequester,
+) {
+    item {
+        TvRow(
+            title = stringResource(LR.string.podcasts),
+            items = podcasts,
+            contentPadding = ContentPadding,
+            key = ImprovedSearchResultItem.PodcastItem::uuid,
+            focusRequester = focusRequester,
+        ) { podcast ->
+            TvPodcastTile(
+                artworkUrl = PodcastImage.getMediumArtworkUrl(podcast.uuid),
+                podcastTitle = podcast.title,
+                onClick = { onOpenPodcast(podcast.uuid) },
+                imageModifier = Modifier.width(TvPodcastTileDefaults.RowImageWidth),
+            )
+        }
+    }
+}
+
+@Composable
+private fun TvSearchSectionTitle(title: String) {
+    Text(
+        text = title,
+        style = MaterialTheme.tvTypography.title3,
+        color = MaterialTheme.tvColors.textPrimary,
+        modifier = Modifier.padding(start = 48.dp, bottom = 10.dp),
+    )
+}
+
+@Composable
+private fun TvSearchMessage(
+    title: String,
+    subtitle: String,
+) {
+    TvEmptyState(
+        title = title,
+        subtitle = subtitle,
+        modifier = Modifier.fillMaxSize(),
+    )
 }
 
 @Preview(device = Devices.TV_1080p)
@@ -132,6 +349,7 @@ private fun TvSearchScreenPreview() {
         Box(modifier = Modifier.fillMaxSize().background(MaterialTheme.tvColors.backgroundSunken)) {
             TvSearchContent(
                 query = "",
+                searchState = TvSearchState.Idle,
                 categories = listOf(
                     DiscoverCategory(id = 1, name = "Comedy", icon = "", source = ""),
                     DiscoverCategory(id = 2, name = "True Crime", icon = "", source = ""),
@@ -139,6 +357,9 @@ private fun TvSearchScreenPreview() {
                 ),
                 discoverRows = emptyList(),
                 onQueryChange = {},
+                onOpenPodcast = {},
+                onPlayEpisode = {},
+                onOpenEpisodeActions = {},
             )
         }
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
@@ -118,7 +118,7 @@ fun TvSearchScreen(
         actionsEpisode?.let { episode ->
             TvEpisodeActionsModal(
                 episode = episode,
-                actionContext = TvEpisodeActionContext.PodcastDetails,
+                actionContext = TvEpisodeActionContext.SearchResults,
                 onDismissRequest = viewModel::dismissEpisodeActions,
                 onShowEpisodeDetails = {
                     detailsEpisode = episode

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
@@ -13,7 +13,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -27,17 +27,12 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.PlatformTextStyle
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.MaterialTheme
-import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.component.LocalOpenNowPlaying
 import au.com.shiftyjelly.pocketcasts.component.LocalTvToastHostState
 import au.com.shiftyjelly.pocketcasts.component.TvCategoryTile
@@ -49,6 +44,7 @@ import au.com.shiftyjelly.pocketcasts.component.TvEpisodeInfoModal
 import au.com.shiftyjelly.pocketcasts.component.TvPodcastTile
 import au.com.shiftyjelly.pocketcasts.component.TvPodcastTileDefaults
 import au.com.shiftyjelly.pocketcasts.component.TvRow
+import au.com.shiftyjelly.pocketcasts.component.TvSectionTitle
 import au.com.shiftyjelly.pocketcasts.component.tvFocusInactiveWhen
 import au.com.shiftyjelly.pocketcasts.compose.loading.LoadingView
 import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverRow
@@ -189,7 +185,9 @@ private fun TvSearchContent(
 
                 is TvSearchState.Error -> TvSearchMessage(
                     title = stringResource(LR.string.error_generic_message),
-                    subtitle = stringResource(LR.string.tv_search_no_results_subtitle),
+                    subtitle = stringResource(LR.string.tv_search_error_subtitle),
+                    actionLabel = stringResource(LR.string.retry),
+                    onAction = { onQueryChange(query) },
                 )
 
                 is TvSearchState.NoResults -> TvSearchMessage(
@@ -260,38 +258,45 @@ private fun TvSearchResults(
     onOpenEpisodeActions: (ImprovedSearchResultItem.EpisodeItem) -> Unit,
     restoreFocusTrigger: Int,
 ) {
-    val podcastsRowFocusRequester = remember { FocusRequester() }
+    val restoreFocusRequester = remember { FocusRequester() }
+    val hasPodcasts = results.podcasts.isNotEmpty()
     var isInitialComposition by remember { mutableStateOf(true) }
     LaunchedEffect(restoreFocusTrigger) {
         if (isInitialComposition) {
             isInitialComposition = false
         } else {
-            runCatching { podcastsRowFocusRequester.requestFocus() }
+            runCatching { restoreFocusRequester.requestFocus() }
         }
     }
 
     LazyColumn(modifier = Modifier.fillMaxSize()) {
-        if (results.podcasts.isNotEmpty()) {
+        if (hasPodcasts) {
             tvSearchPodcastsRow(
                 podcasts = results.podcasts,
                 onOpenPodcast = onOpenPodcast,
-                focusRequester = podcastsRowFocusRequester,
+                focusRequester = restoreFocusRequester,
             )
         }
         if (results.episodes.isNotEmpty()) {
             item {
                 Spacer(modifier = Modifier.height(24.dp))
-                TvSearchSectionTitle(stringResource(LR.string.episodes))
+                TvSectionTitle(
+                    title = stringResource(LR.string.episodes),
+                    modifier = Modifier
+                        .padding(ContentPadding)
+                        .padding(bottom = 17.dp),
+                )
             }
-            items(
+            itemsIndexed(
                 items = results.episodes,
-                key = ImprovedSearchResultItem.EpisodeItem::uuid,
-            ) { episode ->
+                key = { _, episode -> episode.uuid },
+            ) { index, episode ->
                 TvSearchEpisodeRow(
                     episode = episode,
                     onClick = { onPlayEpisode(episode) },
                     onOpenActions = { onOpenEpisodeActions(episode) },
                     modifier = Modifier.padding(ContentPadding),
+                    episodeFocusRequester = if (!hasPodcasts && index == 0) restoreFocusRequester else null,
                 )
                 Spacer(modifier = Modifier.height(12.dp))
             }
@@ -324,27 +329,17 @@ private fun LazyListScope.tvSearchPodcastsRow(
 }
 
 @Composable
-private fun TvSearchSectionTitle(title: String) {
-    Text(
-        text = title,
-        color = MaterialTheme.tvColors.textPrimary,
-        style = TextStyle(
-            fontSize = 17.sp,
-            fontWeight = FontWeight(500),
-            platformStyle = PlatformTextStyle(includeFontPadding = false),
-        ),
-        modifier = Modifier.padding(start = 48.dp, bottom = 17.dp),
-    )
-}
-
-@Composable
 private fun TvSearchMessage(
     title: String,
     subtitle: String,
+    actionLabel: String? = null,
+    onAction: (() -> Unit)? = null,
 ) {
     TvEmptyState(
         title = title,
         subtitle = subtitle,
+        actionLabel = actionLabel,
+        onAction = onAction,
         modifier = Modifier.fillMaxSize(),
     )
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
@@ -27,9 +27,13 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.PlatformTextStyle
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.MaterialTheme
@@ -56,7 +60,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImage
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
 import au.com.shiftyjelly.pocketcasts.theme.TvTheme
 import au.com.shiftyjelly.pocketcasts.theme.tvColors
-import au.com.shiftyjelly.pocketcasts.theme.tvTypography
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 private val ContentPadding = PaddingValues(horizontal = 48.dp)
@@ -324,9 +327,13 @@ private fun LazyListScope.tvSearchPodcastsRow(
 private fun TvSearchSectionTitle(title: String) {
     Text(
         text = title,
-        style = MaterialTheme.tvTypography.title3,
         color = MaterialTheme.tvColors.textPrimary,
-        modifier = Modifier.padding(start = 48.dp, bottom = 10.dp),
+        style = TextStyle(
+            fontSize = 17.sp,
+            fontWeight = FontWeight(500),
+            platformStyle = PlatformTextStyle(includeFontPadding = false),
+        ),
+        modifier = Modifier.padding(start = 48.dp, bottom = 17.dp),
     )
 }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
@@ -108,6 +108,7 @@ class TvSearchViewModel @Inject constructor(
                 val podcasts = (localPodcasts + remoteResults.filterIsInstance<ImprovedSearchResultItem.PodcastItem>())
                     .distinctBy(ImprovedSearchResultItem.PodcastItem::uuid)
                 val episodes = remoteResults.filterIsInstance<ImprovedSearchResultItem.EpisodeItem>()
+                    .distinctBy(ImprovedSearchResultItem.EpisodeItem::uuid)
                 if (podcasts.isEmpty() && episodes.isEmpty()) {
                     TvSearchState.NoResults
                 } else {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
@@ -2,23 +2,44 @@ package au.com.shiftyjelly.pocketcasts.search
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverFeedLoader
 import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverRow
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.to.ImprovedSearchResultItem
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import au.com.shiftyjelly.pocketcasts.repositories.search.ImprovedSearchManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.rx2.await
 import timber.log.Timber
 
 @HiltViewModel
 class TvSearchViewModel @Inject constructor(
     private val discoverFeedLoader: TvDiscoverFeedLoader,
     private val syncManager: SyncManager,
+    private val improvedSearchManager: ImprovedSearchManager,
+    private val podcastManager: PodcastManager,
+    private val episodeManager: EpisodeManager,
+    private val playbackManager: PlaybackManager,
+    private val settings: Settings,
 ) : ViewModel() {
 
     private val _categories = MutableStateFlow<List<DiscoverCategory>>(emptyList())
@@ -26,6 +47,23 @@ class TvSearchViewModel @Inject constructor(
 
     private val _discoverRows = MutableStateFlow<List<TvDiscoverRow>>(emptyList())
     val discoverRows: StateFlow<List<TvDiscoverRow>> = _discoverRows.asStateFlow()
+
+    private val _query = MutableStateFlow("")
+    val query: StateFlow<String> = _query.asStateFlow()
+
+    private val _searchState = MutableStateFlow<TvSearchState>(TvSearchState.Idle)
+    val searchState: StateFlow<TvSearchState> = _searchState.asStateFlow()
+
+    private val _playStarted = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    val playStarted: SharedFlow<Unit> = _playStarted.asSharedFlow()
+
+    private val _playFailures = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    val playFailures: SharedFlow<Unit> = _playFailures.asSharedFlow()
+
+    private val _actionsEpisode = MutableStateFlow<PodcastEpisode?>(null)
+    val actionsEpisode: StateFlow<PodcastEpisode?> = _actionsEpisode.asStateFlow()
+
+    private var searchJob: Job? = null
 
     init {
         viewModelScope.launch {
@@ -52,4 +90,105 @@ class TvSearchViewModel @Inject constructor(
             }
         }
     }
+
+    fun onQueryChange(query: String) {
+        _query.value = query
+        searchJob?.cancel()
+        val term = query.trim()
+        if (term.isEmpty()) {
+            _searchState.value = TvSearchState.Idle
+            return
+        }
+        searchJob = viewModelScope.launch {
+            delay(settings.getPodcastSearchDebounceMs())
+            _searchState.value = TvSearchState.Searching
+            _searchState.value = try {
+                val localPodcasts = podcastManager.findSubscribedFlow(term).first().map(Podcast::toSearchItem)
+                val remoteResults = improvedSearchManager.combinedSearch(term)
+                val podcasts = (localPodcasts + remoteResults.filterIsInstance<ImprovedSearchResultItem.PodcastItem>())
+                    .distinctBy(ImprovedSearchResultItem.PodcastItem::uuid)
+                val episodes = remoteResults.filterIsInstance<ImprovedSearchResultItem.EpisodeItem>()
+                if (podcasts.isEmpty() && episodes.isEmpty()) {
+                    TvSearchState.NoResults
+                } else {
+                    TvSearchState.Results(podcasts = podcasts, episodes = episodes)
+                }
+            } catch (exception: CancellationException) {
+                throw exception
+            } catch (exception: Exception) {
+                Timber.e(exception, "Failed to search on TV")
+                TvSearchState.Error
+            }
+        }
+    }
+
+    fun playEpisode(episode: ImprovedSearchResultItem.EpisodeItem) {
+        viewModelScope.launch {
+            try {
+                val found = hydrate(episode)
+                if (found != null) {
+                    playbackManager.playNowSuspend(episode = found, sourceView = SourceView.SEARCH_RESULTS)
+                    _playStarted.tryEmit(Unit)
+                } else {
+                    Timber.e("Episode %s not found to play from TV search", episode.uuid)
+                    _playFailures.tryEmit(Unit)
+                }
+            } catch (exception: CancellationException) {
+                throw exception
+            } catch (exception: Exception) {
+                Timber.e(exception, "Failed to play episode from TV search")
+                _playFailures.tryEmit(Unit)
+            }
+        }
+    }
+
+    fun openEpisodeActions(episode: ImprovedSearchResultItem.EpisodeItem) {
+        viewModelScope.launch {
+            try {
+                val found = hydrate(episode)
+                if (found != null) {
+                    _actionsEpisode.value = found
+                } else {
+                    Timber.e("Episode %s not found to open actions from TV search", episode.uuid)
+                    _playFailures.tryEmit(Unit)
+                }
+            } catch (exception: CancellationException) {
+                throw exception
+            } catch (exception: Exception) {
+                Timber.e(exception, "Failed to open episode actions from TV search")
+                _playFailures.tryEmit(Unit)
+            }
+        }
+    }
+
+    fun dismissEpisodeActions() {
+        _actionsEpisode.value = null
+    }
+
+    private suspend fun hydrate(episode: ImprovedSearchResultItem.EpisodeItem): PodcastEpisode? {
+        return episodeManager.findByUuid(episode.uuid)
+            ?: run {
+                podcastManager.findOrDownloadPodcastRxSingle(episode.podcastUuid).await()
+                episodeManager.findByUuid(episode.uuid)
+            }
+    }
+}
+
+private fun Podcast.toSearchItem() = ImprovedSearchResultItem.PodcastItem(
+    uuid = uuid,
+    title = title,
+    author = author,
+    isFollowed = true,
+    isExplicit = explicit == true,
+)
+
+sealed interface TvSearchState {
+    data object Idle : TvSearchState
+    data object Searching : TvSearchState
+    data object NoResults : TvSearchState
+    data object Error : TvSearchState
+    data class Results(
+        val podcasts: List<ImprovedSearchResultItem.PodcastItem>,
+        val episodes: List<ImprovedSearchResultItem.EpisodeItem>,
+    ) : TvSearchState
 }

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionTypeTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionTypeTest.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.component
 
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Test
@@ -21,6 +22,11 @@ class TvEpisodeActionTypeTest {
             ),
             actions,
         )
+    }
+
+    @Test
+    fun `search results uses the search results analytics source`() {
+        assertEquals(SourceView.SEARCH_RESULTS, TvEpisodeActionContext.SearchResults.source)
     }
 
     @Test

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModelTest.kt
@@ -40,6 +40,7 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyBlocking
 import org.mockito.kotlin.whenever
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -233,6 +234,36 @@ class TvSearchViewModelTest {
         val state = viewModel.searchState.value as TvSearchState.Results
         assertEquals(listOf("podcast-1"), state.podcasts.map { it.uuid })
         assertEquals(listOf("episode-1"), state.episodes.map { it.uuid })
+    }
+
+    @Test
+    fun `episodes are de-duplicated by uuid`() = runTest {
+        whenever(listRepository.getSearchDiscoverFeed()).thenReturn(discover())
+        whenever { improvedSearchManager.combinedSearch(any()) }.thenReturn(
+            listOf(episodeItem("episode-1"), episodeItem("episode-1"), episodeItem("episode-2")),
+        )
+
+        val viewModel = createViewModel()
+        viewModel.onQueryChange("sugar")
+        advanceUntilIdle()
+
+        val state = viewModel.searchState.value as TvSearchState.Results
+        assertEquals(listOf("episode-1", "episode-2"), state.episodes.map { it.uuid })
+    }
+
+    @Test
+    fun `keystrokes within the debounce window only search the last term`() = runTest {
+        whenever(settings.getPodcastSearchDebounceMs()).thenReturn(300)
+        whenever(listRepository.getSearchDiscoverFeed()).thenReturn(discover())
+        whenever { improvedSearchManager.combinedSearch(any()) }.thenReturn(emptyList())
+
+        val viewModel = createViewModel()
+        viewModel.onQueryChange("su")
+        viewModel.onQueryChange("sugar")
+        advanceUntilIdle()
+
+        verifyBlocking(improvedSearchManager) { combinedSearch(eq("sugar")) }
+        verifyBlocking(improvedSearchManager, never()) { combinedSearch(eq("su")) }
     }
 
     @Test

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModelTest.kt
@@ -4,9 +4,15 @@ import android.content.Context
 import android.content.res.Resources
 import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverFeedLoader
 import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverRow
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.to.ImprovedSearchResultItem
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
 import au.com.shiftyjelly.pocketcasts.repositories.lists.ListRepository
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import au.com.shiftyjelly.pocketcasts.repositories.search.ImprovedSearchManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.servers.model.Discover
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
@@ -18,7 +24,11 @@ import au.com.shiftyjelly.pocketcasts.servers.model.ExpandedStyle
 import au.com.shiftyjelly.pocketcasts.servers.model.ListFeed
 import au.com.shiftyjelly.pocketcasts.servers.model.ListType
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import java.util.Date
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -51,7 +61,14 @@ class TvSearchViewModelTest {
     }
     private val settings = mock<Settings> {
         whenever(it.discoverCountryCode).thenReturn(discoverCountryCode)
+        whenever(it.getPodcastSearchDebounceMs()).thenReturn(0)
     }
+    private val improvedSearchManager = mock<ImprovedSearchManager>()
+    private val podcastManager = mock<PodcastManager> {
+        whenever(it.findSubscribedFlow(any())).thenReturn(flowOf(emptyList()))
+    }
+    private val episodeManager = mock<EpisodeManager>()
+    private val playbackManager = mock<PlaybackManager>()
 
     @Test
     fun `exposes the browse categories from the search feed row`() = runTest {
@@ -191,6 +208,92 @@ class TvSearchViewModelTest {
         assertTrue(viewModel.discoverRows.value.isEmpty())
     }
 
+    @Test
+    fun `a blank query stays idle`() = runTest {
+        whenever(listRepository.getSearchDiscoverFeed()).thenReturn(discover())
+        val viewModel = createViewModel()
+
+        viewModel.onQueryChange("   ")
+        advanceUntilIdle()
+
+        assertEquals(TvSearchState.Idle, viewModel.searchState.value)
+    }
+
+    @Test
+    fun `combined results are split into podcasts and episodes`() = runTest {
+        whenever(listRepository.getSearchDiscoverFeed()).thenReturn(discover())
+        whenever { improvedSearchManager.combinedSearch(any()) }.thenReturn(
+            listOf(podcastItem("podcast-1"), episodeItem("episode-1")),
+        )
+
+        val viewModel = createViewModel()
+        viewModel.onQueryChange("sugar")
+        advanceUntilIdle()
+
+        val state = viewModel.searchState.value as TvSearchState.Results
+        assertEquals(listOf("podcast-1"), state.podcasts.map { it.uuid })
+        assertEquals(listOf("episode-1"), state.episodes.map { it.uuid })
+    }
+
+    @Test
+    fun `empty combined results report no results`() = runTest {
+        whenever(listRepository.getSearchDiscoverFeed()).thenReturn(discover())
+        whenever { improvedSearchManager.combinedSearch(any()) }.thenReturn(emptyList())
+
+        val viewModel = createViewModel()
+        viewModel.onQueryChange("sugar")
+        advanceUntilIdle()
+
+        assertEquals(TvSearchState.NoResults, viewModel.searchState.value)
+    }
+
+    @Test
+    fun `subscribed podcasts lead the results and are not duplicated by the server`() = runTest {
+        whenever(listRepository.getSearchDiscoverFeed()).thenReturn(discover())
+        whenever(podcastManager.findSubscribedFlow(any())).thenReturn(flowOf(listOf(subscribedPodcast("podcast-1"))))
+        whenever { improvedSearchManager.combinedSearch(any()) }.thenReturn(
+            listOf(podcastItem("podcast-1"), podcastItem("podcast-2")),
+        )
+
+        val viewModel = createViewModel()
+        viewModel.onQueryChange("sugar")
+        advanceUntilIdle()
+
+        val state = viewModel.searchState.value as TvSearchState.Results
+        assertEquals(listOf("podcast-1", "podcast-2"), state.podcasts.map { it.uuid })
+        assertTrue(state.podcasts.first().isFollowed)
+    }
+
+    @Test
+    fun `a search failure surfaces the error state`() = runTest {
+        whenever(listRepository.getSearchDiscoverFeed()).thenReturn(discover())
+        whenever { improvedSearchManager.combinedSearch(any()) }.thenThrow(RuntimeException("Network error"))
+
+        val viewModel = createViewModel()
+        viewModel.onQueryChange("sugar")
+        advanceUntilIdle()
+
+        assertEquals(TvSearchState.Error, viewModel.searchState.value)
+    }
+
+    private fun podcastItem(uuid: String) = ImprovedSearchResultItem.PodcastItem(
+        uuid = uuid,
+        title = "Podcast $uuid",
+        author = "Author",
+        isFollowed = false,
+    )
+
+    private fun episodeItem(uuid: String) = ImprovedSearchResultItem.EpisodeItem(
+        uuid = uuid,
+        title = "Episode $uuid",
+        podcastUuid = "podcast-$uuid",
+        podcastTitle = "Podcast",
+        publishedDate = Date(0),
+        duration = 120.seconds,
+    )
+
+    private fun subscribedPodcast(uuid: String) = Podcast(uuid = uuid, title = "Podcast $uuid", author = "Author")
+
     private fun createViewModel() = TvSearchViewModel(
         discoverFeedLoader = TvDiscoverFeedLoader(
             listRepository = listRepository,
@@ -198,6 +301,11 @@ class TvSearchViewModelTest {
             context = context,
         ),
         syncManager = syncManager,
+        improvedSearchManager = improvedSearchManager,
+        podcastManager = podcastManager,
+        episodeManager = episodeManager,
+        playbackManager = playbackManager,
+        settings = settings,
     )
 
     private fun category(id: Int, name: String) = DiscoverCategory(id = id, name = name, icon = "", source = "")


### PR DESCRIPTION
## Description

Wires **real search** into the Android TV Search screen, matching the Apple TV app. Until now the TV Search tab only rendered the idle Discover browse (categories + featured rows) with a display‑only text field. This PR makes it actually search and adds the results UI + podcast/episode handling.

Mirrors the iOS `Pocket Casts TV App/UI/Search` flow:
- **Debounced combined search** (cancel‑on‑keystroke). Reuses `ImprovedSearchManager.combinedSearch` (the same combined endpoint iOS uses) and merges locally‑subscribed podcasts ahead of the server results, de‑duped by uuid.
- **Results** — a Podcasts carousel (`TvRow` of covers) + an Episodes list (podcast name · title · duration, a port of iOS `SearchEpisodeRow`).
- **Actions** — tapping a podcast opens the existing `TvPodcastDetailsScreen` in a `TvDetailOverlay`; tapping an episode hydrates + plays it and opens Now Playing (the exact `TvHomeViewModel.playEpisode` flow, `SourceView.SEARCH_RESULTS`). Focused episode rows reveal a **"…" more button** (as in Up Next / podcast details) that opens the shared `TvEpisodeActionsModal` — Play, Episode details, Go to podcast, Play next/last, Mark as played, Archive. The DTO is hydrated on open so every action persists.
- **Idle** (blank query) keeps the existing Discover browse.

The only shared‑module change: `ImprovedSearchResultItem.EpisodeItem` now carries `podcastTitle` (the server already returns `podcast_title`; it was being dropped), so the episode rows can show the podcast name like iOS. Additive, phone code unaffected.

**Follow‑up (noted, not done here):** `playEpisode` + its `playStarted`/`playFailures` plumbing is now duplicated between the Home and Search view models/screens. Worth extracting into a shared holder before a third tab copies it.

Stacked on `feat/tv-home-auth-feeds` (#5722).

Fixes POC-800 https://linear.app/a8c/issue/POC-800/wire-up-search-apis

## Testing Instructions

1. Run the TV app on an Android TV emulator/device and open the **Search** tab.
2. The idle screen shows the search field (system on‑screen keyboard auto‑opens), **Browse categories**, and the Discover rows.
3. Type a query (e.g. `science`). After a short debounce, results appear: a **Podcasts** carousel and an **Episodes** list.
4. Press **D‑pad down** from the field into the results.
5. Focus an episode row → the **"…"** button appears; open it → the episode actions dialog. Try *Episode details* (opens show notes), *Go to podcast*, *Play*, etc.
6. Select a podcast → its details open in the overlay. Select an episode → it starts playing and Now Playing opens.
7. Clear the query → the idle Discover browse returns.

## Screenshots or Screencast
<img width="1920" height="1080" alt="Screenshot_20260812_140105" src="https://github.com/user-attachments/assets/57f97a1a-9745-42de-a277-e280be8754bb" />


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) the Event Horizon schema to reflect any new or changed analytics. <!-- No analytics changes -->

