### PR TITLE
[TV] Search: Podcasts/Episodes scope filter

### DIFF
--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastGridScaffold.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastGridScaffold.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
@@ -30,20 +31,21 @@ import kotlinx.coroutines.flow.first
 
 @Composable
 internal fun TvPodcastGridScaffold(
-    title: String,
     itemKeys: List<Any>,
     modifier: Modifier = Modifier,
+    title: String? = null,
+    horizontalContentPadding: Dp = 32.dp,
     autoFocusFirstItem: Boolean = false,
     restoreFocusTrigger: Int = 0,
     itemContent: @Composable (index: Int, itemModifier: Modifier) -> Unit,
 ) {
     Column(modifier = modifier) {
-        if (title.isNotEmpty()) {
+        if (title != null) {
             Text(
                 text = title,
                 style = MaterialTheme.tvTypography.title3,
                 color = MaterialTheme.tvColors.textPrimary,
-                modifier = Modifier.padding(start = 32.dp, top = 8.dp, bottom = 10.dp),
+                modifier = Modifier.padding(start = horizontalContentPadding, top = 8.dp, bottom = 10.dp),
             )
         }
         val gridState = rememberLazyGridState()
@@ -74,7 +76,7 @@ internal fun TvPodcastGridScaffold(
             columns = GridCells.Fixed(GRID_COLUMNS),
             horizontalArrangement = Arrangement.spacedBy(16.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp),
-            contentPadding = PaddingValues(start = 32.dp, top = 16.dp, end = 32.dp, bottom = 32.dp),
+            contentPadding = PaddingValues(start = horizontalContentPadding, top = 16.dp, end = horizontalContentPadding, bottom = 32.dp),
             modifier = Modifier
                 .focusRequester(gridFocusRequester)
                 .focusGroup()

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastGridScaffold.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastGridScaffold.kt
@@ -38,12 +38,14 @@ internal fun TvPodcastGridScaffold(
     itemContent: @Composable (index: Int, itemModifier: Modifier) -> Unit,
 ) {
     Column(modifier = modifier) {
-        Text(
-            text = title,
-            style = MaterialTheme.tvTypography.title3,
-            color = MaterialTheme.tvColors.textPrimary,
-            modifier = Modifier.padding(start = 32.dp, top = 8.dp, bottom = 10.dp),
-        )
+        if (title.isNotEmpty()) {
+            Text(
+                text = title,
+                style = MaterialTheme.tvTypography.title3,
+                color = MaterialTheme.tvColors.textPrimary,
+                modifier = Modifier.padding(start = 32.dp, top = 8.dp, bottom = 10.dp),
+            )
+        }
         val gridState = rememberLazyGridState()
         var lastFocusedKey by rememberSaveable { mutableStateOf<String?>(null) }
         val focusRequesters = remember(itemKeys.size) { List(itemKeys.size) { FocusRequester() } }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvTabBar.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvTabBar.kt
@@ -91,7 +91,7 @@ fun TvTabBar(
                         currentTabPosition = currentTabPosition,
                         doesTabRowHaveFocus = doesTabRowHaveFocus,
                         activeColor = MaterialTheme.tvColors.backgroundActive,
-                        inactiveColor = MaterialTheme.tvColors.backgroundActive,
+                        inactiveColor = MaterialTheme.tvColors.backgroundBase,
                     )
                 }
             },
@@ -107,7 +107,7 @@ fun TvTabBar(
                         .then(if (index == selectedTabIndex) Modifier.focusRequester(focusRequester) else Modifier),
                     colors = TabDefaults.pillIndicatorTabColors(
                         contentColor = MaterialTheme.tvColors.textPrimary,
-                        selectedContentColor = MaterialTheme.tvColors.textPrimaryActive,
+                        selectedContentColor = MaterialTheme.tvColors.textPrimary,
                         focusedContentColor = MaterialTheme.tvColors.textPrimary,
                         focusedSelectedContentColor = MaterialTheme.tvColors.textPrimaryActive,
                         inactiveContentColor = MaterialTheme.tvColors.textPrimary,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchEpisodeRow.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchEpisodeRow.kt
@@ -63,10 +63,11 @@ internal fun TvSearchEpisodeRow(
 }
 
 @Composable
-private fun TvSearchEpisodeCard(
+internal fun TvSearchEpisodeCard(
     episode: ImprovedSearchResultItem.EpisodeItem,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    onLongClick: (() -> Unit)? = null,
 ) {
     var isFocused by remember { mutableStateOf(false) }
     val textPrimary = if (isFocused) MaterialTheme.tvColors.textPrimaryActive else MaterialTheme.tvColors.textPrimary
@@ -79,6 +80,7 @@ private fun TvSearchEpisodeCard(
 
     TvTile(
         onClick = onClick,
+        onLongClick = onLongClick,
         scale = CardDefaults.scale(focusedScale = 1.02f),
         shape = CardDefaults.shape(shape = RoundedCornerShape(12.dp)),
         colors = CardDefaults.colors(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchFilters.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchFilters.kt
@@ -1,0 +1,130 @@
+package au.com.shiftyjelly.pocketcasts.search
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.focusRestorer
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.tv.material3.LocalContentColor
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Tab
+import androidx.tv.material3.TabDefaults
+import androidx.tv.material3.TabRow
+import androidx.tv.material3.TabRowDefaults
+import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.theme.TvTheme
+import au.com.shiftyjelly.pocketcasts.theme.tvColors
+import au.com.shiftyjelly.pocketcasts.theme.tvTypography
+
+@Composable
+internal fun TvSearchFilters(
+    selected: TvSearchFilter,
+    onFilterSelect: (TvSearchFilter) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        FilterDivider(modifier = Modifier.weight(1f))
+        Spacer(modifier = Modifier.width(20.dp))
+        TvSearchFilterPills(selected = selected, onFilterSelect = onFilterSelect)
+        Spacer(modifier = Modifier.width(20.dp))
+        FilterDivider(modifier = Modifier.weight(1f))
+    }
+}
+
+@Composable
+private fun TvSearchFilterPills(
+    selected: TvSearchFilter,
+    onFilterSelect: (TvSearchFilter) -> Unit,
+) {
+    val selectedIndex = TvSearchFilter.entries.indexOf(selected)
+    Box(
+        modifier = Modifier
+            .background(MaterialTheme.tvColors.backgroundSunken, RoundedCornerShape(percent = 50))
+            .padding(3.dp),
+    ) {
+        TabRow(
+            selectedTabIndex = selectedIndex,
+            modifier = Modifier.focusRestorer(),
+            containerColor = Color.Transparent,
+            indicator = @Composable { tabPositions, doesTabRowHaveFocus ->
+                tabPositions.getOrNull(selectedIndex)?.let { currentTabPosition ->
+                    TabRowDefaults.PillIndicator(
+                        currentTabPosition = currentTabPosition,
+                        doesTabRowHaveFocus = doesTabRowHaveFocus,
+                        activeColor = MaterialTheme.tvColors.backgroundActive,
+                        inactiveColor = MaterialTheme.tvColors.backgroundActive,
+                    )
+                }
+            },
+        ) {
+            TvSearchFilter.entries.forEachIndexed { index, filter ->
+                Tab(
+                    selected = index == selectedIndex,
+                    onFocus = { onFilterSelect(filter) },
+                    onClick = { onFilterSelect(filter) },
+                    modifier = Modifier
+                        .height(44.dp)
+                        .padding(horizontal = 21.dp),
+                    colors = TabDefaults.pillIndicatorTabColors(
+                        contentColor = MaterialTheme.tvColors.textPrimary,
+                        selectedContentColor = MaterialTheme.tvColors.textPrimaryActive,
+                        focusedContentColor = MaterialTheme.tvColors.textPrimary,
+                        focusedSelectedContentColor = MaterialTheme.tvColors.textPrimaryActive,
+                        inactiveContentColor = MaterialTheme.tvColors.textPrimary,
+                    ),
+                ) {
+                    Box(
+                        modifier = Modifier.fillMaxHeight(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Text(
+                            text = stringResource(filter.labelRes),
+                            color = LocalContentColor.current,
+                            style = MaterialTheme.tvTypography.caption1,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun FilterDivider(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .height(1.dp)
+            .background(MaterialTheme.tvColors.overlayBorder),
+    )
+}
+
+@Preview(device = Devices.TV_1080p)
+@Composable
+private fun TvSearchFiltersPreview() {
+    TvTheme {
+        TvSearchFilters(
+            selected = TvSearchFilter.Podcasts,
+            onFilterSelect = {},
+            modifier = Modifier
+                .background(MaterialTheme.tvColors.backgroundSunken)
+                .padding(48.dp),
+        )
+    }
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchFilters.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchFilters.kt
@@ -69,7 +69,7 @@ private fun TvSearchFilterPills(
                         currentTabPosition = currentTabPosition,
                         doesTabRowHaveFocus = doesTabRowHaveFocus,
                         activeColor = MaterialTheme.tvColors.backgroundActive,
-                        inactiveColor = MaterialTheme.tvColors.backgroundActive,
+                        inactiveColor = MaterialTheme.tvColors.backgroundBase,
                     )
                 }
             },
@@ -84,7 +84,7 @@ private fun TvSearchFilterPills(
                         .padding(horizontal = 21.dp),
                     colors = TabDefaults.pillIndicatorTabColors(
                         contentColor = MaterialTheme.tvColors.textPrimary,
-                        selectedContentColor = MaterialTheme.tvColors.textPrimaryActive,
+                        selectedContentColor = MaterialTheme.tvColors.textPrimary,
                         focusedContentColor = MaterialTheme.tvColors.textPrimary,
                         focusedSelectedContentColor = MaterialTheme.tvColors.textPrimaryActive,
                         inactiveContentColor = MaterialTheme.tvColors.textPrimary,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.search
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.focusGroup
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -13,6 +14,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -26,6 +30,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
@@ -57,10 +62,12 @@ import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImage
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
 import au.com.shiftyjelly.pocketcasts.theme.TvTheme
 import au.com.shiftyjelly.pocketcasts.theme.tvColors
+import androidx.compose.foundation.lazy.grid.itemsIndexed as gridItemsIndexed
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 private val ContentPadding = PaddingValues(horizontal = 48.dp)
 private const val TOP_RESULTS_PREVIEW_COUNT = 6
+private const val EPISODE_GRID_COLUMNS = 2
 
 @Composable
 fun TvSearchScreen(
@@ -315,10 +322,11 @@ private fun TvSearchResults(
                 subtitle = stringResource(LR.string.tv_search_no_results_subtitle),
             )
         } else {
-            TvSearchEpisodeList(
+            TvSearchEpisodeGrid(
                 episodes = results.episodes,
                 onPlayEpisode = onPlayEpisode,
                 onOpenEpisodeActions = onOpenEpisodeActions,
+                restoreFocusTrigger = restoreFocusTrigger,
             )
         }
     }
@@ -381,22 +389,61 @@ private fun TvSearchTopResults(
 }
 
 @Composable
-private fun TvSearchEpisodeList(
+private fun TvSearchEpisodeGrid(
     episodes: List<ImprovedSearchResultItem.EpisodeItem>,
     onPlayEpisode: (ImprovedSearchResultItem.EpisodeItem) -> Unit,
     onOpenEpisodeActions: (ImprovedSearchResultItem.EpisodeItem) -> Unit,
+    restoreFocusTrigger: Int,
 ) {
-    LazyColumn(modifier = Modifier.fillMaxSize()) {
-        items(episodes, key = ImprovedSearchResultItem.EpisodeItem::uuid) { episode ->
-            TvSearchEpisodeRow(
+    val gridState = rememberLazyGridState()
+    val focusRequesters = remember(episodes.size) { List(episodes.size) { FocusRequester() } }
+    val gridFocusRequester = remember { FocusRequester() }
+    var lastFocusedKey by rememberSaveable { mutableStateOf<String?>(null) }
+
+    var isInitialComposition by remember { mutableStateOf(true) }
+    LaunchedEffect(restoreFocusTrigger) {
+        if (isInitialComposition) {
+            isInitialComposition = false
+        } else {
+            runCatching { gridFocusRequester.requestFocus() }
+        }
+    }
+
+    LazyVerticalGrid(
+        state = gridState,
+        columns = GridCells.Fixed(EPISODE_GRID_COLUMNS),
+        horizontalArrangement = Arrangement.spacedBy(24.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        contentPadding = PaddingValues(start = 48.dp, end = 48.dp, bottom = 40.dp),
+        modifier = Modifier
+            .fillMaxSize()
+            .focusRequester(gridFocusRequester)
+            .focusGroup()
+            .focusProperties {
+                onEnter = {
+                    val visible = gridState.layoutInfo.visibleItemsInfo
+                    val target = episodes.indexOfFirst { it.uuid == lastFocusedKey }
+                        .takeIf { index -> index >= 0 && visible.any { it.index == index } }
+                        ?: visible.firstOrNull()?.index
+                    target?.let { runCatching { focusRequesters.getOrNull(it)?.requestFocus() } }
+                }
+            },
+    ) {
+        gridItemsIndexed(episodes, key = { _, episode -> episode.uuid }) { index, episode ->
+            TvSearchEpisodeCard(
                 episode = episode,
                 onClick = { onPlayEpisode(episode) },
-                onOpenActions = { onOpenEpisodeActions(episode) },
-                modifier = Modifier.padding(ContentPadding),
+                onLongClick = { onOpenEpisodeActions(episode) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .focusRequester(focusRequesters[index])
+                    .onFocusChanged { focusState ->
+                        if (focusState.hasFocus) {
+                            lastFocusedKey = episode.uuid
+                        }
+                    },
             )
-            Spacer(modifier = Modifier.height(12.dp))
         }
-        item { Spacer(modifier = Modifier.height(40.dp)) }
     }
 }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
@@ -41,6 +41,7 @@ import au.com.shiftyjelly.pocketcasts.component.TvEmptyState
 import au.com.shiftyjelly.pocketcasts.component.TvEpisodeActionContext
 import au.com.shiftyjelly.pocketcasts.component.TvEpisodeActionsModal
 import au.com.shiftyjelly.pocketcasts.component.TvEpisodeInfoModal
+import au.com.shiftyjelly.pocketcasts.component.TvPodcastGridScaffold
 import au.com.shiftyjelly.pocketcasts.component.TvPodcastTile
 import au.com.shiftyjelly.pocketcasts.component.TvPodcastTileDefaults
 import au.com.shiftyjelly.pocketcasts.component.TvRow
@@ -59,6 +60,7 @@ import au.com.shiftyjelly.pocketcasts.theme.tvColors
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 private val ContentPadding = PaddingValues(horizontal = 48.dp)
+private const val TOP_RESULTS_PREVIEW_COUNT = 6
 
 @Composable
 fun TvSearchScreen(
@@ -67,6 +69,7 @@ fun TvSearchScreen(
 ) {
     val query by viewModel.query.collectAsStateWithLifecycle()
     val searchState by viewModel.searchState.collectAsStateWithLifecycle()
+    val filter by viewModel.filter.collectAsStateWithLifecycle()
     val categories by viewModel.categories.collectAsStateWithLifecycle()
     val discoverRows by viewModel.discoverRows.collectAsStateWithLifecycle()
     val actionsEpisode by viewModel.actionsEpisode.collectAsStateWithLifecycle()
@@ -90,9 +93,11 @@ fun TvSearchScreen(
         TvSearchContent(
             query = query,
             searchState = searchState,
+            filter = filter,
             categories = categories,
             discoverRows = discoverRows,
             onQueryChange = viewModel::onQueryChange,
+            onFilterSelect = viewModel::onFilterSelected,
             onOpenPodcast = { openedPodcastUuid = it },
             onPlayEpisode = viewModel::playEpisode,
             onOpenEpisodeActions = viewModel::openEpisodeActions,
@@ -139,9 +144,11 @@ fun TvSearchScreen(
 private fun TvSearchContent(
     query: String,
     searchState: TvSearchState,
+    filter: TvSearchFilter,
     categories: List<DiscoverCategory>,
     discoverRows: List<TvDiscoverRow>,
     onQueryChange: (String) -> Unit,
+    onFilterSelect: (TvSearchFilter) -> Unit,
     onOpenPodcast: (String) -> Unit,
     onPlayEpisode: (ImprovedSearchResultItem.EpisodeItem) -> Unit,
     onOpenEpisodeActions: (ImprovedSearchResultItem.EpisodeItem) -> Unit,
@@ -163,6 +170,15 @@ private fun TvSearchContent(
                 query = query,
                 onQueryChange = onQueryChange,
                 modifier = Modifier.focusRequester(searchFieldFocusRequester),
+            )
+            Spacer(modifier = Modifier.height(24.dp))
+        }
+
+        if (searchState !is TvSearchState.Idle) {
+            TvSearchFilters(
+                selected = filter,
+                onFilterSelect = onFilterSelect,
+                modifier = Modifier.padding(horizontal = 48.dp),
             )
             Spacer(modifier = Modifier.height(24.dp))
         }
@@ -197,6 +213,7 @@ private fun TvSearchContent(
 
                 is TvSearchState.Results -> TvSearchResults(
                     results = searchState,
+                    filter = filter,
                     onOpenPodcast = onOpenPodcast,
                     onPlayEpisode = onPlayEpisode,
                     onOpenEpisodeActions = onOpenEpisodeActions,
@@ -253,13 +270,71 @@ private fun TvSearchDiscover(
 @Composable
 private fun TvSearchResults(
     results: TvSearchState.Results,
+    filter: TvSearchFilter,
+    onOpenPodcast: (String) -> Unit,
+    onPlayEpisode: (ImprovedSearchResultItem.EpisodeItem) -> Unit,
+    onOpenEpisodeActions: (ImprovedSearchResultItem.EpisodeItem) -> Unit,
+    restoreFocusTrigger: Int,
+) {
+    when (filter) {
+        TvSearchFilter.TopResults -> TvSearchTopResults(
+            podcasts = results.podcasts,
+            episodes = results.episodes,
+            onOpenPodcast = onOpenPodcast,
+            onPlayEpisode = onPlayEpisode,
+            onOpenEpisodeActions = onOpenEpisodeActions,
+            restoreFocusTrigger = restoreFocusTrigger,
+        )
+
+        TvSearchFilter.Podcasts -> if (results.podcasts.isEmpty()) {
+            TvSearchMessage(
+                title = stringResource(LR.string.tv_search_no_results_title),
+                subtitle = stringResource(LR.string.tv_search_no_results_subtitle),
+            )
+        } else {
+            TvPodcastGridScaffold(
+                title = "",
+                itemKeys = results.podcasts.map(ImprovedSearchResultItem.PodcastItem::uuid),
+                modifier = Modifier.fillMaxSize(),
+                restoreFocusTrigger = restoreFocusTrigger,
+            ) { index, itemModifier ->
+                val podcast = results.podcasts[index]
+                TvPodcastTile(
+                    artworkUrl = PodcastImage.getMediumArtworkUrl(podcast.uuid),
+                    podcastTitle = podcast.title,
+                    onClick = { onOpenPodcast(podcast.uuid) },
+                    imageModifier = Modifier.fillMaxWidth(),
+                    modifier = itemModifier,
+                )
+            }
+        }
+
+        TvSearchFilter.Episodes -> if (results.episodes.isEmpty()) {
+            TvSearchMessage(
+                title = stringResource(LR.string.tv_search_no_results_title),
+                subtitle = stringResource(LR.string.tv_search_no_results_subtitle),
+            )
+        } else {
+            TvSearchEpisodeList(
+                episodes = results.episodes,
+                onPlayEpisode = onPlayEpisode,
+                onOpenEpisodeActions = onOpenEpisodeActions,
+            )
+        }
+    }
+}
+
+@Composable
+private fun TvSearchTopResults(
+    podcasts: List<ImprovedSearchResultItem.PodcastItem>,
+    episodes: List<ImprovedSearchResultItem.EpisodeItem>,
     onOpenPodcast: (String) -> Unit,
     onPlayEpisode: (ImprovedSearchResultItem.EpisodeItem) -> Unit,
     onOpenEpisodeActions: (ImprovedSearchResultItem.EpisodeItem) -> Unit,
     restoreFocusTrigger: Int,
 ) {
     val restoreFocusRequester = remember { FocusRequester() }
-    val hasPodcasts = results.podcasts.isNotEmpty()
+    val hasPodcasts = podcasts.isNotEmpty()
     var isInitialComposition by remember { mutableStateOf(true) }
     LaunchedEffect(restoreFocusTrigger) {
         if (isInitialComposition) {
@@ -272,12 +347,12 @@ private fun TvSearchResults(
     LazyColumn(modifier = Modifier.fillMaxSize()) {
         if (hasPodcasts) {
             tvSearchPodcastsRow(
-                podcasts = results.podcasts,
+                podcasts = podcasts,
                 onOpenPodcast = onOpenPodcast,
                 focusRequester = restoreFocusRequester,
             )
         }
-        if (results.episodes.isNotEmpty()) {
+        if (episodes.isNotEmpty()) {
             item {
                 Spacer(modifier = Modifier.height(24.dp))
                 TvSectionTitle(
@@ -288,7 +363,7 @@ private fun TvSearchResults(
                 )
             }
             itemsIndexed(
-                items = results.episodes,
+                items = episodes.take(TOP_RESULTS_PREVIEW_COUNT),
                 key = { _, episode -> episode.uuid },
             ) { index, episode ->
                 TvSearchEpisodeRow(
@@ -300,6 +375,26 @@ private fun TvSearchResults(
                 )
                 Spacer(modifier = Modifier.height(12.dp))
             }
+        }
+        item { Spacer(modifier = Modifier.height(40.dp)) }
+    }
+}
+
+@Composable
+private fun TvSearchEpisodeList(
+    episodes: List<ImprovedSearchResultItem.EpisodeItem>,
+    onPlayEpisode: (ImprovedSearchResultItem.EpisodeItem) -> Unit,
+    onOpenEpisodeActions: (ImprovedSearchResultItem.EpisodeItem) -> Unit,
+) {
+    LazyColumn(modifier = Modifier.fillMaxSize()) {
+        items(episodes, key = ImprovedSearchResultItem.EpisodeItem::uuid) { episode ->
+            TvSearchEpisodeRow(
+                episode = episode,
+                onClick = { onPlayEpisode(episode) },
+                onOpenActions = { onOpenEpisodeActions(episode) },
+                modifier = Modifier.padding(ContentPadding),
+            )
+            Spacer(modifier = Modifier.height(12.dp))
         }
         item { Spacer(modifier = Modifier.height(40.dp)) }
     }
@@ -352,6 +447,7 @@ private fun TvSearchScreenPreview() {
             TvSearchContent(
                 query = "",
                 searchState = TvSearchState.Idle,
+                filter = TvSearchFilter.TopResults,
                 categories = listOf(
                     DiscoverCategory(id = 1, name = "Comedy", icon = "", source = ""),
                     DiscoverCategory(id = 2, name = "True Crime", icon = "", source = ""),
@@ -359,6 +455,7 @@ private fun TvSearchScreenPreview() {
                 ),
                 discoverRows = emptyList(),
                 onQueryChange = {},
+                onFilterSelect = {},
                 onOpenPodcast = {},
                 onPlayEpisode = {},
                 onOpenEpisodeActions = {},

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
@@ -65,7 +66,8 @@ import au.com.shiftyjelly.pocketcasts.theme.tvColors
 import androidx.compose.foundation.lazy.grid.itemsIndexed as gridItemsIndexed
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
-private val ContentPadding = PaddingValues(horizontal = 48.dp)
+private val ContentHorizontalPadding = 48.dp
+private val ContentPadding = PaddingValues(horizontal = ContentHorizontalPadding)
 private const val TOP_RESULTS_PREVIEW_COUNT = 6
 private const val EPISODE_GRID_COLUMNS = 2
 
@@ -163,14 +165,11 @@ private fun TvSearchContent(
     restoreFocusTrigger: Int = 0,
 ) {
     val searchFieldFocusRequester = remember { FocusRequester() }
-    Column(
-        modifier = modifier
-            .fillMaxSize()
-            .focusGroup()
-            .focusProperties {
-                onEnter = { runCatching { searchFieldFocusRequester.requestFocus() } }
-            },
-    ) {
+    LaunchedEffect(Unit) {
+        withFrameNanos {}
+        runCatching { searchFieldFocusRequester.requestFocus() }
+    }
+    Column(modifier = modifier.fillMaxSize()) {
         Column(modifier = Modifier.padding(ContentPadding)) {
             Spacer(modifier = Modifier.height(40.dp))
             TvSearchField(
@@ -185,7 +184,7 @@ private fun TvSearchContent(
             TvSearchFilters(
                 selected = filter,
                 onFilterSelect = onFilterSelect,
-                modifier = Modifier.padding(horizontal = 48.dp),
+                modifier = Modifier.padding(ContentPadding),
             )
             Spacer(modifier = Modifier.height(24.dp))
         }
@@ -300,9 +299,9 @@ private fun TvSearchResults(
             )
         } else {
             TvPodcastGridScaffold(
-                title = "",
                 itemKeys = results.podcasts.map(ImprovedSearchResultItem.PodcastItem::uuid),
                 modifier = Modifier.fillMaxSize(),
+                horizontalContentPadding = ContentHorizontalPadding,
                 restoreFocusTrigger = restoreFocusTrigger,
             ) { index, itemModifier ->
                 val podcast = results.podcasts[index]

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.search
 
+import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
@@ -30,6 +31,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.rx2.await
 import timber.log.Timber
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @HiltViewModel
 class TvSearchViewModel @Inject constructor(
@@ -53,6 +55,9 @@ class TvSearchViewModel @Inject constructor(
 
     private val _searchState = MutableStateFlow<TvSearchState>(TvSearchState.Idle)
     val searchState: StateFlow<TvSearchState> = _searchState.asStateFlow()
+
+    private val _filter = MutableStateFlow(TvSearchFilter.TopResults)
+    val filter: StateFlow<TvSearchFilter> = _filter.asStateFlow()
 
     private val _playStarted = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
     val playStarted: SharedFlow<Unit> = _playStarted.asSharedFlow()
@@ -96,6 +101,7 @@ class TvSearchViewModel @Inject constructor(
         searchJob?.cancel()
         val term = query.trim()
         if (term.isEmpty()) {
+            _filter.value = TvSearchFilter.TopResults
             _searchState.value = TvSearchState.Idle
             return
         }
@@ -121,6 +127,10 @@ class TvSearchViewModel @Inject constructor(
                 TvSearchState.Error
             }
         }
+    }
+
+    fun onFilterSelected(filter: TvSearchFilter) {
+        _filter.value = filter
     }
 
     fun playEpisode(episode: ImprovedSearchResultItem.EpisodeItem) {
@@ -182,6 +192,14 @@ private fun Podcast.toSearchItem() = ImprovedSearchResultItem.PodcastItem(
     isFollowed = true,
     isExplicit = explicit == true,
 )
+
+enum class TvSearchFilter(
+    @StringRes val labelRes: Int,
+) {
+    TopResults(LR.string.search_filters_top_results),
+    Podcasts(LR.string.search_filters_podcasts),
+    Episodes(LR.string.search_filters_episodes),
+}
 
 sealed interface TvSearchState {
     data object Idle : TvSearchState

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModelTest.kt
@@ -307,6 +307,28 @@ class TvSearchViewModelTest {
         assertEquals(TvSearchState.Error, viewModel.searchState.value)
     }
 
+    @Test
+    fun `onFilterSelected updates the filter`() = runTest {
+        whenever(listRepository.getSearchDiscoverFeed()).thenReturn(discover())
+        val viewModel = createViewModel()
+
+        viewModel.onFilterSelected(TvSearchFilter.Episodes)
+
+        assertEquals(TvSearchFilter.Episodes, viewModel.filter.value)
+    }
+
+    @Test
+    fun `clearing the query resets the filter to top results`() = runTest {
+        whenever(listRepository.getSearchDiscoverFeed()).thenReturn(discover())
+        val viewModel = createViewModel()
+
+        viewModel.onFilterSelected(TvSearchFilter.Podcasts)
+        viewModel.onQueryChange("")
+        advanceUntilIdle()
+
+        assertEquals(TvSearchFilter.TopResults, viewModel.filter.value)
+    }
+
     private fun podcastItem(uuid: String) = ImprovedSearchResultItem.PodcastItem(
         uuid = uuid,
         title = "Podcast $uuid",


### PR DESCRIPTION
## Description

Adds the **Podcasts/Episodes scope filter** to the TV Search screen, on top of the basic search PR.

> Stacked on **#5728** (`feat/tv-search-results`). Review/merge that one first.

- **Pill filter** — `Top Results` / `Podcasts` / `Episodes`, styled exactly as the top‑bar tab pills (`androidx.tv.material3` `TabRow` + pill indicator in a `backgroundSunken` container), centered between two divider lines per the Figma. Selecting follows focus, like the top bar.
- **Scopes:**
  - *Top Results* — the combined view (podcasts carousel + a capped episodes preview).
  - *Podcasts* — a 6‑column cover grid (`TvPodcastGridScaffold`).
  - *Episodes* — the full episode list.
- Adds `filter` state + `onFilterSelected` to `TvSearchViewModel` and the scope switching in `TvSearchScreen`. No new strings (reuses `search_filters_*`), no analytics.

Fixes POC-800 https://linear.app/a8c/issue/POC-800/wire-up-search-apis
Figma: Ftk3KwnfqaK4g57yCN63p0-fi-2595_2243

## Testing Instructions

1. Build the branch (stacked on #5728) and open the **Search** tab; type a query.
2. A centered **Top Results / Podcasts / Episodes** pill bar appears between two divider lines.
3. **D‑pad down** from the field lands on the filter; arrow left/right to switch scope (selects on focus).
4. *Top Results* shows podcasts + an episodes preview; *Podcasts* shows the cover grid; *Episodes* shows the full list.
5. Clearing the query hides the filter and returns to the Discover browse.

## Screenshots or Screencast


https://github.com/user-attachments/assets/d4fa5ded-547e-46ff-a307-4ed0e4cf77eb





## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) the Event Horizon schema to reflect any new or changed analytics. <!-- No analytics changes -->

#### I have tested any UI changes...
- [x] with different themes <!-- TV is dark-theme only -->
- [ ] with a landscape orientation <!-- TV is always landscape -->
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack