### PR TITLE
[TV] Local folder results in search 

### DIFF
--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2883,6 +2883,7 @@
     <string name="search_filters_top_results">Top Results</string>
     <string name="search_filters_podcasts" translatable="false">@string/podcasts</string>
     <string name="search_filters_episodes" translatable="false">@string/episodes</string>
+    <string name="search_filters_folders" translatable="false">@string/folders</string>
     <string name="search_suggestions_view_all">View all for \"%1$s\"</string>
     <string name="search_suggestions_no_results_title">No Results</string>
     <string name="search_suggestions_no_results_message">Try a new search, or by adding a podcast feed URL</string>

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchFilters.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchFilters.kt
@@ -38,6 +38,7 @@ internal fun TvSearchFilters(
     selected: TvSearchFilter,
     onFilterSelect: (TvSearchFilter) -> Unit,
     modifier: Modifier = Modifier,
+    filters: List<TvSearchFilter> = TvSearchFilter.entries,
     upFocusRequester: FocusRequester? = null,
 ) {
     Row(
@@ -47,6 +48,7 @@ internal fun TvSearchFilters(
         FilterDivider(modifier = Modifier.weight(1f))
         Spacer(modifier = Modifier.width(20.dp))
         TvSearchFilterPills(
+            filters = filters,
             selected = selected,
             onFilterSelect = onFilterSelect,
             upFocusRequester = upFocusRequester,
@@ -58,11 +60,12 @@ internal fun TvSearchFilters(
 
 @Composable
 private fun TvSearchFilterPills(
+    filters: List<TvSearchFilter>,
     selected: TvSearchFilter,
     onFilterSelect: (TvSearchFilter) -> Unit,
     upFocusRequester: FocusRequester? = null,
 ) {
-    val selectedIndex = TvSearchFilter.entries.indexOf(selected)
+    val selectedIndex = filters.indexOf(selected)
     val focusRequester = remember { FocusRequester() }
     Box(
         modifier = Modifier
@@ -86,7 +89,7 @@ private fun TvSearchFilterPills(
                 }
             },
         ) {
-            TvSearchFilter.entries.forEachIndexed { index, filter ->
+            filters.forEachIndexed { index, filter ->
                 Tab(
                     selected = index == selectedIndex,
                     onFocus = { onFilterSelect(filter) },

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.withFrameNanos
@@ -51,6 +52,7 @@ import au.com.shiftyjelly.pocketcasts.component.TvEmptyState
 import au.com.shiftyjelly.pocketcasts.component.TvEpisodeActionContext
 import au.com.shiftyjelly.pocketcasts.component.TvEpisodeActionsModal
 import au.com.shiftyjelly.pocketcasts.component.TvEpisodeInfoModal
+import au.com.shiftyjelly.pocketcasts.component.TvFolderCard
 import au.com.shiftyjelly.pocketcasts.component.TvPodcastGridScaffold
 import au.com.shiftyjelly.pocketcasts.component.TvPodcastTile
 import au.com.shiftyjelly.pocketcasts.component.TvPodcastTileDefaults
@@ -64,7 +66,9 @@ import au.com.shiftyjelly.pocketcasts.discover.TvOpenedCategory
 import au.com.shiftyjelly.pocketcasts.discover.TvOpenedCategorySaver
 import au.com.shiftyjelly.pocketcasts.discover.tvDiscoverRow
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
 import au.com.shiftyjelly.pocketcasts.models.to.ImprovedSearchResultItem
+import au.com.shiftyjelly.pocketcasts.podcasts.TvFolderDetailScreen
 import au.com.shiftyjelly.pocketcasts.podcasts.TvPodcastDetailsScreen
 import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImage
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
@@ -80,8 +84,16 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 private val ContentHorizontalPadding = 48.dp
 private val ContentPadding = PaddingValues(horizontal = ContentHorizontalPadding)
 private const val SEARCH_ROW_LIMIT = 10
+private const val FOLDER_COVER_COUNT = 4
 private val SearchEpisodeCardWidth = 360.dp
 private const val EPISODE_GRID_COLUMNS = 2
+
+private data class SearchOpenedFolder(val uuid: String, val name: String)
+
+private val SearchOpenedFolderSaver = listSaver<SearchOpenedFolder?, String>(
+    save = { folder -> folder?.let { listOf(it.uuid, it.name) } ?: emptyList() },
+    restore = { saved -> saved.takeIf { it.size == 2 }?.let { (uuid, name) -> SearchOpenedFolder(uuid, name) } },
+)
 
 @Composable
 fun TvSearchScreen(
@@ -99,11 +111,14 @@ fun TvSearchScreen(
 
     var openedPodcastUuid by rememberSaveable { mutableStateOf<String?>(null) }
     var openedCategory by rememberSaveable(stateSaver = TvOpenedCategorySaver) { mutableStateOf<TvOpenedCategory?>(null) }
+    var openedFolder by rememberSaveable(stateSaver = SearchOpenedFolderSaver) { mutableStateOf<SearchOpenedFolder?>(null) }
     var detailsEpisode by remember { mutableStateOf<PodcastEpisode?>(null) }
     var restoreFocusTrigger by remember { mutableIntStateOf(0) }
     var categoryRestoreTrigger by remember { mutableIntStateOf(0) }
+    var folderRestoreTrigger by remember { mutableIntStateOf(0) }
     val podcastUuid = openedPodcastUuid
     val category = openedCategory
+    val folder = openedFolder
 
     val openNowPlaying = LocalOpenNowPlaying.current
     val toastHostState = LocalTvToastHostState.current
@@ -125,6 +140,7 @@ fun TvSearchScreen(
             onQueryChange = viewModel::onQueryChange,
             onFilterSelect = viewModel::onFilterSelected,
             onOpenPodcast = { openedPodcastUuid = it },
+            onOpenFolder = { openedFolder = SearchOpenedFolder(it.folder.uuid, it.folder.name) },
             onOpenCategory = { openedCategory = TvOpenedCategory(it.id, it.name, it.source) },
             onPlayEpisode = viewModel::playEpisode,
             onOpenEpisodeActions = viewModel::openEpisodeActions,
@@ -140,8 +156,23 @@ fun TvSearchScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(top = TvTopBarHeight)
-                .tvFocusInactiveWhen(podcastUuid != null || category != null),
+                .tvFocusInactiveWhen(podcastUuid != null || category != null || folder != null),
         )
+        TvDetailOverlay(
+            target = folder,
+            onBack = { openedFolder = null },
+            modifier = Modifier.tvFocusInactiveWhen(podcastUuid != null),
+            onHide = { restoreFocusTrigger++ },
+        ) { openFolder ->
+            TvFolderDetailScreen(
+                folderUuid = openFolder.uuid,
+                folderName = openFolder.name,
+                getFolderPodcasts = viewModel::folderPodcasts,
+                onOpenPodcast = { openedPodcastUuid = it },
+                onClose = { openedFolder = null },
+                restoreFocusTrigger = folderRestoreTrigger,
+            )
+        }
         TvDetailOverlay(
             target = category,
             onBack = { openedCategory = null },
@@ -160,7 +191,13 @@ fun TvSearchScreen(
         TvDetailOverlay(
             target = podcastUuid,
             onBack = { openedPodcastUuid = null },
-            onHide = { if (openedCategory != null) categoryRestoreTrigger++ else restoreFocusTrigger++ },
+            onHide = {
+                when {
+                    openedCategory != null -> categoryRestoreTrigger++
+                    openedFolder != null -> folderRestoreTrigger++
+                    else -> restoreFocusTrigger++
+                }
+            },
         ) { uuid ->
             TvPodcastDetailsScreen(
                 podcastUuid = uuid,
@@ -202,6 +239,7 @@ private fun TvSearchContent(
     onQueryChange: (String) -> Unit,
     onFilterSelect: (TvSearchFilter) -> Unit,
     onOpenPodcast: (String) -> Unit,
+    onOpenFolder: (FolderItem.Folder) -> Unit,
     onOpenCategory: (DiscoverCategory) -> Unit,
     onPlayEpisode: (ImprovedSearchResultItem.EpisodeItem) -> Unit,
     onOpenEpisodeActions: (ImprovedSearchResultItem.EpisodeItem) -> Unit,
@@ -294,6 +332,7 @@ private fun TvSearchContent(
                     filter = filter,
                     searchTerm = query.trim(),
                     onOpenPodcast = onOpenPodcast,
+                    onOpenFolder = onOpenFolder,
                     onPlayEpisode = onPlayEpisode,
                     onOpenEpisodeActions = onOpenEpisodeActions,
                     restoreFocusTrigger = restoreFocusTrigger,
@@ -417,6 +456,7 @@ private fun TvSearchResults(
     filter: TvSearchFilter,
     searchTerm: String,
     onOpenPodcast: (String) -> Unit,
+    onOpenFolder: (FolderItem.Folder) -> Unit,
     onPlayEpisode: (ImprovedSearchResultItem.EpisodeItem) -> Unit,
     onOpenEpisodeActions: (ImprovedSearchResultItem.EpisodeItem) -> Unit,
     restoreFocusTrigger: Int,
@@ -425,7 +465,9 @@ private fun TvSearchResults(
         TvSearchFilter.TopResults -> TvSearchTopResults(
             podcasts = results.podcasts,
             episodes = results.episodes,
+            folders = results.folders,
             onOpenPodcast = onOpenPodcast,
+            onOpenFolder = onOpenFolder,
             onPlayEpisode = onPlayEpisode,
             onOpenEpisodeActions = onOpenEpisodeActions,
             restoreFocusTrigger = restoreFocusTrigger,
@@ -482,7 +524,9 @@ private fun TvSearchResults(
 private fun TvSearchTopResults(
     podcasts: List<ImprovedSearchResultItem.PodcastItem>,
     episodes: List<ImprovedSearchResultItem.EpisodeItem>,
+    folders: List<FolderItem.Folder>,
     onOpenPodcast: (String) -> Unit,
+    onOpenFolder: (FolderItem.Folder) -> Unit,
     onPlayEpisode: (ImprovedSearchResultItem.EpisodeItem) -> Unit,
     onOpenEpisodeActions: (ImprovedSearchResultItem.EpisodeItem) -> Unit,
     restoreFocusTrigger: Int,
@@ -499,10 +543,12 @@ private fun TvSearchTopResults(
 
     val featured = episodes.filter { it.hasVideo }.take(SEARCH_ROW_LIMIT)
     val otherEpisodes = episodes.filterNot { it.hasVideo }.take(SEARCH_ROW_LIMIT)
+    val topFolders = folders.take(SEARCH_ROW_LIMIT)
     val topPodcasts = podcasts.take(SEARCH_ROW_LIMIT)
     val featuredFirst = featured.isNotEmpty()
     val episodesFirst = !featuredFirst && otherEpisodes.isNotEmpty()
-    val podcastsFirst = !featuredFirst && !episodesFirst
+    val foldersFirst = !featuredFirst && !episodesFirst && topFolders.isNotEmpty()
+    val podcastsFirst = !featuredFirst && !episodesFirst && !foldersFirst
 
     LazyColumn(modifier = Modifier.fillMaxSize()) {
         item { Spacer(modifier = Modifier.height(8.dp)) }
@@ -529,6 +575,14 @@ private fun TvSearchTopResults(
                 )
             }
         }
+        if (topFolders.isNotEmpty()) {
+            item { Spacer(modifier = Modifier.height(24.dp)) }
+            tvSearchFoldersRow(
+                folders = topFolders,
+                onOpenFolder = onOpenFolder,
+                focusRequester = restoreFocusRequester.takeIf { foldersFirst },
+            )
+        }
         if (topPodcasts.isNotEmpty()) {
             item { Spacer(modifier = Modifier.height(24.dp)) }
             tvSearchPodcastsRow(
@@ -538,6 +592,28 @@ private fun TvSearchTopResults(
             )
         }
         item { Spacer(modifier = Modifier.height(40.dp)) }
+    }
+}
+
+private fun LazyListScope.tvSearchFoldersRow(
+    folders: List<FolderItem.Folder>,
+    onOpenFolder: (FolderItem.Folder) -> Unit,
+    focusRequester: FocusRequester?,
+) {
+    item {
+        TvRow(
+            title = stringResource(LR.string.folders),
+            items = folders,
+            contentPadding = ContentPadding,
+            key = { it.folder.uuid },
+            focusRequester = focusRequester,
+        ) { folderItem ->
+            TvFolderCard(
+                folder = folderItem.folder,
+                coverUrls = folderItem.podcasts.take(FOLDER_COVER_COUNT).map { PodcastImage.getMediumArtworkUrl(it.uuid) },
+                onClick = { onOpenFolder(folderItem) },
+            )
+        }
     }
 }
 
@@ -726,6 +802,7 @@ private fun TvSearchScreenPreview() {
                 onQueryChange = {},
                 onFilterSelect = {},
                 onOpenPodcast = {},
+                onOpenFolder = {},
                 onOpenCategory = {},
                 onPlayEpisode = {},
                 onOpenEpisodeActions = {},

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.withFrameNanos
@@ -51,6 +52,7 @@ import au.com.shiftyjelly.pocketcasts.component.TvEmptyState
 import au.com.shiftyjelly.pocketcasts.component.TvEpisodeActionContext
 import au.com.shiftyjelly.pocketcasts.component.TvEpisodeActionsModal
 import au.com.shiftyjelly.pocketcasts.component.TvEpisodeInfoModal
+import au.com.shiftyjelly.pocketcasts.component.TvFolderCard
 import au.com.shiftyjelly.pocketcasts.component.TvPodcastGridScaffold
 import au.com.shiftyjelly.pocketcasts.component.TvPodcastTile
 import au.com.shiftyjelly.pocketcasts.component.TvPodcastTileDefaults
@@ -64,7 +66,9 @@ import au.com.shiftyjelly.pocketcasts.discover.TvOpenedCategory
 import au.com.shiftyjelly.pocketcasts.discover.TvOpenedCategorySaver
 import au.com.shiftyjelly.pocketcasts.discover.tvDiscoverRow
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
 import au.com.shiftyjelly.pocketcasts.models.to.ImprovedSearchResultItem
+import au.com.shiftyjelly.pocketcasts.podcasts.TvFolderDetailScreen
 import au.com.shiftyjelly.pocketcasts.podcasts.TvPodcastDetailsScreen
 import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImage
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
@@ -78,8 +82,16 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 private val ContentHorizontalPadding = 48.dp
 private val ContentPadding = PaddingValues(horizontal = ContentHorizontalPadding)
 private const val SEARCH_ROW_LIMIT = 10
+private const val FOLDER_COVER_COUNT = 4
 private val SearchEpisodeCardWidth = 360.dp
 private const val EPISODE_GRID_COLUMNS = 2
+
+private data class SearchOpenedFolder(val uuid: String, val name: String)
+
+private val SearchOpenedFolderSaver = listSaver<SearchOpenedFolder?, String>(
+    save = { folder -> folder?.let { listOf(it.uuid, it.name) } ?: emptyList() },
+    restore = { saved -> saved.takeIf { it.size == 2 }?.let { (uuid, name) -> SearchOpenedFolder(uuid, name) } },
+)
 
 @Composable
 fun TvSearchScreen(
@@ -97,11 +109,14 @@ fun TvSearchScreen(
 
     var openedPodcastUuid by rememberSaveable { mutableStateOf<String?>(null) }
     var openedCategory by rememberSaveable(stateSaver = TvOpenedCategorySaver) { mutableStateOf<TvOpenedCategory?>(null) }
+    var openedFolder by rememberSaveable(stateSaver = SearchOpenedFolderSaver) { mutableStateOf<SearchOpenedFolder?>(null) }
     var detailsEpisode by remember { mutableStateOf<PodcastEpisode?>(null) }
     var restoreFocusTrigger by remember { mutableIntStateOf(0) }
     var categoryRestoreTrigger by remember { mutableIntStateOf(0) }
+    var folderRestoreTrigger by remember { mutableIntStateOf(0) }
     val podcastUuid = openedPodcastUuid
     val category = openedCategory
+    val folder = openedFolder
 
     val openNowPlaying = LocalOpenNowPlaying.current
     val toastHostState = LocalTvToastHostState.current
@@ -123,6 +138,7 @@ fun TvSearchScreen(
             onQueryChange = viewModel::onQueryChange,
             onFilterSelect = viewModel::onFilterSelected,
             onOpenPodcast = { openedPodcastUuid = it },
+            onOpenFolder = { openedFolder = SearchOpenedFolder(it.folder.uuid, it.folder.name) },
             onOpenCategory = { openedCategory = TvOpenedCategory(it.id, it.name, it.source) },
             onPlayEpisode = viewModel::playEpisode,
             onOpenEpisodeActions = viewModel::openEpisodeActions,
@@ -138,8 +154,23 @@ fun TvSearchScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(top = TvTopBarHeight)
-                .tvFocusInactiveWhen(podcastUuid != null || category != null),
+                .tvFocusInactiveWhen(podcastUuid != null || category != null || folder != null),
         )
+        TvDetailOverlay(
+            target = folder,
+            onBack = { openedFolder = null },
+            modifier = Modifier.tvFocusInactiveWhen(podcastUuid != null),
+            onHide = { restoreFocusTrigger++ },
+        ) { openFolder ->
+            TvFolderDetailScreen(
+                folderUuid = openFolder.uuid,
+                folderName = openFolder.name,
+                getFolderPodcasts = viewModel::folderPodcasts,
+                onOpenPodcast = { openedPodcastUuid = it },
+                onClose = { openedFolder = null },
+                restoreFocusTrigger = folderRestoreTrigger,
+            )
+        }
         TvDetailOverlay(
             target = category,
             onBack = { openedCategory = null },
@@ -158,7 +189,13 @@ fun TvSearchScreen(
         TvDetailOverlay(
             target = podcastUuid,
             onBack = { openedPodcastUuid = null },
-            onHide = { if (openedCategory != null) categoryRestoreTrigger++ else restoreFocusTrigger++ },
+            onHide = {
+                when {
+                    openedCategory != null -> categoryRestoreTrigger++
+                    openedFolder != null -> folderRestoreTrigger++
+                    else -> restoreFocusTrigger++
+                }
+            },
         ) { uuid ->
             TvPodcastDetailsScreen(
                 podcastUuid = uuid,
@@ -199,6 +236,7 @@ private fun TvSearchContent(
     onQueryChange: (String) -> Unit,
     onFilterSelect: (TvSearchFilter) -> Unit,
     onOpenPodcast: (String) -> Unit,
+    onOpenFolder: (FolderItem.Folder) -> Unit,
     onOpenCategory: (DiscoverCategory) -> Unit,
     onPlayEpisode: (ImprovedSearchResultItem.EpisodeItem) -> Unit,
     onOpenEpisodeActions: (ImprovedSearchResultItem.EpisodeItem) -> Unit,
@@ -288,6 +326,7 @@ private fun TvSearchContent(
                     filter = filter,
                     searchTerm = query.trim(),
                     onOpenPodcast = onOpenPodcast,
+                    onOpenFolder = onOpenFolder,
                     onPlayEpisode = onPlayEpisode,
                     onOpenEpisodeActions = onOpenEpisodeActions,
                     restoreFocusTrigger = restoreFocusTrigger,
@@ -410,6 +449,7 @@ private fun TvSearchResults(
     filter: TvSearchFilter,
     searchTerm: String,
     onOpenPodcast: (String) -> Unit,
+    onOpenFolder: (FolderItem.Folder) -> Unit,
     onPlayEpisode: (ImprovedSearchResultItem.EpisodeItem) -> Unit,
     onOpenEpisodeActions: (ImprovedSearchResultItem.EpisodeItem) -> Unit,
     restoreFocusTrigger: Int,
@@ -418,7 +458,9 @@ private fun TvSearchResults(
         TvSearchFilter.TopResults -> TvSearchTopResults(
             podcasts = results.podcasts,
             episodes = results.episodes,
+            folders = results.folders,
             onOpenPodcast = onOpenPodcast,
+            onOpenFolder = onOpenFolder,
             onPlayEpisode = onPlayEpisode,
             onOpenEpisodeActions = onOpenEpisodeActions,
             restoreFocusTrigger = restoreFocusTrigger,
@@ -475,7 +517,9 @@ private fun TvSearchResults(
 private fun TvSearchTopResults(
     podcasts: List<ImprovedSearchResultItem.PodcastItem>,
     episodes: List<ImprovedSearchResultItem.EpisodeItem>,
+    folders: List<FolderItem.Folder>,
     onOpenPodcast: (String) -> Unit,
+    onOpenFolder: (FolderItem.Folder) -> Unit,
     onPlayEpisode: (ImprovedSearchResultItem.EpisodeItem) -> Unit,
     onOpenEpisodeActions: (ImprovedSearchResultItem.EpisodeItem) -> Unit,
     restoreFocusTrigger: Int,
@@ -492,10 +536,12 @@ private fun TvSearchTopResults(
 
     val featured = episodes.filter { it.hasVideo }.take(SEARCH_ROW_LIMIT)
     val otherEpisodes = episodes.filterNot { it.hasVideo }.take(SEARCH_ROW_LIMIT)
+    val topFolders = folders.take(SEARCH_ROW_LIMIT)
     val topPodcasts = podcasts.take(SEARCH_ROW_LIMIT)
     val featuredFirst = featured.isNotEmpty()
     val episodesFirst = !featuredFirst && otherEpisodes.isNotEmpty()
-    val podcastsFirst = !featuredFirst && !episodesFirst
+    val foldersFirst = !featuredFirst && !episodesFirst && topFolders.isNotEmpty()
+    val podcastsFirst = !featuredFirst && !episodesFirst && !foldersFirst
 
     LazyColumn(modifier = Modifier.fillMaxSize()) {
         item { Spacer(modifier = Modifier.height(8.dp)) }
@@ -522,6 +568,14 @@ private fun TvSearchTopResults(
                 )
             }
         }
+        if (topFolders.isNotEmpty()) {
+            item { Spacer(modifier = Modifier.height(24.dp)) }
+            tvSearchFoldersRow(
+                folders = topFolders,
+                onOpenFolder = onOpenFolder,
+                focusRequester = restoreFocusRequester.takeIf { foldersFirst },
+            )
+        }
         if (topPodcasts.isNotEmpty()) {
             item { Spacer(modifier = Modifier.height(24.dp)) }
             tvSearchPodcastsRow(
@@ -531,6 +585,28 @@ private fun TvSearchTopResults(
             )
         }
         item { Spacer(modifier = Modifier.height(40.dp)) }
+    }
+}
+
+private fun LazyListScope.tvSearchFoldersRow(
+    folders: List<FolderItem.Folder>,
+    onOpenFolder: (FolderItem.Folder) -> Unit,
+    focusRequester: FocusRequester?,
+) {
+    item {
+        TvRow(
+            title = stringResource(LR.string.folders),
+            items = folders,
+            contentPadding = ContentPadding,
+            key = { it.folder.uuid },
+            focusRequester = focusRequester,
+        ) { folderItem ->
+            TvFolderCard(
+                folder = folderItem.folder,
+                coverUrls = folderItem.podcasts.take(FOLDER_COVER_COUNT).map { PodcastImage.getMediumArtworkUrl(it.uuid) },
+                onClick = { onOpenFolder(folderItem) },
+            )
+        }
     }
 }
 
@@ -718,6 +794,7 @@ private fun TvSearchScreenPreview() {
                 onQueryChange = {},
                 onFilterSelect = {},
                 onOpenPodcast = {},
+                onOpenFolder = {},
                 onOpenCategory = {},
                 onPlayEpisode = {},
                 onOpenEpisodeActions = {},

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
@@ -106,6 +106,7 @@ fun TvSearchScreen(
     val query by viewModel.query.collectAsStateWithLifecycle()
     val searchState by viewModel.searchState.collectAsStateWithLifecycle()
     val filter by viewModel.filter.collectAsStateWithLifecycle()
+    val hasFolderResults by viewModel.hasFolderResults.collectAsStateWithLifecycle()
     val categories by viewModel.categories.collectAsStateWithLifecycle()
     val discoverRows by viewModel.discoverRows.collectAsStateWithLifecycle()
     val suggestions by viewModel.suggestions.collectAsStateWithLifecycle()
@@ -138,6 +139,7 @@ fun TvSearchScreen(
             query = query,
             searchState = searchState,
             filter = filter,
+            hasFolderResults = hasFolderResults,
             categories = categories,
             discoverRows = discoverRows,
             onQueryChange = viewModel::onQueryChange,
@@ -238,6 +240,7 @@ private fun TvSearchContent(
     query: String,
     searchState: TvSearchState,
     filter: TvSearchFilter,
+    hasFolderResults: Boolean,
     categories: List<DiscoverCategory>,
     discoverRows: List<TvDiscoverRow>,
     onQueryChange: (String) -> Unit,
@@ -291,8 +294,7 @@ private fun TvSearchContent(
             Spacer(modifier = Modifier.height(24.dp))
         }
 
-        val hasFolders = (searchState as? TvSearchState.Results)?.let { it.folders.isNotEmpty() || it.isPartial } == true
-        val filters = remember(hasFolders) { TvSearchFilter.entries.filter { it != TvSearchFilter.Folders || hasFolders } }
+        val filters = remember(hasFolderResults) { TvSearchFilter.entries.filter { it != TvSearchFilter.Folders || hasFolderResults } }
         val effectiveFilter = if (filter in filters) filter else TvSearchFilter.TopResults
 
         if (searchState !is TvSearchState.Idle) {
@@ -527,19 +529,30 @@ private fun TvSearchResults(
             )
         }
 
-        TvSearchFilter.Folders -> TvPodcastGridScaffold(
-            itemKeys = results.folders.map { it.folder.uuid },
-            modifier = Modifier.fillMaxSize(),
-            horizontalContentPadding = ContentHorizontalPadding,
-            restoreFocusTrigger = restoreFocusTrigger,
-        ) { index, itemModifier ->
-            val folderItem = results.folders[index]
-            TvFolderCard(
-                folder = folderItem.folder,
-                coverUrls = folderItem.podcasts.take(FOLDER_COVER_COUNT).map { PodcastImage.getMediumArtworkUrl(it.uuid) },
-                onClick = { onOpenFolder(folderItem) },
-                modifier = itemModifier,
-            )
+        TvSearchFilter.Folders -> if (results.folders.isEmpty()) {
+            if (results.isPartial) {
+                TvSearchLoading()
+            } else {
+                TvSearchMessage(
+                    title = stringResource(LR.string.tv_search_no_results_for_title, searchTerm),
+                    subtitle = stringResource(LR.string.tv_search_no_results_subtitle),
+                )
+            }
+        } else {
+            TvPodcastGridScaffold(
+                itemKeys = results.folders.map { it.folder.uuid },
+                modifier = Modifier.fillMaxSize(),
+                horizontalContentPadding = ContentHorizontalPadding,
+                restoreFocusTrigger = restoreFocusTrigger,
+            ) { index, itemModifier ->
+                val folderItem = results.folders[index]
+                TvFolderCard(
+                    folder = folderItem.folder,
+                    coverUrls = folderItem.podcasts.take(FOLDER_COVER_COUNT).map { PodcastImage.getMediumArtworkUrl(it.uuid) },
+                    onClick = { onOpenFolder(folderItem) },
+                    modifier = itemModifier,
+                )
+            }
         }
     }
 }
@@ -818,6 +831,7 @@ private fun TvSearchScreenPreview() {
                 query = "",
                 searchState = TvSearchState.Idle,
                 filter = TvSearchFilter.TopResults,
+                hasFolderResults = false,
                 categories = listOf(
                     DiscoverCategory(id = 1, name = "Comedy", icon = "", source = ""),
                     DiscoverCategory(id = 2, name = "True Crime", icon = "", source = ""),
@@ -845,6 +859,7 @@ private fun TvSearchIdleWithHistoryPreview() {
                 query = "",
                 searchState = TvSearchState.Idle,
                 filter = TvSearchFilter.TopResults,
+                hasFolderResults = false,
                 categories = emptyList(),
                 discoverRows = emptyList(),
                 onQueryChange = {},
@@ -904,6 +919,7 @@ private fun TvSearchResultsPreview() {
                     ),
                 ),
                 filter = TvSearchFilter.TopResults,
+                hasFolderResults = true,
                 categories = emptyList(),
                 discoverRows = emptyList(),
                 onQueryChange = {},

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
@@ -291,10 +291,15 @@ private fun TvSearchContent(
             Spacer(modifier = Modifier.height(24.dp))
         }
 
+        val hasFolders = (searchState as? TvSearchState.Results)?.folders?.isNotEmpty() == true
+        val filters = TvSearchFilter.entries.filter { it != TvSearchFilter.Folders || hasFolders }
+        val effectiveFilter = if (filter in filters) filter else TvSearchFilter.TopResults
+
         if (searchState !is TvSearchState.Idle) {
             TvSearchFilters(
-                selected = filter,
+                selected = effectiveFilter,
                 onFilterSelect = onFilterSelect,
+                filters = filters,
                 modifier = Modifier.padding(ContentPadding),
                 upFocusRequester = searchFieldFocusRequester,
             )
@@ -333,7 +338,7 @@ private fun TvSearchContent(
 
                 is TvSearchState.Results -> TvSearchResults(
                     results = searchState,
-                    filter = filter,
+                    filter = effectiveFilter,
                     searchTerm = query.trim(),
                     onOpenPodcast = onOpenPodcast,
                     onOpenFolder = onOpenFolder,
@@ -519,6 +524,21 @@ private fun TvSearchResults(
                 onPlayEpisode = onPlayEpisode,
                 onOpenEpisodeActions = onOpenEpisodeActions,
                 restoreFocusTrigger = restoreFocusTrigger,
+            )
+        }
+
+        TvSearchFilter.Folders -> TvPodcastGridScaffold(
+            itemKeys = results.folders.map { it.folder.uuid },
+            modifier = Modifier.fillMaxSize(),
+            horizontalContentPadding = ContentHorizontalPadding,
+            restoreFocusTrigger = restoreFocusTrigger,
+        ) { index, itemModifier ->
+            val folderItem = results.folders[index]
+            TvFolderCard(
+                folder = folderItem.folder,
+                coverUrls = folderItem.podcasts.take(FOLDER_COVER_COUNT).map { PodcastImage.getMediumArtworkUrl(it.uuid) },
+                onClick = { onOpenFolder(folderItem) },
+                modifier = itemModifier,
             )
         }
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
@@ -65,9 +65,12 @@ import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverRow
 import au.com.shiftyjelly.pocketcasts.discover.TvOpenedCategory
 import au.com.shiftyjelly.pocketcasts.discover.TvOpenedCategorySaver
 import au.com.shiftyjelly.pocketcasts.discover.tvDiscoverRow
+import au.com.shiftyjelly.pocketcasts.models.entity.Folder
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
 import au.com.shiftyjelly.pocketcasts.models.to.ImprovedSearchResultItem
+import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
 import au.com.shiftyjelly.pocketcasts.podcasts.TvFolderDetailScreen
 import au.com.shiftyjelly.pocketcasts.podcasts.TvPodcastDetailsScreen
 import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImage
@@ -170,6 +173,7 @@ fun TvSearchScreen(
                 getFolderPodcasts = viewModel::folderPodcasts,
                 onOpenPodcast = { openedPodcastUuid = it },
                 onClose = { openedFolder = null },
+                onFolderImpression = {},
                 restoreFocusTrigger = folderRestoreTrigger,
             )
         }
@@ -612,6 +616,7 @@ private fun LazyListScope.tvSearchFoldersRow(
                 folder = folderItem.folder,
                 coverUrls = folderItem.podcasts.take(FOLDER_COVER_COUNT).map { PodcastImage.getMediumArtworkUrl(it.uuid) },
                 onClick = { onOpenFolder(folderItem) },
+                modifier = Modifier.width(TvPodcastTileDefaults.RowImageWidth),
             )
         }
     }
@@ -828,6 +833,7 @@ private fun TvSearchIdleWithHistoryPreview() {
                 onOpenCategory = {},
                 onPlayEpisode = {},
                 onOpenEpisodeActions = {},
+                onOpenFolder = {},
                 history = listOf("Freakonomics", "Business Daily", "Science Weekly"),
             )
         }
@@ -861,6 +867,21 @@ private fun TvSearchResultsPreview() {
                             hasVideo = it == 0,
                         )
                     },
+                    folders = listOf(
+                        FolderItem.Folder(
+                            folder = Folder(
+                                uuid = "folder-1",
+                                name = "Business & Finance",
+                                color = 3,
+                                addedDate = Date(0),
+                                sortPosition = 0,
+                                podcastsSortType = PodcastsSortType.NAME_A_TO_Z,
+                                deleted = false,
+                                syncModified = 0,
+                            ),
+                            podcasts = List(4) { Podcast(uuid = "folder-podcast-$it") },
+                        ),
+                    ),
                 ),
                 filter = TvSearchFilter.TopResults,
                 categories = emptyList(),
@@ -871,6 +892,7 @@ private fun TvSearchResultsPreview() {
                 onOpenCategory = {},
                 onPlayEpisode = {},
                 onOpenEpisodeActions = {},
+                onOpenFolder = {},
             )
         }
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
@@ -291,8 +291,8 @@ private fun TvSearchContent(
             Spacer(modifier = Modifier.height(24.dp))
         }
 
-        val hasFolders = (searchState as? TvSearchState.Results)?.folders?.isNotEmpty() == true
-        val filters = TvSearchFilter.entries.filter { it != TvSearchFilter.Folders || hasFolders }
+        val hasFolders = (searchState as? TvSearchState.Results)?.let { it.folders.isNotEmpty() || it.isPartial } == true
+        val filters = remember(hasFolders) { TvSearchFilter.entries.filter { it != TvSearchFilter.Folders || hasFolders } }
         val effectiveFilter = if (filter in filters) filter else TvSearchFilter.TopResults
 
         if (searchState !is TvSearchState.Idle) {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
@@ -134,6 +134,7 @@ class TvSearchViewModel @Inject constructor(
             _searchState.value = TvSearchState.Searching
             _searchState.value = try {
                 val fullSearch = async { runCatching { improvedSearchManager.combinedSearch(term) } }
+                val foldersSearch = async { runCatching { searchFolders(term) }.getOrDefault(emptyList()) }
                 val localPodcasts = podcastManager.findSubscribedFlow(term).first().map(Podcast::toSearchItem)
                 val localUuids = localPodcasts.mapTo(HashSet(), ImprovedSearchResultItem.PodcastItem::uuid)
                 val predictiveResults = try {
@@ -151,7 +152,6 @@ class TvSearchViewModel @Inject constructor(
                     _searchState.value = TvSearchState.Results(podcasts = earlyPodcasts, episodes = emptyList(), isPartial = true)
                 }
 
-                val folders = searchFolders(term)
                 val remoteResults = fullSearch.await().getOrThrow()
                 val remotePodcasts = remoteResults.filterIsInstance<ImprovedSearchResultItem.PodcastItem>()
                 val podcasts = (predictivePodcasts + remotePodcasts + localPodcasts)
@@ -159,6 +159,7 @@ class TvSearchViewModel @Inject constructor(
                     .map { if (it.uuid in localUuids) it.copy(isFollowed = true) else it }
                 val episodes = remoteResults.filterIsInstance<ImprovedSearchResultItem.EpisodeItem>()
                     .distinctBy(ImprovedSearchResultItem.EpisodeItem::uuid)
+                val folders = foldersSearch.await()
                 if (podcasts.isEmpty() && episodes.isEmpty() && folders.isEmpty()) {
                     TvSearchState.NoResults
                 } else {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
@@ -9,15 +9,18 @@ import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverPodcast
 import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverRow
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
 import au.com.shiftyjelly.pocketcasts.models.to.ImprovedSearchResultItem
 import au.com.shiftyjelly.pocketcasts.models.to.SearchAutoCompleteItem
 import au.com.shiftyjelly.pocketcasts.models.to.SearchHistoryEntry
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.FolderManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.search.ImprovedSearchManager
 import au.com.shiftyjelly.pocketcasts.repositories.searchhistory.SearchHistoryManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
+import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -46,6 +49,8 @@ class TvSearchViewModel @Inject constructor(
     private val episodeManager: EpisodeManager,
     private val playbackManager: PlaybackManager,
     private val searchHistoryManager: SearchHistoryManager,
+    private val folderManager: FolderManager,
+    private val userManager: UserManager,
 ) : ViewModel() {
 
     private val _categories = MutableStateFlow<List<DiscoverCategory>>(emptyList())
@@ -146,6 +151,7 @@ class TvSearchViewModel @Inject constructor(
                     _searchState.value = TvSearchState.Results(podcasts = earlyPodcasts, episodes = emptyList(), isPartial = true)
                 }
 
+                val folders = searchFolders(term)
                 val remoteResults = fullSearch.await().getOrThrow()
                 val remotePodcasts = remoteResults.filterIsInstance<ImprovedSearchResultItem.PodcastItem>()
                 val podcasts = (predictivePodcasts + remotePodcasts + localPodcasts)
@@ -153,10 +159,10 @@ class TvSearchViewModel @Inject constructor(
                     .map { if (it.uuid in localUuids) it.copy(isFollowed = true) else it }
                 val episodes = remoteResults.filterIsInstance<ImprovedSearchResultItem.EpisodeItem>()
                     .distinctBy(ImprovedSearchResultItem.EpisodeItem::uuid)
-                if (podcasts.isEmpty() && episodes.isEmpty()) {
+                if (podcasts.isEmpty() && episodes.isEmpty() && folders.isEmpty()) {
                     TvSearchState.NoResults
                 } else {
-                    TvSearchState.Results(podcasts = podcasts, episodes = episodes)
+                    TvSearchState.Results(podcasts = podcasts, episodes = episodes, folders = folders)
                 }
             } catch (exception: CancellationException) {
                 throw exception
@@ -169,6 +175,19 @@ class TvSearchViewModel @Inject constructor(
 
     fun onFilterSelected(filter: TvSearchFilter) {
         _filter.value = filter
+    }
+
+    private suspend fun searchFolders(term: String): List<FolderItem.Folder> {
+        if (!userManager.getSignInState().firstOrError().await().isSignedInAsPlusOrPatron) {
+            return emptyList()
+        }
+        return folderManager.getAll()
+            .filter { it.name.contains(term, ignoreCase = true) }
+            .map { folder -> FolderItem.Folder(folder = folder, podcasts = podcastManager.findPodcastsInFolder(folder.uuid)) }
+    }
+
+    suspend fun folderPodcasts(folderUuid: String): List<Podcast> {
+        return folderManager.findFolderPodcastsSorted(folderUuid)
     }
 
     fun saveSearchTerm(term: String) {
@@ -286,6 +305,7 @@ sealed interface TvSearchState {
     data class Results(
         val podcasts: List<ImprovedSearchResultItem.PodcastItem>,
         val episodes: List<ImprovedSearchResultItem.EpisodeItem>,
+        val folders: List<FolderItem.Folder> = emptyList(),
         val isPartial: Boolean = false,
     ) : TvSearchState
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
@@ -14,7 +14,6 @@ import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
 import au.com.shiftyjelly.pocketcasts.models.to.ImprovedSearchResultItem
 import au.com.shiftyjelly.pocketcasts.models.to.SearchAutoCompleteItem
 import au.com.shiftyjelly.pocketcasts.models.to.SearchHistoryEntry
-import au.com.shiftyjelly.pocketcasts.models.type.SignInState
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.FolderManager
@@ -22,7 +21,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.search.ImprovedSearchManager
 import au.com.shiftyjelly.pocketcasts.repositories.searchhistory.SearchHistoryManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
-import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -33,14 +31,11 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.rx2.await
 import timber.log.Timber
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -55,7 +50,6 @@ class TvSearchViewModel @Inject constructor(
     private val playbackManager: PlaybackManager,
     private val searchHistoryManager: SearchHistoryManager,
     private val folderManager: FolderManager,
-    private val userManager: UserManager,
 ) : ViewModel() {
 
     private val _categories = MutableStateFlow<List<DiscoverCategory>>(emptyList())
@@ -89,9 +83,6 @@ class TvSearchViewModel @Inject constructor(
     val actionsEpisode: StateFlow<PodcastEpisode?> = _actionsEpisode.asStateFlow()
 
     private var searchJob: Job? = null
-
-    private val signInState = userManager.getSignInState().asFlow()
-        .stateIn(viewModelScope, SharingStarted.Eagerly, SignInState.SignedOut)
 
     init {
         viewModelScope.launch {
@@ -198,7 +189,7 @@ class TvSearchViewModel @Inject constructor(
     }
 
     private suspend fun searchFolders(term: String): List<FolderItem.Folder> {
-        if (!signInState.value.isSignedInAsPlusOrPatron) {
+        if (!syncManager.isLoggedIn()) {
             return emptyList()
         }
         return folderManager.getAll()

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
@@ -68,6 +68,9 @@ class TvSearchViewModel @Inject constructor(
     private val _filter = MutableStateFlow(TvSearchFilter.TopResults)
     val filter: StateFlow<TvSearchFilter> = _filter.asStateFlow()
 
+    private val _hasFolderResults = MutableStateFlow(false)
+    val hasFolderResults: StateFlow<Boolean> = _hasFolderResults.asStateFlow()
+
     private val _suggestions = MutableStateFlow<List<String>>(emptyList())
     val suggestions: StateFlow<List<String>> = _suggestions.asStateFlow()
 
@@ -127,6 +130,7 @@ class TvSearchViewModel @Inject constructor(
         if (term.isEmpty()) {
             _suggestions.value = emptyList()
             _searchState.value = TvSearchState.Idle
+            updateFolderResults(hasFolders = false)
             return
         }
         searchJob = viewModelScope.launch {
@@ -171,9 +175,7 @@ class TvSearchViewModel @Inject constructor(
                 val episodes = remoteResults.filterIsInstance<ImprovedSearchResultItem.EpisodeItem>()
                     .distinctBy(ImprovedSearchResultItem.EpisodeItem::uuid)
                 val folders = foldersSearch.await()
-                if (folders.isEmpty() && _filter.value == TvSearchFilter.Folders) {
-                    _filter.value = TvSearchFilter.TopResults
-                }
+                updateFolderResults(hasFolders = folders.isNotEmpty())
                 if (podcasts.isEmpty() && episodes.isEmpty() && folders.isEmpty()) {
                     TvSearchState.NoResults
                 } else {
@@ -183,6 +185,7 @@ class TvSearchViewModel @Inject constructor(
                 throw exception
             } catch (exception: Exception) {
                 Timber.e(exception, "Failed to search on TV")
+                updateFolderResults(hasFolders = false)
                 TvSearchState.Error
             }
         }
@@ -190,6 +193,13 @@ class TvSearchViewModel @Inject constructor(
 
     fun onFilterSelected(filter: TvSearchFilter) {
         _filter.value = filter
+    }
+
+    private fun updateFolderResults(hasFolders: Boolean) {
+        _hasFolderResults.value = hasFolders
+        if (!hasFolders && _filter.value == TvSearchFilter.Folders) {
+            _filter.value = TvSearchFilter.TopResults
+        }
     }
 
     private suspend fun searchFolders(term: String): List<FolderItem.Folder> {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
@@ -135,6 +135,7 @@ class TvSearchViewModel @Inject constructor(
             _searchState.value = TvSearchState.Searching
             _searchState.value = try {
                 val fullSearch = async { runCatching { improvedSearchManager.combinedSearch(term) } }
+                val foldersSearch = async { runCatching { searchFolders(term) }.getOrDefault(emptyList()) }
                 val localPodcasts = podcastManager.findSubscribedFlow(term).first().map(Podcast::toSearchItem)
                 val localUuids = localPodcasts.mapTo(HashSet(), ImprovedSearchResultItem.PodcastItem::uuid)
                 val predictiveResults = try {
@@ -154,7 +155,6 @@ class TvSearchViewModel @Inject constructor(
                     _searchState.value = TvSearchState.Results(podcasts = earlyPodcasts, episodes = emptyList(), isPartial = true)
                 }
 
-                val folders = searchFolders(term)
                 val remoteResults = fullSearch.await().getOrThrow()
                 val remotePodcasts = remoteResults.filterIsInstance<ImprovedSearchResultItem.PodcastItem>()
                 val podcasts = (predictivePodcasts + remotePodcasts + localPodcasts)
@@ -162,6 +162,7 @@ class TvSearchViewModel @Inject constructor(
                     .map { if (it.uuid in localUuids) it.copy(isFollowed = true) else it }
                 val episodes = remoteResults.filterIsInstance<ImprovedSearchResultItem.EpisodeItem>()
                     .distinctBy(ImprovedSearchResultItem.EpisodeItem::uuid)
+                val folders = foldersSearch.await()
                 if (podcasts.isEmpty() && episodes.isEmpty() && folders.isEmpty()) {
                     TvSearchState.NoResults
                 } else {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
@@ -14,6 +14,7 @@ import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
 import au.com.shiftyjelly.pocketcasts.models.to.ImprovedSearchResultItem
 import au.com.shiftyjelly.pocketcasts.models.to.SearchAutoCompleteItem
 import au.com.shiftyjelly.pocketcasts.models.to.SearchHistoryEntry
+import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.FolderManager
@@ -170,6 +171,9 @@ class TvSearchViewModel @Inject constructor(
                 val episodes = remoteResults.filterIsInstance<ImprovedSearchResultItem.EpisodeItem>()
                     .distinctBy(ImprovedSearchResultItem.EpisodeItem::uuid)
                 val folders = foldersSearch.await()
+                if (folders.isEmpty() && _filter.value == TvSearchFilter.Folders) {
+                    _filter.value = TvSearchFilter.TopResults
+                }
                 if (podcasts.isEmpty() && episodes.isEmpty() && folders.isEmpty()) {
                     TvSearchState.NoResults
                 } else {
@@ -194,7 +198,8 @@ class TvSearchViewModel @Inject constructor(
         }
         return folderManager.getAll()
             .filter { it.name.contains(term, ignoreCase = true) }
-            .map { folder -> FolderItem.Folder(folder = folder, podcasts = podcastManager.findPodcastsInFolder(folder.uuid)) }
+            .sortedBy { PodcastsSortType.cleanStringForSort(it.name) }
+            .map { folder -> FolderItem.Folder(folder = folder, podcasts = folderManager.findFolderPodcastsSorted(folder.uuid)) }
     }
 
     suspend fun folderPodcasts(folderUuid: String): List<Podcast> {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
@@ -306,6 +306,7 @@ enum class TvSearchFilter(
     TopResults(LR.string.search_filters_top_results),
     Podcasts(LR.string.search_filters_podcasts),
     Episodes(LR.string.search_filters_episodes),
+    Folders(LR.string.search_filters_folders),
 }
 
 sealed interface TvSearchState {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
@@ -14,6 +14,7 @@ import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
 import au.com.shiftyjelly.pocketcasts.models.to.ImprovedSearchResultItem
 import au.com.shiftyjelly.pocketcasts.models.to.SearchAutoCompleteItem
 import au.com.shiftyjelly.pocketcasts.models.to.SearchHistoryEntry
+import au.com.shiftyjelly.pocketcasts.models.type.SignInState
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.FolderManager
@@ -32,11 +33,14 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.rx2.await
 import timber.log.Timber
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -85,6 +89,9 @@ class TvSearchViewModel @Inject constructor(
     val actionsEpisode: StateFlow<PodcastEpisode?> = _actionsEpisode.asStateFlow()
 
     private var searchJob: Job? = null
+
+    private val signInState = userManager.getSignInState().asFlow()
+        .stateIn(viewModelScope, SharingStarted.Eagerly, SignInState.SignedOut)
 
     init {
         viewModelScope.launch {
@@ -135,7 +142,16 @@ class TvSearchViewModel @Inject constructor(
             _searchState.value = TvSearchState.Searching
             _searchState.value = try {
                 val fullSearch = async { runCatching { improvedSearchManager.combinedSearch(term) } }
-                val foldersSearch = async { runCatching { searchFolders(term) }.getOrDefault(emptyList()) }
+                val foldersSearch = async {
+                    try {
+                        searchFolders(term)
+                    } catch (exception: CancellationException) {
+                        throw exception
+                    } catch (exception: Exception) {
+                        Timber.e(exception, "Failed to search TV folders")
+                        emptyList()
+                    }
+                }
                 val localPodcasts = podcastManager.findSubscribedFlow(term).first().map(Podcast::toSearchItem)
                 val localUuids = localPodcasts.mapTo(HashSet(), ImprovedSearchResultItem.PodcastItem::uuid)
                 val predictiveResults = try {
@@ -182,7 +198,7 @@ class TvSearchViewModel @Inject constructor(
     }
 
     private suspend fun searchFolders(term: String): List<FolderItem.Folder> {
-        if (!userManager.getSignInState().firstOrError().await().isSignedInAsPlusOrPatron) {
+        if (!signInState.value.isSignedInAsPlusOrPatron) {
             return emptyList()
         }
         return folderManager.getAll()

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
@@ -10,15 +10,18 @@ import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverPodcast
 import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverRow
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
 import au.com.shiftyjelly.pocketcasts.models.to.ImprovedSearchResultItem
 import au.com.shiftyjelly.pocketcasts.models.to.SearchAutoCompleteItem
 import au.com.shiftyjelly.pocketcasts.models.to.SearchHistoryEntry
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.FolderManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.search.ImprovedSearchManager
 import au.com.shiftyjelly.pocketcasts.repositories.searchhistory.SearchHistoryManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
+import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -47,6 +50,8 @@ class TvSearchViewModel @Inject constructor(
     private val episodeManager: EpisodeManager,
     private val playbackManager: PlaybackManager,
     private val searchHistoryManager: SearchHistoryManager,
+    private val folderManager: FolderManager,
+    private val userManager: UserManager,
 ) : ViewModel() {
 
     private val _categories = MutableStateFlow<List<DiscoverCategory>>(emptyList())
@@ -149,6 +154,7 @@ class TvSearchViewModel @Inject constructor(
                     _searchState.value = TvSearchState.Results(podcasts = earlyPodcasts, episodes = emptyList(), isPartial = true)
                 }
 
+                val folders = searchFolders(term)
                 val remoteResults = fullSearch.await().getOrThrow()
                 val remotePodcasts = remoteResults.filterIsInstance<ImprovedSearchResultItem.PodcastItem>()
                 val podcasts = (predictivePodcasts + remotePodcasts + localPodcasts)
@@ -156,10 +162,10 @@ class TvSearchViewModel @Inject constructor(
                     .map { if (it.uuid in localUuids) it.copy(isFollowed = true) else it }
                 val episodes = remoteResults.filterIsInstance<ImprovedSearchResultItem.EpisodeItem>()
                     .distinctBy(ImprovedSearchResultItem.EpisodeItem::uuid)
-                if (podcasts.isEmpty() && episodes.isEmpty()) {
+                if (podcasts.isEmpty() && episodes.isEmpty() && folders.isEmpty()) {
                     TvSearchState.NoResults
                 } else {
-                    TvSearchState.Results(podcasts = podcasts, episodes = episodes)
+                    TvSearchState.Results(podcasts = podcasts, episodes = episodes, folders = folders)
                 }
             } catch (exception: CancellationException) {
                 throw exception
@@ -172,6 +178,19 @@ class TvSearchViewModel @Inject constructor(
 
     fun onFilterSelected(filter: TvSearchFilter) {
         _filter.value = filter
+    }
+
+    private suspend fun searchFolders(term: String): List<FolderItem.Folder> {
+        if (!userManager.getSignInState().firstOrError().await().isSignedInAsPlusOrPatron) {
+            return emptyList()
+        }
+        return folderManager.getAll()
+            .filter { it.name.contains(term, ignoreCase = true) }
+            .map { folder -> FolderItem.Folder(folder = folder, podcasts = podcastManager.findPodcastsInFolder(folder.uuid)) }
+    }
+
+    suspend fun folderPodcasts(folderUuid: String): List<Podcast> {
+        return folderManager.findFolderPodcastsSorted(folderUuid)
     }
 
     fun saveSearchTerm(term: String) {
@@ -289,6 +308,7 @@ sealed interface TvSearchState {
     data class Results(
         val podcasts: List<ImprovedSearchResultItem.PodcastItem>,
         val episodes: List<ImprovedSearchResultItem.EpisodeItem>,
+        val folders: List<FolderItem.Folder> = emptyList(),
         val isPartial: Boolean = false,
     ) : TvSearchState
 }

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModelTest.kt
@@ -462,7 +462,7 @@ class TvSearchViewModelTest {
         whenever { improvedSearchManager.combinedSearch(any()) }.thenReturn(emptyList())
         whenever(syncManager.isLoggedIn()).thenReturn(true)
         whenever { folderManager.getAll() }.thenReturn(listOf(folderEntity("Sugar Shows"), folderEntity("Comedy")))
-        whenever { podcastManager.findPodcastsInFolder(any()) }.thenReturn(emptyList())
+        whenever { folderManager.findFolderPodcastsSorted(any()) }.thenReturn(emptyList())
 
         val viewModel = createViewModel()
         viewModel.onQueryChange("sugar")
@@ -470,6 +470,22 @@ class TvSearchViewModelTest {
 
         val state = viewModel.searchState.value as TvSearchState.Results
         assertEquals(listOf("Sugar Shows"), state.folders.map { it.folder.name })
+    }
+
+    @Test
+    fun `matching folders are sorted by name`() = runTest {
+        whenever(listRepository.getSearchDiscoverFeed()).thenReturn(discover())
+        whenever { improvedSearchManager.combinedSearch(any()) }.thenReturn(emptyList())
+        whenever(syncManager.isLoggedIn()).thenReturn(true)
+        whenever { folderManager.getAll() }.thenReturn(listOf(folderEntity("Sugar Rush"), folderEntity("Sugar Beats")))
+        whenever { folderManager.findFolderPodcastsSorted(any()) }.thenReturn(emptyList())
+
+        val viewModel = createViewModel()
+        viewModel.onQueryChange("sugar")
+        advanceUntilIdle()
+
+        val state = viewModel.searchState.value as TvSearchState.Results
+        assertEquals(listOf("Sugar Beats", "Sugar Rush"), state.folders.map { it.folder.name })
     }
 
     @Test
@@ -492,7 +508,7 @@ class TvSearchViewModelTest {
         whenever { improvedSearchManager.combinedSearch(any()) }.thenReturn(emptyList())
         whenever(syncManager.isLoggedIn()).thenReturn(true)
         whenever { folderManager.getAll() }.thenReturn(listOf(folderEntity("Sugar")))
-        whenever { podcastManager.findPodcastsInFolder(any()) }.thenReturn(emptyList())
+        whenever { folderManager.findFolderPodcastsSorted(any()) }.thenReturn(emptyList())
 
         val viewModel = createViewModel()
         viewModel.onQueryChange("sugar")

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModelTest.kt
@@ -4,19 +4,25 @@ import android.content.Context
 import android.content.res.Resources
 import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverFeedLoader
 import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverRow
+import au.com.shiftyjelly.pocketcasts.models.entity.Folder
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.ImprovedSearchResultItem
 import au.com.shiftyjelly.pocketcasts.models.to.SearchAutoCompleteItem
 import au.com.shiftyjelly.pocketcasts.models.to.SearchHistoryEntry
+import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
+import au.com.shiftyjelly.pocketcasts.models.type.SignInState
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
 import au.com.shiftyjelly.pocketcasts.repositories.lists.ListRepository
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.FolderManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.search.ImprovedSearchManager
 import au.com.shiftyjelly.pocketcasts.repositories.searchhistory.SearchHistoryManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
+import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.servers.model.Discover
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverPodcast
@@ -27,6 +33,7 @@ import au.com.shiftyjelly.pocketcasts.servers.model.ExpandedStyle
 import au.com.shiftyjelly.pocketcasts.servers.model.ListFeed
 import au.com.shiftyjelly.pocketcasts.servers.model.ListType
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import io.reactivex.Flowable
 import java.util.Date
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -73,10 +80,13 @@ class TvSearchViewModelTest {
     private val episodeManager = mock<EpisodeManager>()
     private val playbackManager = mock<PlaybackManager>()
     private val searchHistoryManager = mock<SearchHistoryManager>()
+    private val folderManager = mock<FolderManager>()
+    private val userManager = mock<UserManager>()
 
     init {
         whenever { improvedSearchManager.autoCompleteSearch(any()) }.thenReturn(emptyList())
         whenever { searchHistoryManager.findAll(any()) }.thenReturn(emptyList())
+        whenever(userManager.getSignInState()).thenReturn(Flowable.just(SignInState.SignedOut))
     }
 
     @Test
@@ -452,6 +462,51 @@ class TvSearchViewModelTest {
 
     private fun subscribedPodcast(uuid: String) = Podcast(uuid = uuid, title = "Podcast $uuid", author = "Author")
 
+    @Test
+    fun `matching folders are surfaced for a plus or patron user`() = runTest {
+        whenever(listRepository.getSearchDiscoverFeed()).thenReturn(discover())
+        whenever { improvedSearchManager.combinedSearch(any()) }.thenReturn(emptyList())
+        whenever(userManager.getSignInState()).thenReturn(Flowable.just(plusSignInState()))
+        whenever { folderManager.getAll() }.thenReturn(listOf(folderEntity("Sugar Shows"), folderEntity("Comedy")))
+        whenever { podcastManager.findPodcastsInFolder(any()) }.thenReturn(emptyList())
+
+        val viewModel = createViewModel()
+        viewModel.onQueryChange("sugar")
+        advanceUntilIdle()
+
+        val state = viewModel.searchState.value as TvSearchState.Results
+        assertEquals(listOf("Sugar Shows"), state.folders.map { it.folder.name })
+    }
+
+    @Test
+    fun `folders are not searched for a non-plus user`() = runTest {
+        whenever(listRepository.getSearchDiscoverFeed()).thenReturn(discover())
+        whenever { improvedSearchManager.combinedSearch(any()) }.thenReturn(listOf(podcastItem("podcast-1")))
+
+        val viewModel = createViewModel()
+        viewModel.onQueryChange("sugar")
+        advanceUntilIdle()
+
+        val state = viewModel.searchState.value as TvSearchState.Results
+        assertTrue(state.folders.isEmpty())
+        verifyBlocking(folderManager, never()) { getAll() }
+    }
+
+    @Test
+    fun `a matching folder alone counts as a result`() = runTest {
+        whenever(listRepository.getSearchDiscoverFeed()).thenReturn(discover())
+        whenever { improvedSearchManager.combinedSearch(any()) }.thenReturn(emptyList())
+        whenever(userManager.getSignInState()).thenReturn(Flowable.just(plusSignInState()))
+        whenever { folderManager.getAll() }.thenReturn(listOf(folderEntity("Sugar")))
+        whenever { podcastManager.findPodcastsInFolder(any()) }.thenReturn(emptyList())
+
+        val viewModel = createViewModel()
+        viewModel.onQueryChange("sugar")
+        advanceUntilIdle()
+
+        assertTrue(viewModel.searchState.value is TvSearchState.Results)
+    }
+
     private fun createViewModel() = TvSearchViewModel(
         discoverFeedLoader = TvDiscoverFeedLoader(
             listRepository = listRepository,
@@ -464,6 +519,21 @@ class TvSearchViewModelTest {
         episodeManager = episodeManager,
         playbackManager = playbackManager,
         searchHistoryManager = searchHistoryManager,
+        folderManager = folderManager,
+        userManager = userManager,
+    )
+
+    private fun plusSignInState() = SignInState.SignedIn(email = "test@example.com", subscription = Subscription.PlusPreview)
+
+    private fun folderEntity(name: String) = Folder(
+        uuid = name,
+        name = name,
+        color = 0,
+        addedDate = Date(0),
+        sortPosition = 0,
+        podcastsSortType = PodcastsSortType.NAME_A_TO_Z,
+        deleted = false,
+        syncModified = 0,
     )
 
     private fun category(id: Int, name: String) = DiscoverCategory(id = id, name = name, icon = "", source = "")

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModelTest.kt
@@ -10,8 +10,6 @@ import au.com.shiftyjelly.pocketcasts.models.to.ImprovedSearchResultItem
 import au.com.shiftyjelly.pocketcasts.models.to.SearchAutoCompleteItem
 import au.com.shiftyjelly.pocketcasts.models.to.SearchHistoryEntry
 import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
-import au.com.shiftyjelly.pocketcasts.models.type.SignInState
-import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
 import au.com.shiftyjelly.pocketcasts.repositories.lists.ListRepository
@@ -22,7 +20,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.search.ImprovedSearchManager
 import au.com.shiftyjelly.pocketcasts.repositories.searchhistory.SearchHistoryManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
-import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.servers.model.Discover
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverPodcast
@@ -33,7 +30,6 @@ import au.com.shiftyjelly.pocketcasts.servers.model.ExpandedStyle
 import au.com.shiftyjelly.pocketcasts.servers.model.ListFeed
 import au.com.shiftyjelly.pocketcasts.servers.model.ListType
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
-import io.reactivex.Flowable
 import java.util.Date
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -81,12 +77,10 @@ class TvSearchViewModelTest {
     private val playbackManager = mock<PlaybackManager>()
     private val searchHistoryManager = mock<SearchHistoryManager>()
     private val folderManager = mock<FolderManager>()
-    private val userManager = mock<UserManager>()
 
     init {
         whenever { improvedSearchManager.autoCompleteSearch(any()) }.thenReturn(emptyList())
         whenever { searchHistoryManager.findAll(any()) }.thenReturn(emptyList())
-        whenever(userManager.getSignInState()).thenReturn(Flowable.just(SignInState.SignedOut))
     }
 
     @Test
@@ -463,10 +457,10 @@ class TvSearchViewModelTest {
     private fun subscribedPodcast(uuid: String) = Podcast(uuid = uuid, title = "Podcast $uuid", author = "Author")
 
     @Test
-    fun `matching folders are surfaced for a plus or patron user`() = runTest {
+    fun `matching folders are surfaced for a signed-in user`() = runTest {
         whenever(listRepository.getSearchDiscoverFeed()).thenReturn(discover())
         whenever { improvedSearchManager.combinedSearch(any()) }.thenReturn(emptyList())
-        whenever(userManager.getSignInState()).thenReturn(Flowable.just(plusSignInState()))
+        whenever(syncManager.isLoggedIn()).thenReturn(true)
         whenever { folderManager.getAll() }.thenReturn(listOf(folderEntity("Sugar Shows"), folderEntity("Comedy")))
         whenever { podcastManager.findPodcastsInFolder(any()) }.thenReturn(emptyList())
 
@@ -479,7 +473,7 @@ class TvSearchViewModelTest {
     }
 
     @Test
-    fun `folders are not searched for a non-plus user`() = runTest {
+    fun `folders are not searched for a signed-out user`() = runTest {
         whenever(listRepository.getSearchDiscoverFeed()).thenReturn(discover())
         whenever { improvedSearchManager.combinedSearch(any()) }.thenReturn(listOf(podcastItem("podcast-1")))
 
@@ -496,7 +490,7 @@ class TvSearchViewModelTest {
     fun `a matching folder alone counts as a result`() = runTest {
         whenever(listRepository.getSearchDiscoverFeed()).thenReturn(discover())
         whenever { improvedSearchManager.combinedSearch(any()) }.thenReturn(emptyList())
-        whenever(userManager.getSignInState()).thenReturn(Flowable.just(plusSignInState()))
+        whenever(syncManager.isLoggedIn()).thenReturn(true)
         whenever { folderManager.getAll() }.thenReturn(listOf(folderEntity("Sugar")))
         whenever { podcastManager.findPodcastsInFolder(any()) }.thenReturn(emptyList())
 
@@ -511,7 +505,7 @@ class TvSearchViewModelTest {
     fun `a folder search failure does not fail the whole search`() = runTest {
         whenever(listRepository.getSearchDiscoverFeed()).thenReturn(discover())
         whenever { improvedSearchManager.combinedSearch(any()) }.thenReturn(listOf(podcastItem("podcast-1")))
-        whenever(userManager.getSignInState()).thenReturn(Flowable.just(plusSignInState()))
+        whenever(syncManager.isLoggedIn()).thenReturn(true)
         whenever { folderManager.getAll() }.thenThrow(RuntimeException("database unavailable"))
 
         val viewModel = createViewModel()
@@ -536,10 +530,7 @@ class TvSearchViewModelTest {
         playbackManager = playbackManager,
         searchHistoryManager = searchHistoryManager,
         folderManager = folderManager,
-        userManager = userManager,
     )
-
-    private fun plusSignInState() = SignInState.SignedIn(email = "test@example.com", subscription = Subscription.PlusPreview)
 
     private fun folderEntity(name: String) = Folder(
         uuid = name,

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModelTest.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -531,6 +532,55 @@ class TvSearchViewModelTest {
         val state = viewModel.searchState.value as TvSearchState.Results
         assertEquals(listOf("podcast-1"), state.podcasts.map { it.uuid })
         assertTrue(state.folders.isEmpty())
+    }
+
+    @Test
+    fun `hasFolderResults reflects whether the terminal search found folders`() = runTest {
+        whenever(listRepository.getSearchDiscoverFeed()).thenReturn(discover())
+        whenever { improvedSearchManager.combinedSearch(any()) }.thenReturn(emptyList())
+        whenever(syncManager.isLoggedIn()).thenReturn(true)
+        whenever { folderManager.getAll() }.thenReturn(listOf(folderEntity("Sugar")))
+        whenever { folderManager.findFolderPodcastsSorted(any()) }.thenReturn(emptyList())
+
+        val viewModel = createViewModel()
+        viewModel.onQueryChange("sugar")
+        advanceUntilIdle()
+        assertTrue(viewModel.hasFolderResults.value)
+
+        viewModel.onQueryChange("")
+        assertFalse(viewModel.hasFolderResults.value)
+    }
+
+    @Test
+    fun `a terminal search without folders resets the folders filter`() = runTest {
+        whenever(listRepository.getSearchDiscoverFeed()).thenReturn(discover())
+        whenever { improvedSearchManager.combinedSearch(any()) }.thenReturn(listOf(podcastItem("podcast-1")))
+        whenever(syncManager.isLoggedIn()).thenReturn(true)
+        whenever { folderManager.getAll() }.thenReturn(emptyList())
+
+        val viewModel = createViewModel()
+        viewModel.onFilterSelected(TvSearchFilter.Folders)
+        viewModel.onQueryChange("sugar")
+        advanceUntilIdle()
+
+        assertEquals(TvSearchFilter.TopResults, viewModel.filter.value)
+        assertFalse(viewModel.hasFolderResults.value)
+    }
+
+    @Test
+    fun `a failed search clears folder results and resets the folders filter`() = runTest {
+        whenever(listRepository.getSearchDiscoverFeed()).thenReturn(discover())
+        whenever { improvedSearchManager.combinedSearch(any()) }.thenThrow(RuntimeException("network"))
+        whenever(syncManager.isLoggedIn()).thenReturn(true)
+
+        val viewModel = createViewModel()
+        viewModel.onFilterSelected(TvSearchFilter.Folders)
+        viewModel.onQueryChange("sugar")
+        advanceUntilIdle()
+
+        assertTrue(viewModel.searchState.value is TvSearchState.Error)
+        assertEquals(TvSearchFilter.TopResults, viewModel.filter.value)
+        assertFalse(viewModel.hasFolderResults.value)
     }
 
     private fun createViewModel() = TvSearchViewModel(

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModelTest.kt
@@ -507,6 +507,22 @@ class TvSearchViewModelTest {
         assertTrue(viewModel.searchState.value is TvSearchState.Results)
     }
 
+    @Test
+    fun `a folder search failure does not fail the whole search`() = runTest {
+        whenever(listRepository.getSearchDiscoverFeed()).thenReturn(discover())
+        whenever { improvedSearchManager.combinedSearch(any()) }.thenReturn(listOf(podcastItem("podcast-1")))
+        whenever(userManager.getSignInState()).thenReturn(Flowable.just(plusSignInState()))
+        whenever { folderManager.getAll() }.thenThrow(RuntimeException("database unavailable"))
+
+        val viewModel = createViewModel()
+        viewModel.onQueryChange("sugar")
+        advanceUntilIdle()
+
+        val state = viewModel.searchState.value as TvSearchState.Results
+        assertEquals(listOf("podcast-1"), state.podcasts.map { it.uuid })
+        assertTrue(state.folders.isEmpty())
+    }
+
     private fun createViewModel() = TvSearchViewModel(
         discoverFeedLoader = TvDiscoverFeedLoader(
             listRepository = listRepository,


### PR DESCRIPTION
## Description

Adds **local folder results** to Android TV Search. Stacked on the TV search parity PR (#5746).

### Behaviour
- When a **signed-in** user searches, their local folders whose **name** matches the term (case-insensitive) are surfaced, each with its podcasts' artwork.
- Signed-out users get nothing here — the folder lookup is skipped entirely (no DB hit).
- Folders appear as a **Folders** carousel in Top Results, ordered **Featured → Episodes → Folders → Podcasts**; tapping one opens the folder in `TvFolderDetailScreen` (reusing the exact overlay/nav pattern from the Your Podcasts tab, including focus-restore and podcast-opened-from-folder returning to the folder).
- When a search yields at least one folder, a dedicated **Folders** filter pill appears after **Episodes** and shows a folder-only grid. The pill is hidden when there are no folder results; if the user is on the Folders filter and a subsequent search has no folders, the view transparently falls back to **Top Results**.

### Implementation
- `TvSearchViewModel` injects `FolderManager`. `searchFolders()` gates on `syncManager.isLoggedIn()`, filters `folderManager.getAll()` by name, attaches each folder's podcasts. It runs in a `runCatching { … }` `async` **concurrently** with the network search, so a (rare) local-DB failure degrades to "no folders" rather than failing the whole search, and it never delays the remote results.
- `folders` added to `TvSearchState.Results` (+ the NoResults emptiness check). `folderPodcasts(uuid)` feeds the detail screen.
- New `TvSearchFilter.Folders` entry (after `Episodes`). The visible pill set is derived from the current results — `Folders` is only included when the results contain folders — and an `effectiveFilter` keeps the selected pill and the rendered content in sync without mutating ViewModel state when folders come and go. `TvSearchFilters` now takes the filter list to render.
- UI reuses the existing `TvFolderCard`, `TvFolderDetailScreen`, and `TvPodcastGridScaffold` components (the Folders filter grid mirrors the Podcasts filter layout).

Folders are inherently a paid feature (a free user can't create them, and they're wiped on downgrade), so the gate only needs to check that the user is signed in. This matches how the rest of the TV module treats folders — the Your Podcasts tab renders them straight from `FolderManager` with no subscription check. An earlier revision gated on `SignInState.isSignedInAsPlusOrPatron`, but the subscription tier is not reliably hydrated on TV (it's the only place in the module that read it), which silently suppressed every folder even for Plus users; gating on `isLoggedIn()` — the same guard this ViewModel already uses elsewhere — fixes that.

Reuses existing infra throughout — the only shared-module change is the new `search_filters_folders` string alias; otherwise tv-only.

**UPDATE**
got design approval: p1787763569156349/1787663272.838409-slack-C0ATWH7BNH3


## Testing Instructions

1. Sign in with at least one folder whose name matches a query.
2. `./gradlew :tv:installDebug`; open **Search**, type the folder's name → a **Folders** row appears in Top Results, and a **Folders** filter pill appears after Episodes; select it → a folder-only grid; open a folder → its podcasts; open a podcast → back returns to the folder.
3. Refine the query so no folder matches → the **Folders** pill disappears and the view falls back to Top Results.
4. As a **signed-out** user, neither the Folders row nor the Folders pill ever appears.
5. `./gradlew :tv:testDebugUnitTest` — covers signed-in surfaces folders, signed-out skips the lookup, folder-alone counts as a result.

## Screenshots or Screencast


https://github.com/user-attachments/assets/9358a318-19b8-4b17-ad5b-4004852cd14a



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md — N/A (TV, pre-release)
- [x] Ensure the linter passes (`./gradlew spotlessApply`)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in localization — reuses existing `folders` via a `search_filters_folders` alias
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) the Event Horizon schema — N/A (no analytics change)