### PR TITLE
[TV] Add category details

### DIFF
--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
@@ -109,9 +109,7 @@ fun TvScaffold(
                     onConsumeOpenRequest = { isNowPlayingOpenRequested = false },
                 )
 
-                is TvTab.Search -> Box(modifier = belowTopBar) {
-                    TvSearchScreen()
-                }
+                is TvTab.Search -> TvSearchScreen()
             }
         }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
@@ -54,7 +54,10 @@ import au.com.shiftyjelly.pocketcasts.component.TvRow
 import au.com.shiftyjelly.pocketcasts.component.TvSectionTitle
 import au.com.shiftyjelly.pocketcasts.component.tvFocusInactiveWhen
 import au.com.shiftyjelly.pocketcasts.compose.loading.LoadingView
+import au.com.shiftyjelly.pocketcasts.discover.TvCategoryPodcastsScreen
 import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverRow
+import au.com.shiftyjelly.pocketcasts.discover.TvOpenedCategory
+import au.com.shiftyjelly.pocketcasts.discover.TvOpenedCategorySaver
 import au.com.shiftyjelly.pocketcasts.discover.tvDiscoverRow
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.ImprovedSearchResultItem
@@ -62,6 +65,7 @@ import au.com.shiftyjelly.pocketcasts.podcasts.TvPodcastDetailsScreen
 import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImage
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
 import au.com.shiftyjelly.pocketcasts.theme.TvTheme
+import au.com.shiftyjelly.pocketcasts.theme.TvTopBarHeight
 import au.com.shiftyjelly.pocketcasts.theme.tvColors
 import androidx.compose.foundation.lazy.grid.itemsIndexed as gridItemsIndexed
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -84,9 +88,12 @@ fun TvSearchScreen(
     val actionsEpisode by viewModel.actionsEpisode.collectAsStateWithLifecycle()
 
     var openedPodcastUuid by rememberSaveable { mutableStateOf<String?>(null) }
+    var openedCategory by rememberSaveable(stateSaver = TvOpenedCategorySaver) { mutableStateOf<TvOpenedCategory?>(null) }
     var detailsEpisode by remember { mutableStateOf<PodcastEpisode?>(null) }
     var restoreFocusTrigger by remember { mutableIntStateOf(0) }
+    var categoryRestoreTrigger by remember { mutableIntStateOf(0) }
     val podcastUuid = openedPodcastUuid
+    val category = openedCategory
 
     val openNowPlaying = LocalOpenNowPlaying.current
     val toastHostState = LocalTvToastHostState.current
@@ -108,17 +115,34 @@ fun TvSearchScreen(
             onQueryChange = viewModel::onQueryChange,
             onFilterSelect = viewModel::onFilterSelected,
             onOpenPodcast = { openedPodcastUuid = it },
+            onOpenCategory = { openedCategory = TvOpenedCategory(it.id, it.name, it.source) },
             onPlayEpisode = viewModel::playEpisode,
             onOpenEpisodeActions = viewModel::openEpisodeActions,
             restoreFocusTrigger = restoreFocusTrigger,
             modifier = Modifier
                 .fillMaxSize()
-                .tvFocusInactiveWhen(podcastUuid != null),
+                .padding(top = TvTopBarHeight)
+                .tvFocusInactiveWhen(podcastUuid != null || category != null),
         )
+        TvDetailOverlay(
+            target = category,
+            onBack = { openedCategory = null },
+            modifier = Modifier.tvFocusInactiveWhen(podcastUuid != null),
+            onHide = { restoreFocusTrigger++ },
+        ) { openCategory ->
+            TvCategoryPodcastsScreen(
+                categoryName = openCategory.name,
+                categorySource = openCategory.source,
+                getCategoryPodcasts = { source -> viewModel.categoryPodcasts(openCategory.id, source) },
+                onOpenPodcast = { openedPodcastUuid = it },
+                onClose = { openedCategory = null },
+                restoreFocusTrigger = categoryRestoreTrigger,
+            )
+        }
         TvDetailOverlay(
             target = podcastUuid,
             onBack = { openedPodcastUuid = null },
-            onHide = { restoreFocusTrigger++ },
+            onHide = { if (openedCategory != null) categoryRestoreTrigger++ else restoreFocusTrigger++ },
         ) { uuid ->
             TvPodcastDetailsScreen(
                 podcastUuid = uuid,
@@ -159,6 +183,7 @@ private fun TvSearchContent(
     onQueryChange: (String) -> Unit,
     onFilterSelect: (TvSearchFilter) -> Unit,
     onOpenPodcast: (String) -> Unit,
+    onOpenCategory: (DiscoverCategory) -> Unit,
     onPlayEpisode: (ImprovedSearchResultItem.EpisodeItem) -> Unit,
     onOpenEpisodeActions: (ImprovedSearchResultItem.EpisodeItem) -> Unit,
     modifier: Modifier = Modifier,
@@ -198,6 +223,9 @@ private fun TvSearchContent(
                 is TvSearchState.Idle -> TvSearchDiscover(
                     categories = categories,
                     discoverRows = discoverRows,
+                    onOpenPodcast = onOpenPodcast,
+                    onOpenCategory = onOpenCategory,
+                    restoreFocusTrigger = restoreFocusTrigger,
                 )
 
                 is TvSearchState.Searching -> LoadingView(
@@ -234,7 +262,24 @@ private fun TvSearchContent(
 private fun TvSearchDiscover(
     categories: List<DiscoverCategory>,
     discoverRows: List<TvDiscoverRow>,
+    onOpenPodcast: (String) -> Unit,
+    onOpenCategory: (DiscoverCategory) -> Unit,
+    restoreFocusTrigger: Int,
 ) {
+    val categoryOffset = if (categories.isNotEmpty()) 1 else 0
+    val rowCount = categoryOffset + discoverRows.size
+    val rowFocusRequesters = remember(rowCount) { List(rowCount) { FocusRequester() } }
+    var lastFocusedRowIndex by rememberSaveable(rowCount) { mutableIntStateOf(0) }
+
+    var isInitialComposition by remember { mutableStateOf(true) }
+    LaunchedEffect(restoreFocusTrigger) {
+        if (isInitialComposition) {
+            isInitialComposition = false
+        } else {
+            runCatching { rowFocusRequesters.getOrNull(lastFocusedRowIndex)?.requestFocus() }
+        }
+    }
+
     LazyColumn(modifier = Modifier.fillMaxSize()) {
         if (categories.isNotEmpty()) {
             item {
@@ -253,19 +298,25 @@ private fun TvSearchDiscover(
                     items = categories,
                     contentPadding = ContentPadding,
                     key = { it.id },
+                    focusRequester = rowFocusRequesters.getOrNull(0),
+                    modifier = Modifier.onFocusChanged { if (it.hasFocus) lastFocusedRowIndex = 0 },
                 ) { category ->
-                    TvCategoryTile(category = category, onClick = {})
+                    TvCategoryTile(category = category, onClick = { onOpenCategory(category) })
                 }
             }
         }
 
-        discoverRows.forEach { row ->
+        discoverRows.forEachIndexed { index, row ->
+            val rowIndex = categoryOffset + index
             item { Spacer(modifier = Modifier.height(24.dp)) }
             tvDiscoverRow(
                 row = row,
-                onOpenPodcast = {},
-                onPlayEpisode = {},
+                onOpenPodcast = onOpenPodcast,
+                onPlayEpisode = {}, // TODO: wire discover-feed episode playback in search
                 contentPadding = ContentPadding,
+                onOpenCategory = onOpenCategory,
+                focusRequester = rowFocusRequesters.getOrNull(rowIndex),
+                modifier = Modifier.onFocusChanged { if (it.hasFocus) lastFocusedRowIndex = rowIndex },
             )
         }
 
@@ -503,6 +554,7 @@ private fun TvSearchScreenPreview() {
                 onQueryChange = {},
                 onFilterSelect = {},
                 onOpenPodcast = {},
+                onOpenCategory = {},
                 onPlayEpisode = {},
                 onOpenEpisodeActions = {},
             )

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverFeedLoader
+import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverPodcast
 import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverRow
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
@@ -131,6 +132,10 @@ class TvSearchViewModel @Inject constructor(
 
     fun onFilterSelected(filter: TvSearchFilter) {
         _filter.value = filter
+    }
+
+    suspend fun categoryPodcasts(categoryId: Int, source: String): List<TvDiscoverPodcast> {
+        return discoverFeedLoader.loadCategoryPodcasts(source, categoryId, syncManager.isLoggedIn())
     }
 
     fun playEpisode(episode: ImprovedSearchResultItem.EpisodeItem) {

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModelTest.kt
@@ -206,6 +206,18 @@ class TvSearchViewModelTest {
     }
 
     @Test
+    fun `categoryPodcasts maps the loaded category feed`() = runTest {
+        whenever(listRepository.getSearchDiscoverFeed()).thenReturn(discover())
+        whenever(listRepository.getHomeDiscoverFeed(isLoggedIn = false)).thenReturn(discover())
+        whenever(listRepository.getListFeed(eq("https://category/us.json"), any()))
+            .thenReturn(podcastFeed("podcast-1", "podcast-2"))
+
+        val podcasts = createViewModel().categoryPodcasts(categoryId = 7, source = "https://category/us.json")
+
+        assertEquals(listOf("podcast-1", "podcast-2"), podcasts.map { it.uuid })
+    }
+
+    @Test
     fun `categories still load when building the discover rows fails`() = runTest {
         whenever(listRepository.getSearchDiscoverFeed()).thenReturn(
             Discover(


### PR DESCRIPTION
## Description

Stacked on #5730 (`feat/tv-home-discover-parity`). Adds the **Search**-screen half of the TV Discover category-details work: the shared category-detail screen and feed loader land in the base PR; this wires them into Search and polishes the browse UX.

- **Category pills → detail.** The Search "Browse categories" pills were a no-op (`onClick = {}`); they now open the shared `TvCategoryPodcastsScreen` via the same `TvDetailOverlay` stacking used on Home. `TvSearchViewModel.categoryPodcasts` loads the grid (region resolution + sponsored merge come from the base loader).
- **Category overlay fills the screen.** `TvScaffold` no longer wraps the Search tab in `belowTopBar` padding; Search pads its own content instead, so the category/podcast detail overlays fill the full height. Previously a category opened from Search left a large empty gap under the (hidden) top bar.
- **Search field scrolls away.** The search field moves into the idle browse `LazyColumn` (first item) so it scrolls with the categories instead of staying pinned. `TvSearchField` autofocus is made one-shot (survives via a stable list-item key) so scrolling back to the top doesn't re-open the keyboard.
- **Focus restore on return.** Returning from a category (or podcast) overlay to the idle browse screen restores focus to the last-focused row (mirroring `TvHomeScreen`), instead of the top-bar profile icon stealing focus.

Fixes POC-840 https://linear.app/a8c/issue/POC-840/category-details

## Testing Instructions

1. Open the Search tab; the field auto-focuses (keyboard up). Press Down to reach the **Browse categories** pills.
2. Scroll down — the search field scrolls away with the content; scroll back up — the keyboard does **not** re-pop.
3. Press a category pill → "Most Popular in {category}" grid opens with **no** empty gap at the top; open a podcast; Back twice.
4. On Back to Search, focus lands on the categories row, not the profile icon.

## Screenshots or Screencast

https://github.com/user-attachments/assets/4a07a2ac-a266-4ca0-8f58-360cfdc2cf90



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md 
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) the Event Horizon schema to reflect any new or changed analytics.

#### I have tested any UI changes...
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
