### PR TITLE
[TV] Your Podcasts analytics

### DIFF
--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvFolderDetailScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvFolderDetailScreen.kt
@@ -39,13 +39,16 @@ fun TvFolderDetailScreen(
     onOpenPodcast: (String) -> Unit,
     onClose: () -> Unit,
     modifier: Modifier = Modifier,
+    onFolderImpression: (podcastCount: Int) -> Unit = {},
     restoreFocusTrigger: Int = 0,
 ) {
     var uiState by remember(folderUuid) { mutableStateOf<TvFolderDetailUiState>(TvFolderDetailUiState.Loading) }
     val currentGetFolderPodcasts by rememberUpdatedState(getFolderPodcasts)
+    val currentOnFolderImpression by rememberUpdatedState(onFolderImpression)
     LaunchedEffect(folderUuid) {
         val podcasts = currentGetFolderPodcasts(folderUuid)
         uiState = if (podcasts.isEmpty()) TvFolderDetailUiState.Empty else TvFolderDetailUiState.Loaded(podcasts)
+        currentOnFolderImpression(podcasts.size)
     }
 
     TvFolderDetailContent(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvFolderDetailScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvFolderDetailScreen.kt
@@ -38,8 +38,8 @@ fun TvFolderDetailScreen(
     getFolderPodcasts: suspend (String) -> List<Podcast>,
     onOpenPodcast: (String) -> Unit,
     onClose: () -> Unit,
+    onFolderImpression: (podcastCount: Int) -> Unit,
     modifier: Modifier = Modifier,
-    onFolderImpression: (podcastCount: Int) -> Unit = {},
     restoreFocusTrigger: Int = 0,
 ) {
     var uiState by remember(folderUuid) { mutableStateOf<TvFolderDetailUiState>(TvFolderDetailUiState.Loading) }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsScreen.kt
@@ -133,7 +133,7 @@ private val OpenedFolderSaver = listSaver<OpenedFolder?, String>(
     save = { folder -> folder?.let { listOf(it.uuid, it.name, it.sortType.name) }.orEmpty() },
     restore = { saved ->
         saved.takeIf { it.size == 3 }?.let { (uuid, name, sortType) ->
-            OpenedFolder(uuid, name, PodcastsSortType.valueOf(sortType))
+            PodcastsSortType.entries.firstOrNull { it.name == sortType }?.let { OpenedFolder(uuid, name, it) }
         }
     },
 )

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -54,15 +55,43 @@ fun TvYourPodcastsScreen(
     var openedPodcastUuid by rememberSaveable { mutableStateOf<String?>(null) }
     var gridRestoreTrigger by remember { mutableIntStateOf(0) }
     var folderRestoreTrigger by remember { mutableIntStateOf(0) }
+    var podcastsListShownTracked by remember { mutableStateOf(false) }
+
+    LaunchedEffect(uiState) {
+        if (!podcastsListShownTracked) {
+            when (val state = uiState) {
+                is TvYourPodcastsUiState.Loaded -> {
+                    viewModel.trackPodcastsListShown(state.items)
+                    podcastsListShownTracked = true
+                }
+
+                is TvYourPodcastsUiState.Empty -> {
+                    viewModel.trackPodcastsListShown(emptyList())
+                    podcastsListShownTracked = true
+                }
+
+                is TvYourPodcastsUiState.Loading -> Unit
+            }
+        }
+    }
 
     val podcastUuid = openedPodcastUuid
     val folder = openedFolder
     Box(modifier = modifier.fillMaxSize()) {
         TvYourPodcastsContent(
             uiState = uiState,
-            onNavigateToHome = onNavigateToHome,
-            onOpenFolder = { openedFolder = OpenedFolder(it.uuid, it.name) },
-            onOpenPodcast = { openedPodcastUuid = it },
+            onNavigateToHome = {
+                viewModel.trackDiscoverButtonTapped()
+                onNavigateToHome()
+            },
+            onOpenFolder = {
+                viewModel.trackFolderTapped()
+                openedFolder = OpenedFolder(it.uuid, it.name, it.podcastsSortType)
+            },
+            onOpenPodcast = {
+                viewModel.trackPodcastTapped()
+                openedPodcastUuid = it
+            },
             modifier = Modifier
                 .fillMaxSize()
                 .padding(top = TvTopBarHeight)
@@ -80,6 +109,7 @@ fun TvYourPodcastsScreen(
                 folderName = openFolder.name,
                 getFolderPodcasts = viewModel::folderPodcasts,
                 onOpenPodcast = { openedPodcastUuid = it },
+                onFolderImpression = { podcastCount -> viewModel.trackFolderShown(podcastCount, openFolder.sortType) },
                 onClose = { openedFolder = null },
                 restoreFocusTrigger = folderRestoreTrigger,
             )
@@ -97,11 +127,15 @@ fun TvYourPodcastsScreen(
     }
 }
 
-private data class OpenedFolder(val uuid: String, val name: String)
+private data class OpenedFolder(val uuid: String, val name: String, val sortType: PodcastsSortType)
 
 private val OpenedFolderSaver = listSaver<OpenedFolder?, String>(
-    save = { folder -> folder?.let { listOf(it.uuid, it.name) }.orEmpty() },
-    restore = { saved -> saved.takeIf { it.size == 2 }?.let { (uuid, name) -> OpenedFolder(uuid, name) } },
+    save = { folder -> folder?.let { listOf(it.uuid, it.name, it.sortType.name) }.orEmpty() },
+    restore = { saved ->
+        saved.takeIf { it.size == 3 }?.let { (uuid, name, sortType) ->
+            OpenedFolder(uuid, name, PodcastsSortType.valueOf(sortType))
+        }
+    },
 )
 
 @Composable

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsScreen.kt
@@ -55,7 +55,7 @@ fun TvYourPodcastsScreen(
     var openedPodcastUuid by rememberSaveable { mutableStateOf<String?>(null) }
     var gridRestoreTrigger by remember { mutableIntStateOf(0) }
     var folderRestoreTrigger by remember { mutableIntStateOf(0) }
-    var podcastsListShownTracked by remember { mutableStateOf(false) }
+    var podcastsListShownTracked by rememberSaveable { mutableStateOf(false) }
 
     LaunchedEffect(uiState) {
         if (!podcastsListShownTracked) {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsViewModel.kt
@@ -100,17 +100,9 @@ class TvYourPodcastsViewModel @Inject constructor(
         eventHorizon.track(
             FolderShownEvent(
                 numberOfPodcasts = numberOfPodcasts.toLong(),
-                sortOrder = sortType.toPodcastListSortType(),
+                sortOrder = sortType.analyticsValue,
             ),
         )
-    }
-
-    private fun PodcastsSortType.toPodcastListSortType() = when (this) {
-        PodcastsSortType.NAME_A_TO_Z -> PodcastListSortType.Name
-        PodcastsSortType.DATE_ADDED_NEWEST_TO_OLDEST -> PodcastListSortType.DateAdded
-        PodcastsSortType.EPISODE_DATE_NEWEST_TO_OLDEST -> PodcastListSortType.EpisodeReleaseDate
-        PodcastsSortType.RECENTLY_PLAYED -> PodcastListSortType.EpisodeRecentlyPlayed
-        PodcastsSortType.DRAG_DROP -> PodcastListSortType.DragAndDrop
     }
 }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsViewModel.kt
@@ -8,6 +8,15 @@ import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
 import au.com.shiftyjelly.pocketcasts.repositories.di.DefaultDispatcher
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.FolderManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import com.automattic.eventhorizon.EventHorizon
+import com.automattic.eventhorizon.FolderShownEvent
+import com.automattic.eventhorizon.PodcastListBadgeType
+import com.automattic.eventhorizon.PodcastListLayoutType
+import com.automattic.eventhorizon.PodcastListSortType
+import com.automattic.eventhorizon.PodcastsListDiscoverButtonTappedEvent
+import com.automattic.eventhorizon.PodcastsListFolderTappedEvent
+import com.automattic.eventhorizon.PodcastsListPodcastTappedEvent
+import com.automattic.eventhorizon.PodcastsListShownEvent
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.milliseconds
@@ -28,6 +37,7 @@ import kotlinx.coroutines.flow.stateIn
 class TvYourPodcastsViewModel @Inject constructor(
     private val podcastManager: PodcastManager,
     private val folderManager: FolderManager,
+    private val eventHorizon: EventHorizon,
     @DefaultDispatcher private val defaultDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
 
@@ -60,6 +70,47 @@ class TvYourPodcastsViewModel @Inject constructor(
 
     suspend fun folderPodcasts(folderUuid: String): List<Podcast> {
         return folderManager.findFolderPodcastsSorted(folderUuid)
+    }
+
+    fun trackPodcastsListShown(items: List<FolderItem>) {
+        eventHorizon.track(
+            PodcastsListShownEvent(
+                numberOfPodcasts = items.count { it is FolderItem.Podcast }.toLong(),
+                numberOfFolders = items.count { it is FolderItem.Folder }.toLong(),
+                badgeType = PodcastListBadgeType.Off,
+                layout = PodcastListLayoutType.LargeArtwork,
+                sortOrder = PodcastListSortType.Name,
+            ),
+        )
+    }
+
+    fun trackPodcastTapped() {
+        eventHorizon.track(PodcastsListPodcastTappedEvent)
+    }
+
+    fun trackFolderTapped() {
+        eventHorizon.track(PodcastsListFolderTappedEvent)
+    }
+
+    fun trackDiscoverButtonTapped() {
+        eventHorizon.track(PodcastsListDiscoverButtonTappedEvent)
+    }
+
+    fun trackFolderShown(numberOfPodcasts: Int, sortType: PodcastsSortType) {
+        eventHorizon.track(
+            FolderShownEvent(
+                numberOfPodcasts = numberOfPodcasts.toLong(),
+                sortOrder = sortType.toPodcastListSortType(),
+            ),
+        )
+    }
+
+    private fun PodcastsSortType.toPodcastListSortType() = when (this) {
+        PodcastsSortType.NAME_A_TO_Z -> PodcastListSortType.Name
+        PodcastsSortType.DATE_ADDED_NEWEST_TO_OLDEST -> PodcastListSortType.DateAdded
+        PodcastsSortType.EPISODE_DATE_NEWEST_TO_OLDEST -> PodcastListSortType.EpisodeReleaseDate
+        PodcastsSortType.RECENTLY_PLAYED -> PodcastListSortType.EpisodeRecentlyPlayed
+        PodcastsSortType.DRAG_DROP -> PodcastListSortType.DragAndDrop
     }
 }
 

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsViewModelTest.kt
@@ -8,6 +8,15 @@ import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.FolderManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import com.automattic.eventhorizon.EventHorizon
+import com.automattic.eventhorizon.FolderShownEvent
+import com.automattic.eventhorizon.PodcastListBadgeType
+import com.automattic.eventhorizon.PodcastListLayoutType
+import com.automattic.eventhorizon.PodcastListSortType
+import com.automattic.eventhorizon.PodcastsListDiscoverButtonTappedEvent
+import com.automattic.eventhorizon.PodcastsListFolderTappedEvent
+import com.automattic.eventhorizon.PodcastsListPodcastTappedEvent
+import com.automattic.eventhorizon.PodcastsListShownEvent
 import java.util.Date
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -19,6 +28,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class TvYourPodcastsViewModelTest {
@@ -40,6 +50,7 @@ class TvYourPodcastsViewModelTest {
             folderPodcasts[invocation.getArgument<String>(0)].orEmpty()
         }
     }
+    private val eventHorizon = mock<EventHorizon>()
 
     @Test
     fun `no podcasts or folders map to the empty state`() = runTest {
@@ -134,9 +145,49 @@ class TvYourPodcastsViewModelTest {
         }
     }
 
+    @Test
+    fun `tracks the podcasts list shown with counts`() = runTest {
+        val items = listOf(podcastItem("a"), podcastItem("b"), folderItem("f"))
+
+        createViewModel().trackPodcastsListShown(items)
+
+        verify(eventHorizon).track(
+            PodcastsListShownEvent(
+                numberOfPodcasts = 2,
+                numberOfFolders = 1,
+                badgeType = PodcastListBadgeType.Off,
+                layout = PodcastListLayoutType.LargeArtwork,
+                sortOrder = PodcastListSortType.Name,
+            ),
+        )
+    }
+
+    @Test
+    fun `tracks podcast and folder taps and the discover button`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.trackPodcastTapped()
+        viewModel.trackFolderTapped()
+        viewModel.trackDiscoverButtonTapped()
+
+        verify(eventHorizon).track(PodcastsListPodcastTappedEvent)
+        verify(eventHorizon).track(PodcastsListFolderTappedEvent)
+        verify(eventHorizon).track(PodcastsListDiscoverButtonTappedEvent)
+    }
+
+    @Test
+    fun `tracks the folder shown with the folder sort order`() = runTest {
+        createViewModel().trackFolderShown(numberOfPodcasts = 4, sortType = PodcastsSortType.EPISODE_DATE_NEWEST_TO_OLDEST)
+
+        verify(eventHorizon).track(
+            FolderShownEvent(numberOfPodcasts = 4, sortOrder = PodcastListSortType.EpisodeReleaseDate),
+        )
+    }
+
     private fun createViewModel() = TvYourPodcastsViewModel(
         podcastManager = podcastManager,
         folderManager = folderManager,
+        eventHorizon = eventHorizon,
         defaultDispatcher = coroutineRule.testDispatcher,
     )
 


### PR DESCRIPTION
## Description

Second screen of the **Android TV → Apple TV analytics parity** program (EventHorizon only): the **Your Podcasts** tab. Stacked on the Home analytics PR (`feat/tv-analytics-home`). Verified against the tvOS app across every tracking layer (`Analytics.track`, `AnalyticsHelper`, model methods) — this screen fires 5 events, all direct `Analytics.track` (no hidden helper layer).

| Event | EventHorizon class | Properties | Fires when |
|---|---|---|---|
| `podcasts_list_shown` | `PodcastsListShownEvent` | `number_of_podcasts, number_of_folders, badge_type, layout, sort_order` | the grid is shown (once, after load; fires for the empty state too) |
| `podcasts_list_podcast_tapped` | `PodcastsListPodcastTappedEvent` | — | tap a podcast in the **main grid** |
| `podcasts_list_folder_tapped` | `PodcastsListFolderTappedEvent` | — | tap a folder |
| `podcasts_list_discover_button_tapped` | `PodcastsListDiscoverButtonTappedEvent` | — | the empty-state action (→ Home) |
| `folder_shown` | `FolderShownEvent` | `number_of_podcasts, sort_order` | a folder's detail is shown (once per open; fires for empty folders too) |

**Schema-mismatch mapping.** The Android EventHorizon classes are the phone-oriented schema and require enum props the tvOS app doesn't send. Mapped to sensible TV values:
- `sort_order` = `Name` — the TV grid is always sorted `NAME_A_TO_Z`, matching tvOS's hardcoded `"name"`.
- `badge_type` = `Off`, `layout` = `LargeArtwork` — the TV grid has no badge/layout options (large-artwork grid).
- `folder_shown` `sort_order` is mapped from the folder's real `PodcastsSortType`.

**Faithful to tvOS:** `podcasts_list_podcast_tapped` fires **only** from the main grid, not from podcast taps inside a folder detail (tvOS `FolderDetailView` fires nothing on podcast tap). Analytics is added via distinct lambdas / an additive `onFolderImpression` callback, so the shared `TvFolderDetailScreen` and other callers are unaffected.

Fixes PCDROID-720 https://linear.app/a8c/issue/PCDROID-720/podcasts-screen-analytics

## Testing Instructions

1. `./gradlew :tv:installDebug`; open the Your Podcasts tab → confirm one `podcasts_list_shown` with the right `number_of_podcasts` / `number_of_folders` in `adb logcat` (debug logs via `LoggingAnalyticsListener`).
2. Tap a podcast → `podcasts_list_podcast_tapped`; tap a folder → `podcasts_list_folder_tapped`.
3. Open a folder → `folder_shown` with the folder's podcast count + sort order. Tap a podcast **inside** the folder → **no** `podcasts_list_podcast_tapped`.
4. With no subscriptions, the empty state's action → `podcasts_list_discover_button_tapped`, then navigates to Home.

## Screenshots or Screencast
<img width="1163" height="129" alt="SCR-20260813-mhqb" src="https://github.com/user-attachments/assets/a82eb3e5-76b7-4774-91a4-d26ca1e64cfc" />


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md — N/A (analytics only)
- [x] Ensure the linter passes (`./gradlew spotlessApply`)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in localization — N/A
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) the Event Horizon schema to reflect any new or changed analytics — existing events, no schema change needed
