### PR TITLE
Enable parallel Gradle tooling sync

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,3 +25,6 @@ org.gradle.configuration-cache=true
 
 # Dependency Analysis Plugin
 dependency.analysis.android.ignored.variants=release,prototype,debugProd
+
+# Enabled parallel sync for Gradle 9.4+
+org.gradle.tooling.parallel=true


### PR DESCRIPTION
## Description

Enables Gradle's parallel tooling API sync by setting `org.gradle.tooling.parallel=true` in `gradle.properties`.

Gradle 9.4 added support for running IDE sync (the Tooling API model-building phase) in parallel across projects, but it is off by default. In a project with this many modules, sync is a significant part of the day-to-day feedback loop, so turning it on should meaningfully cut Android Studio sync time. This only affects the sync/model-building phase, it does not change how builds themselves are configured or executed.

Android Studio keeps adding this file, so I thought it would be good to commit it.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
