### PR TITLE
Remove obsolete `android_build_preflight`

### DIFF
--- a/.buildkite/commands/release-build.sh
+++ b/.buildkite/commands/release-build.sh
@@ -11,4 +11,4 @@ echo "--- :closed_lock_with_key: Installing Secrets"
 bundle exec fastlane run configure_apply
 
 echo "--- :hammer_and_wrench: Building"
-bundle exec fastlane build_and_upload_to_play_store skip_confirm:true skip_prechecks:true create_gh_release:true
+bundle exec fastlane build_and_upload_to_play_store skip_confirm:true create_gh_release:true

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -528,25 +528,22 @@ platform :android do
   # - Creates draft Github release
   #
   # @param skip_confirm [Boolean] If true, avoids any interactive prompt
-  # @param skip_prechecks [Boolean] If true, skips the branch, confirmation and clean-tree checks
   # @param create_gh_release [Boolean] If true, creates a draft GitHub release
   #
-  lane :build_and_upload_to_play_store do |skip_prechecks: false, skip_confirm: false, create_gh_release: false|
+  lane :build_and_upload_to_play_store do |skip_confirm: false, create_gh_release: false|
     version = version_name_current
     build_code = build_code_current
     is_beta = beta_version?(version)
 
-    unless skip_prechecks
-      # Match branch names that begin with `release/`
-      # Skip this check on CI because that action relies on CI env vars, but when this lane is called as part of `code_freeze` the branch changed since the CI build started, so that wouldn't work
-      ensure_git_branch(branch: '^release/') unless is_ci
+    # Match branch names that begin with `release/`
+    # Skip this check on CI because that action relies on CI env vars, but when this lane is called as part of `code_freeze` the branch changed since the CI build started, so that wouldn't work
+    ensure_git_branch(branch: '^release/') unless is_ci
 
-      UI.important("Building version #{version_name_current} (#{build_code_current}) for upload to Google Play Console")
-      UI.user_error!("Terminating as requested. Don't forget to run the remainder of this automation manually.") unless skip_confirm || UI.confirm('Do you want to continue?')
+    UI.important("Building version #{version_name_current} (#{build_code_current}) for upload to Google Play Console")
+    UI.user_error!("Terminating as requested. Don't forget to run the remainder of this automation manually.") unless skip_confirm || UI.confirm('Do you want to continue?')
 
-      # Check local repo status
-      ensure_git_status_clean unless is_ci
-    end
+    # Check local repo status
+    ensure_git_status_clean unless is_ci
 
     release_assets = []
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -528,7 +528,7 @@ platform :android do
   # - Creates draft Github release
   #
   # @param skip_confirm [Boolean] If true, avoids any interactive prompt
-  # @param skip_prechecks [Boolean] If true, skips android_build_preflight
+  # @param skip_prechecks [Boolean] If true, skips the branch, confirmation and clean-tree checks
   # @param create_gh_release [Boolean] If true, creates a draft GitHub release
   #
   lane :build_and_upload_to_play_store do |skip_prechecks: false, skip_confirm: false, create_gh_release: false|
@@ -546,8 +546,6 @@ platform :android do
 
       # Check local repo status
       ensure_git_status_clean unless is_ci
-
-      android_build_preflight
     end
 
     release_assets = []


### PR DESCRIPTION
## Description

The action runs checks that are mostly unnecessary:

- Decrypt secrets, which should already be decrypted
- Check gems are up to date, unrelated to app builds
- Ensure `bundletool` is available, but builds don't use it — its only
  client is `android_send_app_size_metrics`, which runs its own check

See https://github.com/wordpress-mobile/release-toolkit/blob/9322fff453fb4622d4d1add8040dc8d13cee2a1d/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_preflight.rb#L6-L23

The `skip_prechecks` block stays — only the `android_build_preflight` line goes, and the `@param` doc now names the checks that remain.

Fixes https://linear.app/a8c/issue/AINFRA-2965

## Testing Instructions

Validated on CI by throwaway PR #5768, which ran `build_and_upload_to_play_store` **without** `skip_prechecks:true` — so the block this PR edits actually executed — and stopped before the Play Store upload. The build [passed](https://buildkite.com/automattic/pocket-casts-android/builds/18485).

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
