### PR TITLE
[Automotive] Fix truncated dialog button labels (cherry-pick to 8.19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 *   Bug Fixes
     *   Fix a crash when showing a bottom sheet after the app is sent to the background
         ([#5709](https://github.com/Automattic/pocket-casts-android/pull/5709))
+    *   Fix truncated dialog button labels in the Automotive app
+        ([#5751](https://github.com/Automattic/pocket-casts-android/pull/5751))
 
 8.18
 -----

--- a/modules/features/cartheme/src/main/res/layout/car_preference_alert_dialog_button_bar.xml
+++ b/modules/features/cartheme/src/main/res/layout/car_preference_alert_dialog_button_bar.xml
@@ -37,13 +37,13 @@
 
         <Button
             android:id="@android:id/button3"
-            style="@style/Widget.Car.Button.Borderless.Colored"
+            style="@style/Widget.Car.Dialog.Button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"/>
 
         <Button
             android:id="@android:id/button2"
-            style="@style/Widget.Car.Button.Borderless.Colored"
+            style="@style/Widget.Car.Dialog.Button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:gravity="start"
@@ -52,7 +52,7 @@
 
         <Button
             android:id="@android:id/button1"
-            style="@style/Widget.Car.Button.Borderless.Colored"
+            style="@style/Widget.Car.Dialog.Button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"/>
 

--- a/modules/features/cartheme/src/main/res/values-v28/themes.xml
+++ b/modules/features/cartheme/src/main/res/values-v28/themes.xml
@@ -36,9 +36,9 @@
         <item name="android:windowAnimationStyle">@style/Car.Dialog.Animation</item>
         <item name="android:windowTitleStyle">@style/Widget.Car.Dialog.Title</item>
         <item name="alertDialogStyle">@style/AlertDialog</item>
-        <item name="buttonBarNeutralButtonStyle">@style/Widget.Car.Button.Borderless.Colored</item>
-        <item name="buttonBarNegativeButtonStyle">@style/Widget.Car.Button.Borderless.Colored</item>
-        <item name="buttonBarPositiveButtonStyle">@style/Widget.Car.Button.Borderless.Colored</item>
+        <item name="buttonBarNeutralButtonStyle">@style/Widget.Car.Dialog.Button</item>
+        <item name="buttonBarNegativeButtonStyle">@style/Widget.Car.Dialog.Button</item>
+        <item name="buttonBarPositiveButtonStyle">@style/Widget.Car.Dialog.Button</item>
         <item name="listDividerAlertDialog">@drawable/car_preference_divider</item>
     </style>
 </resources>

--- a/modules/features/cartheme/src/main/res/values/styles.xml
+++ b/modules/features/cartheme/src/main/res/values/styles.xml
@@ -571,12 +571,18 @@ limitations under the License.
     </style>
 
     <!-- The style for dialog buttons. -->
-    <style name="Widget.Car.Dialog.Button" parent="Widget.Car.Button.Borderless.Colored">
+    <style name="Widget.Car.Dialog.Button" parent="Widget.MaterialComponents.Button.TextButton">
+        <item name="android:background">?android:attr/selectableItemBackground</item>
         <item name="android:textAppearance">@style/TextAppearance.Car.Body3.Medium</item>
         <item name="android:fontFamily">sans-serif-medium</item>
+        <item name="android:ellipsize">end</item>
+        <item name="android:maxLines">2</item>
+        <item name="android:minHeight">@dimen/car_button_height</item>
         <item name="android:minWidth">@dimen/car_dialog_button_min_width</item>
         <item name="android:paddingStart">@dimen/car_padding_2</item>
         <item name="android:paddingEnd">@dimen/car_padding_2</item>
+        <item name="android:textAllCaps">false</item>
+        <item name="android:textColor">?android:attr/colorButtonNormal</item>
     </style>
 
     <!-- ================= -->

--- a/modules/features/cartheme/src/main/res/values/themes.xml
+++ b/modules/features/cartheme/src/main/res/values/themes.xml
@@ -163,9 +163,9 @@ limitations under the License.
         <item name="android:windowAnimationStyle">@style/Car.Dialog.Animation</item>
         <item name="android:windowTitleStyle">@style/Widget.Car.Dialog.Title</item>
         <item name="alertDialogStyle">@style/AlertDialog</item>
-        <item name="buttonBarNeutralButtonStyle">@style/Widget.Car.Button.Borderless.Colored</item>
-        <item name="buttonBarNegativeButtonStyle">@style/Widget.Car.Button.Borderless.Colored</item>
-        <item name="buttonBarPositiveButtonStyle">@style/Widget.Car.Button.Borderless.Colored</item>
+        <item name="buttonBarNeutralButtonStyle">@style/Widget.Car.Dialog.Button</item>
+        <item name="buttonBarNegativeButtonStyle">@style/Widget.Car.Dialog.Button</item>
+        <item name="buttonBarPositiveButtonStyle">@style/Widget.Car.Dialog.Button</item>
         <item name="listDividerAlertDialog">@drawable/car_preference_divider</item>
         <item name="textInputStyle">@style/Widget.Design.TextInputLayout</item>
     </style>


### PR DESCRIPTION
## Description

Cherry-pick of #5751 into `release/8.19`.

> **This change was already reviewed and merged on `main`.** This PR exists to land it in the upcoming release. CI and a quick review should still
> run to confirm the cherry-pick applies cleanly and introduces no issues on the release branch, since `release/8.19` may have diverged from `main`.

- Original PR: https://github.com/Automattic/pocket-casts-android/pull/5751
- Cherry-picked commit: `27b8822084`

## Testing Instructions

See the original PR (https://github.com/Automattic/pocket-casts-android/pull/5751) for full testing steps. In addition, verify the change behaves as described on top of `release/8.19`.