### PR TITLE
Add delete account to the Automotive account screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 8.19
 -----
+*   New Features
+    *   Add the delete account option to the Automotive account screen
+        ([#5757](https://github.com/Automattic/pocket-casts-android/pull/5757))
 *   Bug Fixes
     *   Fix a crash when showing a bottom sheet after the app is sent to the background
         ([#5709](https://github.com/Automattic/pocket-casts-android/pull/5709))

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.profile
 
+import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
@@ -190,6 +191,11 @@ class AccountDetailsFragment : BaseFragment() {
     }
 
     private fun deleteAccount() {
+        if (Util.isAutomotive(requireContext())) {
+            deleteAccountAutomotive()
+            return
+        }
+
         ConfirmationDialog()
             .setButtonType(ConfirmationDialog.ButtonType.Danger(getString(LR.string.profile_account_delete)))
             .setTitle(getString(LR.string.profile_delete_account_title))
@@ -220,7 +226,7 @@ class AccountDetailsFragment : BaseFragment() {
 
             is DeleteAccountState.Failure -> {
                 accountViewModel.clearDeleteAccountState()
-                AlertDialog.Builder(requireContext())
+                carThemedAlertBuilder(requireContext())
                     .setTitle(getString(LR.string.profile_delete_account_failed_title))
                     .setMessage(state.message ?: getString(LR.string.profile_delete_account_failed_message))
                     .setPositiveButton(getString(LR.string.ok)) { dialog, _ -> dialog.dismiss() }
@@ -236,10 +242,34 @@ class AccountDetailsFragment : BaseFragment() {
         Toast.makeText(requireContext(), LR.string.profile_deleting_account, Toast.LENGTH_LONG).show()
     }
 
+    private fun deleteAccountAutomotive() {
+        val context = context ?: return
+        carThemedAlertBuilder(context)
+            .setTitle(getString(LR.string.profile_delete_account_title))
+            .setMessage(getString(LR.string.profile_delete_account_question))
+            .setPositiveButton(getString(LR.string.profile_account_delete)) { _, _ -> deleteAccountPermanentAutomotive() }
+            .setNegativeButton(getString(LR.string.cancel), null)
+            .show()
+    }
+
+    private fun deleteAccountPermanentAutomotive() {
+        val context = context ?: return
+        carThemedAlertBuilder(context)
+            .setTitle(getString(LR.string.profile_delete_account_title))
+            .setMessage(getString(LR.string.profile_delete_account_permanent_question))
+            .setPositiveButton(getString(LR.string.profile_account_delete_yes)) { _, _ -> performDeleteAccount() }
+            .setNegativeButton(getString(LR.string.cancel), null)
+            .show()
+    }
+
+    private fun carThemedAlertBuilder(context: Context): AlertDialog.Builder {
+        val themedContext = if (Util.isAutomotive(context)) ContextThemeWrapper(context, CR.style.Theme_Car_NoActionBar) else context
+        return AlertDialog.Builder(themedContext)
+    }
+
     private fun signOutAutomotive() {
         val context = context ?: return
-        val themedContext = if (Util.isAutomotive(context)) ContextThemeWrapper(context, CR.style.Theme_Car_NoActionBar) else context
-        val builder = AlertDialog.Builder(themedContext)
+        val builder = carThemedAlertBuilder(context)
         builder.setTitle(getString(LR.string.profile_sign_out))
             .setMessage(getString(LR.string.profile_sign_out_confirm))
             .setPositiveButton(getString(LR.string.profile_sign_out)) { _, _ -> clearDataAlert() }
@@ -249,8 +279,7 @@ class AccountDetailsFragment : BaseFragment() {
 
     private fun clearDataAlert() {
         val context = context ?: return
-        val themedContext = if (Util.isAutomotive(context)) ContextThemeWrapper(context, CR.style.Theme_Car_NoActionBar) else context
-        val builder = AlertDialog.Builder(themedContext)
+        val builder = carThemedAlertBuilder(context)
         builder.setTitle(getString(LR.string.profile_clear_data_question))
             .setMessage(getString(LR.string.profile_clear_data_would_you_also_like_question))
             .setPositiveButton(getString(LR.string.profile_just_sign_out)) { _, _ -> performSignOut() }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
@@ -221,7 +221,12 @@ class AccountDetailsFragment : BaseFragment() {
         when (state) {
             is DeleteAccountState.Success -> {
                 accountViewModel.clearDeleteAccountState()
-                performSignOut()
+                if (Util.isAutomotive(requireContext())) {
+                    // Automotive are often shared, so clear local podcasts
+                    signOutAndClearData()
+                } else {
+                    performSignOut()
+                }
             }
 
             is DeleteAccountState.Failure -> {

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
@@ -226,7 +226,7 @@ class AccountDetailsFragment : BaseFragment() {
 
             is DeleteAccountState.Failure -> {
                 accountViewModel.clearDeleteAccountState()
-                carThemedAlertBuilder(requireContext())
+                themedAlertBuilder(requireContext())
                     .setTitle(getString(LR.string.profile_delete_account_failed_title))
                     .setMessage(state.message ?: getString(LR.string.profile_delete_account_failed_message))
                     .setPositiveButton(getString(LR.string.ok)) { dialog, _ -> dialog.dismiss() }
@@ -244,7 +244,7 @@ class AccountDetailsFragment : BaseFragment() {
 
     private fun deleteAccountAutomotive() {
         val context = context ?: return
-        carThemedAlertBuilder(context)
+        themedAlertBuilder(context)
             .setTitle(getString(LR.string.profile_delete_account_title))
             .setMessage(getString(LR.string.profile_delete_account_question))
             .setPositiveButton(getString(LR.string.profile_account_delete)) { _, _ -> deleteAccountPermanentAutomotive() }
@@ -254,7 +254,7 @@ class AccountDetailsFragment : BaseFragment() {
 
     private fun deleteAccountPermanentAutomotive() {
         val context = context ?: return
-        carThemedAlertBuilder(context)
+        themedAlertBuilder(context)
             .setTitle(getString(LR.string.profile_delete_account_title))
             .setMessage(getString(LR.string.profile_delete_account_permanent_question))
             .setPositiveButton(getString(LR.string.profile_account_delete_yes)) { _, _ -> performDeleteAccount() }
@@ -262,14 +262,14 @@ class AccountDetailsFragment : BaseFragment() {
             .show()
     }
 
-    private fun carThemedAlertBuilder(context: Context): AlertDialog.Builder {
+    private fun themedAlertBuilder(context: Context): AlertDialog.Builder {
         val themedContext = if (Util.isAutomotive(context)) ContextThemeWrapper(context, CR.style.Theme_Car_NoActionBar) else context
         return AlertDialog.Builder(themedContext)
     }
 
     private fun signOutAutomotive() {
         val context = context ?: return
-        val builder = carThemedAlertBuilder(context)
+        val builder = themedAlertBuilder(context)
         builder.setTitle(getString(LR.string.profile_sign_out))
             .setMessage(getString(LR.string.profile_sign_out_confirm))
             .setPositiveButton(getString(LR.string.profile_sign_out)) { _, _ -> clearDataAlert() }
@@ -279,7 +279,7 @@ class AccountDetailsFragment : BaseFragment() {
 
     private fun clearDataAlert() {
         val context = context ?: return
-        val builder = carThemedAlertBuilder(context)
+        val builder = themedAlertBuilder(context)
         builder.setTitle(getString(LR.string.profile_clear_data_question))
             .setMessage(getString(LR.string.profile_clear_data_would_you_also_like_question))
             .setPositiveButton(getString(LR.string.profile_just_sign_out)) { _, _ -> performSignOut() }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
@@ -222,7 +222,7 @@ class AccountDetailsFragment : BaseFragment() {
             is DeleteAccountState.Success -> {
                 accountViewModel.clearDeleteAccountState()
                 if (Util.isAutomotive(requireContext())) {
-                    // Automotive are often shared, so clear local podcasts
+                    // Automotive head units are often shared, so clear the local podcasts
                     signOutAndClearData()
                 } else {
                     performSignOut()

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsPage.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsPage.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -84,7 +85,7 @@ internal fun AccountDetailsPage(
                     badgeIconSize = 18.dp,
                     badgeContentPadding = 6.dp,
                 ),
-                infoFontScale = 1.6f,
+                infoFontScale = 2f,
             )
         } else {
             AccountHeaderConfig(
@@ -100,6 +101,10 @@ internal fun AccountDetailsPage(
             AccountSectionsConfig(
                 iconSize = 48.dp,
                 fontScale = 2f,
+                contentPadding = PaddingValues(horizontal = 24.dp, vertical = 20.dp),
+                iconSpacing = 24.dp,
+                minRowHeight = 96.dp,
+                groupSpacing = 32.dp,
             )
         } else {
             AccountSectionsConfig()
@@ -108,7 +113,7 @@ internal fun AccountDetailsPage(
     val sectionsState = remember(state.isAutomotive, state.sectionsState) {
         if (state.isAutomotive) {
             state.sectionsState.copy(
-                availableSections = listOf(AccountSection.SignOut),
+                availableSections = listOf(AccountSection.SignOut, AccountSection.DeleteAccount),
             )
         } else {
             state.sectionsState

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountSections.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountSections.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -143,7 +144,7 @@ internal fun AccountSections(
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(24.dp)
+                        .height(config.groupSpacing)
                         .background(MaterialTheme.theme.colors.primaryUi03),
                 )
             }
@@ -154,6 +155,10 @@ internal fun AccountSections(
 internal data class AccountSectionsConfig(
     val iconSize: Dp = 24.dp,
     val fontScale: Float = 1f,
+    val contentPadding: PaddingValues = PaddingValues(16.dp),
+    val iconSpacing: Dp = 16.dp,
+    val minRowHeight: Dp = 64.dp,
+    val groupSpacing: Dp = 24.dp,
 )
 
 internal data class AccountSectionsState(
@@ -296,7 +301,7 @@ private fun ButtonSection(
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier
             .fillMaxWidth()
-            .heightIn(min = 64.dp)
+            .heightIn(min = config.minRowHeight)
             .clickable(
                 interactionSource = remember(::MutableInteractionSource),
                 indication = ripple(
@@ -307,7 +312,7 @@ private fun ButtonSection(
             .semantics(mergeDescendants = true) {
                 role = Role.Button
             }
-            .padding(16.dp),
+            .padding(config.contentPadding),
     ) {
         Icon(
             painter = painterResource(section.iconId),
@@ -316,7 +321,7 @@ private fun ButtonSection(
             modifier = Modifier.size(config.iconSize),
         )
         Spacer(
-            modifier = Modifier.width(16.dp),
+            modifier = Modifier.width(config.iconSpacing),
         )
         TextH40(
             text = stringResource(section.titleId),
@@ -337,7 +342,7 @@ private fun SwitchSection(
         verticalAlignment = Alignment.Top,
         modifier = Modifier
             .fillMaxWidth()
-            .heightIn(min = 64.dp)
+            .heightIn(min = config.minRowHeight)
             .height(IntrinsicSize.Max)
             .clickable(
                 interactionSource = remember(::MutableInteractionSource),
@@ -349,7 +354,7 @@ private fun SwitchSection(
             .semantics(mergeDescendants = true) {
                 role = Role.Switch
             }
-            .padding(16.dp),
+            .padding(config.contentPadding),
     ) {
         Icon(
             painter = painterResource(section.iconId),
@@ -358,7 +363,7 @@ private fun SwitchSection(
             modifier = Modifier.size(config.iconSize),
         )
         Spacer(
-            modifier = Modifier.width(16.dp),
+            modifier = Modifier.width(config.iconSpacing),
         )
         Column(
             modifier = Modifier.fillMaxWidth(fraction = 0.75f),


### PR DESCRIPTION
## Description

Adds the "Delete account" option to the Automotive account screen, which previously only offered "Sign out". Because Automotive can't show the app's standard bottom-sheet `ConfirmationDialog`, `deleteAccount()` now branches on `Util.isAutomotive()` and shows a pair of car themed `AlertDialog`s (confirm, then "this is permanent" confirm) before calling through to the same `performDeleteAccount()` path used on mobile.

The car theming logic that `signOutAutomotive()` and `clearDataAlert()` were duplicating is pulled into a single `carThemedAlertBuilder()` helper, which is also now used for the delete-account failure dialog so that it is readable on Automotive too.

## Testing Instructions

1. Build and install the Automotive app: `./gradlew :automotive:installDebug` (or run the `automotive` configuration on an Automotive OS emulator).
2. Sign in to a Pocket Casts account.
3. Open the Profile / Account screen.
4. Verify both "Sign out" and "Delete account" rows are visible, with comfortably large touch targets and spacing.
5. Tap "Delete account". Confirm the first dialog appears with the car theme and readable text. Tap Cancel and confirm nothing happens.
6. Tap "Delete account" again, confirm, and verify the second "this is permanent" dialog appears. Tap Cancel and confirm nothing happens.
7. Tap through both dialogs to confirm deletion, and verify the account is deleted and you are returned to the signed-out state.
8. Verify "Sign out" still works and its dialogs are unchanged.
9. On the mobile app, open Profile -> Account and verify "Delete account" still shows the standard bottom-sheet confirmation flow and behaves as before.

## Screenshots or Screencast

<img width="1080" height="600" alt="Screenshot_20260819_131649" src="https://github.com/user-attachments/assets/3d3f1430-312e-4d7d-9ed3-cc2d5849aa78" />


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

#### I have tested any UI changes...
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
