### PR TITLE
[TV] Up Next analytics

### DIFF
--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextScreen.kt
@@ -76,7 +76,10 @@ fun TvUpNextScreen(
         val openNowPlaying = LocalOpenNowPlaying.current
         TvUpNextContent(
             uiState = uiState,
-            onNavigateToHome = onNavigateToHome,
+            onNavigateToHome = {
+                viewModel.trackDiscoverButtonTapped()
+                onNavigateToHome()
+            },
             onOpenPodcast = { openedPodcastUuid = it },
             onPlayEpisode = { episode ->
                 viewModel.play(episode)

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextScreen.kt
@@ -61,6 +61,7 @@ fun TvUpNextScreen(
     var openedPodcastUuid by rememberSaveable { mutableStateOf<String?>(null) }
 
     LaunchedEffect(Unit) {
+        viewModel.trackUpNextShown()
         viewModel.onShown()
     }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextViewModel.kt
@@ -9,6 +9,10 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.UpNextSyncWorker
+import com.automattic.eventhorizon.EventHorizon
+import com.automattic.eventhorizon.UpNextDiscoverButtonTappedEvent
+import com.automattic.eventhorizon.UpNextShownEvent
+import com.automattic.eventhorizon.UpNextSourceType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
@@ -30,6 +34,7 @@ class TvUpNextViewModel @Inject constructor(
     private val syncManager: SyncManager,
     private val upNextQueue: UpNextQueue,
     private val playbackManager: PlaybackManager,
+    private val eventHorizon: EventHorizon,
 ) : ViewModel() {
 
     val uiState: StateFlow<TvUpNextUiState> = upNextQueue.changesObservable.asFlow()
@@ -51,7 +56,12 @@ class TvUpNextViewModel @Inject constructor(
         )
 
     fun onShown() {
+        eventHorizon.track(UpNextShownEvent(source = UpNextSourceType.TabBar))
         UpNextSyncWorker.enqueue(syncManager, context)
+    }
+
+    fun trackDiscoverButtonTapped() {
+        eventHorizon.track(UpNextDiscoverButtonTappedEvent(source = UpNextSourceType.TabBar))
     }
 
     fun play(episode: PodcastEpisode) {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextViewModel.kt
@@ -56,8 +56,11 @@ class TvUpNextViewModel @Inject constructor(
         )
 
     fun onShown() {
-        eventHorizon.track(UpNextShownEvent(source = UpNextSourceType.TabBar))
         UpNextSyncWorker.enqueue(syncManager, context)
+    }
+
+    fun trackUpNextShown() {
+        eventHorizon.track(UpNextShownEvent(source = UpNextSourceType.TabBar))
     }
 
     fun trackDiscoverButtonTapped() {

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextViewModelTest.kt
@@ -9,6 +9,10 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import com.automattic.eventhorizon.EventHorizon
+import com.automattic.eventhorizon.UpNextDiscoverButtonTappedEvent
+import com.automattic.eventhorizon.UpNextShownEvent
+import com.automattic.eventhorizon.UpNextSourceType
 import io.reactivex.subjects.BehaviorSubject
 import java.util.Date
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -19,6 +23,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyBlocking
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -34,6 +39,7 @@ class TvUpNextViewModelTest {
     private val syncManager = mock<SyncManager>()
     private val context = mock<Context>()
     private val playbackManager = mock<PlaybackManager>()
+    private val eventHorizon = mock<EventHorizon>()
 
     private val currentEpisode = episode("current")
 
@@ -135,11 +141,26 @@ class TvUpNextViewModelTest {
         verifyBlocking(playbackManager) { playNowSuspend(episode = episode, sourceView = SourceView.UP_NEXT) }
     }
 
+    @Test
+    fun `showing the screen tracks the up next shown event`() = runTest {
+        createViewModel().onShown()
+
+        verify(eventHorizon).track(UpNextShownEvent(source = UpNextSourceType.TabBar))
+    }
+
+    @Test
+    fun `tapping the empty state discover button tracks the discover button event`() = runTest {
+        createViewModel().trackDiscoverButtonTapped()
+
+        verify(eventHorizon).track(UpNextDiscoverButtonTappedEvent(source = UpNextSourceType.TabBar))
+    }
+
     private fun createViewModel() = TvUpNextViewModel(
         context = context,
         syncManager = syncManager,
         upNextQueue = upNextQueue,
         playbackManager = playbackManager,
+        eventHorizon = eventHorizon,
     )
 
     private fun episode(uuid: String) = PodcastEpisode(uuid = uuid, publishedDate = Date(0))

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextViewModelTest.kt
@@ -143,7 +143,7 @@ class TvUpNextViewModelTest {
 
     @Test
     fun `showing the screen tracks the up next shown event`() = runTest {
-        createViewModel().onShown()
+        createViewModel().trackUpNextShown()
 
         verify(eventHorizon).track(UpNextShownEvent(source = UpNextSourceType.TabBar))
     }


### PR DESCRIPTION
## Description

Fourth screen of the **Android TV → Apple TV analytics parity** program (EventHorizon only): the **Up Next** tab. Stacked on the Playlists analytics PR. Verified against the tvOS app across every tracking layer.

The tvOS `UpNextView` fires exactly two events on this screen (both in `Pocket Casts TV App/UI/UpNext/UpNextView.swift`):

| Event | EventHorizon class | Properties | Fires when |
|---|---|---|---|
| `up_next_shown` | `UpNextShownEvent` | `source = tab_bar` | the Up Next tab is shown (once per entry, in the existing `onShown()` off `LaunchedEffect`) |
| `up_next_discover_button_tapped` | `UpNextDiscoverButtonTappedEvent` | `source = tab_bar` | the empty-state "discover" button (navigates to Home) |

`source` maps to `UpNextSourceType.TabBar` ("tab_bar"), matching iOS's `up_next_shown` payload. iOS sends **no** source on `up_next_discover_button_tapped`, but the Android EventHorizon class requires one — `TabBar` is the correct screen context (the button lives in the Up Next tab's empty state).

Wired the same way as the sibling Your Podcasts / Playlists screens: `EventHorizon` injected into `TvUpNextViewModel`, `up_next_shown` tracked inside the existing `onShown()`, and a new `trackDiscoverButtonTapped()` invoked by wrapping the empty-state `onNavigateToHome` lambda (that lambda feeds only the empty-state button, so no over-fire).

### `up_next_queue_reordered` — deferred to the Episode Actions PR (not a gap)

tvOS also has `up_next_queue_reordered`, but it fires from the shared `EpisodeUpNextActions.playNext/playLast` queue helper (moving an episode already in Up Next), **not** from the Up Next screen render. Android's equivalent is `TvEpisodeActionsViewModel.playNext/playLast` in the shared `TvEpisodeActionsModal`, which spans the PodcastDetails / Playlist / Up Next / Now Playing contexts. It will be wired once, for the whole modal, in the upcoming **Episode actions** analytics PR — not here. (Android TV has no drag-reorder gesture; these menu actions are the only reorder path.)

Fixes PCDROID-723 https://linear.app/a8c/issue/PCDROID-723/up-next-analytics

## Testing Instructions

1. `./gradlew :tv:installDebug`; open the **Up Next** tab → confirm a single `up_next_shown` with `source=tab_bar` in `adb logcat`.
2. With an empty Up Next queue, focus and activate the discover/empty-state button → `up_next_discover_button_tapped` with `source=tab_bar`, then it navigates to Home.

## Screenshots or Screencast
<img width="590" height="99" alt="SCR-20260813-ptai" src="https://github.com/user-attachments/assets/1bc720ca-f3ec-4c5e-b5ae-45cc6204d2d1" />


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md — N/A (analytics only)
- [x] Ensure the linter passes (`./gradlew spotlessApply`)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in localization — N/A
- [x] Any jetpack compose components I added or changed are covered by compose previews — N/A (no new components)
- [x] I have updated (or requested that someone edit) the Event Horizon schema to reflect any new or changed analytics — existing events, no schema change needed
