### PR TITLE
[TV] Mini-player transport drawer (prototype)

### DIFF
--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
@@ -79,7 +79,10 @@ fun TvScaffold(
             modifier = modifier
                 .fillMaxSize()
                 .onPreviewKeyEvent { event ->
-                    if (event.type == KeyEventType.KeyDown && event.key == Key.Menu) {
+                    val isMenuPress = event.type == KeyEventType.KeyDown &&
+                        event.key == Key.Menu &&
+                        event.nativeKeyEvent.repeatCount == 0
+                    if (isMenuPress && !isProfileModalVisible) {
                         isMiniPlayerVisible = !isMiniPlayerVisible
                         true
                     } else {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
@@ -21,6 +21,11 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -29,6 +34,8 @@ import au.com.shiftyjelly.pocketcasts.component.LocalFocusTvTopBar
 import au.com.shiftyjelly.pocketcasts.component.LocalOpenNowPlaying
 import au.com.shiftyjelly.pocketcasts.component.LocalTvTopBarVisibility
 import au.com.shiftyjelly.pocketcasts.component.TvTopBarVisibility
+import au.com.shiftyjelly.pocketcasts.component.tvFocusInactiveWhen
+import au.com.shiftyjelly.pocketcasts.nowplaying.TvMiniPlayer
 import au.com.shiftyjelly.pocketcasts.nowplaying.TvNowPlayingScreen
 import au.com.shiftyjelly.pocketcasts.playlists.TvPlaylistsScreen
 import au.com.shiftyjelly.pocketcasts.podcasts.TvYourPodcastsScreen
@@ -52,6 +59,7 @@ fun TvScaffold(
     var didFocusTopBar by rememberSaveable { mutableStateOf(false) }
     var isNowPlayingOpenRequested by remember { mutableStateOf(false) }
     var isTopBarFocusRequested by remember { mutableStateOf(false) }
+    var isMiniPlayerVisible by remember { mutableStateOf(false) }
     val focusTopBar: () -> Unit = remember {
         { isTopBarFocusRequested = true }
     }
@@ -67,73 +75,92 @@ fun TvScaffold(
         LocalOpenNowPlaying provides openNowPlaying,
         LocalFocusTvTopBar provides focusTopBar,
     ) {
-        TvScaffoldContent(
-            tabs = uiState.tabs,
-            selectedTabIndex = uiState.selectedTabIndex,
-            profile = uiState.profile,
-            isTopBarVisible = topBarVisibility.isVisible,
-            autoFocusSelectedTab = !didFocusTopBar,
-            onSelectedTabFocus = { didFocusTopBar = true },
-            focusSelectedTab = isTopBarFocusRequested,
-            onConsumeFocusRequest = { isTopBarFocusRequested = false },
-            onTabSelect = viewModel::selectTab,
-            onTabClick = { tab ->
-                if (tab == TvTab.NowPlaying) {
-                    isNowPlayingOpenRequested = true
+        Box(
+            modifier = modifier
+                .fillMaxSize()
+                .onPreviewKeyEvent { event ->
+                    if (event.type == KeyEventType.KeyDown && event.key == Key.Menu) {
+                        isMiniPlayerVisible = !isMiniPlayerVisible
+                        true
+                    } else {
+                        false
+                    }
+                },
+        ) {
+            Box(modifier = Modifier.tvFocusInactiveWhen(isMiniPlayerVisible)) {
+                TvScaffoldContent(
+                    tabs = uiState.tabs,
+                    selectedTabIndex = uiState.selectedTabIndex,
+                    profile = uiState.profile,
+                    isTopBarVisible = topBarVisibility.isVisible,
+                    autoFocusSelectedTab = !didFocusTopBar,
+                    onSelectedTabFocus = { didFocusTopBar = true },
+                    focusSelectedTab = isTopBarFocusRequested,
+                    onConsumeFocusRequest = { isTopBarFocusRequested = false },
+                    onTabSelect = viewModel::selectTab,
+                    onTabClick = { tab ->
+                        if (tab == TvTab.NowPlaying) {
+                            isNowPlayingOpenRequested = true
+                        }
+                    },
+                    onProfileClick = { isProfileModalVisible = true },
+                ) { tab ->
+                    val navigateToHome = { viewModel.selectTab(TvTab.Home) }
+                    // Tabs without a detail screen sit below the bar; the detail-bearing tabs pad their own
+                    // content so their overlays can fill the full height.
+                    val belowTopBar = Modifier.fillMaxSize().padding(top = TvTopBarHeight)
+                    when (tab) {
+                        is TvTab.Home -> TvHomeScreen(
+                            onNavigateToSearch = { viewModel.selectTab(TvTab.Search) },
+                            onCreateAccount = onCreateAccount,
+                        )
+
+                        is TvTab.YourPodcasts -> TvYourPodcastsScreen(
+                            onNavigateToHome = navigateToHome,
+                        )
+
+                        is TvTab.Playlists -> TvPlaylistsScreen()
+
+                        is TvTab.UpNext -> Box(modifier = belowTopBar) {
+                            TvUpNextScreen(onNavigateToHome = navigateToHome)
+                        }
+
+                        is TvTab.NowPlaying -> TvNowPlayingScreen(
+                            isOpenRequested = isNowPlayingOpenRequested,
+                            onConsumeOpenRequest = { isNowPlayingOpenRequested = false },
+                        )
+
+                        is TvTab.Search -> TvSearchScreen()
+                    }
                 }
-            },
-            onProfileClick = { isProfileModalVisible = true },
-            modifier = modifier,
-        ) { tab ->
-            val navigateToHome = { viewModel.selectTab(TvTab.Home) }
-            // Tabs without a detail screen sit below the bar; the detail-bearing tabs pad their own
-            // content so their overlays can fill the full height.
-            val belowTopBar = Modifier.fillMaxSize().padding(top = TvTopBarHeight)
-            when (tab) {
-                is TvTab.Home -> TvHomeScreen(
-                    onNavigateToSearch = { viewModel.selectTab(TvTab.Search) },
-                    onCreateAccount = onCreateAccount,
-                )
 
-                is TvTab.YourPodcasts -> TvYourPodcastsScreen(
-                    onNavigateToHome = navigateToHome,
-                )
-
-                is TvTab.Playlists -> TvPlaylistsScreen()
-
-                is TvTab.UpNext -> Box(modifier = belowTopBar) {
-                    TvUpNextScreen(onNavigateToHome = navigateToHome)
+                if (isProfileModalVisible) {
+                    TvProfileModal(
+                        profile = uiState.profile,
+                        onDismissRequest = { isProfileModalVisible = false },
+                        onLogIn = {
+                            isProfileModalVisible = false
+                            onLogIn()
+                        },
+                        onCreateAccount = {
+                            isProfileModalVisible = false
+                            onCreateAccount()
+                        },
+                        // TODO: wire up the Starred Episodes and Listening History destinations.
+                        onStarredEpisodes = {},
+                        onListeningHistory = {},
+                        onLogOut = {
+                            isProfileModalVisible = false
+                            viewModel.signOut()
+                            onSignedOut()
+                        },
+                    )
                 }
-
-                is TvTab.NowPlaying -> TvNowPlayingScreen(
-                    isOpenRequested = isNowPlayingOpenRequested,
-                    onConsumeOpenRequest = { isNowPlayingOpenRequested = false },
-                )
-
-                is TvTab.Search -> TvSearchScreen()
             }
-        }
-
-        if (isProfileModalVisible) {
-            TvProfileModal(
-                profile = uiState.profile,
-                onDismissRequest = { isProfileModalVisible = false },
-                onLogIn = {
-                    isProfileModalVisible = false
-                    onLogIn()
-                },
-                onCreateAccount = {
-                    isProfileModalVisible = false
-                    onCreateAccount()
-                },
-                // TODO: wire up the Starred Episodes and Listening History destinations.
-                onStarredEpisodes = {},
-                onListeningHistory = {},
-                onLogOut = {
-                    isProfileModalVisible = false
-                    viewModel.signOut()
-                    onSignedOut()
-                },
+            TvMiniPlayer(
+                visible = isMiniPlayerVisible,
+                onDismiss = { isMiniPlayerVisible = false },
+                modifier = Modifier.align(Alignment.BottomCenter),
             )
         }
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvMiniPlayer.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvMiniPlayer.kt
@@ -1,0 +1,186 @@
+package au.com.shiftyjelly.pocketcasts.nowplaying
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.component.TvArtworkImage
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.type.TrimMode
+import au.com.shiftyjelly.pocketcasts.theme.TvTheme
+import au.com.shiftyjelly.pocketcasts.theme.tvColors
+import au.com.shiftyjelly.pocketcasts.theme.tvTypography
+import java.util.Date
+
+@Composable
+fun TvMiniPlayer(
+    visible: Boolean,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: TvNowPlayingViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val loaded = uiState as? TvNowPlayingUiState.Loaded
+
+    val currentOnDismiss by rememberUpdatedState(onDismiss)
+    LaunchedEffect(visible, loaded == null) {
+        if (visible && loaded == null) {
+            currentOnDismiss()
+        }
+    }
+
+    var retained by remember { mutableStateOf<TvNowPlayingUiState.Loaded?>(null) }
+    if (loaded != null) {
+        retained = loaded
+    }
+
+    AnimatedVisibility(
+        visible = visible && loaded != null,
+        enter = slideInVertically { it } + fadeIn(),
+        exit = slideOutVertically { it } + fadeOut(),
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        retained?.let { state ->
+            MiniPlayerContent(
+                state = state,
+                onPlayPause = viewModel::playPause,
+                onSkipBackward = viewModel::skipBackward,
+                onSkipForward = viewModel::skipForward,
+                onDismiss = onDismiss,
+            )
+        }
+    }
+}
+
+@Composable
+private fun MiniPlayerContent(
+    state: TvNowPlayingUiState.Loaded,
+    onPlayPause: () -> Unit,
+    onSkipBackward: () -> Unit,
+    onSkipForward: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val seekBarFocusRequester = remember { FocusRequester() }
+    LaunchedEffect(Unit) {
+        withFrameNanos {}
+        runCatching { seekBarFocusRequester.requestFocus() }
+    }
+    BackHandler(onBack = onDismiss)
+
+    val episode = state.episode
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(DrawerShape)
+            .background(MaterialTheme.tvColors.overlayContainer)
+            .border(1.dp, MaterialTheme.tvColors.overlayBorder, DrawerShape)
+            .padding(horizontal = DrawerHorizontalInset, vertical = 24.dp),
+    ) {
+        TvArtworkImage(
+            model = episode.artworkModel(),
+            modifier = Modifier
+                .size(ArtworkSize)
+                .clip(RoundedCornerShape(8.dp)),
+        )
+        Spacer(modifier = Modifier.width(24.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            state.podcastTitle?.let { podcastTitle ->
+                Text(
+                    text = podcastTitle,
+                    style = MaterialTheme.tvTypography.caption1,
+                    color = MaterialTheme.tvColors.textSecondary,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            Text(
+                text = episode.title,
+                style = MaterialTheme.tvTypography.callout,
+                color = MaterialTheme.tvColors.textPrimary,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            TvSeekBar(
+                positionMs = state.positionMs,
+                durationMs = state.durationMs,
+                onSkipBack = onSkipBackward,
+                onSkipForward = onSkipForward,
+                onPlayPause = onPlayPause,
+                focusRequester = seekBarFocusRequester,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+    }
+}
+
+private val DrawerShape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp)
+private val DrawerHorizontalInset = 56.dp
+private val ArtworkSize = 96.dp
+
+@Preview(widthDp = 960)
+@Composable
+private fun TvMiniPlayerPreview() {
+    TvTheme {
+        MiniPlayerContent(
+            state = TvNowPlayingUiState.Loaded(
+                episode = PodcastEpisode(
+                    uuid = "episode-uuid",
+                    title = "Episode title that might be quite long and wrap onto two lines",
+                    podcastUuid = "podcast-uuid",
+                    publishedDate = Date(0),
+                ),
+                podcastTitle = "Podcast title",
+                isPlaying = true,
+                isBuffering = false,
+                errorMessage = null,
+                positionMs = 600_000,
+                durationMs = 3_600_000,
+                bufferedMs = 1_200_000,
+                isVideo = false,
+                player = null,
+                playbackSpeed = 1.0,
+                trimMode = TrimMode.OFF,
+                isVolumeBoosted = false,
+            ),
+            onPlayPause = {},
+            onSkipBackward = {},
+            onSkipForward = {},
+            onDismiss = {},
+        )
+    }
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
@@ -523,7 +523,7 @@ private val chromeRevealConsumedKeys = setOf(
     Key.DirectionRight,
 )
 
-private fun BaseEpisode.artworkModel(): Any? = when (this) {
+internal fun BaseEpisode.artworkModel(): Any? = when (this) {
     is PodcastEpisode -> PodcastImage.getMediumArtworkUrl(podcastUuid)
     is UserEpisode -> artworkUrl
 }


### PR DESCRIPTION
## Description

Adds a **TV mini-player**: a transport-control drawer that slides up over whatever you're browsing when you press the remote's **Menu / Options** key, so you can pause, skip, and scrub without leaving the current screen. Menu again (or Back) dismisses it.

This is a **prototype for design-team review** — parity with the mini-player drawer proposed in the (closed) external PR #5737. It reuses the existing Now Playing infrastructure rather than adding new plumbing:

- **New:** `tv/…/nowplaying/TvMiniPlayer.kt` — the drawer. Reuses `TvNowPlayingViewModel` (shared instance → same playback state/actions as the full Now Playing screen), `TvSeekBar` (which already handles play/pause on OK and skip on left/right), and `TvArtworkImage`. Shows artwork + podcast/episode title + the seek bar inside a slide-up scrim. Renders only when something is playing; a Menu press with nothing playing is a no-op.
- **Wiring:** `TvScaffold.kt` — a root `onPreviewKeyEvent` toggles the drawer on `Key.Menu` (guarded against key-repeat and suppressed while the profile modal is open), the browse content is marked `tvFocusInactiveWhen(visible)` so the D-pad drives the drawer, and the drawer is hosted as the top layer.
- **Reuse:** promoted the existing `BaseEpisode.artworkModel()` helper in `TvNowPlayingScreen` from `private` to `internal` instead of duplicating artwork resolution.

No new strings, no analytics, no feature flag.

## Testing Instructions

1. Sign in on an Android TV / Google TV device and start playing an episode.
2. From any browse screen (Home / Your Podcasts / Playlists / Up Next), press the remote **Menu** key.
   - On remotes without a Menu button (e.g. the Google TV Streamer), trigger it with `adb shell input keyevent 82`.
3. The mini-player slides up showing artwork, titles, and the seek bar → OK toggles play/pause, Left/Right skip, and the position updates live.
4. Press Menu again or Back → the drawer slides away.
5. With nothing playing, press Menu → nothing happens (no-op).

### Verified on a Google TV Streamer (real hardware)
- Drawer opens over the browse screen on Menu, showing the current episode (artwork + "Mad About Movies" + episode title + seek bar).
- Skip forward on the seek bar works (position advanced 01:29 → 01:44).
- Dismiss on Menu works.

### Known issues to resolve before this leaves prototype
- **Focus isolation is incomplete:** while the drawer is open, a D-pad press still reached the browse layer behind it (the top-bar tab moved). `tvFocusInactiveWhen` isn't fully trapping the D-pad here — needs a proper focus trap.
- **Focus handback on dismiss is not implemented:** after closing the drawer, focus is not deliberately returned to the browse grid. The repo's restore-focus pattern is per-screen (each screen owns its `FocusRequester`s) and isn't reachable from the scaffold, so this needs a considered approach rather than wrapping the whole scaffold in a new focus group (which has caused TV focus regressions before).
- **Scope:** transport-only by design (no speed/effects, no expand-to-Now-Playing); those are deliberately out of scope for the demo.

## Screenshots or Screencast

<!-- Drag these in from the scratchpad:
  tv_mini_open.png  — drawer open over the Up Next screen
-->
_Mini-player open over a browse screen (drag `tv_mini_open.png` in here)._

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md <!-- N/A: consistent with other in-development [TV] PRs -->
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes <!-- UI/focus wiring; validated on-device -->
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml` <!-- no new strings -->
- [x] Any jetpack compose components I added or changed are covered by compose previews <!-- TvMiniPlayer has a @Preview -->
- [x] I have updated (or requested that someone edit) the Event Horizon schema to reflect any new or changed analytics. <!-- no analytics -->

#### I have tested any UI changes...
<!-- TV is dark-theme only and leanback-landscape; TalkBack/large-font not applicable to this prototype -->
