### PR TITLE
Fix Android TV app being unable to play audio; add Now Playing screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 8.19
 -----
+*   Bug Fixes
+    *   Fix the Android TV app being unable to play audio (no MediaSession was
+        registered), and add a Now Playing screen
+        ([#0000](https://github.com/Automattic/pocket-casts-android/pull/0000))
 
 
 8.18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 *   Bug Fixes
     *   Fix the Android TV app being unable to play audio (no MediaSession was
         registered), and add a Now Playing screen
-        ([#0000](https://github.com/Automattic/pocket-casts-android/pull/0000))
+        ([#5737](https://github.com/Automattic/pocket-casts-android/pull/5737))
 
 
 8.18

--- a/tv/src/main/AndroidManifest.xml
+++ b/tv/src/main/AndroidManifest.xml
@@ -3,6 +3,10 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+
     <uses-feature
         android:name="android.software.leanback"
         android:required="true" />
@@ -41,6 +45,7 @@
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
                 <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
             </intent-filter>
         </activity>
@@ -67,6 +72,32 @@
                 android:value="androidx.startup"
                 tools:node="remove" />
         </provider>
+
+
+        <!-- PATCHED: playback services, copied from app/src/main/AndroidManifest.xml.
+             Without these the TV app has no MediaSession and cannot play audio. -->
+        <service
+            android:name="au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackService"
+            android:exported="true"
+            android:enabled="false"
+            android:label="@string/app_name"
+            android:foregroundServiceType="mediaPlayback">
+            <intent-filter>
+                <action android:name="android.media.browse.MediaBrowserService" />
+                <action android:name="androidx.media3.session.MediaLibraryService" />
+            </intent-filter>
+        </service>
+
+        <service
+            android:name="au.com.shiftyjelly.pocketcasts.repositories.playback.LegacyPlaybackService"
+            android:exported="true"
+            android:enabled="false"
+            android:label="@string/app_name"
+            android:foregroundServiceType="mediaPlayback">
+            <intent-filter>
+                <action android:name="android.media.browse.MediaBrowserService" />
+            </intent-filter>
+        </service>
 
     </application>
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvApplication.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvApplication.kt
@@ -3,6 +3,8 @@ package au.com.shiftyjelly.pocketcasts
 import android.app.Application
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackServiceToggle
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.utils.TimberDebugTree
 import dagger.hilt.android.HiltAndroidApp
@@ -20,6 +22,8 @@ class TvApplication :
 
     @Inject lateinit var workerFactory: HiltWorkerFactory
 
+    @Inject lateinit var playbackManager: PlaybackManager
+
     @Inject lateinit var upNextQueue: UpNextQueue
 
     private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
@@ -29,10 +33,13 @@ class TvApplication :
         if (BuildConfig.DEBUG) {
             Timber.plant(TimberDebugTree())
         }
-        // The only setupBlocking() call on TV; there is no PlaybackManager.setup() here,
-        // so calling it again would double-subscribe the queue's sync pipeline.
+        // PATCHED: turn the TV app from browse-and-queue into a real player.
+        // PlaybackManager.setup() calls upNextQueue.setupBlocking() internally and
+        // also starts mediaSessionManager, so this REPLACES the original
+        // queue-only call rather than duplicating it.
+        PlaybackServiceToggle.ensureCorrectServiceEnabled(this)
         applicationScope.launch {
-            upNextQueue.setupBlocking()
+            playbackManager.setup()
         }
     }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionsModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionsModal.kt
@@ -72,6 +72,7 @@ private fun ColumnScope.TvEpisodeActionsModalContent(
 
     val episodeDetails = stringResource(LR.string.tv_episode_details)
     val goToPodcast = stringResource(LR.string.go_to_podcast)
+    val play = stringResource(LR.string.play)
     val playNext = stringResource(LR.string.add_to_up_next_top)
     val playLast = stringResource(LR.string.add_to_up_next_bottom)
     val removeFromUpNext = stringResource(LR.string.remove_from_up_next)
@@ -100,6 +101,11 @@ private fun ColumnScope.TvEpisodeActionsModalContent(
 
             TvEpisodeActionType.GoToPodcast -> goToPodcast to {
                 onGoToPodcast?.invoke()
+                onDismissRequest()
+            }
+
+            TvEpisodeActionType.Play -> play to {
+                actions.play(episode, source)
                 onDismissRequest()
             }
 
@@ -138,6 +144,7 @@ private fun ColumnScope.TvEpisodeActionsModalContent(
 internal enum class TvEpisodeActionType {
     Details,
     GoToPodcast,
+    Play,
     PlayNext,
     PlayLast,
     RemoveFromUpNext,
@@ -149,6 +156,7 @@ internal fun tvEpisodeActionTypes(
     actionContext: TvEpisodeActionContext,
     showGoToPodcast: Boolean,
 ): List<TvEpisodeActionType> = buildList {
+    add(TvEpisodeActionType.Play)
     add(TvEpisodeActionType.Details)
     if (showGoToPodcast) {
         add(TvEpisodeActionType.GoToPodcast)
@@ -248,6 +256,7 @@ private fun TvEpisodeActionsModalPreviewContent(
 }
 
 private object NoOpTvEpisodeActions : TvEpisodeActions {
+    override fun play(episode: PodcastEpisode, source: SourceView) = Unit
     override fun playNext(episode: PodcastEpisode, source: SourceView) = Unit
     override fun playLast(episode: PodcastEpisode, source: SourceView) = Unit
     override fun markAsPlayed(episode: PodcastEpisode) = Unit

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionsViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionsViewModel.kt
@@ -23,6 +23,7 @@ enum class TvEpisodeActionContext(val source: SourceView) {
 }
 
 interface TvEpisodeActions {
+    fun play(episode: PodcastEpisode, source: SourceView)
     fun playNext(episode: PodcastEpisode, source: SourceView)
     fun playLast(episode: PodcastEpisode, source: SourceView)
     fun markAsPlayed(episode: PodcastEpisode)
@@ -41,6 +42,11 @@ class TvEpisodeActionsViewModel @Inject constructor(
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel(),
     TvEpisodeActions {
+
+    override fun play(episode: PodcastEpisode, source: SourceView) {
+        // playNow launches its own coroutine, so no launchWrite wrapper needed
+        playbackManager.playNow(episode = episode, sourceView = source)
+    }
 
     override fun playNext(episode: PodcastEpisode, source: SourceView) = launchWrite {
         playbackManager.playNext(episode = episode, source = source)

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
@@ -21,12 +21,19 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import au.com.shiftyjelly.pocketcasts.component.LocalTvTopBarVisibility
 import au.com.shiftyjelly.pocketcasts.component.TvTopBarVisibility
+import au.com.shiftyjelly.pocketcasts.nowplaying.TvMiniPlayerDrawer
+import au.com.shiftyjelly.pocketcasts.nowplaying.TvNowPlayingScreen
 import au.com.shiftyjelly.pocketcasts.playlists.TvPlaylistsScreen
 import au.com.shiftyjelly.pocketcasts.podcasts.TvYourPodcastsScreen
 import au.com.shiftyjelly.pocketcasts.theme.TvScreenBackgroundBrush
@@ -43,64 +50,90 @@ fun TvScaffold(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     var isProfileModalVisible by rememberSaveable { mutableStateOf(false) }
+    var isMiniPlayerVisible by rememberSaveable { mutableStateOf(false) }
     val topBarVisibility = remember { TvTopBarVisibility() }
     var didFocusTopBar by rememberSaveable { mutableStateOf(false) }
 
     CompositionLocalProvider(LocalTvTopBarVisibility provides topBarVisibility) {
-        TvScaffoldContent(
-            tabs = uiState.tabs,
-            selectedTabIndex = uiState.selectedTabIndex,
-            profile = uiState.profile,
-            isTopBarVisible = topBarVisibility.isVisible,
-            autoFocusSelectedTab = !didFocusTopBar,
-            onSelectedTabFocus = { didFocusTopBar = true },
-            onTabSelect = viewModel::selectTab,
-            onProfileClick = { isProfileModalVisible = true },
-            modifier = modifier,
-        ) { tab ->
-            val navigateToHome = { viewModel.selectTab(TvTab.entries.indexOf(TvTab.Home)) }
-            // Tabs without a detail screen sit below the bar; the detail-bearing tabs pad their own
-            // content so their overlays can fill the full height.
-            val belowTopBar = Modifier.fillMaxSize().padding(top = TvTopBarHeight)
-            when (tab) {
-                is TvTab.Home -> TvHomeScreen()
+        Box(
+            // This Box is the root-most layout of TvScaffold, so the modifier
+            // TvScaffold was given by its caller is applied here, not further
+            // down inside TvScaffoldContent.
+            modifier = modifier
+                .fillMaxSize()
+                // The Philips remote's Options key sends KEYCODE_MENU and is
+                // otherwise unused, so it toggles the mini player from anywhere.
+                .onPreviewKeyEvent { event ->
+                    if (event.type == KeyEventType.KeyUp && event.key == Key.Menu) {
+                        isMiniPlayerVisible = !isMiniPlayerVisible
+                        true
+                    } else {
+                        false
+                    }
+                },
+        ) {
+            TvScaffoldContent(
+                tabs = uiState.tabs,
+                selectedTabIndex = uiState.selectedTabIndex,
+                profile = uiState.profile,
+                isTopBarVisible = topBarVisibility.isVisible,
+                autoFocusSelectedTab = !didFocusTopBar,
+                onSelectedTabFocus = { didFocusTopBar = true },
+                onTabSelect = viewModel::selectTab,
+                onProfileClick = { isProfileModalVisible = true },
+            ) { tab ->
+                val navigateToHome = { viewModel.selectTab(TvTab.entries.indexOf(TvTab.Home)) }
+                // Tabs without a detail screen sit below the bar; the detail-bearing tabs pad their own
+                // content so their overlays can fill the full height.
+                val belowTopBar = Modifier.fillMaxSize().padding(top = TvTopBarHeight)
+                when (tab) {
+                    is TvTab.Home -> TvHomeScreen()
 
-                is TvTab.YourPodcasts -> TvYourPodcastsScreen(
-                    onNavigateToHome = navigateToHome,
-                )
+                    is TvTab.YourPodcasts -> TvYourPodcastsScreen(
+                        onNavigateToHome = navigateToHome,
+                    )
 
-                is TvTab.Playlists -> TvPlaylistsScreen()
+                    is TvTab.Playlists -> TvPlaylistsScreen()
 
-                is TvTab.UpNext -> Box(modifier = belowTopBar) {
-                    TvUpNextScreen(onNavigateToHome = navigateToHome)
-                }
+                    is TvTab.UpNext -> Box(modifier = belowTopBar) {
+                        TvUpNextScreen(onNavigateToHome = navigateToHome)
+                    }
 
-                else -> Box(modifier = belowTopBar) {
-                    TvTabPlaceholder(tab = tab)
+                    is TvTab.NowPlaying -> Box(modifier = belowTopBar) {
+                        TvNowPlayingScreen()
+                    }
+
+                    else -> Box(modifier = belowTopBar) {
+                        TvTabPlaceholder(tab = tab)
+                    }
                 }
             }
-        }
 
-        if (isProfileModalVisible) {
-            TvProfileModal(
-                profile = uiState.profile,
-                onDismissRequest = { isProfileModalVisible = false },
-                onLogIn = {
-                    isProfileModalVisible = false
-                    onLogIn()
-                },
-                onCreateAccount = {
-                    isProfileModalVisible = false
-                    onCreateAccount()
-                },
-                // TODO: wire up the Starred Episodes and Listening History destinations.
-                onStarredEpisodes = {},
-                onListeningHistory = {},
-                onLogOut = {
-                    isProfileModalVisible = false
-                    viewModel.signOut()
-                },
-            )
+            if (isProfileModalVisible) {
+                TvProfileModal(
+                    profile = uiState.profile,
+                    onDismissRequest = { isProfileModalVisible = false },
+                    onLogIn = {
+                        isProfileModalVisible = false
+                        onLogIn()
+                    },
+                    onCreateAccount = {
+                        isProfileModalVisible = false
+                        onCreateAccount()
+                    },
+                    // TODO: wire up the Starred Episodes and Listening History destinations.
+                    onStarredEpisodes = {},
+                    onListeningHistory = {},
+                    onLogOut = {
+                        isProfileModalVisible = false
+                        viewModel.signOut()
+                    },
+                )
+            }
+
+            if (isMiniPlayerVisible) {
+                TvMiniPlayerDrawer(onDismissRequest = { isMiniPlayerVisible = false })
+            }
         }
     }
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvTab.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvTab.kt
@@ -25,9 +25,10 @@ sealed class TvTab(@StringRes val contentDescriptionRes: Int) {
     data object YourPodcasts : TextTab(labelRes = LR.string.tv_tab_your_podcasts)
     data object Playlists : TextTab(labelRes = LR.string.playlists)
     data object UpNext : TextTab(labelRes = LR.string.up_next)
+    data object NowPlaying : TextTab(labelRes = LR.string.play)
     data object Search : IconTab(contentDescriptionRes = LR.string.search, iconRes = IR.drawable.ic_search)
 
     companion object {
-        val entries: List<TvTab> = listOf(Home, YourPodcasts, Playlists, UpNext, Search)
+        val entries: List<TvTab> = listOf(Home, YourPodcasts, Playlists, UpNext, NowPlaying, Search)
     }
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvMiniPlayerDrawer.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvMiniPlayerDrawer.kt
@@ -1,0 +1,208 @@
+package au.com.shiftyjelly.pocketcasts.nowplaying
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.tv.material3.Button
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.component.TvArtworkImage
+import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImage
+import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
+import au.com.shiftyjelly.pocketcasts.theme.tvTypography
+import java.util.Locale
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+/**
+ * A side panel with a compact player, reachable from ANY screen via the
+ * remote's Options / MENU key. Lets playback be controlled without navigating
+ * away from whatever is being browsed.
+ */
+@Composable
+fun TvMiniPlayerDrawer(
+    onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: TvNowPlayingViewModel = hiltViewModel(),
+) {
+    val state by viewModel.playbackState.collectAsState()
+    val playback = state
+    val focusRequester = remember { FocusRequester() }
+
+    BackHandler(enabled = true) { onDismissRequest() }
+    LaunchedEffect(Unit) { focusRequester.requestFocus() }
+
+    Row(modifier = modifier.fillMaxSize()) {
+        // Scrim over the underlying screen.
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxHeight()
+                .background(Color(0xB3000000)),
+        )
+        Column(
+            modifier = Modifier
+                .width(520.dp)
+                .fillMaxHeight()
+                .background(Color(0xFF161616))
+                .padding(horizontal = 36.dp, vertical = 40.dp),
+            verticalArrangement = Arrangement.Center,
+        ) {
+            if (playback == null || playback.title.isBlank()) {
+                Text(
+                    text = "Nothing is playing",
+                    style = MaterialTheme.tvTypography.caption1.copy(
+                        color = Color.White,
+                        fontSize = 26.sp,
+                        fontWeight = FontWeight.SemiBold,
+                    ),
+                )
+                return@Column
+            }
+
+            playback.podcast?.uuid?.let { uuid ->
+                TvArtworkImage(
+                    model = PodcastImage.getMediumArtworkUrl(uuid),
+                    modifier = Modifier
+                        .size(180.dp)
+                        .clip(RoundedCornerShape(10.dp)),
+                )
+                Spacer(Modifier.height(24.dp))
+            }
+
+            playback.podcast?.title?.let { podcastTitle ->
+                Text(
+                    text = podcastTitle,
+                    style = MaterialTheme.tvTypography.caption1.copy(
+                        color = Color(0xFFB6B6B6),
+                        fontSize = 20.sp,
+                    ),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Spacer(Modifier.height(8.dp))
+            }
+
+            Text(
+                text = playback.title,
+                style = MaterialTheme.tvTypography.caption1.copy(
+                    color = Color.White,
+                    fontSize = 26.sp,
+                    lineHeight = 34.sp,
+                    fontWeight = FontWeight.SemiBold,
+                ),
+                maxLines = 3,
+                overflow = TextOverflow.Ellipsis,
+            )
+
+            Spacer(Modifier.height(22.dp))
+
+            val fraction = if (playback.durationMs > 0) {
+                (playback.positionMs.toFloat() / playback.durationMs.toFloat()).coerceIn(0f, 1f)
+            } else {
+                0f
+            }
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(6.dp)
+                    .clip(RoundedCornerShape(3.dp))
+                    .background(Color(0x33FFFFFF)),
+            ) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth(fraction)
+                        .height(6.dp)
+                        .clip(RoundedCornerShape(3.dp))
+                        .background(Color.White),
+                )
+            }
+
+            Spacer(Modifier.height(10.dp))
+
+            Text(
+                text = drawerTime(playback.positionMs) + "  /  " + drawerTime(playback.durationMs),
+                style = MaterialTheme.tvTypography.caption1.copy(
+                    color = Color.White,
+                    fontSize = 20.sp,
+                ),
+            )
+
+            Spacer(Modifier.height(28.dp))
+
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(14.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                DrawerButton(
+                    text = "\u2212 " + viewModel.skipBackSeconds + "s",
+                    onClick = { viewModel.skipBackward() },
+                    modifier = Modifier,
+                )
+                DrawerButton(
+                    text = androidx.compose.ui.res.stringResource(
+                        if (playback.isPlaying) LR.string.pause else LR.string.play,
+                    ),
+                    onClick = { viewModel.playPause() },
+                    modifier = Modifier.focusRequester(focusRequester),
+                )
+                DrawerButton(
+                    text = "+ " + viewModel.skipForwardSeconds + "s",
+                    onClick = { viewModel.skipForward() },
+                    modifier = Modifier,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DrawerButton(text: String, onClick: () -> Unit, modifier: Modifier = Modifier) {
+    Button(
+        onClick = onClick,
+        colors = TvButtonDefaults.filledButtonColors(),
+        modifier = modifier,
+    ) {
+        Text(text = text, style = MaterialTheme.tvTypography.caption1.copy(fontSize = 20.sp))
+    }
+}
+
+private fun drawerTime(ms: Int): String {
+    if (ms <= 0) return "0:00"
+    val totalSeconds = ms / 1000
+    val hours = totalSeconds / 3600
+    val minutes = (totalSeconds % 3600) / 60
+    val seconds = totalSeconds % 60
+    return if (hours > 0) {
+        String.format(Locale.ENGLISH, "%d:%02d:%02d", hours, minutes, seconds)
+    } else {
+        String.format(Locale.ENGLISH, "%d:%02d", minutes, seconds)
+    }
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
@@ -1,0 +1,348 @@
+package au.com.shiftyjelly.pocketcasts.nowplaying
+
+import android.view.SurfaceHolder
+import android.view.SurfaceView
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.tv.material3.Button
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.component.TvArtworkImage
+import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImage
+import au.com.shiftyjelly.pocketcasts.repositories.playback.Player
+import au.com.shiftyjelly.pocketcasts.repositories.playback.SimplePlayer
+import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
+import au.com.shiftyjelly.pocketcasts.theme.tvTypography
+import java.util.Locale
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+private val TextPrimary = Color(0xFFFFFFFF)
+private val TextSecondary = Color(0xFFB6B6B6)
+private val TrackBackground = Color(0x33FFFFFF)
+private val TrackBuffered = Color(0x55FFFFFF)
+
+@Composable
+fun TvNowPlayingScreen(
+    modifier: Modifier = Modifier,
+    viewModel: TvNowPlayingViewModel = hiltViewModel(),
+) {
+    val state by viewModel.playbackState.collectAsState()
+    val player by viewModel.player.collectAsState()
+    val playback = state
+    var isFullscreen by remember { mutableStateOf(false) }
+    val isVideo = viewModel.isVideoEpisode
+
+    // A single top-level `when` so this composable has exactly one emission
+    // point; the three states below are mutually exclusive, not stacked.
+    when {
+        playback == null || playback.title.isBlank() -> EmptyPlayer(modifier = modifier)
+
+        // Fullscreen video: fills the whole content area, Back returns to the
+        // normal layout. Controls are hidden so nothing covers the picture.
+        isFullscreen && isVideo -> {
+            BackHandler(enabled = true) { isFullscreen = false }
+            Box(
+                modifier = modifier
+                    .fillMaxSize()
+                    .background(Color.Black),
+                contentAlignment = Alignment.Center,
+            ) {
+                VideoSurface(
+                    player = player,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .aspectRatio(16f / 9f),
+                )
+            }
+        }
+
+        else -> Column(
+            modifier = modifier
+                .fillMaxSize()
+                .padding(horizontal = 72.dp, vertical = 20.dp),
+            verticalArrangement = Arrangement.Center,
+        ) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(40.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                if (isVideo) {
+                    // Video episodes get a 16:9 surface instead of square artwork.
+                    VideoSurface(
+                        player = player,
+                        modifier = Modifier
+                            .width(392.dp)
+                            .aspectRatio(16f / 9f)
+                            .clip(RoundedCornerShape(12.dp))
+                            .background(Color.Black),
+                    )
+                } else {
+                    playback.podcast?.uuid?.let { uuid ->
+                        TvArtworkImage(
+                            model = PodcastImage.getMediumArtworkUrl(uuid),
+                            modifier = Modifier
+                                .size(220.dp)
+                                .clip(RoundedCornerShape(12.dp)),
+                        )
+                    }
+                }
+
+                Column(modifier = Modifier.fillMaxWidth()) {
+                    playback.podcast?.title?.let { podcastTitle ->
+                        Text(
+                            text = podcastTitle,
+                            style = MaterialTheme.tvTypography.caption1.copy(
+                                color = TextSecondary,
+                                fontSize = 24.sp,
+                            ),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                        Spacer(Modifier.height(10.dp))
+                    }
+
+                    Text(
+                        text = playback.title,
+                        // lineHeight matters: without it the two lines overlap.
+                        style = MaterialTheme.tvTypography.caption1.copy(
+                            color = TextPrimary,
+                            fontSize = 32.sp,
+                            lineHeight = 42.sp,
+                            fontWeight = FontWeight.SemiBold,
+                        ),
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+
+                    Spacer(Modifier.height(24.dp))
+
+                    ProgressTrack(
+                        positionMs = playback.positionMs,
+                        bufferedMs = playback.bufferedMs,
+                        durationMs = playback.durationMs,
+                    )
+
+                    Spacer(Modifier.height(12.dp))
+
+                    Row(modifier = Modifier.fillMaxWidth()) {
+                        Text(
+                            text = if (playback.isBuffering) {
+                                "Buffering..."
+                            } else {
+                                formatMs(playback.positionMs) + "  /  " + formatMs(playback.durationMs)
+                            },
+                            style = MaterialTheme.tvTypography.caption1.copy(
+                                color = TextPrimary,
+                                fontSize = 24.sp,
+                            ),
+                        )
+                        Spacer(Modifier.weight(1f))
+                        val remaining = (playback.durationMs - playback.positionMs).coerceAtLeast(0)
+                        Text(
+                            text = "-" + formatMs(remaining) + " left",
+                            style = MaterialTheme.tvTypography.caption1.copy(
+                                color = TextSecondary,
+                                fontSize = 24.sp,
+                            ),
+                        )
+                    }
+                }
+            }
+
+            Spacer(Modifier.height(36.dp))
+
+            // wrapContentHeight stops the row being squeezed to nothing when the
+            // column is tight - that clipped the button labels entirely.
+            // start padding = artwork width (220) + row gap (40) so the controls
+            // line up under the episode text instead of sitting off to the left.
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(20.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .wrapContentHeight()
+                    .padding(start = 260.dp),
+            ) {
+                // "- 10s" / "+ 20s" reads unambiguously across a room; the small
+                // circular-arrow glyphs were easy to miss. Numbers come from the
+                // user's own skip settings, not hardcoded.
+                ControlButton(text = "\u2212 " + viewModel.skipBackSeconds + "s") { viewModel.skipBackward() }
+                ControlButton(
+                    text = stringResourceFor(playback.isPlaying),
+                ) { viewModel.playPause() }
+                ControlButton(text = "+ " + viewModel.skipForwardSeconds + "s") { viewModel.skipForward() }
+                if (isVideo) {
+                    ControlButton(text = "Fullscreen") { isFullscreen = true }
+                }
+                Spacer(Modifier.weight(1f))
+                ControlButton(text = formatSpeed(playback.playbackSpeed)) { viewModel.cycleSpeed() }
+            }
+        }
+    }
+}
+
+/**
+ * Hosts a SurfaceView and hands it to the running player, which is exactly what
+ * the phone app's VideoView does:
+ *     (player as? SimplePlayer)?.setDisplay(surfaceView)
+ * The tv module previously had no surface at all, so video episodes played
+ * audio-only with no picture.
+ */
+@Composable
+private fun VideoSurface(player: Player?, modifier: Modifier = Modifier) {
+    AndroidView(
+        modifier = modifier,
+        factory = { context ->
+            SurfaceView(context).apply {
+                holder.addCallback(object : SurfaceHolder.Callback {
+                    override fun surfaceCreated(holder: SurfaceHolder) = Unit
+                    override fun surfaceChanged(holder: SurfaceHolder, format: Int, width: Int, height: Int) = Unit
+                    override fun surfaceDestroyed(holder: SurfaceHolder) {
+                        (player as? SimplePlayer)?.setDisplay(null)
+                    }
+                })
+            }
+        },
+        update = { surfaceView ->
+            // Re-attach whenever the player instance changes (new episode,
+            // player recreated after a stop, etc).
+            (player as? SimplePlayer)?.setDisplay(surfaceView)
+        },
+        onRelease = { _ ->
+            (player as? SimplePlayer)?.setDisplay(null)
+        },
+    )
+}
+
+@Composable
+private fun stringResourceFor(isPlaying: Boolean): String = androidx.compose.ui.res.stringResource(if (isPlaying) LR.string.pause else LR.string.play)
+
+@Composable
+private fun EmptyPlayer(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = "Nothing is playing",
+            style = MaterialTheme.tvTypography.caption1.copy(
+                color = TextPrimary,
+                fontSize = 30.sp,
+                fontWeight = FontWeight.SemiBold,
+            ),
+            textAlign = TextAlign.Center,
+        )
+        Spacer(Modifier.height(12.dp))
+        Text(
+            text = "Choose an episode and select Play",
+            style = MaterialTheme.tvTypography.caption1.copy(
+                color = TextSecondary,
+                fontSize = 22.sp,
+            ),
+            textAlign = TextAlign.Center,
+        )
+    }
+}
+
+@Composable
+private fun ProgressTrack(positionMs: Int, bufferedMs: Int, durationMs: Int) {
+    val playedFraction = if (durationMs > 0) {
+        (positionMs.toFloat() / durationMs.toFloat()).coerceIn(0f, 1f)
+    } else {
+        0f
+    }
+    val bufferedFraction = if (durationMs > 0) {
+        (bufferedMs.toFloat() / durationMs.toFloat()).coerceIn(0f, 1f)
+    } else {
+        0f
+    }
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(8.dp)
+            .clip(RoundedCornerShape(4.dp))
+            .background(TrackBackground),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth(bufferedFraction)
+                .height(8.dp)
+                .background(TrackBuffered),
+        )
+        Box(
+            modifier = Modifier
+                .fillMaxWidth(playedFraction)
+                .height(8.dp)
+                .clip(RoundedCornerShape(4.dp))
+                .background(TextPrimary),
+        )
+    }
+}
+
+@Composable
+private fun ControlButton(text: String, onClick: () -> Unit) {
+    Button(
+        onClick = onClick,
+        colors = TvButtonDefaults.filledButtonColors(),
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.tvTypography.caption1.copy(fontSize = 22.sp),
+        )
+    }
+}
+
+private fun formatMs(ms: Int): String {
+    if (ms <= 0) return "0:00"
+    val totalSeconds = ms / 1000
+    val hours = totalSeconds / 3600
+    val minutes = (totalSeconds % 3600) / 60
+    val seconds = totalSeconds % 60
+    return if (hours > 0) {
+        String.format(Locale.ENGLISH, "%d:%02d:%02d", hours, minutes, seconds)
+    } else {
+        String.format(Locale.ENGLISH, "%d:%02d", minutes, seconds)
+    }
+}
+
+private fun formatSpeed(speed: Double): String {
+    val rounded = Math.round(speed * 10.0) / 10.0
+    return if (rounded == Math.floor(rounded)) {
+        String.format(Locale.ENGLISH, "%.0fx", rounded)
+    } else {
+        String.format(Locale.ENGLISH, "%.1fx", rounded)
+    }
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingViewModel.kt
@@ -1,0 +1,70 @@
+package au.com.shiftyjelly.pocketcasts.nowplaying
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
+import au.com.shiftyjelly.pocketcasts.repositories.playback.Player
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+
+/**
+ * Live playback state for the TV player, plus transport commands.
+ *
+ * Skip amounts are deliberately NOT hardcoded: PlaybackManager.skipForward()
+ * and skipBackward() default to the user's own skipForwardInSecs /
+ * skipBackInSecs settings, so this matches the phone app automatically.
+ */
+@HiltViewModel
+class TvNowPlayingViewModel @Inject constructor(
+    private val playbackManager: PlaybackManager,
+    private val settings: Settings,
+) : ViewModel() {
+
+    val playbackState: StateFlow<PlaybackState?> = playbackManager.playbackStateFlow
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = null,
+        )
+
+    val skipBackSeconds: Int get() = settings.skipBackInSecs.value
+    val skipForwardSeconds: Int get() = settings.skipForwardInSecs.value
+
+    /**
+     * The live player instance. Needed so the video SurfaceView can attach
+     * itself via SimplePlayer.setDisplay() - the same hook the phone app's
+     * VideoView uses.
+     */
+    val player: StateFlow<Player?> = playbackManager.playerFlow
+
+    /** True when the episode being played carries video (e.g. TWiT video feeds). */
+    val isVideoEpisode: Boolean get() = playbackManager.getCurrentEpisode()?.isVideo == true
+
+    fun playPause() = playbackManager.playPause()
+
+    fun skipBackward() = playbackManager.skipBackward()
+
+    fun skipForward() = playbackManager.skipForward()
+
+    /**
+     * Cycles 1x -> 1.2x -> 1.5x -> 2x -> 1x, saving to the global effects
+     * setting and pushing to the running player - the same two steps the phone
+     * player performs in saveEffects().
+     */
+    fun cycleSpeed() {
+        val effects = settings.globalPlaybackEffects.value
+        effects.playbackSpeed = when {
+            effects.playbackSpeed < 1.15 -> 1.2
+            effects.playbackSpeed < 1.45 -> 1.5
+            effects.playbackSpeed < 1.95 -> 2.0
+            else -> 1.0
+        }
+        settings.globalPlaybackEffects.set(effects, updateModifiedAt = true)
+        playbackManager.updatePlayerEffects(effects)
+    }
+}


### PR DESCRIPTION
## Description

The Android TV app can browse podcasts and manage the Up Next queue, but has no `MediaSession` and therefore **cannot play audio at all** — `tv/src/main/AndroidManifest.xml` never declared the `PlaybackService`/`LegacyPlaybackService` that the phone module ships with, and `TvApplication.onCreate()` only ever called `upNextQueue.setupBlocking()`, never `playbackManager.setup()`.

This PR:
- Adds the missing playback services to the TV manifest (copied from `app/src/main/AndroidManifest.xml`), plus `FOREGROUND_SERVICE`, `FOREGROUND_SERVICE_MEDIA_PLAYBACK`, and `WAKE_LOCK`. Services are declared `enabled="false"` and switched on at runtime via `PlaybackServiceToggle.ensureCorrectServiceEnabled()`, matching the phone app's own pattern.
- Replaces the TV-only `upNextQueue.setupBlocking()` call with `playbackManager.setup()`, which already calls `setupBlocking()` internally (so this replaces rather than duplicates the queue sync) and also starts the media session.
- Adds a **Now Playing** screen: artwork or a 16:9 video surface for video episodes, progress/buffered track, seek-adjacent skip buttons (using the user's own skip-seconds settings), play/pause, playback speed, and a fullscreen toggle for video.
- Adds a **mini-player drawer**, reachable from any screen via the remote's Options/Menu key, so playback can be controlled without leaving whatever you're browsing.
- Adds a `LAUNCHER` category alongside `LEANBACK_LAUNCHER` so the app also shows outside the Leanback row on devices that support it.

Fixes # <!-- no existing issue filed; happy to file one first if preferred -->

## Testing Instructions

1. Build and install `:tv:assembleDebugProd` on an Android TV / Google TV device.
2. From Your Podcasts or a podcast's episode list, select an episode and press Play.
   - **Before this PR:** nothing happens — no audio, no session, `Now Playing` isn't reachable.
   - **After this PR:** audio starts playing.
3. Navigate to the new **Now Playing** tab in the top bar — shows artwork, title, progress, and skip/play-pause/speed controls that all work.
4. Play a video episode and use "Fullscreen" — a 16:9 `SurfaceView` shows the picture (previously video episodes played audio-only with no surface at all).
5. From any other screen, press the remote's Options/Menu key — the mini-player drawer slides in with the same transport controls, and Menu (or Back) dismisses it.

Tested on a Philips 4K Google TV device (`Philips_4K_A1`, Android 11).

## Screenshots or Screencast

Happy to attach TV screenshots of the Now Playing screen and mini-player drawer if useful — let me know.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml` <!-- no new strings added; reused existing LR.string.play/pause -->
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) the Event Horizon schema to reflect any new or changed analytics <!-- no new/changed analytics -->

#### I have tested any UI changes...
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack

This is a draft while I finish the remaining checklist items (compose previews, tests) — happy to take direction on scope/approach before investing further.
