### PR TITLE
[TV] Fix search failing on unknown combined-search result types

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/search/ImprovedSearchManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/search/ImprovedSearchManagerImpl.kt
@@ -53,6 +53,8 @@ class ImprovedSearchManagerImpl @Inject constructor(
                     publishedDate = it.publishedDate,
                     duration = it.duration.seconds,
                 )
+
+                CombinedResult.Unknown -> null
             }
         }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/search/ImprovedSearchManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/search/ImprovedSearchManagerImpl.kt
@@ -16,7 +16,7 @@ class ImprovedSearchManagerImpl @Inject constructor(
 ) : ImprovedSearchManager {
     override suspend fun autoCompleteSearch(term: String): List<SearchAutoCompleteItem> {
         val response = autoCompleteSearchService.autoCompleteSearch(query = term, termsLimit = null, podcastsLimit = null)
-        return response.results.map {
+        return response.results.mapNotNull {
             when (it) {
                 is AutoCompleteResult.TermResult -> SearchAutoCompleteItem.Term(term = it.value)
 
@@ -26,6 +26,8 @@ class ImprovedSearchManagerImpl @Inject constructor(
                     author = it.value.author.orEmpty(),
                     isExplicit = it.value.explicit == true,
                 )
+
+                AutoCompleteResult.Unknown -> null
             }
         }
     }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/search/ImprovedSearchManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/search/ImprovedSearchManagerImplTest.kt
@@ -66,4 +66,24 @@ class ImprovedSearchManagerImplTest {
         val episode = results.filterIsInstance<ImprovedSearchResultItem.EpisodeItem>().single()
         assertEquals("Business Daily", episode.podcastTitle)
     }
+
+    @Test
+    fun `combined search drops unknown result types`() = runTest {
+        whenever(combinedSearchService.combinedSearch(any())) doReturn CombinedSearchResponse(
+            results = listOf(
+                CombinedResult.PodcastResult(
+                    uuid = "podcast-uuid",
+                    title = "Big Sugar",
+                    author = "Weekday Fun Productions",
+                    slug = "big-sugar",
+                    explicit = false,
+                ),
+                CombinedResult.Unknown,
+            ),
+        )
+
+        val results = manager.combinedSearch("big sugar")
+
+        assertEquals(listOf("podcast-uuid"), results.map { it.uuid })
+    }
 }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/search/ImprovedSearchManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/search/ImprovedSearchManagerImplTest.kt
@@ -1,16 +1,21 @@
 package au.com.shiftyjelly.pocketcasts.repositories.search
 
 import au.com.shiftyjelly.pocketcasts.models.to.ImprovedSearchResultItem
+import au.com.shiftyjelly.pocketcasts.models.to.SearchAutoCompleteItem
 import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheService
+import au.com.shiftyjelly.pocketcasts.servers.search.AutoCompleteResponse
+import au.com.shiftyjelly.pocketcasts.servers.search.AutoCompleteResult
 import au.com.shiftyjelly.pocketcasts.servers.search.AutoCompleteSearchService
 import au.com.shiftyjelly.pocketcasts.servers.search.CombinedResult
 import au.com.shiftyjelly.pocketcasts.servers.search.CombinedSearchResponse
+import au.com.shiftyjelly.pocketcasts.servers.search.PodcastResultValue
 import java.util.Date
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
@@ -85,5 +90,28 @@ class ImprovedSearchManagerImplTest {
         val results = manager.combinedSearch("big sugar")
 
         assertEquals(listOf("podcast-uuid"), results.map { it.uuid })
+    }
+
+    @Test
+    fun `autocomplete search drops unknown result types`() = runTest {
+        whenever(autoCompleteSearchService.autoCompleteSearch(any(), anyOrNull(), anyOrNull())) doReturn AutoCompleteResponse(
+            results = listOf(
+                AutoCompleteResult.TermResult(value = "big sugar"),
+                AutoCompleteResult.PodcastResult(
+                    value = PodcastResultValue(uuid = "podcast-uuid", title = "Big Sugar"),
+                ),
+                AutoCompleteResult.Unknown,
+            ),
+        )
+
+        val results = manager.autoCompleteSearch("big sugar")
+
+        assertEquals(
+            listOf<SearchAutoCompleteItem>(
+                SearchAutoCompleteItem.Term(term = "big sugar"),
+                SearchAutoCompleteItem.Podcast(uuid = "podcast-uuid", title = "Big Sugar", author = "", isExplicit = false),
+            ),
+            results,
+        )
     }
 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/search/AutoCompleteResponse.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/search/AutoCompleteResponse.kt
@@ -19,10 +19,13 @@ sealed class AutoCompleteResult {
         val value: PodcastResultValue,
     ) : AutoCompleteResult()
 
+    data object Unknown : AutoCompleteResult()
+
     companion object {
         val jsonAdapter = PolymorphicJsonAdapterFactory.of(AutoCompleteResult::class.java, "type")
             .withSubtype(TermResult::class.java, "term")
             .withSubtype(PodcastResult::class.java, "podcast")
+            .withDefaultValue(Unknown)
     }
 }
 

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/search/CombinedSearchResponse.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/search/CombinedSearchResponse.kt
@@ -16,7 +16,7 @@ sealed interface CombinedResult {
         val uuid: String,
         val title: String? = null,
         val author: String? = "",
-        val slug: String,
+        val slug: String = "",
         val explicit: Boolean? = null,
     ) : CombinedResult
 
@@ -33,7 +33,7 @@ sealed interface CombinedResult {
         @Json(name = "podcast_title")
         val podcastTitle: String,
         @Json(name = "podcast_slug")
-        val podcastSlug: String,
+        val podcastSlug: String = "",
     ) : CombinedResult
 
     data object Unknown : CombinedResult

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/search/CombinedSearchResponse.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/search/CombinedSearchResponse.kt
@@ -36,9 +36,12 @@ sealed interface CombinedResult {
         val podcastSlug: String,
     ) : CombinedResult
 
+    data object Unknown : CombinedResult
+
     companion object {
         val jsonAdapter = PolymorphicJsonAdapterFactory.of(CombinedResult::class.java, "type")
             .withSubtype(PodcastResult::class.java, "podcast")
             .withSubtype(EpisodeResult::class.java, "episode")
+            .withDefaultValue(Unknown)
     }
 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/search/CombinedSearchResponse.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/search/CombinedSearchResponse.kt
@@ -16,7 +16,7 @@ sealed interface CombinedResult {
         val uuid: String,
         val title: String? = null,
         val author: String? = "",
-        val slug: String = "",
+        val slug: String? = null,
         val explicit: Boolean? = null,
     ) : CombinedResult
 
@@ -26,14 +26,14 @@ sealed interface CombinedResult {
         val title: String,
         @Json(name = "published_date")
         val publishedDate: Date = Date(),
-        val url: String,
+        val url: String? = null,
         val duration: Long = 0L,
         @Json(name = "podcast_uuid")
         val podcastUuid: String,
         @Json(name = "podcast_title")
         val podcastTitle: String,
         @Json(name = "podcast_slug")
-        val podcastSlug: String = "",
+        val podcastSlug: String? = null,
     ) : CombinedResult
 
     data object Unknown : CombinedResult

--- a/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/search/AutoCompleteResponseTest.kt
+++ b/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/search/AutoCompleteResponseTest.kt
@@ -1,0 +1,28 @@
+package au.com.shiftyjelly.pocketcasts.servers.search
+
+import com.squareup.moshi.Moshi
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AutoCompleteResponseTest {
+    private val adapter = Moshi.Builder()
+        .add(AutoCompleteResult.jsonAdapter)
+        .build()
+        .adapter(AutoCompleteResponse::class.java)
+
+    @Test
+    fun `unknown result types map to Unknown without failing the whole response`() {
+        val response = adapter.fromJson(
+            """
+            {"results":[
+              {"value":"freakonomics","type":"term"},
+              {"value":{"uuid":"p1","title":"Freakonomics Radio"},"type":"podcast"},
+              {"value":"anything","type":"network"}
+            ]}
+            """.trimIndent(),
+        )
+
+        val types = response?.results?.map { it::class.simpleName }
+        assertEquals(listOf("TermResult", "PodcastResult", "Unknown"), types)
+    }
+}

--- a/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/search/CombinedSearchResponseTest.kt
+++ b/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/search/CombinedSearchResponseTest.kt
@@ -1,0 +1,31 @@
+package au.com.shiftyjelly.pocketcasts.servers.search
+
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.adapters.Rfc3339DateJsonAdapter
+import java.util.Date
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CombinedSearchResponseTest {
+    private val adapter = Moshi.Builder()
+        .add(Date::class.java, Rfc3339DateJsonAdapter().nullSafe())
+        .add(CombinedResult.jsonAdapter)
+        .build()
+        .adapter(CombinedSearchResponse::class.java)
+
+    @Test
+    fun `unknown result types map to Unknown without failing the whole response`() {
+        val response = adapter.fromJson(
+            """
+            {"results":[
+              {"uuid":"p1","title":"Freakonomics Radio","slug":"freakonomics-radio","type":"podcast"},
+              {"uuid":"n1","title":"Some Network","type":"network"},
+              {"uuid":"p2","title":"Another Show","slug":"another-show","type":"podcast"}
+            ]}
+            """.trimIndent(),
+        )
+
+        val types = response?.results?.map { it::class.simpleName }
+        assertEquals(listOf("PodcastResult", "Unknown", "PodcastResult"), types)
+    }
+}

--- a/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/search/CombinedSearchResponseTest.kt
+++ b/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/search/CombinedSearchResponseTest.kt
@@ -28,4 +28,20 @@ class CombinedSearchResponseTest {
         val types = response?.results?.map { it::class.simpleName }
         assertEquals(listOf("PodcastResult", "Unknown", "PodcastResult"), types)
     }
+
+    @Test
+    fun `registered podcast and episode subtypes decode alongside the fallback`() {
+        val response = adapter.fromJson(
+            """
+            {"results":[
+              {"uuid":"p1","title":"Freakonomics Radio","slug":"freakonomics-radio","type":"podcast"},
+              {"uuid":"e1","title":"Ep 1","url":"https://example.com/1.mp3","published_date":"2024-01-02T03:04:05Z","podcast_uuid":"p1","podcast_title":"Freakonomics Radio","podcast_slug":"freakonomics-radio","type":"episode"},
+              {"uuid":"n1","title":"Some Network","type":"network"}
+            ]}
+            """.trimIndent(),
+        )
+
+        val types = response?.results?.map { it::class.simpleName }
+        assertEquals(listOf("PodcastResult", "EpisodeResult", "Unknown"), types)
+    }
 }

--- a/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/search/CombinedSearchResponseTest.kt
+++ b/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/search/CombinedSearchResponseTest.kt
@@ -44,4 +44,19 @@ class CombinedSearchResponseTest {
         val types = response?.results?.map { it::class.simpleName }
         assertEquals(listOf("PodcastResult", "EpisodeResult", "Unknown"), types)
     }
+
+    @Test
+    fun `explicit null on unread fields decodes without failing the whole response`() {
+        val response = adapter.fromJson(
+            """
+            {"results":[
+              {"uuid":"p1","title":"Freakonomics Radio","slug":null,"type":"podcast"},
+              {"uuid":"e1","title":"Ep 1","url":null,"published_date":"2024-01-02T03:04:05Z","podcast_uuid":"p1","podcast_title":"Freakonomics Radio","podcast_slug":null,"type":"episode"}
+            ]}
+            """.trimIndent(),
+        )
+
+        val types = response?.results?.map { it::class.simpleName }
+        assertEquals(listOf("PodcastResult", "EpisodeResult"), types)
+    }
 }


### PR DESCRIPTION
## Description

Search hard-fails whenever the `/search/combined` response contains a result the client doesn't recognise. The response is decoded with a Moshi `PolymorphicJsonAdapterFactory` keyed on `type`, registered only for `podcast` and `episode`. The server also returns `"type":"network"` results (podcast networks), and the factory throws `JsonDataException: Expected one of [podcast, episode] for key 'type' but found 'network'` — which aborts decoding of the **entire** response, so a search that returned perfectly good podcasts and episodes surfaces as a generic error with **zero** results.

This reproduces for common queries (e.g. `news`, `search`) and affects **both phone and TV** search (both go through `ImprovedSearchManager.combinedSearch`). Verified live: `POST /search/combined` returns HTTP 200 with valid results, yet the app shows the error state, with this stacktrace:

```
com.squareup.moshi.JsonDataException: Expected one of [podcast, episode] for key 'type' but found 'network'.
  at ...CombinedSearchResponseJsonAdapter.fromJson(CombinedSearchResponse.kt)
```

### Fix

Add an `Unknown` fallback to the polymorphic adapter (`withDefaultValue(Unknown)`) so any unrecognised `type` (today `network`, and any future type) decodes to `CombinedResult.Unknown` instead of throwing. `ImprovedSearchManagerImpl.combinedSearch` already uses `mapNotNull`, so unknown results are simply dropped and the rest of the results render normally.

## Testing Instructions

1. Search for a term that returns a network (e.g. `news`) on phone or TV → results now appear instead of an error.
2. Unit tests: `./gradlew :modules:services:servers:testDebugUnitTest --tests "*CombinedSearchResponseTest*" :modules:services:repositories:testDebugUnitTest --tests "*ImprovedSearchManagerImplTest*"` — covers the adapter tolerating a `network` result and the mapping dropping `Unknown`.

## Screenshots or Screencast
| Before fix | After fix | 
| --- | --- |
| <video src="https://github.com/user-attachments/assets/a2501524-1156-4670-a346-5bb88d44d37e" /> | <video src="https://github.com/user-attachments/assets/1d38dc72-d45f-4ff3-8f72-de5acccadfc3"/> |



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md — N/A (bug fix, no user-facing string)
- [x] Ensure the linter passes (`./gradlew spotlessApply`)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in localization — N/A
- [x] Any jetpack compose components I added or changed are covered by compose previews — N/A
- [x] I have updated (or requested that someone edit) the Event Horizon schema to reflect any new or changed analytics — N/A
