### PR TITLE
[TV] Episode actions & details analytics

### DIFF
--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionsModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionsModal.kt
@@ -63,7 +63,7 @@ private fun ColumnScope.TvEpisodeActionsModalContent(
     var pendingConfirmation by remember { mutableStateOf<TvEpisodeActionConfirmation?>(null) }
     var returnFocusLabel by remember { mutableStateOf<String?>(null) }
     val focusRequester = remember { FocusRequester() }
-    LaunchedEffect(Unit) {
+    LaunchedEffect(episode.uuid) {
         actions.trackActionsShown(actionContext.episodeViewSource)
     }
     LaunchedEffect(pendingConfirmation) {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionsModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionsModal.kt
@@ -21,6 +21,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.theme.TvTheme
+import com.automattic.eventhorizon.EpisodeViewSourceType
 import java.util.Date
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -62,6 +63,9 @@ private fun ColumnScope.TvEpisodeActionsModalContent(
     var pendingConfirmation by remember { mutableStateOf<TvEpisodeActionConfirmation?>(null) }
     var returnFocusLabel by remember { mutableStateOf<String?>(null) }
     val focusRequester = remember { FocusRequester() }
+    LaunchedEffect(Unit) {
+        actions.trackActionsShown(actionContext.episodeViewSource)
+    }
     LaunchedEffect(pendingConfirmation) {
         if (pendingConfirmation == null) {
             focusRequester.requestFocus()
@@ -317,6 +321,7 @@ private object NoOpTvEpisodeActions : TvEpisodeActions {
     override fun archive(episode: PodcastEpisode) = Unit
     override fun unarchive(episode: PodcastEpisode) = Unit
     override fun removeFromUpNext(episode: PodcastEpisode, source: SourceView) = Unit
+    override fun trackActionsShown(source: EpisodeViewSourceType) = Unit
 }
 
 private val ContentPadding = PaddingValues(horizontal = 24.dp, vertical = 27.dp)

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionsViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionsViewModel.kt
@@ -50,10 +50,6 @@ class TvEpisodeActionsViewModel @Inject constructor(
 ) : ViewModel(),
     TvEpisodeActions {
 
-    override fun trackActionsShown(source: EpisodeViewSourceType) {
-        eventHorizon.track(EpisodeActionsShownEvent(source = source))
-    }
-
     override fun play(episode: PodcastEpisode, source: SourceView) = launchWrite {
         playbackManager.playNowSuspend(episode = episode, sourceView = source)
     }
@@ -84,6 +80,10 @@ class TvEpisodeActionsViewModel @Inject constructor(
 
     override fun removeFromUpNext(episode: PodcastEpisode, source: SourceView) {
         playbackManager.removeEpisode(episodeToRemove = episode, source = source)
+    }
+
+    override fun trackActionsShown(source: EpisodeViewSourceType) {
+        eventHorizon.track(EpisodeActionsShownEvent(source = source))
     }
 
     private fun launchWrite(block: suspend () -> Unit) {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionsViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionsViewModel.kt
@@ -8,6 +8,9 @@ import au.com.shiftyjelly.pocketcasts.repositories.di.IoDispatcher
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import com.automattic.eventhorizon.EpisodeActionsShownEvent
+import com.automattic.eventhorizon.EpisodeViewSourceType
+import com.automattic.eventhorizon.EventHorizon
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
@@ -16,12 +19,12 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
-enum class TvEpisodeActionContext(val source: SourceView) {
-    PodcastDetails(SourceView.PODCAST_SCREEN),
-    SearchResults(SourceView.SEARCH_RESULTS),
-    Playlist(SourceView.FILTERS),
-    UpNext(SourceView.UP_NEXT),
-    NowPlaying(SourceView.PLAYER),
+enum class TvEpisodeActionContext(val source: SourceView, val episodeViewSource: EpisodeViewSourceType) {
+    PodcastDetails(SourceView.PODCAST_SCREEN, EpisodeViewSourceType.PodcastScreen),
+    SearchResults(SourceView.SEARCH_RESULTS, EpisodeViewSourceType.Search),
+    Playlist(SourceView.FILTERS, EpisodeViewSourceType.Filters),
+    UpNext(SourceView.UP_NEXT, EpisodeViewSourceType.UpNext),
+    NowPlaying(SourceView.PLAYER, EpisodeViewSourceType.NowPlaying),
 }
 
 interface TvEpisodeActions {
@@ -33,6 +36,7 @@ interface TvEpisodeActions {
     fun archive(episode: PodcastEpisode)
     fun unarchive(episode: PodcastEpisode)
     fun removeFromUpNext(episode: PodcastEpisode, source: SourceView)
+    fun trackActionsShown(source: EpisodeViewSourceType)
 }
 
 @HiltViewModel
@@ -40,10 +44,15 @@ class TvEpisodeActionsViewModel @Inject constructor(
     private val episodeManager: EpisodeManager,
     private val playbackManager: PlaybackManager,
     private val podcastManager: PodcastManager,
+    private val eventHorizon: EventHorizon,
     @ApplicationScope private val applicationScope: CoroutineScope,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel(),
     TvEpisodeActions {
+
+    override fun trackActionsShown(source: EpisodeViewSourceType) {
+        eventHorizon.track(EpisodeActionsShownEvent(source = source))
+    }
 
     override fun play(episode: PodcastEpisode, source: SourceView) = launchWrite {
         playbackManager.playNowSuspend(episode = episode, sourceView = source)

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeInfoModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeInfoModal.kt
@@ -50,6 +50,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImage
 import au.com.shiftyjelly.pocketcasts.theme.TvTheme
 import au.com.shiftyjelly.pocketcasts.theme.tvColors
 import au.com.shiftyjelly.pocketcasts.theme.tvTypography
+import com.automattic.eventhorizon.EpisodeViewSourceType
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -59,11 +60,13 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 @Composable
 fun TvEpisodeInfoModal(
     episode: PodcastEpisode,
+    source: EpisodeViewSourceType,
     onDismissRequest: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: TvEpisodeInfoViewModel = hiltViewModel(),
 ) {
     LaunchedEffect(episode.uuid) {
+        viewModel.trackShown(source)
         viewModel.load(episode.podcastUuid, episode.uuid)
     }
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeInfoModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeInfoModal.kt
@@ -50,7 +50,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImage
 import au.com.shiftyjelly.pocketcasts.theme.TvTheme
 import au.com.shiftyjelly.pocketcasts.theme.tvColors
 import au.com.shiftyjelly.pocketcasts.theme.tvTypography
-import com.automattic.eventhorizon.EpisodeViewSourceType
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -60,13 +59,13 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 @Composable
 fun TvEpisodeInfoModal(
     episode: PodcastEpisode,
-    source: EpisodeViewSourceType,
+    actionContext: TvEpisodeActionContext,
     onDismissRequest: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: TvEpisodeInfoViewModel = hiltViewModel(),
 ) {
     LaunchedEffect(episode.uuid) {
-        viewModel.trackShown(source)
+        viewModel.trackDetailShown(actionContext.episodeViewSource)
         viewModel.load(episode.podcastUuid, episode.uuid)
     }
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeInfoViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeInfoViewModel.kt
@@ -5,6 +5,9 @@ import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.shownotes.ShowNotesManager
 import au.com.shiftyjelly.pocketcasts.servers.shownotes.ShowNotesState
+import com.automattic.eventhorizon.EpisodeDetailShownEvent
+import com.automattic.eventhorizon.EpisodeViewSourceType
+import com.automattic.eventhorizon.EventHorizon
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -17,11 +20,16 @@ import kotlinx.coroutines.launch
 class TvEpisodeInfoViewModel @Inject constructor(
     private val podcastManager: PodcastManager,
     private val showNotesManager: ShowNotesManager,
+    private val eventHorizon: EventHorizon,
 ) : ViewModel() {
     private val _uiState = MutableStateFlow<UiState?>(null)
     val uiState: StateFlow<UiState?> = _uiState.asStateFlow()
 
     private var loadedEpisodeUuid: String? = null
+
+    fun trackShown(source: EpisodeViewSourceType) {
+        eventHorizon.track(EpisodeDetailShownEvent(source = source))
+    }
 
     fun load(podcastUuid: String, episodeUuid: String) {
         if (episodeUuid == loadedEpisodeUuid) {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeInfoViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeInfoViewModel.kt
@@ -27,7 +27,7 @@ class TvEpisodeInfoViewModel @Inject constructor(
 
     private var loadedEpisodeUuid: String? = null
 
-    fun trackShown(source: EpisodeViewSourceType) {
+    fun trackDetailShown(source: EpisodeViewSourceType) {
         eventHorizon.track(EpisodeDetailShownEvent(source = source))
     }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
@@ -82,6 +82,7 @@ import au.com.shiftyjelly.pocketcasts.theme.TvTheme
 import au.com.shiftyjelly.pocketcasts.theme.TvTopBarHeight
 import au.com.shiftyjelly.pocketcasts.theme.tvColors
 import au.com.shiftyjelly.pocketcasts.theme.tvTypography
+import com.automattic.eventhorizon.EpisodeViewSourceType
 import java.util.Date
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.delay
@@ -356,6 +357,7 @@ private fun TvNowPlayingContent(
         if (isDetailsModalVisible) {
             TvEpisodeInfoModal(
                 episode = episode,
+                source = EpisodeViewSourceType.NowPlaying,
                 onDismissRequest = { isDetailsModalVisible = false },
             )
         }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
@@ -82,7 +82,6 @@ import au.com.shiftyjelly.pocketcasts.theme.TvTheme
 import au.com.shiftyjelly.pocketcasts.theme.TvTopBarHeight
 import au.com.shiftyjelly.pocketcasts.theme.tvColors
 import au.com.shiftyjelly.pocketcasts.theme.tvTypography
-import com.automattic.eventhorizon.EpisodeViewSourceType
 import java.util.Date
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.delay
@@ -357,7 +356,7 @@ private fun TvNowPlayingContent(
         if (isDetailsModalVisible) {
             TvEpisodeInfoModal(
                 episode = episode,
-                source = EpisodeViewSourceType.NowPlaying,
+                actionContext = TvEpisodeActionContext.NowPlaying,
                 onDismissRequest = { isDetailsModalVisible = false },
             )
         }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
@@ -69,6 +69,7 @@ import au.com.shiftyjelly.pocketcasts.theme.TvDetailsArtworkSize
 import au.com.shiftyjelly.pocketcasts.theme.TvTheme
 import au.com.shiftyjelly.pocketcasts.theme.tvColors
 import au.com.shiftyjelly.pocketcasts.theme.tvTypography
+import com.automattic.eventhorizon.EpisodeViewSourceType
 import java.util.Date
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -334,6 +335,7 @@ private fun EpisodeList(
     detailsEpisode?.let { episode ->
         TvEpisodeInfoModal(
             episode = episode,
+            source = EpisodeViewSourceType.Filters,
             onDismissRequest = { detailsEpisode = null },
         )
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
@@ -69,7 +69,6 @@ import au.com.shiftyjelly.pocketcasts.theme.TvDetailsArtworkSize
 import au.com.shiftyjelly.pocketcasts.theme.TvTheme
 import au.com.shiftyjelly.pocketcasts.theme.tvColors
 import au.com.shiftyjelly.pocketcasts.theme.tvTypography
-import com.automattic.eventhorizon.EpisodeViewSourceType
 import java.util.Date
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -335,7 +334,7 @@ private fun EpisodeList(
     detailsEpisode?.let { episode ->
         TvEpisodeInfoModal(
             episode = episode,
-            source = EpisodeViewSourceType.Filters,
+            actionContext = TvEpisodeActionContext.Playlist,
             onDismissRequest = { detailsEpisode = null },
         )
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
@@ -67,6 +67,7 @@ import au.com.shiftyjelly.pocketcasts.theme.TvDetailsArtworkSize
 import au.com.shiftyjelly.pocketcasts.theme.TvTheme
 import au.com.shiftyjelly.pocketcasts.theme.tvColors
 import au.com.shiftyjelly.pocketcasts.theme.tvTypography
+import com.automattic.eventhorizon.EpisodeViewSourceType
 import java.util.Date
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -342,6 +343,7 @@ private fun EpisodeList(
     detailsEpisode?.let { episode ->
         TvEpisodeInfoModal(
             episode = episode,
+            source = EpisodeViewSourceType.PodcastScreen,
             onDismissRequest = { detailsEpisode = null },
         )
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
@@ -67,7 +67,6 @@ import au.com.shiftyjelly.pocketcasts.theme.TvDetailsArtworkSize
 import au.com.shiftyjelly.pocketcasts.theme.TvTheme
 import au.com.shiftyjelly.pocketcasts.theme.tvColors
 import au.com.shiftyjelly.pocketcasts.theme.tvTypography
-import com.automattic.eventhorizon.EpisodeViewSourceType
 import java.util.Date
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -343,7 +342,7 @@ private fun EpisodeList(
     detailsEpisode?.let { episode ->
         TvEpisodeInfoModal(
             episode = episode,
-            source = EpisodeViewSourceType.PodcastScreen,
+            actionContext = TvEpisodeActionContext.PodcastDetails,
             onDismissRequest = { detailsEpisode = null },
         )
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
@@ -67,6 +67,7 @@ import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
 import au.com.shiftyjelly.pocketcasts.theme.TvTheme
 import au.com.shiftyjelly.pocketcasts.theme.TvTopBarHeight
 import au.com.shiftyjelly.pocketcasts.theme.tvColors
+import com.automattic.eventhorizon.EpisodeViewSourceType
 import androidx.compose.foundation.lazy.grid.itemsIndexed as gridItemsIndexed
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -167,6 +168,7 @@ fun TvSearchScreen(
         detailsEpisode?.let { episode ->
             TvEpisodeInfoModal(
                 episode = episode,
+                source = EpisodeViewSourceType.Search,
                 onDismissRequest = { detailsEpisode = null },
             )
         }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
@@ -67,7 +67,6 @@ import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
 import au.com.shiftyjelly.pocketcasts.theme.TvTheme
 import au.com.shiftyjelly.pocketcasts.theme.TvTopBarHeight
 import au.com.shiftyjelly.pocketcasts.theme.tvColors
-import com.automattic.eventhorizon.EpisodeViewSourceType
 import androidx.compose.foundation.lazy.grid.itemsIndexed as gridItemsIndexed
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -168,7 +167,7 @@ fun TvSearchScreen(
         detailsEpisode?.let { episode ->
             TvEpisodeInfoModal(
                 episode = episode,
-                source = EpisodeViewSourceType.Search,
+                actionContext = TvEpisodeActionContext.SearchResults,
                 onDismissRequest = { detailsEpisode = null },
             )
         }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextScreen.kt
@@ -48,7 +48,6 @@ import au.com.shiftyjelly.pocketcasts.podcasts.TvPodcastDetailsScreen
 import au.com.shiftyjelly.pocketcasts.theme.TvTheme
 import au.com.shiftyjelly.pocketcasts.theme.tvColors
 import au.com.shiftyjelly.pocketcasts.theme.tvTypography
-import com.automattic.eventhorizon.EpisodeViewSourceType
 import java.util.Date
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -185,7 +184,7 @@ private fun UpNextList(
     detailsEpisode?.let { episode ->
         TvEpisodeInfoModal(
             episode = episode,
-            source = EpisodeViewSourceType.UpNext,
+            actionContext = TvEpisodeActionContext.UpNext,
             onDismissRequest = { detailsEpisode = null },
         )
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextScreen.kt
@@ -48,6 +48,7 @@ import au.com.shiftyjelly.pocketcasts.podcasts.TvPodcastDetailsScreen
 import au.com.shiftyjelly.pocketcasts.theme.TvTheme
 import au.com.shiftyjelly.pocketcasts.theme.tvColors
 import au.com.shiftyjelly.pocketcasts.theme.tvTypography
+import com.automattic.eventhorizon.EpisodeViewSourceType
 import java.util.Date
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -184,6 +185,7 @@ private fun UpNextList(
     detailsEpisode?.let { episode ->
         TvEpisodeInfoModal(
             episode = episode,
+            source = EpisodeViewSourceType.UpNext,
             onDismissRequest = { detailsEpisode = null },
         )
     }

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionTypeTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionTypeTest.kt
@@ -1,11 +1,30 @@
 package au.com.shiftyjelly.pocketcasts.component
 
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import com.automattic.eventhorizon.EpisodeViewSourceType
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Test
 
 class TvEpisodeActionTypeTest {
+
+    @Test
+    fun `every action context maps to the matching analytics and event sources`() {
+        val expected = mapOf(
+            TvEpisodeActionContext.PodcastDetails to (SourceView.PODCAST_SCREEN to EpisodeViewSourceType.PodcastScreen),
+            TvEpisodeActionContext.SearchResults to (SourceView.SEARCH_RESULTS to EpisodeViewSourceType.Search),
+            TvEpisodeActionContext.Playlist to (SourceView.FILTERS to EpisodeViewSourceType.Filters),
+            TvEpisodeActionContext.UpNext to (SourceView.UP_NEXT to EpisodeViewSourceType.UpNext),
+            TvEpisodeActionContext.NowPlaying to (SourceView.PLAYER to EpisodeViewSourceType.NowPlaying),
+        )
+
+        assertEquals(TvEpisodeActionContext.entries.toSet(), expected.keys)
+        TvEpisodeActionContext.entries.forEach { context ->
+            val (source, episodeViewSource) = expected.getValue(context)
+            assertEquals(source, context.source)
+            assertEquals(episodeViewSource, context.episodeViewSource)
+        }
+    }
 
     @Test
     fun `podcast details shows played and archive toggles but no go to podcast`() {

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionsViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionsViewModelTest.kt
@@ -6,6 +6,9 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import com.automattic.eventhorizon.EpisodeActionsShownEvent
+import com.automattic.eventhorizon.EpisodeViewSourceType
+import com.automattic.eventhorizon.EventHorizon
 import java.util.Date
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -25,6 +28,7 @@ class TvEpisodeActionsViewModelTest {
     private val episodeManager = mock<EpisodeManager>()
     private val playbackManager = mock<PlaybackManager>()
     private val podcastManager = mock<PodcastManager>()
+    private val eventHorizon = mock<EventHorizon>()
 
     private val episode = PodcastEpisode(
         uuid = "episode-uuid",
@@ -37,9 +41,17 @@ class TvEpisodeActionsViewModelTest {
         episodeManager = episodeManager,
         playbackManager = playbackManager,
         podcastManager = podcastManager,
+        eventHorizon = eventHorizon,
         applicationScope = CoroutineScope(coroutineRule.testDispatcher),
         ioDispatcher = coroutineRule.testDispatcher,
     )
+
+    @Test
+    fun `tracking actions shown records the event with the source`() = runTest {
+        viewModel().trackActionsShown(EpisodeViewSourceType.Search)
+
+        verify(eventHorizon).track(EpisodeActionsShownEvent(source = EpisodeViewSourceType.Search))
+    }
 
     @Test
     fun `play starts playback of the episode`() = runTest {

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeInfoViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeInfoViewModelTest.kt
@@ -43,7 +43,7 @@ class TvEpisodeInfoViewModelTest {
 
     @Test
     fun `tracking shown records the detail shown event with the source`() = runTest {
-        createViewModel().trackShown(EpisodeViewSourceType.PodcastScreen)
+        createViewModel().trackDetailShown(EpisodeViewSourceType.PodcastScreen)
 
         verify(eventHorizon).track(EpisodeDetailShownEvent(source = EpisodeViewSourceType.PodcastScreen))
     }

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeInfoViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeInfoViewModelTest.kt
@@ -7,6 +7,9 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.shownotes.ShowNotesManager
 import au.com.shiftyjelly.pocketcasts.servers.shownotes.ShowNotesState
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import com.automattic.eventhorizon.EpisodeDetailShownEvent
+import com.automattic.eventhorizon.EpisodeViewSourceType
+import com.automattic.eventhorizon.EventHorizon
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -19,6 +22,7 @@ import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyBlocking
 import org.mockito.kotlin.whenever
 
@@ -30,10 +34,18 @@ class TvEpisodeInfoViewModelTest {
 
     private val podcastManager = mock<PodcastManager>()
     private val showNotesManager = mock<ShowNotesManager>()
+    private val eventHorizon = mock<EventHorizon>()
 
     @Test
     fun `initial state is null`() = runTest {
         assertNull(createViewModel().uiState.value)
+    }
+
+    @Test
+    fun `tracking shown records the detail shown event with the source`() = runTest {
+        createViewModel().trackShown(EpisodeViewSourceType.PodcastScreen)
+
+        verify(eventHorizon).track(EpisodeDetailShownEvent(source = EpisodeViewSourceType.PodcastScreen))
     }
 
     @Test
@@ -148,5 +160,6 @@ class TvEpisodeInfoViewModelTest {
     private fun createViewModel() = TvEpisodeInfoViewModel(
         podcastManager = podcastManager,
         showNotesManager = showNotesManager,
+        eventHorizon = eventHorizon,
     )
 }


### PR DESCRIPTION
## Description

Fifth screen-area of the **Android TV → Apple TV analytics parity** program (EventHorizon only): the shared **episode options modal** and **episode details modal**. Stacked on the Up Next analytics PR. Verified event-by-event against the tvOS app.

| Event | EventHorizon class | Properties | Fires when |
|---|---|---|---|
| `episode_actions_shown` | `EpisodeActionsShownEvent` | `source` | the episode options modal (`TvEpisodeActionsModal`) appears |
| `episode_detail_shown` | `EpisodeDetailShownEvent` | `source` | the episode details / show-notes modal (`TvEpisodeInfoModal`) appears |

tvOS fires these bare (`EpisodeRow.swift:292` `.onAppear` and `EpisodeShowNotesView.swift:26` `.task`, no properties), but both Android EventHorizon classes **require** a `source: EpisodeViewSourceType`. We map it from the surface the modal is shown on:

| Surface | `source` |
|---|---|
| Podcast details | `podcast_screen` |
| Playlist | `filters` |
| Up Next | `up_next` |
| Now Playing | `now_playing` |
| Search | `search` |

Wired the established way: `EventHorizon` injected into `TvEpisodeActionsViewModel` (new `trackActionsShown(source)` on the `TvEpisodeActions` interface) and `TvEpisodeInfoViewModel` (new `trackDetailShown(source)`); each fires once from the modal's `LaunchedEffect(episode.uuid)` on appear. The `source` mapping lives in one place — the new `episodeViewSource` column on the `TvEpisodeActionContext` enum — and both modals derive it from the `TvEpisodeActionContext` passed at each of the 5 call sites, so the two events can't drift apart.

### Two decisions worth calling out

**1. `episode_actions_shown` from Search — intentionally fired (diverges from Apple TV).**
Apple TV's Search/Discover results use a *reduced* menu (`DiscoveryEpisodeMenuButtons`) that has no tracking, so Apple TV does **not** emit `episode_actions_shown` there. Android TV reuses the full `TvEpisodeActionsModal` for search results, and we chose to fire the event from Search too, stamped `source=search`. This is a deliberate divergence for completeness of Android's own analytics — noted here so it's not mistaken for an accidental over-fire.

**2. The `source` mapping lives only in the `TvEpisodeActionContext` enum.**
Each context already carried a `SourceView` (used for playback actions); this PR adds an `episodeViewSource: EpisodeViewSourceType` column alongside it for the two new shown-events. Both the actions modal and the details modal read their `source` from the same `TvEpisodeActionContext`, so a screen can't report `episode_actions_shown` and `episode_detail_shown` with mismatched sources, and a future surface only has to add one enum entry. No existing playback `source` changes here — Search already used `TvEpisodeActionContext.SearchResults` (`SourceView.SEARCH_RESULTS`) on the base branch.

### Not in scope: `up_next_queue_reordered`

Apple TV fires `up_next_queue_reordered` from the shared Play Next / Play Last helper, but **only** when the episode is already in Up Next (a move). Android's `PlaybackManager.playNext/playLast` instead unconditionally fire a *different* event (`episode_added_to_up_next`) with no move-detection, and the reorder event is fired nowhere in the Android codebase. Layering iOS's semantics on top would double-count and needs a `slots` value iOS never sends — so it's deliberately deferred as its own decision.

Fixes PCDROID-724 https://linear.app/a8c/issue/PCDROID-724/podcast-details-analytics

## Testing Instructions

1. `./gradlew :tv:installDebug`.
2. From Podcast details / Playlist / Up Next / Now Playing / Search, open an episode's options menu → confirm one `episode_actions_shown` with the matching `source` in `adb logcat`.
3. From the options menu tap **Episode details** → confirm one `episode_detail_shown` with the same `source`.

## Screenshots or Screencast
<img width="567" height="182" alt="SCR-20260814-qgni" src="https://github.com/user-attachments/assets/69fcbb97-1e86-4c7e-9f0b-ddef0d1d6262" />


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md — N/A (analytics only)
- [x] Ensure the linter passes (`./gradlew spotlessApply`)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in localization — N/A
- [x] Any jetpack compose components I added or changed are covered by compose previews — existing previews updated (no-op tracking)
- [x] I have updated (or requested that someone edit) the Event Horizon schema to reflect any new or changed analytics — existing events, no schema change needed

