### PR TITLE
[TV] Return to the welcome screen after signing out

### DIFF
--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvApplication.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvApplication.kt
@@ -5,6 +5,7 @@ import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.utils.TimberDebugTree
+import au.com.shiftyjelly.pocketcasts.utils.log.RxJavaUncaughtExceptionHandling
 import dagger.hilt.android.HiltAndroidApp
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
@@ -29,6 +30,7 @@ class TvApplication :
         if (BuildConfig.DEBUG) {
             Timber.plant(TimberDebugTree())
         }
+        RxJavaUncaughtExceptionHandling.setUp()
         // setup() subscribes the Up Next queue's sync pipeline itself, so there must be no
         // separate UpNextQueue.setupBlocking() call on TV.
         applicationScope.launch {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
@@ -42,6 +42,7 @@ import au.com.shiftyjelly.pocketcasts.upnext.TvUpNextScreen
 fun TvScaffold(
     onLogIn: () -> Unit,
     onCreateAccount: () -> Unit,
+    onSignedOut: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: TvScaffoldViewModel = hiltViewModel(),
 ) {
@@ -131,6 +132,7 @@ fun TvScaffold(
                 onLogOut = {
                     isProfileModalVisible = false
                     viewModel.signOut()
+                    onSignedOut()
                 },
             )
         }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingNavHost.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingNavHost.kt
@@ -28,6 +28,11 @@ fun TvOnboardingNavHost(
     viewModel: TvOnboardingViewModel = hiltViewModel(),
 ) {
     val navController = rememberNavController()
+    val navigateClearingBackStack: (String) -> Unit = { route ->
+        navController.navigate(route) {
+            popUpTo(navController.graph.id) { inclusive = true }
+        }
+    }
     val toastHostState = remember { TvToastHostState() }
     CompositionLocalProvider(LocalTvToastHostState provides toastHostState) {
         Box(modifier = modifier.fillMaxSize()) {
@@ -54,11 +59,7 @@ fun TvOnboardingNavHost(
                 }
                 composable(TvOnboardingRoutes.SIGN_IN) {
                     TvSignInScreen(
-                        onSignInComplete = {
-                            navController.navigate(TvOnboardingRoutes.SYNCING) {
-                                popUpTo(navController.graph.id) { inclusive = true }
-                            }
-                        },
+                        onSignInComplete = { navigateClearingBackStack(TvOnboardingRoutes.SYNCING) },
                     )
                 }
                 composable(TvOnboardingRoutes.SYNCING) {
@@ -74,11 +75,7 @@ fun TvOnboardingNavHost(
                     TvScaffold(
                         onLogIn = { navController.navigate(TvOnboardingRoutes.SIGN_IN) },
                         onCreateAccount = { navController.navigate(TvOnboardingRoutes.CREATE_ACCOUNT) },
-                        onSignedOut = {
-                            navController.navigate(TvOnboardingRoutes.LANDING) {
-                                popUpTo(navController.graph.id) { inclusive = true }
-                            }
-                        },
+                        onSignedOut = { navigateClearingBackStack(TvOnboardingRoutes.LANDING) },
                     )
                 }
             }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingNavHost.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingNavHost.kt
@@ -41,7 +41,6 @@ fun TvOnboardingNavHost(
                         onSignIn = { navController.navigate(TvOnboardingRoutes.SIGN_IN) },
                         onCreateAccount = { navController.navigate(TvOnboardingRoutes.CREATE_ACCOUNT) },
                         onContinueWithoutAccount = {
-                            viewModel.completeOnboarding()
                             navController.navigate(TvOnboardingRoutes.HOME) {
                                 popUpTo(TvOnboardingRoutes.LANDING) { inclusive = true }
                             }
@@ -65,7 +64,6 @@ fun TvOnboardingNavHost(
                 composable(TvOnboardingRoutes.SYNCING) {
                     TvSyncingScreen(
                         onSyncComplete = {
-                            viewModel.completeOnboarding()
                             navController.navigate(TvOnboardingRoutes.HOME) {
                                 popUpTo(TvOnboardingRoutes.SYNCING) { inclusive = true }
                             }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingNavHost.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingNavHost.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -31,6 +32,11 @@ fun TvOnboardingNavHost(
     val navigateClearingBackStack: (String) -> Unit = { route ->
         navController.navigate(route) {
             popUpTo(navController.graph.id) { inclusive = true }
+        }
+    }
+    LaunchedEffect(Unit) {
+        if (viewModel.startDestination == TvOnboardingRoutes.HOME) {
+            viewModel.refreshOnLaunch()
         }
     }
     val toastHostState = remember { TvToastHostState() }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingNavHost.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingNavHost.kt
@@ -74,6 +74,11 @@ fun TvOnboardingNavHost(
                     TvScaffold(
                         onLogIn = { navController.navigate(TvOnboardingRoutes.SIGN_IN) },
                         onCreateAccount = { navController.navigate(TvOnboardingRoutes.CREATE_ACCOUNT) },
+                        onSignedOut = {
+                            navController.navigate(TvOnboardingRoutes.LANDING) {
+                                popUpTo(navController.graph.id) { inclusive = true }
+                            }
+                        },
                     )
                 }
             }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingViewModel.kt
@@ -1,21 +1,17 @@
 package au.com.shiftyjelly.pocketcasts.onboarding
 
 import androidx.lifecycle.ViewModel
-import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
 @HiltViewModel
 class TvOnboardingViewModel @Inject constructor(
-    private val settings: Settings,
+    syncManager: SyncManager,
 ) : ViewModel() {
-    val startDestination: String = if (settings.hasCompletedOnboarding()) {
+    val startDestination: String = if (syncManager.isLoggedIn()) {
         TvOnboardingRoutes.HOME
     } else {
         TvOnboardingRoutes.LANDING
-    }
-
-    fun completeOnboarding() {
-        settings.setHasDoneInitialOnboarding()
     }
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingViewModel.kt
@@ -1,19 +1,30 @@
 package au.com.shiftyjelly.pocketcasts.onboarding
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
+import au.com.shiftyjelly.pocketcasts.repositories.sync.UpNextSyncWorker
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 
 @HiltViewModel
 class TvOnboardingViewModel @Inject constructor(
-    syncManager: SyncManager,
+    @ApplicationContext private val context: Context,
+    private val syncManager: SyncManager,
+    private val podcastManager: PodcastManager,
     settings: Settings,
 ) : ViewModel() {
     val startDestination: String = if (syncManager.isLoggedIn() && !settings.getFullySignedOut()) {
         TvOnboardingRoutes.HOME
     } else {
         TvOnboardingRoutes.LANDING
+    }
+
+    fun refreshOnLaunch() {
+        podcastManager.refreshPodcasts("tv launch")
+        UpNextSyncWorker.enqueue(syncManager, context)
     }
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingViewModel.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.onboarding
 
 import androidx.lifecycle.ViewModel
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -8,8 +9,9 @@ import javax.inject.Inject
 @HiltViewModel
 class TvOnboardingViewModel @Inject constructor(
     syncManager: SyncManager,
+    settings: Settings,
 ) : ViewModel() {
-    val startDestination: String = if (syncManager.isLoggedIn()) {
+    val startDestination: String = if (syncManager.isLoggedIn() && !settings.getFullySignedOut()) {
         TvOnboardingRoutes.HOME
     } else {
         TvOnboardingRoutes.LANDING

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingViewModelTest.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.onboarding
 
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -9,18 +10,28 @@ import org.mockito.kotlin.whenever
 class TvOnboardingViewModelTest {
 
     private val syncManager = mock<SyncManager>()
+    private val settings = mock<Settings>()
 
     @Test
     fun `start destination is landing when signed out`() {
         whenever(syncManager.isLoggedIn()).thenReturn(false)
-        val viewModel = TvOnboardingViewModel(syncManager)
-        assertEquals(TvOnboardingRoutes.LANDING, viewModel.startDestination)
+        whenever(settings.getFullySignedOut()).thenReturn(true)
+        assertEquals(TvOnboardingRoutes.LANDING, viewModel().startDestination)
     }
 
     @Test
-    fun `start destination is home when signed in`() {
+    fun `start destination is home when signed in and not fully signed out`() {
         whenever(syncManager.isLoggedIn()).thenReturn(true)
-        val viewModel = TvOnboardingViewModel(syncManager)
-        assertEquals(TvOnboardingRoutes.HOME, viewModel.startDestination)
+        whenever(settings.getFullySignedOut()).thenReturn(false)
+        assertEquals(TvOnboardingRoutes.HOME, viewModel().startDestination)
     }
+
+    @Test
+    fun `start destination is landing when logged in but sign-out is pending`() {
+        whenever(syncManager.isLoggedIn()).thenReturn(true)
+        whenever(settings.getFullySignedOut()).thenReturn(true)
+        assertEquals(TvOnboardingRoutes.LANDING, viewModel().startDestination)
+    }
+
+    private fun viewModel() = TvOnboardingViewModel(syncManager, settings)
 }

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingViewModelTest.kt
@@ -1,6 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.onboarding
 
+import android.content.Context
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -9,13 +11,14 @@ import org.mockito.kotlin.whenever
 
 class TvOnboardingViewModelTest {
 
+    private val context = mock<Context>()
     private val syncManager = mock<SyncManager>()
+    private val podcastManager = mock<PodcastManager>()
     private val settings = mock<Settings>()
 
     @Test
     fun `start destination is landing when signed out`() {
         whenever(syncManager.isLoggedIn()).thenReturn(false)
-        whenever(settings.getFullySignedOut()).thenReturn(true)
         assertEquals(TvOnboardingRoutes.LANDING, viewModel().startDestination)
     }
 
@@ -33,5 +36,5 @@ class TvOnboardingViewModelTest {
         assertEquals(TvOnboardingRoutes.LANDING, viewModel().startDestination)
     }
 
-    private fun viewModel() = TvOnboardingViewModel(syncManager, settings)
+    private fun viewModel() = TvOnboardingViewModel(context, syncManager, podcastManager, settings)
 }

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingViewModelTest.kt
@@ -1,34 +1,26 @@
 package au.com.shiftyjelly.pocketcasts.onboarding
 
-import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 class TvOnboardingViewModelTest {
 
-    private val settings = mock<Settings>()
+    private val syncManager = mock<SyncManager>()
 
     @Test
-    fun `start destination is landing when onboarding not completed`() {
-        whenever(settings.hasCompletedOnboarding()).thenReturn(false)
-        val viewModel = TvOnboardingViewModel(settings)
+    fun `start destination is landing when signed out`() {
+        whenever(syncManager.isLoggedIn()).thenReturn(false)
+        val viewModel = TvOnboardingViewModel(syncManager)
         assertEquals(TvOnboardingRoutes.LANDING, viewModel.startDestination)
     }
 
     @Test
-    fun `start destination is home when onboarding completed`() {
-        whenever(settings.hasCompletedOnboarding()).thenReturn(true)
-        val viewModel = TvOnboardingViewModel(settings)
+    fun `start destination is home when signed in`() {
+        whenever(syncManager.isLoggedIn()).thenReturn(true)
+        val viewModel = TvOnboardingViewModel(syncManager)
         assertEquals(TvOnboardingRoutes.HOME, viewModel.startDestination)
-    }
-
-    @Test
-    fun `complete onboarding persists to settings`() {
-        val viewModel = TvOnboardingViewModel(settings)
-        viewModel.completeOnboarding()
-        verify(settings).setHasDoneInitialOnboarding()
     }
 }


### PR DESCRIPTION
## Description

Brings the Android TV logout/launch flow to parity with the Apple TV app.

**Problem:** After signing out on Android TV, the next cold launch dropped the user on the Welcome/landing screen inconsistently. The launch destination was gated on `Settings.hasCompletedOnboarding()` (`DONE_INITIAL_ONBOARDING_KEY`), which sign-out wipes via `clearUserPreferences()`. So "browse without account" persisted across launches (skipped Welcome forever) while a sign-out did not — and logging out in-session silently left you on the Home scaffold rather than returning to Welcome.

**Apple TV behavior (parity target):** `AppCoordinator` gates the launch screen purely on `isLoggedIn` (keychain). "Browse without account" is ephemeral in-memory state that never persists, and `logout()` wipes data then immediately returns to the Welcome screen. Every signed-out cold launch shows Welcome.

**This change:**
- `TvOnboardingViewModel.startDestination` now gates on `SyncManager.isLoggedIn()` instead of `Settings.hasCompletedOnboarding()`. The now-vestigial `completeOnboarding()` method and its two `TvOnboardingNavHost` call-sites are removed (nothing else in `:tv` reads the onboarding flag). Browse-without-account is now per-session, matching tvOS.
- `TvScaffold` gains an `onSignedOut` callback; the profile modal's **Log Out** now calls `signOut()` and then navigates back to the Welcome (LANDING) screen, clearing the Home back-stack — mirroring Apple TV's `logout() { … state = .welcome }`.

The async data wipe continues to run in `@ApplicationScope`, unaffected by the navigation/ViewModel teardown.

**Out of scope:** Apple TV's `.dataLossResync` state (fresh DB but keychain still logged in → forced re-sync spinner) has no Android TV equivalent and is not added here.

## Testing Instructions

1. Sign in on the Android TV app and reach the Home screen.
2. Open the profile modal → **Log Out**. Verify you are returned to the Welcome screen immediately.
3. Fully close and cold-launch the app. Verify it opens on the Welcome screen (signed-out) rather than Home.
4. From Welcome, tap **Browse without account**, then fully close and cold-launch again. Verify it returns to Welcome (browsing no longer persists across launches).
5. Sign in, close, and cold-launch. Verify it opens straight into Home (signed-in gate).

## Screenshots or Screencast

https://github.com/user-attachments/assets/84cce1e6-8955-41fb-af43-babc9559a4f6



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) the Event Horizon schema to reflect any new or changed analytics.