### PR TITLE
Remove openssl gem requirement

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,10 +13,3 @@ gem 'fastlane-plugin-wpmreleasetoolkit', '~> 14.11'
 
 # Used in scripts/themes/
 gem 'google-apis-sheets_v4', '~> 0.48'
-
-# To avoid errors like:
-#
-# SSL_connect returned=1 errno=0 peeraddr=3.5.132.155:443 state=error: certificate verify failed (unable to get certificate CRL)
-#
-# See https://github.com/ruby/openssl/issues/949
-gem 'openssl', '~> 4.0'

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@
 
 source 'https://rubygems.org'
 
+ruby file: '.ruby-version'
+
 gem 'danger-dangermattic', '~> 1.4'
 gem 'fastlane', '~> 2.238'
 gem 'fastlane-plugin-firebase_app_distribution', '~> 1.0'

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,6 @@
 
 source 'https://rubygems.org'
 
-ruby file: '.ruby-version'
-
 gem 'danger-dangermattic', '~> 1.4'
 gem 'fastlane', '~> 2.238'
 gem 'fastlane-plugin-firebase_app_distribution', '~> 1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -391,5 +391,8 @@ DEPENDENCIES
   fastlane-plugin-wpmreleasetoolkit (~> 14.11)
   google-apis-sheets_v4 (~> 0.48)
 
+RUBY VERSION
+  ruby 3.4.9
+
 BUNDLED WITH
   4.0.17

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -279,7 +279,6 @@ GEM
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
     open4 (1.3.4)
-    openssl (4.0.2)
     options (2.3.2)
     optparse (0.8.1)
     os (1.1.4)
@@ -391,7 +390,6 @@ DEPENDENCIES
   fastlane-plugin-firebase_app_distribution (~> 1.0)
   fastlane-plugin-wpmreleasetoolkit (~> 14.11)
   google-apis-sheets_v4 (~> 0.48)
-  openssl (~> 4.0)
 
 BUNDLED WITH
   4.0.17

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -391,8 +391,5 @@ DEPENDENCIES
   fastlane-plugin-wpmreleasetoolkit (~> 14.11)
   google-apis-sheets_v4 (~> 0.48)
 
-RUBY VERSION
-  ruby 3.4.9
-
 BUNDLED WITH
   4.0.17


### PR DESCRIPTION
Tweaking https://github.com/Automattic/pocket-casts-android/pull/5733 to remove `faraday`, I noticed `openssl` was in `Gemfile` still.

I recalled the requirement was due to a compatibility issue between `openssl` and earlier versions of Ruby.

~~I asked Opus 5 to validate and it pointed out that, while the removal was appropriate, there was no way enforcing the 3.4.9 Ruby version, so a machine with no tooling to read and respect `.ruby-version` might end up on an old version that still has the issue.~~

~~It suggested to force the Ruby version in `Gemfile` via `ruby file: .ruby-version`. That was a TIL for me.~~

~~While it's quite unlikely we'd run in a machine with old Ruby version running the automation, the idea of ensuring the version is respected seem valuable. I think we should adopt it.~~

~~Let's use this PR to see how it looks like.~~
