### PR TITLE
Add delete account to the Automotive account screen (cherry-pick to 8.19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 8.19
 -----
+*   New Features
+    *   Add the delete account option to the Automotive account screen
+        ([#5757](https://github.com/Automattic/pocket-casts-android/pull/5757))
 *   Bug Fixes
     *   Fix a crash when showing a bottom sheet after the app is sent to the background
         ([#5709](https://github.com/Automattic/pocket-casts-android/pull/5709))

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.profile
 
+import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
@@ -190,6 +191,11 @@ class AccountDetailsFragment : BaseFragment() {
     }
 
     private fun deleteAccount() {
+        if (Util.isAutomotive(requireContext())) {
+            deleteAccountAutomotive()
+            return
+        }
+
         ConfirmationDialog()
             .setButtonType(ConfirmationDialog.ButtonType.Danger(getString(LR.string.profile_account_delete)))
             .setTitle(getString(LR.string.profile_delete_account_title))
@@ -215,12 +221,17 @@ class AccountDetailsFragment : BaseFragment() {
         when (state) {
             is DeleteAccountState.Success -> {
                 accountViewModel.clearDeleteAccountState()
-                performSignOut()
+                if (Util.isAutomotive(requireContext())) {
+                    // Automotive head units are often shared, so clear the local podcasts
+                    signOutAndClearData()
+                } else {
+                    performSignOut()
+                }
             }
 
             is DeleteAccountState.Failure -> {
                 accountViewModel.clearDeleteAccountState()
-                AlertDialog.Builder(requireContext())
+                themedAlertBuilder(requireContext())
                     .setTitle(getString(LR.string.profile_delete_account_failed_title))
                     .setMessage(state.message ?: getString(LR.string.profile_delete_account_failed_message))
                     .setPositiveButton(getString(LR.string.ok)) { dialog, _ -> dialog.dismiss() }
@@ -236,10 +247,34 @@ class AccountDetailsFragment : BaseFragment() {
         Toast.makeText(requireContext(), LR.string.profile_deleting_account, Toast.LENGTH_LONG).show()
     }
 
+    private fun deleteAccountAutomotive() {
+        val context = context ?: return
+        themedAlertBuilder(context)
+            .setTitle(getString(LR.string.profile_delete_account_title))
+            .setMessage(getString(LR.string.profile_delete_account_question))
+            .setPositiveButton(getString(LR.string.profile_account_delete)) { _, _ -> deleteAccountPermanentAutomotive() }
+            .setNegativeButton(getString(LR.string.cancel), null)
+            .show()
+    }
+
+    private fun deleteAccountPermanentAutomotive() {
+        val context = context ?: return
+        themedAlertBuilder(context)
+            .setTitle(getString(LR.string.profile_delete_account_title))
+            .setMessage(getString(LR.string.profile_delete_account_permanent_question))
+            .setPositiveButton(getString(LR.string.profile_account_delete_yes)) { _, _ -> performDeleteAccount() }
+            .setNegativeButton(getString(LR.string.cancel), null)
+            .show()
+    }
+
+    private fun themedAlertBuilder(context: Context): AlertDialog.Builder {
+        val themedContext = if (Util.isAutomotive(context)) ContextThemeWrapper(context, CR.style.Theme_Car_NoActionBar) else context
+        return AlertDialog.Builder(themedContext)
+    }
+
     private fun signOutAutomotive() {
         val context = context ?: return
-        val themedContext = if (Util.isAutomotive(context)) ContextThemeWrapper(context, CR.style.Theme_Car_NoActionBar) else context
-        val builder = AlertDialog.Builder(themedContext)
+        val builder = themedAlertBuilder(context)
         builder.setTitle(getString(LR.string.profile_sign_out))
             .setMessage(getString(LR.string.profile_sign_out_confirm))
             .setPositiveButton(getString(LR.string.profile_sign_out)) { _, _ -> clearDataAlert() }
@@ -249,8 +284,7 @@ class AccountDetailsFragment : BaseFragment() {
 
     private fun clearDataAlert() {
         val context = context ?: return
-        val themedContext = if (Util.isAutomotive(context)) ContextThemeWrapper(context, CR.style.Theme_Car_NoActionBar) else context
-        val builder = AlertDialog.Builder(themedContext)
+        val builder = themedAlertBuilder(context)
         builder.setTitle(getString(LR.string.profile_clear_data_question))
             .setMessage(getString(LR.string.profile_clear_data_would_you_also_like_question))
             .setPositiveButton(getString(LR.string.profile_just_sign_out)) { _, _ -> performSignOut() }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsPage.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsPage.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -84,7 +85,7 @@ internal fun AccountDetailsPage(
                     badgeIconSize = 18.dp,
                     badgeContentPadding = 6.dp,
                 ),
-                infoFontScale = 1.6f,
+                infoFontScale = 2f,
             )
         } else {
             AccountHeaderConfig(
@@ -100,6 +101,10 @@ internal fun AccountDetailsPage(
             AccountSectionsConfig(
                 iconSize = 48.dp,
                 fontScale = 2f,
+                contentPadding = PaddingValues(horizontal = 24.dp, vertical = 20.dp),
+                iconSpacing = 24.dp,
+                minRowHeight = 96.dp,
+                groupSpacing = 32.dp,
             )
         } else {
             AccountSectionsConfig()
@@ -108,7 +113,7 @@ internal fun AccountDetailsPage(
     val sectionsState = remember(state.isAutomotive, state.sectionsState) {
         if (state.isAutomotive) {
             state.sectionsState.copy(
-                availableSections = listOf(AccountSection.SignOut),
+                availableSections = listOf(AccountSection.SignOut, AccountSection.DeleteAccount),
             )
         } else {
             state.sectionsState

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountSections.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountSections.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -143,7 +144,7 @@ internal fun AccountSections(
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(24.dp)
+                        .height(config.groupSpacing)
                         .background(MaterialTheme.theme.colors.primaryUi03),
                 )
             }
@@ -154,6 +155,10 @@ internal fun AccountSections(
 internal data class AccountSectionsConfig(
     val iconSize: Dp = 24.dp,
     val fontScale: Float = 1f,
+    val contentPadding: PaddingValues = PaddingValues(16.dp),
+    val iconSpacing: Dp = 16.dp,
+    val minRowHeight: Dp = 64.dp,
+    val groupSpacing: Dp = 24.dp,
 )
 
 internal data class AccountSectionsState(
@@ -296,7 +301,7 @@ private fun ButtonSection(
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier
             .fillMaxWidth()
-            .heightIn(min = 64.dp)
+            .heightIn(min = config.minRowHeight)
             .clickable(
                 interactionSource = remember(::MutableInteractionSource),
                 indication = ripple(
@@ -307,7 +312,7 @@ private fun ButtonSection(
             .semantics(mergeDescendants = true) {
                 role = Role.Button
             }
-            .padding(16.dp),
+            .padding(config.contentPadding),
     ) {
         Icon(
             painter = painterResource(section.iconId),
@@ -316,7 +321,7 @@ private fun ButtonSection(
             modifier = Modifier.size(config.iconSize),
         )
         Spacer(
-            modifier = Modifier.width(16.dp),
+            modifier = Modifier.width(config.iconSpacing),
         )
         TextH40(
             text = stringResource(section.titleId),
@@ -337,7 +342,7 @@ private fun SwitchSection(
         verticalAlignment = Alignment.Top,
         modifier = Modifier
             .fillMaxWidth()
-            .heightIn(min = 64.dp)
+            .heightIn(min = config.minRowHeight)
             .height(IntrinsicSize.Max)
             .clickable(
                 interactionSource = remember(::MutableInteractionSource),
@@ -349,7 +354,7 @@ private fun SwitchSection(
             .semantics(mergeDescendants = true) {
                 role = Role.Switch
             }
-            .padding(16.dp),
+            .padding(config.contentPadding),
     ) {
         Icon(
             painter = painterResource(section.iconId),
@@ -358,7 +363,7 @@ private fun SwitchSection(
             modifier = Modifier.size(config.iconSize),
         )
         Spacer(
-            modifier = Modifier.width(16.dp),
+            modifier = Modifier.width(config.iconSpacing),
         )
         Column(
             modifier = Modifier.fillMaxWidth(fraction = 0.75f),


### PR DESCRIPTION
## Description

Cherry-pick of #5757 into `release/8.19`.

> **This change was already reviewed and merged on `main`.** This PR exists to land it in the upcoming release. CI and a quick review should still run to confirm the cherry-pick applies cleanly and introduces no issues on the release branch, since `release/8.19` may have diverged from `main`.

- Original PR: https://github.com/Automattic/pocket-casts-android/pull/5757
- Cherry-picked commit: `2cc7874178`

## Testing Instructions

See the original PR (https://github.com/Automattic/pocket-casts-android/pull/5757) for full testing steps. In addition, verify the change behaves as described on top of `release/8.19`.
