### PR TITLE
[TV] Search suggestions and history

### DIFF
--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -261,6 +261,7 @@
     <string name="tv_banner_discover_more_subtitle">Your next obsession is in here somewhere</string>
     <string name="tv_banner_discover_more_action_title">Discover more shows</string>
     <string name="tv_search_prompt">Podcasts, shows, authors</string>
+    <string name="tv_search_recent">Recent searches</string>
     <string name="tv_search_searching">Searching…</string>
     <string name="tv_search_no_results_title">No results</string>
     <string name="tv_search_no_results_for_title">No results for \“%1$s\”</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -262,6 +262,7 @@
     <string name="tv_banner_discover_more_action_title">Discover more shows</string>
     <string name="tv_search_prompt">Podcasts, shows, authors</string>
     <string name="tv_search_recent">Recent searches</string>
+    <string name="tv_search_featured">Featured</string>
     <string name="tv_search_searching">Searching…</string>
     <string name="tv_search_no_results_title">No results</string>
     <string name="tv_search_no_results_for_title">No results for \“%1$s\”</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -260,8 +260,10 @@
     <string name="tv_banner_discover_more_title">You haven\'t seen the half of it</string>
     <string name="tv_banner_discover_more_subtitle">Your next obsession is in here somewhere</string>
     <string name="tv_banner_discover_more_action_title">Discover more shows</string>
+    <string name="tv_search_prompt">Podcasts, shows, authors</string>
     <string name="tv_search_searching">Searching…</string>
     <string name="tv_search_no_results_title">No results</string>
+    <string name="tv_search_no_results_for_title">No results for \“%1$s\”</string>
     <string name="tv_search_no_results_subtitle">Try more general or different keywords.</string>
     <string name="tv_search_error_subtitle">Check your connection and try again.</string>
     <string name="tv_profile_starred_episodes">Starred Episodes</string>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/ImprovedSearchResultItem.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/ImprovedSearchResultItem.kt
@@ -32,5 +32,6 @@ sealed interface ImprovedSearchResultItem {
         val podcastTitle: String,
         val publishedDate: Date,
         val duration: Duration,
+        val hasVideo: Boolean = false,
     ) : ImprovedSearchResultItem
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/search/ImprovedSearchManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/search/ImprovedSearchManagerImpl.kt
@@ -54,7 +54,7 @@ class ImprovedSearchManagerImpl @Inject constructor(
                     podcastTitle = it.podcastTitle,
                     publishedDate = it.publishedDate,
                     duration = it.duration.seconds,
-                    hasVideo = it.hasVideo,
+                    hasVideo = it.hasVideo == true,
                 )
 
                 CombinedResult.Unknown -> null

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/search/ImprovedSearchManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/search/ImprovedSearchManagerImpl.kt
@@ -54,6 +54,7 @@ class ImprovedSearchManagerImpl @Inject constructor(
                     podcastTitle = it.podcastTitle,
                     publishedDate = it.publishedDate,
                     duration = it.duration.seconds,
+                    hasVideo = it.hasVideo,
                 )
 
                 CombinedResult.Unknown -> null

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/search/CombinedSearchResponse.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/search/CombinedSearchResponse.kt
@@ -34,6 +34,8 @@ sealed interface CombinedResult {
         val podcastTitle: String,
         @Json(name = "podcast_slug")
         val podcastSlug: String? = null,
+        @Json(name = "has_video")
+        val hasVideo: Boolean = false,
     ) : CombinedResult
 
     data object Unknown : CombinedResult

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/search/CombinedSearchResponse.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/search/CombinedSearchResponse.kt
@@ -34,6 +34,8 @@ sealed interface CombinedResult {
         val podcastTitle: String,
         @Json(name = "podcast_slug")
         val podcastSlug: String = "",
+        @Json(name = "has_video")
+        val hasVideo: Boolean = false,
     ) : CombinedResult
 
     data object Unknown : CombinedResult

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/search/CombinedSearchResponse.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/search/CombinedSearchResponse.kt
@@ -35,7 +35,7 @@ sealed interface CombinedResult {
         @Json(name = "podcast_slug")
         val podcastSlug: String? = null,
         @Json(name = "has_video")
-        val hasVideo: Boolean = false,
+        val hasVideo: Boolean? = null,
     ) : CombinedResult
 
     data object Unknown : CombinedResult

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchEpisodeRow.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchEpisodeRow.kt
@@ -18,8 +18,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextOverflow
@@ -30,7 +28,6 @@ import androidx.tv.material3.CardDefaults
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.component.TvArtworkImage
-import au.com.shiftyjelly.pocketcasts.component.TvEpisodeListItemContainer
 import au.com.shiftyjelly.pocketcasts.component.TvTile
 import au.com.shiftyjelly.pocketcasts.localization.helper.TimeHelper
 import au.com.shiftyjelly.pocketcasts.models.to.ImprovedSearchResultItem

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchEpisodeRow.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchEpisodeRow.kt
@@ -42,27 +42,6 @@ import java.util.Date
 import kotlin.time.Duration.Companion.seconds
 
 @Composable
-internal fun TvSearchEpisodeRow(
-    episode: ImprovedSearchResultItem.EpisodeItem,
-    onClick: () -> Unit,
-    onOpenActions: () -> Unit,
-    modifier: Modifier = Modifier,
-    episodeFocusRequester: FocusRequester? = null,
-) {
-    TvEpisodeListItemContainer(
-        onOpenActions = onOpenActions,
-        modifier = modifier,
-    ) { rowModifier ->
-        TvSearchEpisodeCard(
-            episode = episode,
-            onClick = onClick,
-            modifier = rowModifier
-                .then(if (episodeFocusRequester != null) Modifier.focusRequester(episodeFocusRequester) else Modifier),
-        )
-    }
-}
-
-@Composable
 internal fun TvSearchEpisodeCard(
     episode: ImprovedSearchResultItem.EpisodeItem,
     onClick: () -> Unit,
@@ -139,10 +118,10 @@ internal fun TvSearchEpisodeCard(
 
 @Preview(device = Devices.TV_1080p)
 @Composable
-private fun TvSearchEpisodeRowPreview() {
+private fun TvSearchEpisodeCardPreview() {
     TvTheme {
         Box(modifier = Modifier.background(MaterialTheme.tvColors.backgroundSunken).padding(48.dp)) {
-            TvSearchEpisodeRow(
+            TvSearchEpisodeCard(
                 episode = ImprovedSearchResultItem.EpisodeItem(
                     uuid = "episode-1",
                     title = "The real cost of sugar and how it shapes the food we eat",
@@ -152,7 +131,6 @@ private fun TvSearchEpisodeRowPreview() {
                     duration = 1440.seconds,
                 ),
                 onClick = {},
-                onOpenActions = {},
             )
         }
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchField.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchField.kt
@@ -57,6 +57,7 @@ internal fun TvSearchField(
     query: String,
     onQueryChange: (String) -> Unit,
     modifier: Modifier = Modifier,
+    onEditingChange: (Boolean) -> Unit = {},
 ) {
     var editing by remember { mutableStateOf(false) }
     var restoreRestFocus by remember { mutableStateOf(false) }
@@ -66,6 +67,7 @@ internal fun TvSearchField(
     val keyboardController = LocalSoftwareKeyboardController.current
 
     LaunchedEffect(editing) {
+        onEditingChange(editing)
         if (editing) {
             runCatching { fieldFocusRequester.requestFocus() }
             keyboardController?.show()

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchField.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchField.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -65,9 +66,10 @@ internal fun TvSearchField(
     val restFocusRequester = remember { FocusRequester() }
     val focusManager = LocalFocusManager.current
     val keyboardController = LocalSoftwareKeyboardController.current
+    val currentOnEditingChange by rememberUpdatedState(onEditingChange)
 
     LaunchedEffect(editing) {
-        onEditingChange(editing)
+        currentOnEditingChange(editing)
         if (editing) {
             runCatching { fieldFocusRequester.requestFocus() }
             keyboardController?.show()

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchField.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchField.kt
@@ -175,7 +175,7 @@ private fun TvSearchFieldContent(
         Box(contentAlignment = Alignment.CenterStart) {
             if (query.isEmpty()) {
                 Text(
-                    text = stringResource(LR.string.search),
+                    text = stringResource(LR.string.tv_search_prompt),
                     style = MaterialTheme.tvTypography.title3,
                     color = MaterialTheme.tvColors.textSecondary,
                 )

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
@@ -238,10 +238,7 @@ private fun TvSearchContent(
         if (showSuggestions) {
             TvSearchSuggestions(
                 suggestions = suggestions,
-                onSuggestionSelect = { term ->
-                    suggestionsFocused = false
-                    onSuggestionSelect(term)
-                },
+                onSuggestionSelect = onSuggestionSelect,
                 modifier = Modifier.onFocusChanged { suggestionsFocused = it.hasFocus },
             )
             Spacer(modifier = Modifier.height(24.dp))
@@ -428,10 +425,14 @@ private fun TvSearchResults(
         )
 
         TvSearchFilter.Podcasts -> if (results.podcasts.isEmpty()) {
-            TvSearchMessage(
-                title = stringResource(LR.string.tv_search_no_results_for_title, searchTerm),
-                subtitle = stringResource(LR.string.tv_search_no_results_subtitle),
-            )
+            if (results.isPartial) {
+                TvSearchLoading()
+            } else {
+                TvSearchMessage(
+                    title = stringResource(LR.string.tv_search_no_results_for_title, searchTerm),
+                    subtitle = stringResource(LR.string.tv_search_no_results_subtitle),
+                )
+            }
         } else {
             TvPodcastGridScaffold(
                 itemKeys = results.podcasts.map(ImprovedSearchResultItem.PodcastItem::uuid),
@@ -451,10 +452,14 @@ private fun TvSearchResults(
         }
 
         TvSearchFilter.Episodes -> if (results.episodes.isEmpty()) {
-            TvSearchMessage(
-                title = stringResource(LR.string.tv_search_no_results_for_title, searchTerm),
-                subtitle = stringResource(LR.string.tv_search_no_results_subtitle),
-            )
+            if (results.isPartial) {
+                TvSearchLoading()
+            } else {
+                TvSearchMessage(
+                    title = stringResource(LR.string.tv_search_no_results_for_title, searchTerm),
+                    subtitle = stringResource(LR.string.tv_search_no_results_subtitle),
+                )
+            }
         } else {
             TvSearchEpisodeGrid(
                 episodes = results.episodes,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
@@ -234,7 +235,19 @@ private fun TvSearchContent(
             Spacer(modifier = Modifier.height(24.dp))
         }
 
-        if (searchState !is TvSearchState.Idle && !showSuggestions) {
+        if (showSuggestions) {
+            TvSearchSuggestions(
+                suggestions = suggestions,
+                onSuggestionSelect = { term ->
+                    suggestionsFocused = false
+                    onSuggestionSelect(term)
+                },
+                modifier = Modifier.onFocusChanged { suggestionsFocused = it.hasFocus },
+            )
+            Spacer(modifier = Modifier.height(24.dp))
+        }
+
+        if (searchState !is TvSearchState.Idle) {
             TvSearchFilters(
                 selected = filter,
                 onFilterSelect = onFilterSelect,
@@ -248,17 +261,6 @@ private fun TvSearchContent(
                 .fillMaxWidth()
                 .weight(1f),
         ) {
-            if (showSuggestions) {
-                TvSearchSuggestions(
-                    suggestions = suggestions,
-                    onSuggestionSelect = { term ->
-                        suggestionsFocused = false
-                        onSuggestionSelect(term)
-                    },
-                    modifier = Modifier.onFocusChanged { suggestionsFocused = it.hasFocus },
-                )
-                return@Box
-            }
             when (searchState) {
                 is TvSearchState.Idle -> TvSearchIdle(
                     history = history,
@@ -655,21 +657,19 @@ private fun TvSearchSuggestions(
     onSuggestionSelect: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    LazyColumn(
-        modifier = modifier.fillMaxSize(),
-        contentPadding = PaddingValues(horizontal = ContentHorizontalPadding, vertical = 8.dp),
-        verticalArrangement = Arrangement.spacedBy(4.dp),
+    LazyRow(
+        modifier = modifier.fillMaxWidth(),
+        contentPadding = ContentPadding,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         items(suggestions) { term ->
-            TvTile(
-                onClick = { onSuggestionSelect(term) },
-                modifier = Modifier.fillMaxWidth(),
-            ) {
+            TvTile(onClick = { onSuggestionSelect(term) }) {
                 Text(
                     text = term,
                     style = MaterialTheme.tvTypography.body,
                     color = MaterialTheme.tvColors.textPrimary,
-                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+                    maxLines = 1,
+                    modifier = Modifier.padding(horizontal = 20.dp, vertical = 12.dp),
                 )
             }
         }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
@@ -78,7 +78,8 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 private val ContentHorizontalPadding = 48.dp
 private val ContentPadding = PaddingValues(horizontal = ContentHorizontalPadding)
-private const val TOP_RESULTS_PREVIEW_COUNT = 6
+private const val SEARCH_ROW_LIMIT = 10
+private val SearchEpisodeCardWidth = 360.dp
 private const val EPISODE_GRID_COLUMNS = 2
 
 @Composable
@@ -462,7 +463,6 @@ private fun TvSearchTopResults(
     restoreFocusTrigger: Int,
 ) {
     val restoreFocusRequester = remember { FocusRequester() }
-    val hasPodcasts = podcasts.isNotEmpty()
     var isInitialComposition by remember { mutableStateOf(true) }
     LaunchedEffect(restoreFocusTrigger) {
         if (isInitialComposition) {
@@ -472,39 +472,71 @@ private fun TvSearchTopResults(
         }
     }
 
+    val featured = episodes.filter { it.hasVideo }.take(SEARCH_ROW_LIMIT)
+    val otherEpisodes = episodes.filterNot { it.hasVideo }.take(SEARCH_ROW_LIMIT)
+    val topPodcasts = podcasts.take(SEARCH_ROW_LIMIT)
+    val featuredFirst = featured.isNotEmpty()
+    val episodesFirst = !featuredFirst && otherEpisodes.isNotEmpty()
+    val podcastsFirst = !featuredFirst && !episodesFirst
+
     LazyColumn(modifier = Modifier.fillMaxSize()) {
-        if (hasPodcasts) {
+        item { Spacer(modifier = Modifier.height(8.dp)) }
+        if (featured.isNotEmpty()) {
+            item {
+                TvSearchEpisodeCarousel(
+                    title = stringResource(LR.string.tv_search_featured),
+                    episodes = featured,
+                    onPlayEpisode = onPlayEpisode,
+                    onOpenEpisodeActions = onOpenEpisodeActions,
+                    focusRequester = restoreFocusRequester.takeIf { featuredFirst },
+                )
+            }
+        }
+        if (otherEpisodes.isNotEmpty()) {
+            item { Spacer(modifier = Modifier.height(24.dp)) }
+            item {
+                TvSearchEpisodeCarousel(
+                    title = stringResource(LR.string.episodes),
+                    episodes = otherEpisodes,
+                    onPlayEpisode = onPlayEpisode,
+                    onOpenEpisodeActions = onOpenEpisodeActions,
+                    focusRequester = restoreFocusRequester.takeIf { episodesFirst },
+                )
+            }
+        }
+        if (topPodcasts.isNotEmpty()) {
+            item { Spacer(modifier = Modifier.height(24.dp)) }
             tvSearchPodcastsRow(
-                podcasts = podcasts,
+                podcasts = topPodcasts,
                 onOpenPodcast = onOpenPodcast,
-                focusRequester = restoreFocusRequester,
+                focusRequester = restoreFocusRequester.takeIf { podcastsFirst },
             )
         }
-        if (episodes.isNotEmpty()) {
-            item {
-                Spacer(modifier = Modifier.height(24.dp))
-                TvSectionTitle(
-                    title = stringResource(LR.string.episodes),
-                    modifier = Modifier
-                        .padding(ContentPadding)
-                        .padding(bottom = 17.dp),
-                )
-            }
-            itemsIndexed(
-                items = episodes.take(TOP_RESULTS_PREVIEW_COUNT),
-                key = { _, episode -> episode.uuid },
-            ) { index, episode ->
-                TvSearchEpisodeRow(
-                    episode = episode,
-                    onClick = { onPlayEpisode(episode) },
-                    onOpenActions = { onOpenEpisodeActions(episode) },
-                    modifier = Modifier.padding(ContentPadding),
-                    episodeFocusRequester = if (!hasPodcasts && index == 0) restoreFocusRequester else null,
-                )
-                Spacer(modifier = Modifier.height(12.dp))
-            }
-        }
         item { Spacer(modifier = Modifier.height(40.dp)) }
+    }
+}
+
+@Composable
+private fun TvSearchEpisodeCarousel(
+    title: String,
+    episodes: List<ImprovedSearchResultItem.EpisodeItem>,
+    onPlayEpisode: (ImprovedSearchResultItem.EpisodeItem) -> Unit,
+    onOpenEpisodeActions: (ImprovedSearchResultItem.EpisodeItem) -> Unit,
+    focusRequester: FocusRequester?,
+) {
+    TvRow(
+        title = title,
+        items = episodes,
+        contentPadding = ContentPadding,
+        key = ImprovedSearchResultItem.EpisodeItem::uuid,
+        focusRequester = focusRequester,
+    ) { episode ->
+        TvSearchEpisodeCard(
+            episode = episode,
+            onClick = { onPlayEpisode(episode) },
+            onLongClick = { onOpenEpisodeActions(episode) },
+            modifier = Modifier.width(SearchEpisodeCardWidth),
+        )
     }
 }
 
@@ -570,7 +602,7 @@ private fun TvSearchEpisodeGrid(
 private fun LazyListScope.tvSearchPodcastsRow(
     podcasts: List<ImprovedSearchResultItem.PodcastItem>,
     onOpenPodcast: (String) -> Unit,
-    focusRequester: FocusRequester,
+    focusRequester: FocusRequester?,
 ) {
     item {
         TvRow(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
@@ -27,6 +28,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
@@ -39,6 +41,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.component.LocalOpenNowPlaying
 import au.com.shiftyjelly.pocketcasts.component.LocalTvToastHostState
 import au.com.shiftyjelly.pocketcasts.component.TvCategoryTile
@@ -67,6 +70,7 @@ import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
 import au.com.shiftyjelly.pocketcasts.theme.TvTheme
 import au.com.shiftyjelly.pocketcasts.theme.TvTopBarHeight
 import au.com.shiftyjelly.pocketcasts.theme.tvColors
+import au.com.shiftyjelly.pocketcasts.theme.tvTypography
 import androidx.compose.foundation.lazy.grid.itemsIndexed as gridItemsIndexed
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -229,10 +233,7 @@ private fun TvSearchContent(
                     restoreFocusTrigger = restoreFocusTrigger,
                 )
 
-                is TvSearchState.Searching -> LoadingView(
-                    color = MaterialTheme.tvColors.textPrimary,
-                    modifier = Modifier.fillMaxSize(),
-                )
+                is TvSearchState.Searching -> TvSearchLoading()
 
                 is TvSearchState.Error -> TvSearchMessage(
                     title = stringResource(LR.string.error_generic_message),
@@ -242,13 +243,14 @@ private fun TvSearchContent(
                 )
 
                 is TvSearchState.NoResults -> TvSearchMessage(
-                    title = stringResource(LR.string.tv_search_no_results_title),
+                    title = stringResource(LR.string.tv_search_no_results_for_title, query.trim()),
                     subtitle = stringResource(LR.string.tv_search_no_results_subtitle),
                 )
 
                 is TvSearchState.Results -> TvSearchResults(
                     results = searchState,
                     filter = filter,
+                    searchTerm = query.trim(),
                     onOpenPodcast = onOpenPodcast,
                     onPlayEpisode = onPlayEpisode,
                     onOpenEpisodeActions = onOpenEpisodeActions,
@@ -330,6 +332,7 @@ private fun TvSearchDiscover(
 private fun TvSearchResults(
     results: TvSearchState.Results,
     filter: TvSearchFilter,
+    searchTerm: String,
     onOpenPodcast: (String) -> Unit,
     onPlayEpisode: (ImprovedSearchResultItem.EpisodeItem) -> Unit,
     onOpenEpisodeActions: (ImprovedSearchResultItem.EpisodeItem) -> Unit,
@@ -347,7 +350,7 @@ private fun TvSearchResults(
 
         TvSearchFilter.Podcasts -> if (results.podcasts.isEmpty()) {
             TvSearchMessage(
-                title = stringResource(LR.string.tv_search_no_results_title),
+                title = stringResource(LR.string.tv_search_no_results_for_title, searchTerm),
                 subtitle = stringResource(LR.string.tv_search_no_results_subtitle),
             )
         } else {
@@ -370,7 +373,7 @@ private fun TvSearchResults(
 
         TvSearchFilter.Episodes -> if (results.episodes.isEmpty()) {
             TvSearchMessage(
-                title = stringResource(LR.string.tv_search_no_results_title),
+                title = stringResource(LR.string.tv_search_no_results_for_title, searchTerm),
                 subtitle = stringResource(LR.string.tv_search_no_results_subtitle),
             )
         } else {
@@ -536,6 +539,25 @@ private fun TvSearchMessage(
         onAction = onAction,
         modifier = Modifier.fillMaxSize(),
     )
+}
+
+@Composable
+private fun TvSearchLoading() {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        LoadingView(
+            color = MaterialTheme.tvColors.textPrimary,
+            modifier = Modifier.size(48.dp),
+        )
+        Text(
+            text = stringResource(LR.string.tv_search_searching),
+            style = MaterialTheme.tvTypography.body,
+            color = MaterialTheme.tvColors.textSecondary,
+        )
+    }
 }
 
 @Preview(device = Devices.TV_1080p)

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -55,7 +54,6 @@ import au.com.shiftyjelly.pocketcasts.component.TvPodcastGridScaffold
 import au.com.shiftyjelly.pocketcasts.component.TvPodcastTile
 import au.com.shiftyjelly.pocketcasts.component.TvPodcastTileDefaults
 import au.com.shiftyjelly.pocketcasts.component.TvRow
-import au.com.shiftyjelly.pocketcasts.component.TvSectionTitle
 import au.com.shiftyjelly.pocketcasts.component.TvTile
 import au.com.shiftyjelly.pocketcasts.component.tvFocusInactiveWhen
 import au.com.shiftyjelly.pocketcasts.compose.loading.LoadingView
@@ -130,7 +128,11 @@ fun TvSearchScreen(
             history = history,
             onHistorySelect = viewModel::onQueryChange,
             suggestions = suggestions,
-            onSuggestionSelect = viewModel::onQueryChange,
+            onSuggestionSelect = { term ->
+                viewModel.saveSearchTerm(term)
+                viewModel.onQueryChange(term)
+            },
+            onSaveSearch = viewModel::saveSearchTerm,
             restoreFocusTrigger = restoreFocusTrigger,
             modifier = Modifier
                 .fillMaxSize()
@@ -205,6 +207,7 @@ private fun TvSearchContent(
     onHistorySelect: (String) -> Unit = {},
     suggestions: List<String> = emptyList(),
     onSuggestionSelect: (String) -> Unit = {},
+    onSaveSearch: (String) -> Unit = {},
     restoreFocusTrigger: Int = 0,
 ) {
     val searchFieldFocusRequester = remember { FocusRequester() }
@@ -221,7 +224,12 @@ private fun TvSearchContent(
             TvSearchField(
                 query = query,
                 onQueryChange = onQueryChange,
-                onEditingChange = { isEditing = it },
+                onEditingChange = { editing ->
+                    if (!editing && isEditing && query.isNotBlank()) {
+                        onSaveSearch(query)
+                    }
+                    isEditing = editing
+                },
                 modifier = Modifier.focusRequester(searchFieldFocusRequester),
             )
             Spacer(modifier = Modifier.height(24.dp))
@@ -244,7 +252,10 @@ private fun TvSearchContent(
             if (showSuggestions) {
                 TvSearchSuggestions(
                     suggestions = suggestions,
-                    onSuggestionSelect = onSuggestionSelect,
+                    onSuggestionSelect = { term ->
+                        suggestionsFocused = false
+                        onSuggestionSelect(term)
+                    },
                     modifier = Modifier.onFocusChanged { suggestionsFocused = it.hasFocus },
                 )
                 return@Box

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
@@ -235,7 +236,19 @@ private fun TvSearchContent(
             Spacer(modifier = Modifier.height(24.dp))
         }
 
-        if (searchState !is TvSearchState.Idle && !showSuggestions) {
+        if (showSuggestions) {
+            TvSearchSuggestions(
+                suggestions = suggestions,
+                onSuggestionSelect = { term ->
+                    suggestionsFocused = false
+                    onSuggestionSelect(term)
+                },
+                modifier = Modifier.onFocusChanged { suggestionsFocused = it.hasFocus },
+            )
+            Spacer(modifier = Modifier.height(24.dp))
+        }
+
+        if (searchState !is TvSearchState.Idle) {
             TvSearchFilters(
                 selected = filter,
                 onFilterSelect = onFilterSelect,
@@ -249,17 +262,6 @@ private fun TvSearchContent(
                 .fillMaxWidth()
                 .weight(1f),
         ) {
-            if (showSuggestions) {
-                TvSearchSuggestions(
-                    suggestions = suggestions,
-                    onSuggestionSelect = { term ->
-                        suggestionsFocused = false
-                        onSuggestionSelect(term)
-                    },
-                    modifier = Modifier.onFocusChanged { suggestionsFocused = it.hasFocus },
-                )
-                return@Box
-            }
             when (searchState) {
                 is TvSearchState.Idle -> TvSearchIdle(
                     history = history,
@@ -657,21 +659,19 @@ private fun TvSearchSuggestions(
     onSuggestionSelect: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    LazyColumn(
-        modifier = modifier.fillMaxSize(),
-        contentPadding = PaddingValues(horizontal = ContentHorizontalPadding, vertical = 8.dp),
-        verticalArrangement = Arrangement.spacedBy(4.dp),
+    LazyRow(
+        modifier = modifier.fillMaxWidth(),
+        contentPadding = ContentPadding,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         items(suggestions) { term ->
-            TvTile(
-                onClick = { onSuggestionSelect(term) },
-                modifier = Modifier.fillMaxWidth(),
-            ) {
+            TvTile(onClick = { onSuggestionSelect(term) }) {
                 Text(
                     text = term,
                     style = MaterialTheme.tvTypography.body,
                     color = MaterialTheme.tvColors.textPrimary,
-                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+                    maxLines = 1,
+                    modifier = Modifier.padding(horizontal = 20.dp, vertical = 12.dp),
                 )
             }
         }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
@@ -92,6 +92,7 @@ fun TvSearchScreen(
     val categories by viewModel.categories.collectAsStateWithLifecycle()
     val discoverRows by viewModel.discoverRows.collectAsStateWithLifecycle()
     val suggestions by viewModel.suggestions.collectAsStateWithLifecycle()
+    val history by viewModel.history.collectAsStateWithLifecycle()
     val actionsEpisode by viewModel.actionsEpisode.collectAsStateWithLifecycle()
 
     var openedPodcastUuid by rememberSaveable { mutableStateOf<String?>(null) }
@@ -125,6 +126,8 @@ fun TvSearchScreen(
             onOpenCategory = { openedCategory = TvOpenedCategory(it.id, it.name, it.source) },
             onPlayEpisode = viewModel::playEpisode,
             onOpenEpisodeActions = viewModel::openEpisodeActions,
+            history = history,
+            onHistorySelect = viewModel::onQueryChange,
             suggestions = suggestions,
             onSuggestionSelect = viewModel::onQueryChange,
             restoreFocusTrigger = restoreFocusTrigger,
@@ -197,6 +200,8 @@ private fun TvSearchContent(
     onPlayEpisode: (ImprovedSearchResultItem.EpisodeItem) -> Unit,
     onOpenEpisodeActions: (ImprovedSearchResultItem.EpisodeItem) -> Unit,
     modifier: Modifier = Modifier,
+    history: List<String> = emptyList(),
+    onHistorySelect: (String) -> Unit = {},
     suggestions: List<String> = emptyList(),
     onSuggestionSelect: (String) -> Unit = {},
     restoreFocusTrigger: Int = 0,
@@ -244,9 +249,11 @@ private fun TvSearchContent(
                 return@Box
             }
             when (searchState) {
-                is TvSearchState.Idle -> TvSearchDiscover(
+                is TvSearchState.Idle -> TvSearchIdle(
+                    history = history,
                     categories = categories,
                     discoverRows = discoverRows,
+                    onHistorySelect = onHistorySelect,
                     onOpenPodcast = onOpenPodcast,
                     onOpenCategory = onOpenCategory,
                     restoreFocusTrigger = restoreFocusTrigger,
@@ -281,12 +288,53 @@ private fun TvSearchContent(
 }
 
 @Composable
+private fun TvSearchIdle(
+    history: List<String>,
+    categories: List<DiscoverCategory>,
+    discoverRows: List<TvDiscoverRow>,
+    onHistorySelect: (String) -> Unit,
+    onOpenPodcast: (String) -> Unit,
+    onOpenCategory: (DiscoverCategory) -> Unit,
+    restoreFocusTrigger: Int,
+) {
+    Column(modifier = Modifier.fillMaxSize()) {
+        if (history.isNotEmpty()) {
+            TvRow(
+                title = stringResource(LR.string.tv_search_recent),
+                items = history,
+                contentPadding = ContentPadding,
+                key = { it },
+            ) { term ->
+                TvTile(onClick = { onHistorySelect(term) }) {
+                    Text(
+                        text = term,
+                        style = MaterialTheme.tvTypography.body,
+                        color = MaterialTheme.tvColors.textPrimary,
+                        modifier = Modifier.padding(horizontal = 20.dp, vertical = 12.dp),
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.height(24.dp))
+        }
+        TvSearchDiscover(
+            categories = categories,
+            discoverRows = discoverRows,
+            onOpenPodcast = onOpenPodcast,
+            onOpenCategory = onOpenCategory,
+            restoreFocusTrigger = restoreFocusTrigger,
+            modifier = Modifier.weight(1f),
+        )
+    }
+}
+
+@Composable
 private fun TvSearchDiscover(
     categories: List<DiscoverCategory>,
     discoverRows: List<TvDiscoverRow>,
     onOpenPodcast: (String) -> Unit,
     onOpenCategory: (DiscoverCategory) -> Unit,
     restoreFocusTrigger: Int,
+    modifier: Modifier = Modifier,
 ) {
     val categoryOffset = if (categories.isNotEmpty()) 1 else 0
     val rowCount = categoryOffset + discoverRows.size
@@ -302,7 +350,7 @@ private fun TvSearchDiscover(
         }
     }
 
-    LazyColumn(modifier = Modifier.fillMaxSize()) {
+    LazyColumn(modifier = modifier.fillMaxSize()) {
         if (categories.isNotEmpty()) {
             item {
                 Box(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
@@ -92,6 +92,7 @@ fun TvSearchScreen(
     val categories by viewModel.categories.collectAsStateWithLifecycle()
     val discoverRows by viewModel.discoverRows.collectAsStateWithLifecycle()
     val suggestions by viewModel.suggestions.collectAsStateWithLifecycle()
+    val history by viewModel.history.collectAsStateWithLifecycle()
     val actionsEpisode by viewModel.actionsEpisode.collectAsStateWithLifecycle()
 
     var openedPodcastUuid by rememberSaveable { mutableStateOf<String?>(null) }
@@ -125,6 +126,8 @@ fun TvSearchScreen(
             onOpenCategory = { openedCategory = TvOpenedCategory(it.id, it.name, it.source) },
             onPlayEpisode = viewModel::playEpisode,
             onOpenEpisodeActions = viewModel::openEpisodeActions,
+            history = history,
+            onHistorySelect = viewModel::onQueryChange,
             suggestions = suggestions,
             onSuggestionSelect = viewModel::onQueryChange,
             restoreFocusTrigger = restoreFocusTrigger,
@@ -196,6 +199,8 @@ private fun TvSearchContent(
     onPlayEpisode: (ImprovedSearchResultItem.EpisodeItem) -> Unit,
     onOpenEpisodeActions: (ImprovedSearchResultItem.EpisodeItem) -> Unit,
     modifier: Modifier = Modifier,
+    history: List<String> = emptyList(),
+    onHistorySelect: (String) -> Unit = {},
     suggestions: List<String> = emptyList(),
     onSuggestionSelect: (String) -> Unit = {},
     restoreFocusTrigger: Int = 0,
@@ -243,9 +248,11 @@ private fun TvSearchContent(
                 return@Box
             }
             when (searchState) {
-                is TvSearchState.Idle -> TvSearchDiscover(
+                is TvSearchState.Idle -> TvSearchIdle(
+                    history = history,
                     categories = categories,
                     discoverRows = discoverRows,
+                    onHistorySelect = onHistorySelect,
                     onOpenPodcast = onOpenPodcast,
                     onOpenCategory = onOpenCategory,
                     restoreFocusTrigger = restoreFocusTrigger,
@@ -280,12 +287,53 @@ private fun TvSearchContent(
 }
 
 @Composable
+private fun TvSearchIdle(
+    history: List<String>,
+    categories: List<DiscoverCategory>,
+    discoverRows: List<TvDiscoverRow>,
+    onHistorySelect: (String) -> Unit,
+    onOpenPodcast: (String) -> Unit,
+    onOpenCategory: (DiscoverCategory) -> Unit,
+    restoreFocusTrigger: Int,
+) {
+    Column(modifier = Modifier.fillMaxSize()) {
+        if (history.isNotEmpty()) {
+            TvRow(
+                title = stringResource(LR.string.tv_search_recent),
+                items = history,
+                contentPadding = ContentPadding,
+                key = { it },
+            ) { term ->
+                TvTile(onClick = { onHistorySelect(term) }) {
+                    Text(
+                        text = term,
+                        style = MaterialTheme.tvTypography.body,
+                        color = MaterialTheme.tvColors.textPrimary,
+                        modifier = Modifier.padding(horizontal = 20.dp, vertical = 12.dp),
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.height(24.dp))
+        }
+        TvSearchDiscover(
+            categories = categories,
+            discoverRows = discoverRows,
+            onOpenPodcast = onOpenPodcast,
+            onOpenCategory = onOpenCategory,
+            restoreFocusTrigger = restoreFocusTrigger,
+            modifier = Modifier.weight(1f),
+        )
+    }
+}
+
+@Composable
 private fun TvSearchDiscover(
     categories: List<DiscoverCategory>,
     discoverRows: List<TvDiscoverRow>,
     onOpenPodcast: (String) -> Unit,
     onOpenCategory: (DiscoverCategory) -> Unit,
     restoreFocusTrigger: Int,
+    modifier: Modifier = Modifier,
 ) {
     val categoryOffset = if (categories.isNotEmpty()) 1 else 0
     val rowCount = categoryOffset + discoverRows.size
@@ -301,7 +349,7 @@ private fun TvSearchDiscover(
         }
     }
 
-    LazyColumn(modifier = Modifier.fillMaxSize()) {
+    LazyColumn(modifier = modifier.fillMaxSize()) {
         if (categories.isNotEmpty()) {
             item {
                 Box(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
@@ -27,6 +28,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
@@ -39,6 +41,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.component.LocalOpenNowPlaying
 import au.com.shiftyjelly.pocketcasts.component.LocalTvToastHostState
 import au.com.shiftyjelly.pocketcasts.component.TvCategoryTile
@@ -67,6 +70,7 @@ import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
 import au.com.shiftyjelly.pocketcasts.theme.TvTheme
 import au.com.shiftyjelly.pocketcasts.theme.TvTopBarHeight
 import au.com.shiftyjelly.pocketcasts.theme.tvColors
+import au.com.shiftyjelly.pocketcasts.theme.tvTypography
 import androidx.compose.foundation.lazy.grid.itemsIndexed as gridItemsIndexed
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -228,10 +232,7 @@ private fun TvSearchContent(
                     restoreFocusTrigger = restoreFocusTrigger,
                 )
 
-                is TvSearchState.Searching -> LoadingView(
-                    color = MaterialTheme.tvColors.textPrimary,
-                    modifier = Modifier.fillMaxSize(),
-                )
+                is TvSearchState.Searching -> TvSearchLoading()
 
                 is TvSearchState.Error -> TvSearchMessage(
                     title = stringResource(LR.string.error_generic_message),
@@ -241,13 +242,14 @@ private fun TvSearchContent(
                 )
 
                 is TvSearchState.NoResults -> TvSearchMessage(
-                    title = stringResource(LR.string.tv_search_no_results_title),
+                    title = stringResource(LR.string.tv_search_no_results_for_title, query.trim()),
                     subtitle = stringResource(LR.string.tv_search_no_results_subtitle),
                 )
 
                 is TvSearchState.Results -> TvSearchResults(
                     results = searchState,
                     filter = filter,
+                    searchTerm = query.trim(),
                     onOpenPodcast = onOpenPodcast,
                     onPlayEpisode = onPlayEpisode,
                     onOpenEpisodeActions = onOpenEpisodeActions,
@@ -328,6 +330,7 @@ private fun TvSearchDiscover(
 private fun TvSearchResults(
     results: TvSearchState.Results,
     filter: TvSearchFilter,
+    searchTerm: String,
     onOpenPodcast: (String) -> Unit,
     onPlayEpisode: (ImprovedSearchResultItem.EpisodeItem) -> Unit,
     onOpenEpisodeActions: (ImprovedSearchResultItem.EpisodeItem) -> Unit,
@@ -345,7 +348,7 @@ private fun TvSearchResults(
 
         TvSearchFilter.Podcasts -> if (results.podcasts.isEmpty()) {
             TvSearchMessage(
-                title = stringResource(LR.string.tv_search_no_results_title),
+                title = stringResource(LR.string.tv_search_no_results_for_title, searchTerm),
                 subtitle = stringResource(LR.string.tv_search_no_results_subtitle),
             )
         } else {
@@ -368,7 +371,7 @@ private fun TvSearchResults(
 
         TvSearchFilter.Episodes -> if (results.episodes.isEmpty()) {
             TvSearchMessage(
-                title = stringResource(LR.string.tv_search_no_results_title),
+                title = stringResource(LR.string.tv_search_no_results_for_title, searchTerm),
                 subtitle = stringResource(LR.string.tv_search_no_results_subtitle),
             )
         } else {
@@ -534,6 +537,25 @@ private fun TvSearchMessage(
         onAction = onAction,
         modifier = Modifier.fillMaxSize(),
     )
+}
+
+@Composable
+private fun TvSearchLoading() {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        LoadingView(
+            color = MaterialTheme.tvColors.textPrimary,
+            modifier = Modifier.size(48.dp),
+        )
+        Text(
+            text = stringResource(LR.string.tv_search_searching),
+            style = MaterialTheme.tvTypography.body,
+            color = MaterialTheme.tvColors.textSecondary,
+        )
+    }
 }
 
 @Preview(device = Devices.TV_1080p)

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
@@ -72,6 +72,8 @@ import au.com.shiftyjelly.pocketcasts.theme.TvTheme
 import au.com.shiftyjelly.pocketcasts.theme.TvTopBarHeight
 import au.com.shiftyjelly.pocketcasts.theme.tvColors
 import au.com.shiftyjelly.pocketcasts.theme.tvTypography
+import java.util.Date
+import kotlin.time.Duration.Companion.seconds
 import androidx.compose.foundation.lazy.grid.itemsIndexed as gridItemsIndexed
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -694,6 +696,7 @@ private fun TvSearchLoading() {
             color = MaterialTheme.tvColors.textPrimary,
             modifier = Modifier.size(48.dp),
         )
+        Spacer(modifier = Modifier.height(16.dp))
         Text(
             text = stringResource(LR.string.tv_search_searching),
             style = MaterialTheme.tvTypography.body,
@@ -724,6 +727,94 @@ private fun TvSearchScreenPreview() {
                 onPlayEpisode = {},
                 onOpenEpisodeActions = {},
             )
+        }
+    }
+}
+
+@Preview(device = Devices.TV_1080p)
+@Composable
+private fun TvSearchIdleWithHistoryPreview() {
+    TvTheme {
+        Box(modifier = Modifier.fillMaxSize().background(MaterialTheme.tvColors.backgroundSunken)) {
+            TvSearchContent(
+                query = "",
+                searchState = TvSearchState.Idle,
+                filter = TvSearchFilter.TopResults,
+                categories = emptyList(),
+                discoverRows = emptyList(),
+                onQueryChange = {},
+                onFilterSelect = {},
+                onOpenPodcast = {},
+                onOpenCategory = {},
+                onPlayEpisode = {},
+                onOpenEpisodeActions = {},
+                history = listOf("Freakonomics", "Business Daily", "Science Weekly"),
+            )
+        }
+    }
+}
+
+@Preview(device = Devices.TV_1080p)
+@Composable
+private fun TvSearchResultsPreview() {
+    TvTheme {
+        Box(modifier = Modifier.fillMaxSize().background(MaterialTheme.tvColors.backgroundSunken)) {
+            TvSearchContent(
+                query = "business",
+                searchState = TvSearchState.Results(
+                    podcasts = List(4) {
+                        ImprovedSearchResultItem.PodcastItem(
+                            uuid = "podcast-$it",
+                            title = "Business Daily $it",
+                            author = "BBC",
+                            isFollowed = it == 0,
+                        )
+                    },
+                    episodes = List(3) {
+                        ImprovedSearchResultItem.EpisodeItem(
+                            uuid = "episode-$it",
+                            title = "The real cost of sugar and how it shapes the food we eat",
+                            podcastUuid = "podcast-$it",
+                            podcastTitle = "Business Daily",
+                            publishedDate = Date(0),
+                            duration = 1440.seconds,
+                            hasVideo = it == 0,
+                        )
+                    },
+                ),
+                filter = TvSearchFilter.TopResults,
+                categories = emptyList(),
+                discoverRows = emptyList(),
+                onQueryChange = {},
+                onFilterSelect = {},
+                onOpenPodcast = {},
+                onOpenCategory = {},
+                onPlayEpisode = {},
+                onOpenEpisodeActions = {},
+            )
+        }
+    }
+}
+
+@Preview(device = Devices.TV_1080p)
+@Composable
+private fun TvSearchSuggestionsPreview() {
+    TvTheme {
+        Box(modifier = Modifier.background(MaterialTheme.tvColors.backgroundSunken).padding(48.dp)) {
+            TvSearchSuggestions(
+                suggestions = listOf("business daily", "business wars", "business insider"),
+                onSuggestionSelect = {},
+            )
+        }
+    }
+}
+
+@Preview(device = Devices.TV_1080p)
+@Composable
+private fun TvSearchLoadingPreview() {
+    TvTheme {
+        Box(modifier = Modifier.fillMaxSize().background(MaterialTheme.tvColors.backgroundSunken)) {
+            TvSearchLoading()
         }
     }
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
@@ -239,10 +239,7 @@ private fun TvSearchContent(
         if (showSuggestions) {
             TvSearchSuggestions(
                 suggestions = suggestions,
-                onSuggestionSelect = { term ->
-                    suggestionsFocused = false
-                    onSuggestionSelect(term)
-                },
+                onSuggestionSelect = onSuggestionSelect,
                 modifier = Modifier.onFocusChanged { suggestionsFocused = it.hasFocus },
             )
             Spacer(modifier = Modifier.height(24.dp))
@@ -430,10 +427,14 @@ private fun TvSearchResults(
         )
 
         TvSearchFilter.Podcasts -> if (results.podcasts.isEmpty()) {
-            TvSearchMessage(
-                title = stringResource(LR.string.tv_search_no_results_for_title, searchTerm),
-                subtitle = stringResource(LR.string.tv_search_no_results_subtitle),
-            )
+            if (results.isPartial) {
+                TvSearchLoading()
+            } else {
+                TvSearchMessage(
+                    title = stringResource(LR.string.tv_search_no_results_for_title, searchTerm),
+                    subtitle = stringResource(LR.string.tv_search_no_results_subtitle),
+                )
+            }
         } else {
             TvPodcastGridScaffold(
                 itemKeys = results.podcasts.map(ImprovedSearchResultItem.PodcastItem::uuid),
@@ -453,10 +454,14 @@ private fun TvSearchResults(
         }
 
         TvSearchFilter.Episodes -> if (results.episodes.isEmpty()) {
-            TvSearchMessage(
-                title = stringResource(LR.string.tv_search_no_results_for_title, searchTerm),
-                subtitle = stringResource(LR.string.tv_search_no_results_subtitle),
-            )
+            if (results.isPartial) {
+                TvSearchLoading()
+            } else {
+                TvSearchMessage(
+                    title = stringResource(LR.string.tv_search_no_results_for_title, searchTerm),
+                    subtitle = stringResource(LR.string.tv_search_no_results_subtitle),
+                )
+            }
         } else {
             TvSearchEpisodeGrid(
                 episodes = results.episodes,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
@@ -78,7 +78,8 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 private val ContentHorizontalPadding = 48.dp
 private val ContentPadding = PaddingValues(horizontal = ContentHorizontalPadding)
-private const val TOP_RESULTS_PREVIEW_COUNT = 6
+private const val SEARCH_ROW_LIMIT = 10
+private val SearchEpisodeCardWidth = 360.dp
 private const val EPISODE_GRID_COLUMNS = 2
 
 @Composable
@@ -464,7 +465,6 @@ private fun TvSearchTopResults(
     restoreFocusTrigger: Int,
 ) {
     val restoreFocusRequester = remember { FocusRequester() }
-    val hasPodcasts = podcasts.isNotEmpty()
     var isInitialComposition by remember { mutableStateOf(true) }
     LaunchedEffect(restoreFocusTrigger) {
         if (isInitialComposition) {
@@ -474,39 +474,71 @@ private fun TvSearchTopResults(
         }
     }
 
+    val featured = episodes.filter { it.hasVideo }.take(SEARCH_ROW_LIMIT)
+    val otherEpisodes = episodes.filterNot { it.hasVideo }.take(SEARCH_ROW_LIMIT)
+    val topPodcasts = podcasts.take(SEARCH_ROW_LIMIT)
+    val featuredFirst = featured.isNotEmpty()
+    val episodesFirst = !featuredFirst && otherEpisodes.isNotEmpty()
+    val podcastsFirst = !featuredFirst && !episodesFirst
+
     LazyColumn(modifier = Modifier.fillMaxSize()) {
-        if (hasPodcasts) {
+        item { Spacer(modifier = Modifier.height(8.dp)) }
+        if (featured.isNotEmpty()) {
+            item {
+                TvSearchEpisodeCarousel(
+                    title = stringResource(LR.string.tv_search_featured),
+                    episodes = featured,
+                    onPlayEpisode = onPlayEpisode,
+                    onOpenEpisodeActions = onOpenEpisodeActions,
+                    focusRequester = restoreFocusRequester.takeIf { featuredFirst },
+                )
+            }
+        }
+        if (otherEpisodes.isNotEmpty()) {
+            item { Spacer(modifier = Modifier.height(24.dp)) }
+            item {
+                TvSearchEpisodeCarousel(
+                    title = stringResource(LR.string.episodes),
+                    episodes = otherEpisodes,
+                    onPlayEpisode = onPlayEpisode,
+                    onOpenEpisodeActions = onOpenEpisodeActions,
+                    focusRequester = restoreFocusRequester.takeIf { episodesFirst },
+                )
+            }
+        }
+        if (topPodcasts.isNotEmpty()) {
+            item { Spacer(modifier = Modifier.height(24.dp)) }
             tvSearchPodcastsRow(
-                podcasts = podcasts,
+                podcasts = topPodcasts,
                 onOpenPodcast = onOpenPodcast,
-                focusRequester = restoreFocusRequester,
+                focusRequester = restoreFocusRequester.takeIf { podcastsFirst },
             )
         }
-        if (episodes.isNotEmpty()) {
-            item {
-                Spacer(modifier = Modifier.height(24.dp))
-                TvSectionTitle(
-                    title = stringResource(LR.string.episodes),
-                    modifier = Modifier
-                        .padding(ContentPadding)
-                        .padding(bottom = 17.dp),
-                )
-            }
-            itemsIndexed(
-                items = episodes.take(TOP_RESULTS_PREVIEW_COUNT),
-                key = { _, episode -> episode.uuid },
-            ) { index, episode ->
-                TvSearchEpisodeRow(
-                    episode = episode,
-                    onClick = { onPlayEpisode(episode) },
-                    onOpenActions = { onOpenEpisodeActions(episode) },
-                    modifier = Modifier.padding(ContentPadding),
-                    episodeFocusRequester = if (!hasPodcasts && index == 0) restoreFocusRequester else null,
-                )
-                Spacer(modifier = Modifier.height(12.dp))
-            }
-        }
         item { Spacer(modifier = Modifier.height(40.dp)) }
+    }
+}
+
+@Composable
+private fun TvSearchEpisodeCarousel(
+    title: String,
+    episodes: List<ImprovedSearchResultItem.EpisodeItem>,
+    onPlayEpisode: (ImprovedSearchResultItem.EpisodeItem) -> Unit,
+    onOpenEpisodeActions: (ImprovedSearchResultItem.EpisodeItem) -> Unit,
+    focusRequester: FocusRequester?,
+) {
+    TvRow(
+        title = title,
+        items = episodes,
+        contentPadding = ContentPadding,
+        key = ImprovedSearchResultItem.EpisodeItem::uuid,
+        focusRequester = focusRequester,
+    ) { episode ->
+        TvSearchEpisodeCard(
+            episode = episode,
+            onClick = { onPlayEpisode(episode) },
+            onLongClick = { onOpenEpisodeActions(episode) },
+            modifier = Modifier.width(SearchEpisodeCardWidth),
+        )
     }
 }
 
@@ -572,7 +604,7 @@ private fun TvSearchEpisodeGrid(
 private fun LazyListScope.tvSearchPodcastsRow(
     podcasts: List<ImprovedSearchResultItem.PodcastItem>,
     onOpenPodcast: (String) -> Unit,
-    focusRequester: FocusRequester,
+    focusRequester: FocusRequester?,
 ) {
     item {
         TvRow(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -55,6 +56,7 @@ import au.com.shiftyjelly.pocketcasts.component.TvPodcastTile
 import au.com.shiftyjelly.pocketcasts.component.TvPodcastTileDefaults
 import au.com.shiftyjelly.pocketcasts.component.TvRow
 import au.com.shiftyjelly.pocketcasts.component.TvSectionTitle
+import au.com.shiftyjelly.pocketcasts.component.TvTile
 import au.com.shiftyjelly.pocketcasts.component.tvFocusInactiveWhen
 import au.com.shiftyjelly.pocketcasts.compose.loading.LoadingView
 import au.com.shiftyjelly.pocketcasts.discover.TvCategoryPodcastsScreen
@@ -89,6 +91,7 @@ fun TvSearchScreen(
     val filter by viewModel.filter.collectAsStateWithLifecycle()
     val categories by viewModel.categories.collectAsStateWithLifecycle()
     val discoverRows by viewModel.discoverRows.collectAsStateWithLifecycle()
+    val suggestions by viewModel.suggestions.collectAsStateWithLifecycle()
     val actionsEpisode by viewModel.actionsEpisode.collectAsStateWithLifecycle()
 
     var openedPodcastUuid by rememberSaveable { mutableStateOf<String?>(null) }
@@ -122,6 +125,8 @@ fun TvSearchScreen(
             onOpenCategory = { openedCategory = TvOpenedCategory(it.id, it.name, it.source) },
             onPlayEpisode = viewModel::playEpisode,
             onOpenEpisodeActions = viewModel::openEpisodeActions,
+            suggestions = suggestions,
+            onSuggestionSelect = viewModel::onQueryChange,
             restoreFocusTrigger = restoreFocusTrigger,
             modifier = Modifier
                 .fillMaxSize()
@@ -192,9 +197,14 @@ private fun TvSearchContent(
     onPlayEpisode: (ImprovedSearchResultItem.EpisodeItem) -> Unit,
     onOpenEpisodeActions: (ImprovedSearchResultItem.EpisodeItem) -> Unit,
     modifier: Modifier = Modifier,
+    suggestions: List<String> = emptyList(),
+    onSuggestionSelect: (String) -> Unit = {},
     restoreFocusTrigger: Int = 0,
 ) {
     val searchFieldFocusRequester = remember { FocusRequester() }
+    var isEditing by remember { mutableStateOf(false) }
+    var suggestionsFocused by remember { mutableStateOf(false) }
+    val showSuggestions = (isEditing || suggestionsFocused) && suggestions.isNotEmpty()
     LaunchedEffect(Unit) {
         withFrameNanos {}
         runCatching { searchFieldFocusRequester.requestFocus() }
@@ -205,12 +215,13 @@ private fun TvSearchContent(
             TvSearchField(
                 query = query,
                 onQueryChange = onQueryChange,
+                onEditingChange = { isEditing = it },
                 modifier = Modifier.focusRequester(searchFieldFocusRequester),
             )
             Spacer(modifier = Modifier.height(24.dp))
         }
 
-        if (searchState !is TvSearchState.Idle) {
+        if (searchState !is TvSearchState.Idle && !showSuggestions) {
             TvSearchFilters(
                 selected = filter,
                 onFilterSelect = onFilterSelect,
@@ -224,6 +235,14 @@ private fun TvSearchContent(
                 .fillMaxWidth()
                 .weight(1f),
         ) {
+            if (showSuggestions) {
+                TvSearchSuggestions(
+                    suggestions = suggestions,
+                    onSuggestionSelect = onSuggestionSelect,
+                    modifier = Modifier.onFocusChanged { suggestionsFocused = it.hasFocus },
+                )
+                return@Box
+            }
             when (searchState) {
                 is TvSearchState.Idle -> TvSearchDiscover(
                     categories = categories,
@@ -539,6 +558,33 @@ private fun TvSearchMessage(
         onAction = onAction,
         modifier = Modifier.fillMaxSize(),
     )
+}
+
+@Composable
+private fun TvSearchSuggestions(
+    suggestions: List<String>,
+    onSuggestionSelect: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(horizontal = ContentHorizontalPadding, vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        items(suggestions) { term ->
+            TvTile(
+                onClick = { onSuggestionSelect(term) },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(
+                    text = term,
+                    style = MaterialTheme.tvTypography.body,
+                    color = MaterialTheme.tvColors.textPrimary,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+                )
+            }
+        }
+    }
 }
 
 @Composable

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -55,6 +56,7 @@ import au.com.shiftyjelly.pocketcasts.component.TvPodcastTile
 import au.com.shiftyjelly.pocketcasts.component.TvPodcastTileDefaults
 import au.com.shiftyjelly.pocketcasts.component.TvRow
 import au.com.shiftyjelly.pocketcasts.component.TvSectionTitle
+import au.com.shiftyjelly.pocketcasts.component.TvTile
 import au.com.shiftyjelly.pocketcasts.component.tvFocusInactiveWhen
 import au.com.shiftyjelly.pocketcasts.compose.loading.LoadingView
 import au.com.shiftyjelly.pocketcasts.discover.TvCategoryPodcastsScreen
@@ -89,6 +91,7 @@ fun TvSearchScreen(
     val filter by viewModel.filter.collectAsStateWithLifecycle()
     val categories by viewModel.categories.collectAsStateWithLifecycle()
     val discoverRows by viewModel.discoverRows.collectAsStateWithLifecycle()
+    val suggestions by viewModel.suggestions.collectAsStateWithLifecycle()
     val actionsEpisode by viewModel.actionsEpisode.collectAsStateWithLifecycle()
 
     var openedPodcastUuid by rememberSaveable { mutableStateOf<String?>(null) }
@@ -122,6 +125,8 @@ fun TvSearchScreen(
             onOpenCategory = { openedCategory = TvOpenedCategory(it.id, it.name, it.source) },
             onPlayEpisode = viewModel::playEpisode,
             onOpenEpisodeActions = viewModel::openEpisodeActions,
+            suggestions = suggestions,
+            onSuggestionSelect = viewModel::onQueryChange,
             restoreFocusTrigger = restoreFocusTrigger,
             modifier = Modifier
                 .fillMaxSize()
@@ -191,9 +196,14 @@ private fun TvSearchContent(
     onPlayEpisode: (ImprovedSearchResultItem.EpisodeItem) -> Unit,
     onOpenEpisodeActions: (ImprovedSearchResultItem.EpisodeItem) -> Unit,
     modifier: Modifier = Modifier,
+    suggestions: List<String> = emptyList(),
+    onSuggestionSelect: (String) -> Unit = {},
     restoreFocusTrigger: Int = 0,
 ) {
     val searchFieldFocusRequester = remember { FocusRequester() }
+    var isEditing by remember { mutableStateOf(false) }
+    var suggestionsFocused by remember { mutableStateOf(false) }
+    val showSuggestions = (isEditing || suggestionsFocused) && suggestions.isNotEmpty()
     LaunchedEffect(Unit) {
         withFrameNanos {}
         runCatching { searchFieldFocusRequester.requestFocus() }
@@ -204,12 +214,13 @@ private fun TvSearchContent(
             TvSearchField(
                 query = query,
                 onQueryChange = onQueryChange,
+                onEditingChange = { isEditing = it },
                 modifier = Modifier.focusRequester(searchFieldFocusRequester),
             )
             Spacer(modifier = Modifier.height(24.dp))
         }
 
-        if (searchState !is TvSearchState.Idle) {
+        if (searchState !is TvSearchState.Idle && !showSuggestions) {
             TvSearchFilters(
                 selected = filter,
                 onFilterSelect = onFilterSelect,
@@ -223,6 +234,14 @@ private fun TvSearchContent(
                 .fillMaxWidth()
                 .weight(1f),
         ) {
+            if (showSuggestions) {
+                TvSearchSuggestions(
+                    suggestions = suggestions,
+                    onSuggestionSelect = onSuggestionSelect,
+                    modifier = Modifier.onFocusChanged { suggestionsFocused = it.hasFocus },
+                )
+                return@Box
+            }
             when (searchState) {
                 is TvSearchState.Idle -> TvSearchDiscover(
                     categories = categories,
@@ -537,6 +556,33 @@ private fun TvSearchMessage(
         onAction = onAction,
         modifier = Modifier.fillMaxSize(),
     )
+}
+
+@Composable
+private fun TvSearchSuggestions(
+    suggestions: List<String>,
+    onSuggestionSelect: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(horizontal = ContentHorizontalPadding, vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        items(suggestions) { term ->
+            TvTile(
+                onClick = { onSuggestionSelect(term) },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(
+                    text = term,
+                    style = MaterialTheme.tvTypography.body,
+                    color = MaterialTheme.tvColors.textPrimary,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+                )
+            }
+        }
+    }
 }
 
 @Composable

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -55,7 +54,6 @@ import au.com.shiftyjelly.pocketcasts.component.TvPodcastGridScaffold
 import au.com.shiftyjelly.pocketcasts.component.TvPodcastTile
 import au.com.shiftyjelly.pocketcasts.component.TvPodcastTileDefaults
 import au.com.shiftyjelly.pocketcasts.component.TvRow
-import au.com.shiftyjelly.pocketcasts.component.TvSectionTitle
 import au.com.shiftyjelly.pocketcasts.component.TvTile
 import au.com.shiftyjelly.pocketcasts.component.tvFocusInactiveWhen
 import au.com.shiftyjelly.pocketcasts.compose.loading.LoadingView
@@ -130,7 +128,11 @@ fun TvSearchScreen(
             history = history,
             onHistorySelect = viewModel::onQueryChange,
             suggestions = suggestions,
-            onSuggestionSelect = viewModel::onQueryChange,
+            onSuggestionSelect = { term ->
+                viewModel.saveSearchTerm(term)
+                viewModel.onQueryChange(term)
+            },
+            onSaveSearch = viewModel::saveSearchTerm,
             restoreFocusTrigger = restoreFocusTrigger,
             modifier = Modifier
                 .fillMaxSize()
@@ -204,6 +206,7 @@ private fun TvSearchContent(
     onHistorySelect: (String) -> Unit = {},
     suggestions: List<String> = emptyList(),
     onSuggestionSelect: (String) -> Unit = {},
+    onSaveSearch: (String) -> Unit = {},
     restoreFocusTrigger: Int = 0,
 ) {
     val searchFieldFocusRequester = remember { FocusRequester() }
@@ -220,7 +223,12 @@ private fun TvSearchContent(
             TvSearchField(
                 query = query,
                 onQueryChange = onQueryChange,
-                onEditingChange = { isEditing = it },
+                onEditingChange = { editing ->
+                    if (!editing && isEditing && query.isNotBlank()) {
+                        onSaveSearch(query)
+                    }
+                    isEditing = editing
+                },
                 modifier = Modifier.focusRequester(searchFieldFocusRequester),
             )
             Spacer(modifier = Modifier.height(24.dp))
@@ -243,7 +251,10 @@ private fun TvSearchContent(
             if (showSuggestions) {
                 TvSearchSuggestions(
                     suggestions = suggestions,
-                    onSuggestionSelect = onSuggestionSelect,
+                    onSuggestionSelect = { term ->
+                        suggestionsFocused = false
+                        onSuggestionSelect(term)
+                    },
                     modifier = Modifier.onFocusChanged { suggestionsFocused = it.hasFocus },
                 )
                 return@Box

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
@@ -142,7 +142,9 @@ class TvSearchViewModel @Inject constructor(
                 }
                 _suggestions.value = predictiveResults.filterIsInstance<SearchAutoCompleteItem.Term>().map { it.term }
                 val predictivePodcasts = predictiveResults.filterIsInstance<SearchAutoCompleteItem.Podcast>().map { it.toSearchItem() }
-                val earlyPodcasts = (predictivePodcasts + localPodcasts).distinctBy(ImprovedSearchResultItem.PodcastItem::uuid)
+                val earlyPodcasts = (predictivePodcasts + localPodcasts)
+                    .distinctBy(ImprovedSearchResultItem.PodcastItem::uuid)
+                    .map { if (it.uuid in localUuids) it.copy(isFollowed = true) else it }
                 if (earlyPodcasts.isNotEmpty()) {
                     _searchState.value = TvSearchState.Results(podcasts = earlyPodcasts, episodes = emptyList(), isPartial = true)
                 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
@@ -24,6 +24,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -104,7 +105,15 @@ class TvSearchViewModel @Inject constructor(
                 }
             }
         }
-        viewModelScope.launch { refreshHistory() }
+        viewModelScope.launch {
+            try {
+                refreshHistory()
+            } catch (exception: CancellationException) {
+                throw exception
+            } catch (exception: Exception) {
+                Timber.e(exception, "Failed to load TV search history")
+            }
+        }
     }
 
     fun onQueryChange(query: String) {
@@ -119,28 +128,30 @@ class TvSearchViewModel @Inject constructor(
         searchJob = viewModelScope.launch {
             delay(SEARCH_DEBOUNCE_MS)
             _searchState.value = TvSearchState.Searching
-
-            val localPodcasts = podcastManager.findSubscribedFlow(term).first().map(Podcast::toSearchItem)
-            val predictiveResults = try {
-                improvedSearchManager.autoCompleteSearch(term)
-            } catch (exception: CancellationException) {
-                throw exception
-            } catch (exception: Exception) {
-                Timber.e(exception, "Failed to load TV search suggestions")
-                emptyList()
-            }
-            _suggestions.value = predictiveResults.filterIsInstance<SearchAutoCompleteItem.Term>().map { it.term }
-            val predictivePodcasts = predictiveResults.filterIsInstance<SearchAutoCompleteItem.Podcast>().map { it.toSearchItem() }
-            val earlyPodcasts = (predictivePodcasts + localPodcasts).distinctBy(ImprovedSearchResultItem.PodcastItem::uuid)
-            if (earlyPodcasts.isNotEmpty()) {
-                _searchState.value = TvSearchState.Results(podcasts = earlyPodcasts, episodes = emptyList())
-            }
-
             _searchState.value = try {
-                val remoteResults = improvedSearchManager.combinedSearch(term)
+                val fullSearch = async { runCatching { improvedSearchManager.combinedSearch(term) } }
+                val localPodcasts = podcastManager.findSubscribedFlow(term).first().map(Podcast::toSearchItem)
+                val localUuids = localPodcasts.mapTo(HashSet(), ImprovedSearchResultItem.PodcastItem::uuid)
+                val predictiveResults = try {
+                    improvedSearchManager.autoCompleteSearch(term)
+                } catch (exception: CancellationException) {
+                    throw exception
+                } catch (exception: Exception) {
+                    Timber.e(exception, "Failed to load TV search suggestions")
+                    emptyList()
+                }
+                _suggestions.value = predictiveResults.filterIsInstance<SearchAutoCompleteItem.Term>().map { it.term }
+                val predictivePodcasts = predictiveResults.filterIsInstance<SearchAutoCompleteItem.Podcast>().map { it.toSearchItem() }
+                val earlyPodcasts = (predictivePodcasts + localPodcasts).distinctBy(ImprovedSearchResultItem.PodcastItem::uuid)
+                if (earlyPodcasts.isNotEmpty()) {
+                    _searchState.value = TvSearchState.Results(podcasts = earlyPodcasts, episodes = emptyList(), isPartial = true)
+                }
+
+                val remoteResults = fullSearch.await().getOrThrow()
                 val remotePodcasts = remoteResults.filterIsInstance<ImprovedSearchResultItem.PodcastItem>()
                 val podcasts = (predictivePodcasts + remotePodcasts + localPodcasts)
                     .distinctBy(ImprovedSearchResultItem.PodcastItem::uuid)
+                    .map { if (it.uuid in localUuids) it.copy(isFollowed = true) else it }
                 val episodes = remoteResults.filterIsInstance<ImprovedSearchResultItem.EpisodeItem>()
                     .distinctBy(ImprovedSearchResultItem.EpisodeItem::uuid)
                 if (podcasts.isEmpty() && episodes.isEmpty()) {
@@ -167,9 +178,14 @@ class TvSearchViewModel @Inject constructor(
             return
         }
         viewModelScope.launch {
-            searchHistoryManager.add(SearchHistoryEntry.SearchTerm(term = trimmed))
-            searchHistoryManager.truncateHistory(SEARCH_HISTORY_LIMIT)
-            refreshHistory()
+            try {
+                searchHistoryManager.add(SearchHistoryEntry.SearchTerm(term = trimmed))
+                refreshHistory()
+            } catch (exception: CancellationException) {
+                throw exception
+            } catch (exception: Exception) {
+                Timber.e(exception, "Failed to save TV search history")
+            }
         }
     }
 
@@ -236,7 +252,6 @@ class TvSearchViewModel @Inject constructor(
 
     companion object {
         private const val SEARCH_DEBOUNCE_MS = 300L
-        private const val SEARCH_HISTORY_LIMIT = 20
     }
 }
 
@@ -272,5 +287,6 @@ sealed interface TvSearchState {
     data class Results(
         val podcasts: List<ImprovedSearchResultItem.PodcastItem>,
         val episodes: List<ImprovedSearchResultItem.EpisodeItem>,
+        val isPartial: Boolean = false,
     ) : TvSearchState
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
@@ -11,6 +11,7 @@ import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverRow
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.ImprovedSearchResultItem
+import au.com.shiftyjelly.pocketcasts.models.to.SearchAutoCompleteItem
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
@@ -59,6 +60,9 @@ class TvSearchViewModel @Inject constructor(
     private val _filter = MutableStateFlow(TvSearchFilter.TopResults)
     val filter: StateFlow<TvSearchFilter> = _filter.asStateFlow()
 
+    private val _suggestions = MutableStateFlow<List<String>>(emptyList())
+    val suggestions: StateFlow<List<String>> = _suggestions.asStateFlow()
+
     private val _playStarted = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
     val playStarted: SharedFlow<Unit> = _playStarted.asSharedFlow()
 
@@ -101,16 +105,34 @@ class TvSearchViewModel @Inject constructor(
         searchJob?.cancel()
         val term = query.trim()
         if (term.isEmpty()) {
+            _suggestions.value = emptyList()
             _searchState.value = TvSearchState.Idle
             return
         }
         searchJob = viewModelScope.launch {
             delay(SEARCH_DEBOUNCE_MS)
             _searchState.value = TvSearchState.Searching
+
+            val localPodcasts = podcastManager.findSubscribedFlow(term).first().map(Podcast::toSearchItem)
+            val predictiveResults = try {
+                improvedSearchManager.autoCompleteSearch(term)
+            } catch (exception: CancellationException) {
+                throw exception
+            } catch (exception: Exception) {
+                Timber.e(exception, "Failed to load TV search suggestions")
+                emptyList()
+            }
+            _suggestions.value = predictiveResults.filterIsInstance<SearchAutoCompleteItem.Term>().map { it.term }
+            val predictivePodcasts = predictiveResults.filterIsInstance<SearchAutoCompleteItem.Podcast>().map { it.toSearchItem() }
+            val earlyPodcasts = (predictivePodcasts + localPodcasts).distinctBy(ImprovedSearchResultItem.PodcastItem::uuid)
+            if (earlyPodcasts.isNotEmpty()) {
+                _searchState.value = TvSearchState.Results(podcasts = earlyPodcasts, episodes = emptyList())
+            }
+
             _searchState.value = try {
-                val localPodcasts = podcastManager.findSubscribedFlow(term).first().map(Podcast::toSearchItem)
                 val remoteResults = improvedSearchManager.combinedSearch(term)
-                val podcasts = (localPodcasts + remoteResults.filterIsInstance<ImprovedSearchResultItem.PodcastItem>())
+                val remotePodcasts = remoteResults.filterIsInstance<ImprovedSearchResultItem.PodcastItem>()
+                val podcasts = (predictivePodcasts + remotePodcasts + localPodcasts)
                     .distinctBy(ImprovedSearchResultItem.PodcastItem::uuid)
                 val episodes = remoteResults.filterIsInstance<ImprovedSearchResultItem.EpisodeItem>()
                     .distinctBy(ImprovedSearchResultItem.EpisodeItem::uuid)
@@ -198,6 +220,14 @@ private fun Podcast.toSearchItem() = ImprovedSearchResultItem.PodcastItem(
     author = author,
     isFollowed = true,
     isExplicit = explicit == true,
+)
+
+private fun SearchAutoCompleteItem.Podcast.toSearchItem() = ImprovedSearchResultItem.PodcastItem(
+    uuid = uuid,
+    title = title,
+    author = author,
+    isFollowed = isSubscribed,
+    isExplicit = isExplicit,
 )
 
 enum class TvSearchFilter(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
@@ -23,6 +23,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -103,7 +104,15 @@ class TvSearchViewModel @Inject constructor(
                 }
             }
         }
-        viewModelScope.launch { refreshHistory() }
+        viewModelScope.launch {
+            try {
+                refreshHistory()
+            } catch (exception: CancellationException) {
+                throw exception
+            } catch (exception: Exception) {
+                Timber.e(exception, "Failed to load TV search history")
+            }
+        }
     }
 
     fun onQueryChange(query: String) {
@@ -118,28 +127,30 @@ class TvSearchViewModel @Inject constructor(
         searchJob = viewModelScope.launch {
             delay(SEARCH_DEBOUNCE_MS)
             _searchState.value = TvSearchState.Searching
-
-            val localPodcasts = podcastManager.findSubscribedFlow(term).first().map(Podcast::toSearchItem)
-            val predictiveResults = try {
-                improvedSearchManager.autoCompleteSearch(term)
-            } catch (exception: CancellationException) {
-                throw exception
-            } catch (exception: Exception) {
-                Timber.e(exception, "Failed to load TV search suggestions")
-                emptyList()
-            }
-            _suggestions.value = predictiveResults.filterIsInstance<SearchAutoCompleteItem.Term>().map { it.term }
-            val predictivePodcasts = predictiveResults.filterIsInstance<SearchAutoCompleteItem.Podcast>().map { it.toSearchItem() }
-            val earlyPodcasts = (predictivePodcasts + localPodcasts).distinctBy(ImprovedSearchResultItem.PodcastItem::uuid)
-            if (earlyPodcasts.isNotEmpty()) {
-                _searchState.value = TvSearchState.Results(podcasts = earlyPodcasts, episodes = emptyList())
-            }
-
             _searchState.value = try {
-                val remoteResults = improvedSearchManager.combinedSearch(term)
+                val fullSearch = async { runCatching { improvedSearchManager.combinedSearch(term) } }
+                val localPodcasts = podcastManager.findSubscribedFlow(term).first().map(Podcast::toSearchItem)
+                val localUuids = localPodcasts.mapTo(HashSet(), ImprovedSearchResultItem.PodcastItem::uuid)
+                val predictiveResults = try {
+                    improvedSearchManager.autoCompleteSearch(term)
+                } catch (exception: CancellationException) {
+                    throw exception
+                } catch (exception: Exception) {
+                    Timber.e(exception, "Failed to load TV search suggestions")
+                    emptyList()
+                }
+                _suggestions.value = predictiveResults.filterIsInstance<SearchAutoCompleteItem.Term>().map { it.term }
+                val predictivePodcasts = predictiveResults.filterIsInstance<SearchAutoCompleteItem.Podcast>().map { it.toSearchItem() }
+                val earlyPodcasts = (predictivePodcasts + localPodcasts).distinctBy(ImprovedSearchResultItem.PodcastItem::uuid)
+                if (earlyPodcasts.isNotEmpty()) {
+                    _searchState.value = TvSearchState.Results(podcasts = earlyPodcasts, episodes = emptyList(), isPartial = true)
+                }
+
+                val remoteResults = fullSearch.await().getOrThrow()
                 val remotePodcasts = remoteResults.filterIsInstance<ImprovedSearchResultItem.PodcastItem>()
                 val podcasts = (predictivePodcasts + remotePodcasts + localPodcasts)
                     .distinctBy(ImprovedSearchResultItem.PodcastItem::uuid)
+                    .map { if (it.uuid in localUuids) it.copy(isFollowed = true) else it }
                 val episodes = remoteResults.filterIsInstance<ImprovedSearchResultItem.EpisodeItem>()
                     .distinctBy(ImprovedSearchResultItem.EpisodeItem::uuid)
                 if (podcasts.isEmpty() && episodes.isEmpty()) {
@@ -166,9 +177,14 @@ class TvSearchViewModel @Inject constructor(
             return
         }
         viewModelScope.launch {
-            searchHistoryManager.add(SearchHistoryEntry.SearchTerm(term = trimmed))
-            searchHistoryManager.truncateHistory(SEARCH_HISTORY_LIMIT)
-            refreshHistory()
+            try {
+                searchHistoryManager.add(SearchHistoryEntry.SearchTerm(term = trimmed))
+                refreshHistory()
+            } catch (exception: CancellationException) {
+                throw exception
+            } catch (exception: Exception) {
+                Timber.e(exception, "Failed to save TV search history")
+            }
         }
     }
 
@@ -235,7 +251,6 @@ class TvSearchViewModel @Inject constructor(
 
     companion object {
         private const val SEARCH_DEBOUNCE_MS = 300L
-        private const val SEARCH_HISTORY_LIMIT = 20
     }
 }
 
@@ -271,5 +286,6 @@ sealed interface TvSearchState {
     data class Results(
         val podcasts: List<ImprovedSearchResultItem.PodcastItem>,
         val episodes: List<ImprovedSearchResultItem.EpisodeItem>,
+        val isPartial: Boolean = false,
     ) : TvSearchState
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
@@ -12,10 +12,12 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.ImprovedSearchResultItem
 import au.com.shiftyjelly.pocketcasts.models.to.SearchAutoCompleteItem
+import au.com.shiftyjelly.pocketcasts.models.to.SearchHistoryEntry
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.search.ImprovedSearchManager
+import au.com.shiftyjelly.pocketcasts.repositories.searchhistory.SearchHistoryManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -43,6 +45,7 @@ class TvSearchViewModel @Inject constructor(
     private val podcastManager: PodcastManager,
     private val episodeManager: EpisodeManager,
     private val playbackManager: PlaybackManager,
+    private val searchHistoryManager: SearchHistoryManager,
 ) : ViewModel() {
 
     private val _categories = MutableStateFlow<List<DiscoverCategory>>(emptyList())
@@ -62,6 +65,9 @@ class TvSearchViewModel @Inject constructor(
 
     private val _suggestions = MutableStateFlow<List<String>>(emptyList())
     val suggestions: StateFlow<List<String>> = _suggestions.asStateFlow()
+
+    private val _history = MutableStateFlow<List<String>>(emptyList())
+    val history: StateFlow<List<String>> = _history.asStateFlow()
 
     private val _playStarted = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
     val playStarted: SharedFlow<Unit> = _playStarted.asSharedFlow()
@@ -98,6 +104,7 @@ class TvSearchViewModel @Inject constructor(
                 }
             }
         }
+        viewModelScope.launch { refreshHistory() }
     }
 
     fun onQueryChange(query: String) {
@@ -112,6 +119,7 @@ class TvSearchViewModel @Inject constructor(
         searchJob = viewModelScope.launch {
             delay(SEARCH_DEBOUNCE_MS)
             _searchState.value = TvSearchState.Searching
+            saveSearchTerm(term)
 
             val localPodcasts = podcastManager.findSubscribedFlow(term).first().map(Podcast::toSearchItem)
             val predictiveResults = try {
@@ -152,6 +160,24 @@ class TvSearchViewModel @Inject constructor(
 
     fun onFilterSelected(filter: TvSearchFilter) {
         _filter.value = filter
+    }
+
+    fun saveSearchTerm(term: String) {
+        val trimmed = term.trim()
+        if (trimmed.isEmpty()) {
+            return
+        }
+        viewModelScope.launch {
+            searchHistoryManager.add(SearchHistoryEntry.SearchTerm(term = trimmed))
+            searchHistoryManager.truncateHistory(SEARCH_HISTORY_LIMIT)
+            refreshHistory()
+        }
+    }
+
+    private suspend fun refreshHistory() {
+        _history.value = searchHistoryManager.findAll(showFolders = false)
+            .filterIsInstance<SearchHistoryEntry.SearchTerm>()
+            .map(SearchHistoryEntry.SearchTerm::term)
     }
 
     suspend fun categoryPodcasts(categoryId: Int, source: String): TvCategoryPodcasts {
@@ -211,6 +237,7 @@ class TvSearchViewModel @Inject constructor(
 
     companion object {
         private const val SEARCH_DEBOUNCE_MS = 300L
+        private const val SEARCH_HISTORY_LIMIT = 20
     }
 }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
@@ -11,10 +11,12 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.ImprovedSearchResultItem
 import au.com.shiftyjelly.pocketcasts.models.to.SearchAutoCompleteItem
+import au.com.shiftyjelly.pocketcasts.models.to.SearchHistoryEntry
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.search.ImprovedSearchManager
+import au.com.shiftyjelly.pocketcasts.repositories.searchhistory.SearchHistoryManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -42,6 +44,7 @@ class TvSearchViewModel @Inject constructor(
     private val podcastManager: PodcastManager,
     private val episodeManager: EpisodeManager,
     private val playbackManager: PlaybackManager,
+    private val searchHistoryManager: SearchHistoryManager,
 ) : ViewModel() {
 
     private val _categories = MutableStateFlow<List<DiscoverCategory>>(emptyList())
@@ -61,6 +64,9 @@ class TvSearchViewModel @Inject constructor(
 
     private val _suggestions = MutableStateFlow<List<String>>(emptyList())
     val suggestions: StateFlow<List<String>> = _suggestions.asStateFlow()
+
+    private val _history = MutableStateFlow<List<String>>(emptyList())
+    val history: StateFlow<List<String>> = _history.asStateFlow()
 
     private val _playStarted = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
     val playStarted: SharedFlow<Unit> = _playStarted.asSharedFlow()
@@ -97,6 +103,7 @@ class TvSearchViewModel @Inject constructor(
                 }
             }
         }
+        viewModelScope.launch { refreshHistory() }
     }
 
     fun onQueryChange(query: String) {
@@ -111,6 +118,7 @@ class TvSearchViewModel @Inject constructor(
         searchJob = viewModelScope.launch {
             delay(SEARCH_DEBOUNCE_MS)
             _searchState.value = TvSearchState.Searching
+            saveSearchTerm(term)
 
             val localPodcasts = podcastManager.findSubscribedFlow(term).first().map(Podcast::toSearchItem)
             val predictiveResults = try {
@@ -151,6 +159,24 @@ class TvSearchViewModel @Inject constructor(
 
     fun onFilterSelected(filter: TvSearchFilter) {
         _filter.value = filter
+    }
+
+    fun saveSearchTerm(term: String) {
+        val trimmed = term.trim()
+        if (trimmed.isEmpty()) {
+            return
+        }
+        viewModelScope.launch {
+            searchHistoryManager.add(SearchHistoryEntry.SearchTerm(term = trimmed))
+            searchHistoryManager.truncateHistory(SEARCH_HISTORY_LIMIT)
+            refreshHistory()
+        }
+    }
+
+    private suspend fun refreshHistory() {
+        _history.value = searchHistoryManager.findAll(showFolders = false)
+            .filterIsInstance<SearchHistoryEntry.SearchTerm>()
+            .map(SearchHistoryEntry.SearchTerm::term)
     }
 
     suspend fun categoryPodcasts(categoryId: Int, source: String): List<TvDiscoverPodcast> {
@@ -210,6 +236,7 @@ class TvSearchViewModel @Inject constructor(
 
     companion object {
         private const val SEARCH_DEBOUNCE_MS = 300L
+        private const val SEARCH_HISTORY_LIMIT = 20
     }
 }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
@@ -119,7 +119,6 @@ class TvSearchViewModel @Inject constructor(
         searchJob = viewModelScope.launch {
             delay(SEARCH_DEBOUNCE_MS)
             _searchState.value = TvSearchState.Searching
-            saveSearchTerm(term)
 
             val localPodcasts = podcastManager.findSubscribedFlow(term).first().map(Podcast::toSearchItem)
             val predictiveResults = try {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
@@ -10,6 +10,7 @@ import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverRow
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.ImprovedSearchResultItem
+import au.com.shiftyjelly.pocketcasts.models.to.SearchAutoCompleteItem
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
@@ -58,6 +59,9 @@ class TvSearchViewModel @Inject constructor(
     private val _filter = MutableStateFlow(TvSearchFilter.TopResults)
     val filter: StateFlow<TvSearchFilter> = _filter.asStateFlow()
 
+    private val _suggestions = MutableStateFlow<List<String>>(emptyList())
+    val suggestions: StateFlow<List<String>> = _suggestions.asStateFlow()
+
     private val _playStarted = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
     val playStarted: SharedFlow<Unit> = _playStarted.asSharedFlow()
 
@@ -100,16 +104,34 @@ class TvSearchViewModel @Inject constructor(
         searchJob?.cancel()
         val term = query.trim()
         if (term.isEmpty()) {
+            _suggestions.value = emptyList()
             _searchState.value = TvSearchState.Idle
             return
         }
         searchJob = viewModelScope.launch {
             delay(SEARCH_DEBOUNCE_MS)
             _searchState.value = TvSearchState.Searching
+
+            val localPodcasts = podcastManager.findSubscribedFlow(term).first().map(Podcast::toSearchItem)
+            val predictiveResults = try {
+                improvedSearchManager.autoCompleteSearch(term)
+            } catch (exception: CancellationException) {
+                throw exception
+            } catch (exception: Exception) {
+                Timber.e(exception, "Failed to load TV search suggestions")
+                emptyList()
+            }
+            _suggestions.value = predictiveResults.filterIsInstance<SearchAutoCompleteItem.Term>().map { it.term }
+            val predictivePodcasts = predictiveResults.filterIsInstance<SearchAutoCompleteItem.Podcast>().map { it.toSearchItem() }
+            val earlyPodcasts = (predictivePodcasts + localPodcasts).distinctBy(ImprovedSearchResultItem.PodcastItem::uuid)
+            if (earlyPodcasts.isNotEmpty()) {
+                _searchState.value = TvSearchState.Results(podcasts = earlyPodcasts, episodes = emptyList())
+            }
+
             _searchState.value = try {
-                val localPodcasts = podcastManager.findSubscribedFlow(term).first().map(Podcast::toSearchItem)
                 val remoteResults = improvedSearchManager.combinedSearch(term)
-                val podcasts = (localPodcasts + remoteResults.filterIsInstance<ImprovedSearchResultItem.PodcastItem>())
+                val remotePodcasts = remoteResults.filterIsInstance<ImprovedSearchResultItem.PodcastItem>()
+                val podcasts = (predictivePodcasts + remotePodcasts + localPodcasts)
                     .distinctBy(ImprovedSearchResultItem.PodcastItem::uuid)
                 val episodes = remoteResults.filterIsInstance<ImprovedSearchResultItem.EpisodeItem>()
                     .distinctBy(ImprovedSearchResultItem.EpisodeItem::uuid)
@@ -197,6 +219,14 @@ private fun Podcast.toSearchItem() = ImprovedSearchResultItem.PodcastItem(
     author = author,
     isFollowed = true,
     isExplicit = explicit == true,
+)
+
+private fun SearchAutoCompleteItem.Podcast.toSearchItem() = ImprovedSearchResultItem.PodcastItem(
+    uuid = uuid,
+    title = title,
+    author = author,
+    isFollowed = isSubscribed,
+    isExplicit = isExplicit,
 )
 
 enum class TvSearchFilter(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
@@ -11,7 +11,6 @@ import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverRow
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.ImprovedSearchResultItem
-import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
@@ -43,7 +42,6 @@ class TvSearchViewModel @Inject constructor(
     private val podcastManager: PodcastManager,
     private val episodeManager: EpisodeManager,
     private val playbackManager: PlaybackManager,
-    private val settings: Settings,
 ) : ViewModel() {
 
     private val _categories = MutableStateFlow<List<DiscoverCategory>>(emptyList())
@@ -103,12 +101,11 @@ class TvSearchViewModel @Inject constructor(
         searchJob?.cancel()
         val term = query.trim()
         if (term.isEmpty()) {
-            _filter.value = TvSearchFilter.TopResults
             _searchState.value = TvSearchState.Idle
             return
         }
         searchJob = viewModelScope.launch {
-            delay(settings.getPodcastSearchDebounceMs())
+            delay(SEARCH_DEBOUNCE_MS)
             _searchState.value = TvSearchState.Searching
             _searchState.value = try {
                 val localPodcasts = podcastManager.findSubscribedFlow(term).first().map(Podcast::toSearchItem)
@@ -188,6 +185,10 @@ class TvSearchViewModel @Inject constructor(
                 podcastManager.findOrDownloadPodcastRxSingle(episode.podcastUuid).await()
                 episodeManager.findByUuid(episode.uuid)
             }
+    }
+
+    companion object {
+        private const val SEARCH_DEBOUNCE_MS = 300L
     }
 }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
@@ -118,7 +118,6 @@ class TvSearchViewModel @Inject constructor(
         searchJob = viewModelScope.launch {
             delay(SEARCH_DEBOUNCE_MS)
             _searchState.value = TvSearchState.Searching
-            saveSearchTerm(term)
 
             val localPodcasts = podcastManager.findSubscribedFlow(term).first().map(Podcast::toSearchItem)
             val predictiveResults = try {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
@@ -10,7 +10,6 @@ import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverRow
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.ImprovedSearchResultItem
-import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
@@ -42,7 +41,6 @@ class TvSearchViewModel @Inject constructor(
     private val podcastManager: PodcastManager,
     private val episodeManager: EpisodeManager,
     private val playbackManager: PlaybackManager,
-    private val settings: Settings,
 ) : ViewModel() {
 
     private val _categories = MutableStateFlow<List<DiscoverCategory>>(emptyList())
@@ -102,12 +100,11 @@ class TvSearchViewModel @Inject constructor(
         searchJob?.cancel()
         val term = query.trim()
         if (term.isEmpty()) {
-            _filter.value = TvSearchFilter.TopResults
             _searchState.value = TvSearchState.Idle
             return
         }
         searchJob = viewModelScope.launch {
-            delay(settings.getPodcastSearchDebounceMs())
+            delay(SEARCH_DEBOUNCE_MS)
             _searchState.value = TvSearchState.Searching
             _searchState.value = try {
                 val localPodcasts = podcastManager.findSubscribedFlow(term).first().map(Podcast::toSearchItem)
@@ -187,6 +184,10 @@ class TvSearchViewModel @Inject constructor(
                 podcastManager.findOrDownloadPodcastRxSingle(episode.podcastUuid).await()
                 episodeManager.findByUuid(episode.uuid)
             }
+    }
+
+    companion object {
+        private const val SEARCH_DEBOUNCE_MS = 300L
     }
 }
 

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModelTest.kt
@@ -345,20 +345,31 @@ class TvSearchViewModelTest {
     }
 
     @Test
-    fun `searching a term saves it to history and exposes recent searches`() = runTest {
+    fun `saving a search term persists it and exposes recent searches`() = runTest {
         whenever(listRepository.getSearchDiscoverFeed()).thenReturn(discover())
-        whenever { improvedSearchManager.combinedSearch(any()) }.thenReturn(emptyList())
         whenever { searchHistoryManager.findAll(any()) }.thenReturn(
             listOf(SearchHistoryEntry.SearchTerm(term = "sugar")),
         )
 
         val viewModel = createViewModel()
-        viewModel.onQueryChange("sugar")
+        viewModel.saveSearchTerm("sugar")
         advanceUntilIdle()
 
         verifyBlocking(searchHistoryManager) { add(any()) }
         verifyBlocking(searchHistoryManager) { truncateHistory(20) }
         assertEquals(listOf("sugar"), viewModel.history.value)
+    }
+
+    @Test
+    fun `searching does not save partial terms to history`() = runTest {
+        whenever(listRepository.getSearchDiscoverFeed()).thenReturn(discover())
+        whenever { improvedSearchManager.combinedSearch(any()) }.thenReturn(emptyList())
+
+        val viewModel = createViewModel()
+        viewModel.onQueryChange("sug")
+        advanceUntilIdle()
+
+        verifyBlocking(searchHistoryManager, never()) { add(any()) }
     }
 
     @Test

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModelTest.kt
@@ -356,8 +356,19 @@ class TvSearchViewModelTest {
         advanceUntilIdle()
 
         verifyBlocking(searchHistoryManager) { add(any()) }
-        verifyBlocking(searchHistoryManager) { truncateHistory(20) }
         assertEquals(listOf("sugar"), viewModel.history.value)
+    }
+
+    @Test
+    fun `a failure fetching subscribed podcasts surfaces the error state`() = runTest {
+        whenever(listRepository.getSearchDiscoverFeed()).thenReturn(discover())
+        whenever(podcastManager.findSubscribedFlow(any())).thenThrow(RuntimeException("database unavailable"))
+
+        val viewModel = createViewModel()
+        viewModel.onQueryChange("sugar")
+        advanceUntilIdle()
+
+        assertEquals(TvSearchState.Error, viewModel.searchState.value)
     }
 
     @Test

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModelTest.kt
@@ -6,6 +6,7 @@ import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverFeedLoader
 import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverRow
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.ImprovedSearchResultItem
+import au.com.shiftyjelly.pocketcasts.models.to.SearchAutoCompleteItem
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
 import au.com.shiftyjelly.pocketcasts.repositories.lists.ListRepository
@@ -69,6 +70,10 @@ class TvSearchViewModelTest {
     }
     private val episodeManager = mock<EpisodeManager>()
     private val playbackManager = mock<PlaybackManager>()
+
+    init {
+        whenever { improvedSearchManager.autoCompleteSearch(any()) }.thenReturn(emptyList())
+    }
 
     @Test
     fun `exposes the browse categories from the search feed row`() = runTest {
@@ -305,11 +310,11 @@ class TvSearchViewModelTest {
     }
 
     @Test
-    fun `subscribed podcasts lead the results and are not duplicated by the server`() = runTest {
+    fun `server results lead and subscribed podcasts fill the remaining gaps`() = runTest {
         whenever(listRepository.getSearchDiscoverFeed()).thenReturn(discover())
         whenever(podcastManager.findSubscribedFlow(any())).thenReturn(flowOf(listOf(subscribedPodcast("podcast-1"))))
         whenever { improvedSearchManager.combinedSearch(any()) }.thenReturn(
-            listOf(podcastItem("podcast-1"), podcastItem("podcast-2")),
+            listOf(podcastItem("podcast-2")),
         )
 
         val viewModel = createViewModel()
@@ -317,8 +322,39 @@ class TvSearchViewModelTest {
         advanceUntilIdle()
 
         val state = viewModel.searchState.value as TvSearchState.Results
-        assertEquals(listOf("podcast-1", "podcast-2"), state.podcasts.map { it.uuid })
-        assertTrue(state.podcasts.first().isFollowed)
+        assertEquals(listOf("podcast-2", "podcast-1"), state.podcasts.map { it.uuid })
+    }
+
+    @Test
+    fun `predictive term results are exposed as suggestions`() = runTest {
+        whenever(listRepository.getSearchDiscoverFeed()).thenReturn(discover())
+        whenever { improvedSearchManager.autoCompleteSearch(any()) }.thenReturn(
+            listOf(SearchAutoCompleteItem.Term("sugar rush"), SearchAutoCompleteItem.Term("sugar high")),
+        )
+        whenever { improvedSearchManager.combinedSearch(any()) }.thenReturn(emptyList())
+
+        val viewModel = createViewModel()
+        viewModel.onQueryChange("sugar")
+        advanceUntilIdle()
+
+        assertEquals(listOf("sugar rush", "sugar high"), viewModel.suggestions.value)
+    }
+
+    @Test
+    fun `clearing the query clears the suggestions`() = runTest {
+        whenever(listRepository.getSearchDiscoverFeed()).thenReturn(discover())
+        whenever { improvedSearchManager.autoCompleteSearch(any()) }.thenReturn(
+            listOf(SearchAutoCompleteItem.Term("sugar")),
+        )
+        whenever { improvedSearchManager.combinedSearch(any()) }.thenReturn(emptyList())
+        val viewModel = createViewModel()
+        viewModel.onQueryChange("sugar")
+        advanceUntilIdle()
+        assertTrue(viewModel.suggestions.value.isNotEmpty())
+
+        viewModel.onQueryChange("")
+
+        assertTrue(viewModel.suggestions.value.isEmpty())
     }
 
     @Test

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModelTest.kt
@@ -62,7 +62,6 @@ class TvSearchViewModelTest {
     }
     private val settings = mock<Settings> {
         whenever(it.discoverCountryCode).thenReturn(discoverCountryCode)
-        whenever(it.getPodcastSearchDebounceMs()).thenReturn(0)
     }
     private val improvedSearchManager = mock<ImprovedSearchManager>()
     private val podcastManager = mock<PodcastManager> {
@@ -281,7 +280,6 @@ class TvSearchViewModelTest {
 
     @Test
     fun `keystrokes within the debounce window only search the last term`() = runTest {
-        whenever(settings.getPodcastSearchDebounceMs()).thenReturn(300)
         whenever(listRepository.getSearchDiscoverFeed()).thenReturn(discover())
         whenever { improvedSearchManager.combinedSearch(any()) }.thenReturn(emptyList())
 
@@ -346,7 +344,7 @@ class TvSearchViewModelTest {
     }
 
     @Test
-    fun `clearing the query resets the filter to top results`() = runTest {
+    fun `clearing the query preserves the selected filter`() = runTest {
         whenever(listRepository.getSearchDiscoverFeed()).thenReturn(discover())
         val viewModel = createViewModel()
 
@@ -354,7 +352,7 @@ class TvSearchViewModelTest {
         viewModel.onQueryChange("")
         advanceUntilIdle()
 
-        assertEquals(TvSearchFilter.TopResults, viewModel.filter.value)
+        assertEquals(TvSearchFilter.Podcasts, viewModel.filter.value)
     }
 
     private fun podcastItem(uuid: String) = ImprovedSearchResultItem.PodcastItem(
@@ -386,7 +384,6 @@ class TvSearchViewModelTest {
         podcastManager = podcastManager,
         episodeManager = episodeManager,
         playbackManager = playbackManager,
-        settings = settings,
     )
 
     private fun category(id: Int, name: String) = DiscoverCategory(id = id, name = name, icon = "", source = "")

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModelTest.kt
@@ -7,6 +7,7 @@ import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverRow
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.ImprovedSearchResultItem
 import au.com.shiftyjelly.pocketcasts.models.to.SearchAutoCompleteItem
+import au.com.shiftyjelly.pocketcasts.models.to.SearchHistoryEntry
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
 import au.com.shiftyjelly.pocketcasts.repositories.lists.ListRepository
@@ -14,6 +15,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.search.ImprovedSearchManager
+import au.com.shiftyjelly.pocketcasts.repositories.searchhistory.SearchHistoryManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.servers.model.Discover
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
@@ -70,9 +72,11 @@ class TvSearchViewModelTest {
     }
     private val episodeManager = mock<EpisodeManager>()
     private val playbackManager = mock<PlaybackManager>()
+    private val searchHistoryManager = mock<SearchHistoryManager>()
 
     init {
         whenever { improvedSearchManager.autoCompleteSearch(any()) }.thenReturn(emptyList())
+        whenever { searchHistoryManager.findAll(any()) }.thenReturn(emptyList())
     }
 
     @Test
@@ -341,6 +345,23 @@ class TvSearchViewModelTest {
     }
 
     @Test
+    fun `searching a term saves it to history and exposes recent searches`() = runTest {
+        whenever(listRepository.getSearchDiscoverFeed()).thenReturn(discover())
+        whenever { improvedSearchManager.combinedSearch(any()) }.thenReturn(emptyList())
+        whenever { searchHistoryManager.findAll(any()) }.thenReturn(
+            listOf(SearchHistoryEntry.SearchTerm(term = "sugar")),
+        )
+
+        val viewModel = createViewModel()
+        viewModel.onQueryChange("sugar")
+        advanceUntilIdle()
+
+        verifyBlocking(searchHistoryManager) { add(any()) }
+        verifyBlocking(searchHistoryManager) { truncateHistory(20) }
+        assertEquals(listOf("sugar"), viewModel.history.value)
+    }
+
+    @Test
     fun `clearing the query clears the suggestions`() = runTest {
         whenever(listRepository.getSearchDiscoverFeed()).thenReturn(discover())
         whenever { improvedSearchManager.autoCompleteSearch(any()) }.thenReturn(
@@ -420,6 +441,7 @@ class TvSearchViewModelTest {
         podcastManager = podcastManager,
         episodeManager = episodeManager,
         playbackManager = playbackManager,
+        searchHistoryManager = searchHistoryManager,
     )
 
     private fun category(id: Int, name: String) = DiscoverCategory(id = id, name = name, icon = "", source = "")


### PR DESCRIPTION
## Description

Brings the Android TV **Search** screen up to parity with the Apple TV app (`pocket-casts-ios/Pocket Casts TV App/UI/Search`), closing a set of gaps found in a behavioural audit. **Stacked on #5745** (the combined-search crash fix) — review/merge that first; this PR's diff excludes it.

### What changed

| Area | Before (Android TV) | After (Apple TV parity) |
|---|---|---|
| **Debounce** | 2000ms (shared phone remote-config default) | **300ms** TV constant — matches iOS, far snappier |
| **Empty results** | generic "No results" | **"No results for "term""** (shows the query) |
| **Loading** | bare spinner | spinner + **"Searching…"** label (string existed, was unused) |
| **Scope on clear** | reset to Top Results | **preserved** (matches iOS) |
| **Field prompt** | "Search" | **"Podcasts, shows, authors"** |
| **Search flow** | single `combinedSearch` (all-at-once) | **two-phase**: predictive (`autoCompleteSearch`) → fast podcasts + term suggestions, then full search fills in episodes |
| **Suggestions** | none | **term suggestions while typing**, rendered above the keyboard; tap to fill |
| **History** | never saved/shown (manager only used to *wipe* on sign-out) | **saved** on finishing a search / picking a suggestion + **"Recent searches"** row in the idle area |
| **Video episodes** | `has_video` dropped by the DTO | parsed through DTO → model, driving a **Featured video row** |
| **Top Results** | Podcasts → Episodes (vertical) | **Featured (video) → Episodes → Podcasts** horizontal carousels (matches `SearchTopResultsView`) |
| **Podcast ordering** | subscribed-first | **server-relevance first**, subscribed fill gaps (matches iOS) — see flag below |

Shared `servers`/`model` change: `CombinedResult.EpisodeResult` now parses `has_video`, and `ImprovedSearchResultItem.EpisodeItem` carries `hasVideo` (additive, defaults false — benefits phone too).

### ⚠️ Needs design approval
There is an ongoing conversation about the UX, see slack: p1786735532787109-slack-C0ATWH7BNH3

**UPDATE**
UX is approved!

Fixes POC-848 https://linear.app/a8c/issue/POC-848/search-suggestions-and-history

### Notes / follow-ups
- **Suggestions can't live inside the system keyboard** — Android exposes no API to inject candidates into a third-party IME (and a custom keyboard was previously rejected by design), so they render in-app just above the keyboard.
- **Episodes scope** still shows a flat grid of all episodes; splitting out the Featured video row *there* too is a small follow-up.
- **Focus-restore** after returning from a detail now lands on the first Top-Results section (was the Podcasts row) — coarse, not a bug.
- **Device UI verification pending**: the shared TV emulator is hard to drive precisely and isn't logged in; the logic + crash fix are unit-tested and all module builds/tests are green, but the interactive Compose UI (suggestions/history/carousels focus) should be eyeballed on a real device. Screenshots to follow.

## Testing Instructions

1. Merge/stack on #5745 so search works (otherwise `network`-type results still error).
2. `./gradlew :tv:installDebug`. Open **Search**, type a query:
   - term suggestions appear above the keyboard while typing; tapping one fills + searches.
   - podcasts appear quickly, then episodes fill in.
   - Top Results shows Featured (video) → Episodes → Podcasts carousels.
   - an empty query returns to the idle browse; if you've searched before, a **Recent searches** row appears.
   - a no-match query shows **"No results for "…""**.
3. Unit tests: `./gradlew :tv:testDebugUnitTest :modules:services:servers:testDebugUnitTest :modules:services:repositories:testDebugUnitTest`.

## Screenshots or Screencast

https://github.com/user-attachments/assets/d331015a-e47c-4f2a-a1c4-e6e4f4fe929f



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md — N/A (TV, pre-release)
- [x] Ensure the linter passes (`./gradlew spotlessApply`)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in localization
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) the Event Horizon schema — N/A (no analytics change)