### PR TITLE
[TV] Playlist analytics

### DIFF
--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeListControls.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeListControls.kt
@@ -91,12 +91,16 @@ fun <T> TvSortButton(
     label: @Composable (T) -> String,
     onSelect: (T) -> Unit,
     modifier: Modifier = Modifier,
+    onExpand: () -> Unit = {},
 ) {
     var isExpanded by remember { mutableStateOf(false) }
 
     Box(modifier = modifier) {
         IconButton(
-            onClick = { isExpanded = true },
+            onClick = {
+                onExpand()
+                isExpanded = true
+            },
             colors = TvButtonDefaults.iconButtonColors(),
         ) {
             Icon(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeListControls.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeListControls.kt
@@ -92,6 +92,7 @@ fun <T> TvSortButton(
     onSelect: (T) -> Unit,
     modifier: Modifier = Modifier,
     onExpand: () -> Unit = {},
+    leftFocusRequester: FocusRequester? = null,
 ) {
     var isExpanded by remember { mutableStateOf(false) }
 
@@ -102,6 +103,7 @@ fun <T> TvSortButton(
                 isExpanded = true
             },
             colors = TvButtonDefaults.iconButtonColors(),
+            modifier = Modifier.focusProperties { leftFocusRequester?.let { left = it } },
         ) {
             Icon(
                 painter = painterResource(IR.drawable.ic_sort),

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsScreen.kt
@@ -75,6 +75,15 @@ fun TvPlaylistsScreen(
     var isDownloadModalVisible by rememberSaveable { mutableStateOf(false) }
     var openedPlaylist by rememberSaveable(stateSaver = OpenedPlaylistSaver) { mutableStateOf<OpenedPlaylist?>(null) }
     var restoreFocusTrigger by remember { mutableIntStateOf(0) }
+    var filterListShownTracked by remember { mutableStateOf(false) }
+
+    LaunchedEffect(uiState) {
+        val state = uiState
+        if (!filterListShownTracked && state is TvPlaylistsUiState.Loaded) {
+            viewModel.trackPlaylistsListShown(state.playlists.size)
+            filterListShownTracked = true
+        }
+    }
 
     val playlist = openedPlaylist
     Box(modifier = modifier.fillMaxSize()) {
@@ -85,7 +94,10 @@ fun TvPlaylistsScreen(
             refreshArtworkUuids = viewModel::refreshArtworkUuids,
             refreshEpisodeCount = viewModel::refreshEpisodeCount,
             findPodcastTint = viewModel::findPodcastTint,
-            onCreatePlaylist = { isDownloadModalVisible = true },
+            onCreatePlaylist = {
+                viewModel.trackCreateButtonTapped()
+                isDownloadModalVisible = true
+            },
             onOpenPlaylist = { preview ->
                 isDownloadModalVisible = false
                 openedPlaylist = OpenedPlaylist(preview.uuid, preview.type)

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsViewModel.kt
@@ -7,6 +7,9 @@ import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistPreview
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.SmartPlaylistPreview
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import com.automattic.eventhorizon.EventHorizon
+import com.automattic.eventhorizon.FilterCreateButtonTappedEvent
+import com.automattic.eventhorizon.FilterListShownEvent
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.milliseconds
@@ -20,6 +23,7 @@ import kotlinx.coroutines.flow.stateIn
 class TvPlaylistsViewModel @Inject constructor(
     private val playlistManager: PlaylistManager,
     private val podcastManager: PodcastManager,
+    private val eventHorizon: EventHorizon,
 ) : ViewModel() {
 
     val uiState: StateFlow<TvPlaylistsUiState> = playlistManager.playlistPreviewsFlow()
@@ -46,6 +50,14 @@ class TvPlaylistsViewModel @Inject constructor(
 
     suspend fun findPodcastTint(podcastUuid: String): Int? {
         return podcastManager.findPodcastByUuid(podcastUuid)?.tintColorForLightBg?.takeIf { it != 0 }
+    }
+
+    fun trackPlaylistsListShown(filterCount: Int) {
+        eventHorizon.track(FilterListShownEvent(filterCount = filterCount.toLong()))
+    }
+
+    fun trackCreateButtonTapped() {
+        eventHorizon.track(FilterCreateButtonTappedEvent)
     }
 
     private fun isDownloadPlaylist(preview: PlaylistPreview): Boolean {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
@@ -125,6 +125,7 @@ fun TvPlaylistDetailsScreen(
         TvPlaylistDetailsContent(
             uiState = uiState,
             onChangeSortType = viewModel::changeSortType,
+            onSortTap = viewModel::trackSortByTapped,
             onToggleArchiveFilter = viewModel::toggleArchiveFilter,
             onOpenPodcast = { openedPodcastUuid = it },
             onPlayAll = viewModel::playAll,
@@ -158,6 +159,7 @@ private fun TvPlaylistDetailsContent(
     onOpenPodcast: (String) -> Unit,
     onPlayAll: () -> Unit,
     modifier: Modifier = Modifier,
+    onSortTap: () -> Unit = {},
 ) {
     Box(modifier = modifier.fillMaxSize()) {
         when (uiState) {
@@ -189,6 +191,7 @@ private fun TvPlaylistDetailsContent(
                         SortableEpisodeList(
                             uiState = uiState,
                             onChangeSortType = onChangeSortType,
+                            onSortTap = onSortTap,
                             onToggleArchiveFilter = onToggleArchiveFilter,
                             onOpenPodcast = onOpenPodcast,
                             playAllFocusRequester = playAllFocusRequester,
@@ -209,6 +212,7 @@ private fun SortableEpisodeList(
     onOpenPodcast: (String) -> Unit,
     playAllFocusRequester: FocusRequester,
     modifier: Modifier = Modifier,
+    onSortTap: () -> Unit = {},
 ) {
     val listState = rememberLazyListState()
     val sortType = uiState.playlist.settings.sortType
@@ -241,6 +245,7 @@ private fun SortableEpisodeList(
                 options = uiState.playlist.availableSortTypes,
                 label = { it.displayLabel() },
                 onSelect = onChangeSortType,
+                onExpand = onSortTap,
                 modifier = if (isManual) {
                     Modifier
                 } else {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.pluralStringResource
@@ -218,6 +219,8 @@ private fun SortableEpisodeList(
             listState.scrollToItem(0)
         }
     }
+    val isManual = uiState.playlist.type == Playlist.Type.Manual
+    val leftFocusRequester = playAllFocusRequester.takeIf { uiState.episodes.isNotEmpty() }
     Column(modifier = modifier) {
         Row(
             horizontalArrangement = Arrangement.spacedBy(12.dp),
@@ -226,16 +229,23 @@ private fun SortableEpisodeList(
                 .align(Alignment.End)
                 .padding(bottom = 12.dp),
         ) {
-            TvArchivedFilterButton(
-                isShowingArchived = uiState.isShowingArchivedOnDevice,
-                onToggleArchiveFilter = onToggleArchiveFilter,
-                leftFocusRequester = playAllFocusRequester.takeIf { uiState.episodes.isNotEmpty() },
-            )
+            if (isManual) {
+                TvArchivedFilterButton(
+                    isShowingArchived = uiState.isShowingArchivedOnDevice,
+                    onToggleArchiveFilter = onToggleArchiveFilter,
+                    leftFocusRequester = leftFocusRequester,
+                )
+            }
             TvSortButton(
                 selected = sortType,
                 options = uiState.playlist.availableSortTypes,
                 label = { it.displayLabel() },
                 onSelect = onChangeSortType,
+                modifier = if (isManual) {
+                    Modifier
+                } else {
+                    Modifier.focusProperties { leftFocusRequester?.let { left = it } }
+                },
             )
         }
         if (uiState.episodes.isNotEmpty()) {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
@@ -51,6 +51,7 @@ import au.com.shiftyjelly.pocketcasts.component.TvModalButton
 import au.com.shiftyjelly.pocketcasts.component.TvModalSurface
 import au.com.shiftyjelly.pocketcasts.component.TvSortButton
 import au.com.shiftyjelly.pocketcasts.component.rememberTvEpisodeListFocus
+import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.compose.components.PlaylistArtwork
 import au.com.shiftyjelly.pocketcasts.compose.components.displayLabel
 import au.com.shiftyjelly.pocketcasts.compose.loading.LoadingView
@@ -91,6 +92,8 @@ fun TvPlaylistDetailsScreen(
     val upNextName = stringResource(LR.string.up_next)
     val savedToast = stringResource(LR.string.up_next_as_playlist_saved)
     val noEpisodesToast = stringResource(LR.string.play_all_no_episodes_message)
+
+    CallOnce { viewModel.trackFilterShown() }
 
     LaunchedEffect(uiState, onClose) {
         if (uiState is TvPlaylistDetailsUiState.NotFound) {
@@ -138,7 +141,10 @@ fun TvPlaylistDetailsScreen(
                 isReplaceUpNextConfirmationVisible = false
                 viewModel.replaceUpNextAndPlay(saveUpNext = true, upNextName = upNextName)
             },
-            onCancel = { isReplaceUpNextConfirmationVisible = false },
+            onCancel = {
+                isReplaceUpNextConfirmationVisible = false
+                viewModel.trackPlayAllDismissed()
+            },
         )
     }
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
@@ -154,11 +154,11 @@ fun TvPlaylistDetailsScreen(
 private fun TvPlaylistDetailsContent(
     uiState: TvPlaylistDetailsUiState,
     onChangeSortType: (PlaylistEpisodeSortType) -> Unit,
+    onSortTap: () -> Unit,
     onToggleArchiveFilter: () -> Unit,
     onOpenPodcast: (String) -> Unit,
     onPlayAll: () -> Unit,
     modifier: Modifier = Modifier,
-    onSortTap: () -> Unit = {},
 ) {
     Box(modifier = modifier.fillMaxSize()) {
         when (uiState) {
@@ -207,11 +207,11 @@ private fun TvPlaylistDetailsContent(
 private fun SortableEpisodeList(
     uiState: TvPlaylistDetailsUiState.Loaded,
     onChangeSortType: (PlaylistEpisodeSortType) -> Unit,
+    onSortTap: () -> Unit,
     onToggleArchiveFilter: () -> Unit,
     onOpenPodcast: (String) -> Unit,
     playAllFocusRequester: FocusRequester,
     modifier: Modifier = Modifier,
-    onSortTap: () -> Unit = {},
 ) {
     val listState = rememberLazyListState()
     val sortType = uiState.playlist.settings.sortType
@@ -503,6 +503,7 @@ private fun TvPlaylistDetailsPreview() {
                 isShowingArchivedOnDevice = false,
             ),
             onChangeSortType = {},
+            onSortTap = {},
             onToggleArchiveFilter = {},
             onOpenPodcast = {},
             onPlayAll = {},
@@ -535,6 +536,7 @@ private fun TvPlaylistDetailsLoadedPreview() {
                 isShowingArchivedOnDevice = false,
             ),
             onChangeSortType = {},
+            onSortTap = {},
             onToggleArchiveFilter = {},
             onOpenPodcast = {},
             onPlayAll = {},

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.pluralStringResource
@@ -246,11 +245,7 @@ private fun SortableEpisodeList(
                 label = { it.displayLabel() },
                 onSelect = onChangeSortType,
                 onExpand = onSortTap,
-                modifier = if (isManual) {
-                    Modifier
-                } else {
-                    Modifier.focusProperties { leftFocusRequester?.let { left = it } }
-                },
+                leftFocusRequester = if (isManual) null else leftFocusRequester,
             )
         }
         if (uiState.episodes.isNotEmpty()) {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModel.kt
@@ -71,7 +71,9 @@ class TvPlaylistDetailsViewModel @AssistedInject constructor(
         Playlist.Type.Smart -> playlistManager.smartPlaylistFlow(playlistUuid, includeArchived = true)
     }
 
-    private val isShowingArchivedFlow = MutableStateFlow(preferences.isPlaylistShowingArchived(playlistUuid))
+    private val isShowingArchivedFlow = MutableStateFlow(
+        playlistType == Playlist.Type.Manual && preferences.isPlaylistShowingArchived(playlistUuid),
+    )
 
     val uiState: StateFlow<TvPlaylistDetailsUiState> = combine(
         playlistFlow,
@@ -113,10 +115,9 @@ class TvPlaylistDetailsViewModel @AssistedInject constructor(
     }
 
     fun toggleArchiveFilter() {
+        if (playlistType != Playlist.Type.Manual) return
         val isShowingArchived = !isShowingArchivedFlow.value
-        if (playlistType == Playlist.Type.Manual) {
-            eventHorizon.track(if (isShowingArchived) FilterShowArchivedTappedEvent else FilterHideArchivedTappedEvent)
-        }
+        eventHorizon.track(if (isShowingArchived) FilterShowArchivedTappedEvent else FilterHideArchivedTappedEvent)
         preferences.setPlaylistShowingArchived(playlistUuid, isShowingArchived)
         isShowingArchivedFlow.value = isShowingArchived
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModel.kt
@@ -12,6 +12,13 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.PlayAllHandler
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlayAllResponse
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.Playlist
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
+import com.automattic.eventhorizon.EventHorizon
+import com.automattic.eventhorizon.FilterHideArchivedTappedEvent
+import com.automattic.eventhorizon.FilterPlayAllDismissedEvent
+import com.automattic.eventhorizon.FilterPlayAllReplaceAndPlayTappedEvent
+import com.automattic.eventhorizon.FilterPlayAllTappedEvent
+import com.automattic.eventhorizon.FilterShowArchivedTappedEvent
+import com.automattic.eventhorizon.FilterShownEvent
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -41,10 +48,13 @@ class TvPlaylistDetailsViewModel @AssistedInject constructor(
     @Assisted private val playlistType: Playlist.Type,
     private val playlistManager: PlaylistManager,
     private val preferences: TvPreferences,
+    private val eventHorizon: EventHorizon,
     playAllHandlerFactory: PlayAllHandler.Factory,
 ) : ViewModel() {
 
     private val playAllHandler = playAllHandlerFactory.create(SourceView.FILTERS)
+
+    private val filterType = playlistType.analyticsValue
 
     private val _events = MutableSharedFlow<TvPlaylistDetailsEvent>(extraBufferCapacity = 2)
     val events: SharedFlow<TvPlaylistDetailsEvent> = _events.asSharedFlow()
@@ -87,8 +97,19 @@ class TvPlaylistDetailsViewModel @AssistedInject constructor(
         }
     }
 
+    fun trackFilterShown() {
+        eventHorizon.track(FilterShownEvent(filterType = filterType))
+    }
+
+    fun trackPlayAllDismissed() {
+        eventHorizon.track(FilterPlayAllDismissedEvent(filterType = filterType))
+    }
+
     fun toggleArchiveFilter() {
         val isShowingArchived = !isShowingArchivedFlow.value
+        if (playlistType == Playlist.Type.Manual) {
+            eventHorizon.track(if (isShowingArchived) FilterShowArchivedTappedEvent else FilterHideArchivedTappedEvent)
+        }
         preferences.setPlaylistShowingArchived(playlistUuid, isShowingArchived)
         isShowingArchivedFlow.value = isShowingArchived
     }
@@ -97,9 +118,12 @@ class TvPlaylistDetailsViewModel @AssistedInject constructor(
         if (isBusy) {
             return
         }
+        val episodes = (uiState.value as? TvPlaylistDetailsUiState.Loaded)?.episodes.orEmpty()
+        if (episodes.isNotEmpty()) {
+            eventHorizon.track(FilterPlayAllTappedEvent(filterType = filterType))
+        }
         playAllJob = viewModelScope.launch {
             try {
-                val episodes = (uiState.value as? TvPlaylistDetailsUiState.Loaded)?.episodes.orEmpty()
                 when (playAllHandler.handlePlayAllEpisodes(episodes)) {
                     PlayAllResponse.DoNothing -> _events.tryEmit(TvPlaylistDetailsEvent.OpenNowPlaying)
                     PlayAllResponse.ShowWarning -> _events.tryEmit(TvPlaylistDetailsEvent.ShowReplaceUpNextConfirmation)
@@ -117,6 +141,7 @@ class TvPlaylistDetailsViewModel @AssistedInject constructor(
         if (isBusy) {
             return
         }
+        eventHorizon.track(FilterPlayAllReplaceAndPlayTappedEvent(filterType = filterType, saveUpNext = saveUpNext))
         replaceUpNextJob = viewModelScope.launch {
             val played = withContext(NonCancellable) {
                 if (saveUpNext) {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModel.kt
@@ -19,6 +19,8 @@ import com.automattic.eventhorizon.FilterPlayAllReplaceAndPlayTappedEvent
 import com.automattic.eventhorizon.FilterPlayAllTappedEvent
 import com.automattic.eventhorizon.FilterShowArchivedTappedEvent
 import com.automattic.eventhorizon.FilterShownEvent
+import com.automattic.eventhorizon.FilterSortByChangedEvent
+import com.automattic.eventhorizon.FilterSortByTappedEvent
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -91,7 +93,12 @@ class TvPlaylistDetailsViewModel @AssistedInject constructor(
         TvPlaylistDetailsUiState.Loading,
     )
 
+    fun trackSortByTapped() {
+        eventHorizon.track(FilterSortByTappedEvent(filterType = filterType))
+    }
+
     fun changeSortType(sortType: PlaylistEpisodeSortType) {
+        eventHorizon.track(FilterSortByChangedEvent(sortOrder = sortType.analyticsValue, filterType = filterType))
         viewModelScope.launch {
             playlistManager.updateSortType(playlistUuid, sortType)
         }

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsViewModelTest.kt
@@ -11,6 +11,9 @@ import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistPreview
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.SmartPlaylistPreview
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import com.automattic.eventhorizon.EventHorizon
+import com.automattic.eventhorizon.FilterCreateButtonTappedEvent
+import com.automattic.eventhorizon.FilterListShownEvent
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.runTest
@@ -20,6 +23,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class TvPlaylistsViewModelTest {
@@ -32,6 +36,21 @@ class TvPlaylistsViewModelTest {
         on { playlistPreviewsFlow() } doReturn playlistPreviews
     }
     private val podcastManager = mock<PodcastManager>()
+    private val eventHorizon = mock<EventHorizon>()
+
+    @Test
+    fun `tracks the playlists list shown with the filter count`() = runTest {
+        createViewModel().trackPlaylistsListShown(3)
+
+        verify(eventHorizon).track(FilterListShownEvent(filterCount = 3))
+    }
+
+    @Test
+    fun `tracks the create button tapped`() = runTest {
+        createViewModel().trackCreateButtonTapped()
+
+        verify(eventHorizon).track(FilterCreateButtonTappedEvent)
+    }
 
     @Test
     fun `state starts as loading`() = runTest {
@@ -115,6 +134,7 @@ class TvPlaylistsViewModelTest {
     private fun createViewModel(podcastManager: PodcastManager = this.podcastManager) = TvPlaylistsViewModel(
         playlistManager = playlistManager,
         podcastManager = podcastManager,
+        eventHorizon = eventHorizon,
     )
 
     private fun smartPreview(

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModelTest.kt
@@ -11,6 +11,14 @@ import au.com.shiftyjelly.pocketcasts.repositories.playlist.ManualPlaylist
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.Playlist
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import com.automattic.eventhorizon.EventHorizon
+import com.automattic.eventhorizon.FilterHideArchivedTappedEvent
+import com.automattic.eventhorizon.FilterPlayAllDismissedEvent
+import com.automattic.eventhorizon.FilterPlayAllReplaceAndPlayTappedEvent
+import com.automattic.eventhorizon.FilterPlayAllTappedEvent
+import com.automattic.eventhorizon.FilterShowArchivedTappedEvent
+import com.automattic.eventhorizon.FilterShownEvent
+import com.automattic.eventhorizon.PlaylistType
 import java.util.Date
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -41,6 +49,7 @@ class TvPlaylistDetailsViewModelTest {
     private val playlists = MutableSharedFlow<ManualPlaylist?>(replay = 1)
     private val playlistManager = mock<PlaylistManager> {
         on { manualPlaylistFlow(any(), anyOrNull(), any()) } doReturn playlists
+        on { smartPlaylistFlow(any(), anyOrNull(), any()) } doReturn MutableSharedFlow(replay = 1)
     }
     private val preferences = mock<TvPreferences>()
 
@@ -48,6 +57,7 @@ class TvPlaylistDetailsViewModelTest {
     private val playAllHandlerFactory = mock<PlayAllHandler.Factory> {
         on { create(any()) } doReturn playAllHandler
     }
+    private val eventHorizon = mock<EventHorizon>()
 
     private val availableEpisode = episode(uuid = "episode-1", isArchived = false)
     private val archivedEpisode = episode(uuid = "episode-2", isArchived = true)
@@ -338,11 +348,77 @@ class TvPlaylistDetailsViewModelTest {
         }
     }
 
-    private fun createViewModel(prefs: TvPreferences = preferences) = TvPlaylistDetailsViewModel(
+    @Test
+    fun `tracks the filter shown with the playlist type`() = runTest {
+        createViewModel().trackFilterShown()
+
+        verify(eventHorizon).track(FilterShownEvent(filterType = PlaylistType.Manual))
+    }
+
+    @Test
+    fun `toggling the archive filter on a manual playlist tracks show then hide`() = runTest {
+        val viewModel = createViewModel(playlistType = Playlist.Type.Manual)
+
+        viewModel.toggleArchiveFilter()
+        viewModel.toggleArchiveFilter()
+
+        verify(eventHorizon).track(FilterShowArchivedTappedEvent)
+        verify(eventHorizon).track(FilterHideArchivedTappedEvent)
+    }
+
+    @Test
+    fun `toggling the archive filter on a smart playlist tracks nothing`() = runTest {
+        val viewModel = createViewModel(playlistType = Playlist.Type.Smart)
+
+        viewModel.toggleArchiveFilter()
+
+        verify(eventHorizon, never()).track(FilterShowArchivedTappedEvent)
+        verify(eventHorizon, never()).track(FilterHideArchivedTappedEvent)
+    }
+
+    @Test
+    fun `play all tracks the tapped event`() = runTest {
+        whenever(playAllHandler.handlePlayAllEpisodes(any())) doReturn PlayAllResponse.DoNothing
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            assertEquals(TvPlaylistDetailsUiState.Loading, awaitItem())
+            playlists.emit(playlist(availableEpisode))
+            awaitItem()
+            viewModel.playAll()
+            advanceUntilIdle()
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        verify(eventHorizon).track(FilterPlayAllTappedEvent(filterType = PlaylistType.Manual))
+    }
+
+    @Test
+    fun `replacing up next tracks the replace and play event`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.replaceUpNextAndPlay(saveUpNext = true, upNextName = "Up Next")
+        advanceUntilIdle()
+
+        verify(eventHorizon).track(FilterPlayAllReplaceAndPlayTappedEvent(filterType = PlaylistType.Manual, saveUpNext = true))
+    }
+
+    @Test
+    fun `tracks the play all dismissed event`() = runTest {
+        createViewModel().trackPlayAllDismissed()
+
+        verify(eventHorizon).track(FilterPlayAllDismissedEvent(filterType = PlaylistType.Manual))
+    }
+
+    private fun createViewModel(
+        prefs: TvPreferences = preferences,
+        playlistType: Playlist.Type = Playlist.Type.Manual,
+    ) = TvPlaylistDetailsViewModel(
         playlistUuid = "playlist-uuid",
-        playlistType = Playlist.Type.Manual,
+        playlistType = playlistType,
         playlistManager = playlistManager,
         preferences = prefs,
+        eventHorizon = eventHorizon,
         playAllHandlerFactory = playAllHandlerFactory,
     )
 

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModelTest.kt
@@ -5,12 +5,14 @@ import au.com.shiftyjelly.pocketcasts.models.entity.ManualPlaylistEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.PlaylistEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.PlaylistEpisodeSortType
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules
 import au.com.shiftyjelly.pocketcasts.preferences.TvPreferences
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlayAllHandler
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlayAllResponse
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.ManualPlaylist
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.Playlist
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.SmartPlaylist
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import com.automattic.eventhorizon.EventHorizon
 import com.automattic.eventhorizon.FilterHideArchivedTappedEvent
@@ -111,7 +113,7 @@ class TvPlaylistDetailsViewModelTest {
         viewModel.uiState.test {
             assertEquals(TvPlaylistDetailsUiState.Loading, awaitItem())
 
-            smartPlaylists.emit(playlist(availableEpisode, archivedEpisode))
+            smartPlaylists.emit(smartPlaylist(availableEpisode, archivedEpisode))
 
             val state = awaitItem() as TvPlaylistDetailsUiState.Loaded
             assertEquals(listOf(availableEpisode), state.episodes)
@@ -397,6 +399,7 @@ class TvPlaylistDetailsViewModelTest {
 
         verify(eventHorizon, never()).track(FilterShowArchivedTappedEvent)
         verify(eventHorizon, never()).track(FilterHideArchivedTappedEvent)
+        verify(preferences, never()).setPlaylistShowingArchived(any(), any())
     }
 
     @Test
@@ -417,6 +420,23 @@ class TvPlaylistDetailsViewModelTest {
     }
 
     @Test
+    fun `play all does not track the tapped event when there are no episodes`() = runTest {
+        whenever(playAllHandler.handlePlayAllEpisodes(any())) doReturn PlayAllResponse.ShowNoEpisodesToPlay
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            assertEquals(TvPlaylistDetailsUiState.Loading, awaitItem())
+            playlists.emit(playlist())
+            awaitItem()
+            viewModel.playAll()
+            advanceUntilIdle()
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        verify(eventHorizon, never()).track(any<FilterPlayAllTappedEvent>())
+    }
+
+    @Test
     fun `replacing up next tracks the replace and play event`() = runTest {
         val viewModel = createViewModel()
 
@@ -424,6 +444,16 @@ class TvPlaylistDetailsViewModelTest {
         advanceUntilIdle()
 
         verify(eventHorizon).track(FilterPlayAllReplaceAndPlayTappedEvent(filterType = PlaylistType.Manual, saveUpNext = true))
+    }
+
+    @Test
+    fun `replacing up next without saving tracks the replace and play event with save disabled`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.replaceUpNextAndPlay(saveUpNext = false, upNextName = "Up Next")
+        advanceUntilIdle()
+
+        verify(eventHorizon).track(FilterPlayAllReplaceAndPlayTappedEvent(filterType = PlaylistType.Manual, saveUpNext = false))
     }
 
     @Test
@@ -466,6 +496,15 @@ class TvPlaylistDetailsViewModelTest {
     private fun playlist(vararg episodes: PodcastEpisode) = ManualPlaylist(
         uuid = "playlist-uuid",
         title = "Playlist",
+        episodes = episodes.map(PlaylistEpisode::Available),
+        settings = Playlist.Settings.ForPreview,
+        metadata = Playlist.Metadata.ForPreview,
+    )
+
+    private fun smartPlaylist(vararg episodes: PodcastEpisode) = SmartPlaylist(
+        uuid = "playlist-uuid",
+        title = "Playlist",
+        smartRules = SmartRules.Default,
         episodes = episodes.map(PlaylistEpisode::Available),
         settings = Playlist.Settings.ForPreview,
         metadata = Playlist.Metadata.ForPreview,

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModelTest.kt
@@ -100,6 +100,26 @@ class TvPlaylistDetailsViewModelTest {
     }
 
     @Test
+    fun `smart playlists ignore the stored archived preference`() = runTest {
+        val preferences = mock<TvPreferences> {
+            on { isPlaylistShowingArchived("playlist-uuid") } doReturn true
+        }
+        val smartPlaylists = MutableSharedFlow<Playlist?>(replay = 1)
+        doReturn(smartPlaylists).whenever(playlistManager).smartPlaylistFlow(any(), anyOrNull(), any())
+        val viewModel = createViewModel(preferences, playlistType = Playlist.Type.Smart)
+
+        viewModel.uiState.test {
+            assertEquals(TvPlaylistDetailsUiState.Loading, awaitItem())
+
+            smartPlaylists.emit(playlist(availableEpisode, archivedEpisode))
+
+            val state = awaitItem() as TvPlaylistDetailsUiState.Loaded
+            assertEquals(listOf(availableEpisode), state.episodes)
+            assertEquals(false, state.isShowingArchivedOnDevice)
+        }
+    }
+
+    @Test
     fun `only available episodes are surfaced`() = runTest {
         val available = episode(uuid = "available", isArchived = false)
         val unavailable = PlaylistEpisode.Unavailable(ManualPlaylistEpisode.test(episodeUuid = "unavailable"))

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsViewModelTest.kt
@@ -4,6 +4,7 @@ import app.cash.turbine.test
 import au.com.shiftyjelly.pocketcasts.models.entity.ManualPlaylistEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.PlaylistEpisode
+import au.com.shiftyjelly.pocketcasts.models.type.PlaylistEpisodeSortType
 import au.com.shiftyjelly.pocketcasts.preferences.TvPreferences
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlayAllHandler
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlayAllResponse
@@ -18,6 +19,8 @@ import com.automattic.eventhorizon.FilterPlayAllReplaceAndPlayTappedEvent
 import com.automattic.eventhorizon.FilterPlayAllTappedEvent
 import com.automattic.eventhorizon.FilterShowArchivedTappedEvent
 import com.automattic.eventhorizon.FilterShownEvent
+import com.automattic.eventhorizon.FilterSortByChangedEvent
+import com.automattic.eventhorizon.FilterSortByTappedEvent
 import com.automattic.eventhorizon.PlaylistType
 import java.util.Date
 import kotlinx.coroutines.CompletableDeferred
@@ -401,6 +404,24 @@ class TvPlaylistDetailsViewModelTest {
         advanceUntilIdle()
 
         verify(eventHorizon).track(FilterPlayAllReplaceAndPlayTappedEvent(filterType = PlaylistType.Manual, saveUpNext = true))
+    }
+
+    @Test
+    fun `tracks the sort by tapped event`() = runTest {
+        createViewModel().trackSortByTapped()
+
+        verify(eventHorizon).track(FilterSortByTappedEvent(filterType = PlaylistType.Manual))
+    }
+
+    @Test
+    fun `changing the sort type tracks the sort by changed event`() = runTest {
+        val sortType = PlaylistEpisodeSortType.NewestToOldest
+
+        createViewModel().changeSortType(sortType)
+
+        verify(eventHorizon).track(
+            FilterSortByChangedEvent(sortOrder = sortType.analyticsValue, filterType = PlaylistType.Manual),
+        )
     }
 
     @Test


### PR DESCRIPTION
## Description

Third screen of the **Android TV → Apple TV analytics parity** program (EventHorizon only): the **Playlists** tab (list + detail). Stacked on the Your Podcasts analytics PR. Verified against the tvOS app across every tracking layer — all direct `Analytics.track`, no hidden helper layer.

| Event | EventHorizon class | Properties | Fires when |
|---|---|---|---|
| `filter_list_shown` | `FilterListShownEvent` | `filter_count` | playlists list shown (once, after load) |
| `filter_create_button_tapped` | `FilterCreateButtonTappedEvent` | — | the create button (opens the "download app" modal — you can't create playlists on TV) |
| `filter_shown` | `FilterShownEvent` | `filter_type` | a playlist's detail is shown |
| `filter_show_archived_tapped` / `filter_hide_archived_tapped` | data objects | — | toggle the archived filter (by the new value) |
| `filter_play_all_tapped` | `FilterPlayAllTappedEvent` | `filter_type` | Play All (only when the playlist has episodes) |
| `filter_play_all_replace_and_play_tapped` | `FilterPlayAllReplaceAndPlayTappedEvent` | `filter_type, save_up_next` | the replace-Up-Next confirmation (save vs discard) |
| `filter_play_all_dismissed` | `FilterPlayAllDismissedEvent` | `filter_type` | the replace-Up-Next confirmation is cancelled |
|

`filter_type` = `manual` / `smart`, derived from `Playlist.Type.analyticsValue` (→ `PlaylistType`), matching iOS's `isManual ? "manual" : "smart"`.

**Archive toggle is manual-only** for analytics, matching iOS (`PlaylistDetailView.swift:225` gates the archive menu behind `if model.isManual`) — so `filter_show/hide_archived_tapped` fires only for manual playlists.

**Archive toggle is now manual-only in the UI too.** A review surfaced that the Android TV archive-filter toggle was shown for **smart** playlists as well, whereas Apple TV only shows it for manual (`PlaylistDetailView.swift:225`). A second commit hides the toggle for smart playlists (with the Play-All left-focus preserved on the sort button), closing both the analytics and the feature gap.

**Faithful to tvOS:** show-vs-hide-archived is chosen by the new value; `filter_play_all_tapped` only fires when there are episodes (mirrors iOS's `guard !episodes.isEmpty`); the replace/dismiss events carry the same `save_up_next` / `filter_type` payloads. All wired into the existing VM methods (`toggleArchiveFilter`, `playAll`, `replaceUpNextAndPlay`) plus `CallOnce` for `filter_shown` and a dismiss hook on the confirmation modal.

Fixes PCDROID-721 https://linear.app/a8c/issue/PCDROID-721/playlists-analytics

## Testing Instructions

1. `./gradlew :tv:installDebug`; open the Playlists tab → confirm one `filter_list_shown` with `filter_count` in `adb logcat`.
2. Tap the create button → `filter_create_button_tapped` (+ the download-app modal).
3. Open a playlist → `filter_shown` with `filter_type`. Toggle the archived filter → `filter_show_archived_tapped` / `filter_hide_archived_tapped`.
4. Play All on a non-empty playlist → `filter_play_all_tapped`; if it prompts to replace Up Next: save → `filter_play_all_replace_and_play_tapped save_up_next=true`; without saving → `save_up_next=false`; cancel → `filter_play_all_dismissed`.
5. Open the sort menu → `filter_sort_by_tapped`; pick a different sort order → `filter_sort_by_changed` with `sort_order`.

## Screenshots or Screencast
<img width="833" height="373" alt="SCR-20260813-oxgz" src="https://github.com/user-attachments/assets/1d35a26d-8203-4b6f-8107-2f0c9f0965da" />


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md — N/A (analytics only)
- [x] Ensure the linter passes (`./gradlew spotlessApply`)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in localization — N/A
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) the Event Horizon schema to reflect any new or changed analytics — existing events, no schema change needed

