### PR TITLE
[Automotive] Fix truncated dialog button labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 *   Bug Fixes
     *   Fix a crash when showing a bottom sheet after the app is sent to the background
         ([#5709](https://github.com/Automattic/pocket-casts-android/pull/5709))
+    *   Fix truncated dialog button labels in the Automotive app
+        ([#5751](https://github.com/Automattic/pocket-casts-android/pull/5751))
 
 8.18
 -----

--- a/modules/features/cartheme/src/main/res/layout/car_preference_alert_dialog_button_bar.xml
+++ b/modules/features/cartheme/src/main/res/layout/car_preference_alert_dialog_button_bar.xml
@@ -37,13 +37,13 @@
 
         <Button
             android:id="@android:id/button3"
-            style="@style/Widget.Car.Button.Borderless.Colored"
+            style="@style/Widget.Car.Dialog.Button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"/>
 
         <Button
             android:id="@android:id/button2"
-            style="@style/Widget.Car.Button.Borderless.Colored"
+            style="@style/Widget.Car.Dialog.Button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:gravity="start"
@@ -52,7 +52,7 @@
 
         <Button
             android:id="@android:id/button1"
-            style="@style/Widget.Car.Button.Borderless.Colored"
+            style="@style/Widget.Car.Dialog.Button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"/>
 

--- a/modules/features/cartheme/src/main/res/values-v28/themes.xml
+++ b/modules/features/cartheme/src/main/res/values-v28/themes.xml
@@ -36,9 +36,9 @@
         <item name="android:windowAnimationStyle">@style/Car.Dialog.Animation</item>
         <item name="android:windowTitleStyle">@style/Widget.Car.Dialog.Title</item>
         <item name="alertDialogStyle">@style/AlertDialog</item>
-        <item name="buttonBarNeutralButtonStyle">@style/Widget.Car.Button.Borderless.Colored</item>
-        <item name="buttonBarNegativeButtonStyle">@style/Widget.Car.Button.Borderless.Colored</item>
-        <item name="buttonBarPositiveButtonStyle">@style/Widget.Car.Button.Borderless.Colored</item>
+        <item name="buttonBarNeutralButtonStyle">@style/Widget.Car.Dialog.Button</item>
+        <item name="buttonBarNegativeButtonStyle">@style/Widget.Car.Dialog.Button</item>
+        <item name="buttonBarPositiveButtonStyle">@style/Widget.Car.Dialog.Button</item>
         <item name="listDividerAlertDialog">@drawable/car_preference_divider</item>
     </style>
 </resources>

--- a/modules/features/cartheme/src/main/res/values/styles.xml
+++ b/modules/features/cartheme/src/main/res/values/styles.xml
@@ -571,12 +571,18 @@ limitations under the License.
     </style>
 
     <!-- The style for dialog buttons. -->
-    <style name="Widget.Car.Dialog.Button" parent="Widget.Car.Button.Borderless.Colored">
+    <style name="Widget.Car.Dialog.Button" parent="Widget.MaterialComponents.Button.TextButton">
+        <item name="android:background">?android:attr/selectableItemBackground</item>
         <item name="android:textAppearance">@style/TextAppearance.Car.Body3.Medium</item>
         <item name="android:fontFamily">sans-serif-medium</item>
+        <item name="android:ellipsize">end</item>
+        <item name="android:maxLines">2</item>
+        <item name="android:minHeight">@dimen/car_button_height</item>
         <item name="android:minWidth">@dimen/car_dialog_button_min_width</item>
         <item name="android:paddingStart">@dimen/car_padding_2</item>
         <item name="android:paddingEnd">@dimen/car_padding_2</item>
+        <item name="android:textAllCaps">false</item>
+        <item name="android:textColor">?android:attr/colorButtonNormal</item>
     </style>
 
     <!-- ================= -->

--- a/modules/features/cartheme/src/main/res/values/themes.xml
+++ b/modules/features/cartheme/src/main/res/values/themes.xml
@@ -163,9 +163,9 @@ limitations under the License.
         <item name="android:windowAnimationStyle">@style/Car.Dialog.Animation</item>
         <item name="android:windowTitleStyle">@style/Widget.Car.Dialog.Title</item>
         <item name="alertDialogStyle">@style/AlertDialog</item>
-        <item name="buttonBarNeutralButtonStyle">@style/Widget.Car.Button.Borderless.Colored</item>
-        <item name="buttonBarNegativeButtonStyle">@style/Widget.Car.Button.Borderless.Colored</item>
-        <item name="buttonBarPositiveButtonStyle">@style/Widget.Car.Button.Borderless.Colored</item>
+        <item name="buttonBarNeutralButtonStyle">@style/Widget.Car.Dialog.Button</item>
+        <item name="buttonBarNegativeButtonStyle">@style/Widget.Car.Dialog.Button</item>
+        <item name="buttonBarPositiveButtonStyle">@style/Widget.Car.Dialog.Button</item>
         <item name="listDividerAlertDialog">@drawable/car_preference_divider</item>
         <item name="textInputStyle">@style/Widget.Design.TextInputLayout</item>
     </style>


### PR DESCRIPTION
## Description

Dialog buttons in the Automotive app clipped their label mid-character in some languages, for example the "Just sign out" button in Korean on the clear data dialog.

## Testing Instructions

1. Install the Automotive app on an AAOS emulator or head unit.
2. Set the device language to Korean. Settings → System → Languages & input → Languages → 한국어
3. Sign in, go to Profile, tap Sign out, tap the right option on the first dialog.
4. The right hand button should read 방금 로그아웃했습니다. in full, wrapping to a second line rather than being clipped mid-character.

## Screenshots or Screencast

**Before** 
<img width="1080" height="600" alt="Screenshot_20260819_124556" src="https://github.com/user-attachments/assets/79528c08-a9c2-4002-9970-531ca1bda9d9" />

**After**

<img width="1080" height="600" alt="Screenshot_20260819_131649" src="https://github.com/user-attachments/assets/40e29828-da42-4375-8c91-d1765303552f" />

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

#### I have tested any UI changes...
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
