### PR TITLE
[DO NOT MERGE] Validate build lane for #5767

### DIFF
--- a/.buildkite/commands/validate-build-lane.sh
+++ b/.buildkite/commands/validate-build-lane.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "--- :rubygems: Setting up Gems"
+install_gems
+
+echo "--- :closed_lock_with_key: Installing Secrets"
+bundle exec fastlane run configure_apply
+
+echo "--- :hammer_and_wrench: Running build_and_upload_to_play_store with prechecks ON (stop before Play Store upload)"
+LOG="$(mktemp)"
+# Deliberately no `skip_prechecks:true`: the prechecks block is the code this PR changed.
+bundle exec fastlane build_and_upload_to_play_store skip_confirm:true | tee "${LOG}"
+
+if ! grep -F 'VALIDATION: prechecks block completed' "${LOG}"; then
+  echo "VALIDATION: lane did not print the prechecks marker; refusing to treat this as a pass"
+  exit 1
+fi
+
+if ! grep -F 'VALIDATION: bundle built' "${LOG}"; then
+  echo "VALIDATION: lane did not print the bundle marker; refusing to treat this as a pass"
+  exit 1
+fi

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,108 +1,15 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 ---
 
+# Validation-only for Automattic/pocket-casts-android#5767. Close; do not merge.
+
 agents:
   queue: "android"
 
 steps:
-  - label: Gradle Wrapper Validation
-    command: validate_gradle_wrapper
-    agents:
-      queue: linter
-
-  # Wait for Gradle Wrapper to be validated before running any other jobs
-  - wait
-
-  - group: "Linters"
-    steps:
-      - label: ":danger: Danger - PR Check"
-        command: danger
-        key: danger
-        if: "build.pull_request.id != null"
-        retry:
-          manual:
-            permit_on_passed: true
-        agents:
-          queue: "linter"
-
-      - label: 'Lint'
-        command: ".buildkite/commands/lint.sh"
-        plugins: [ $CI_TOOLKIT ]
-        artifact_paths:
-          - "**/build/reports/lint-results*.*"
-
-  - label: 'Unit tests'
-    command: ".buildkite/commands/run-unit-tests.sh"
-    plugins: [ $CI_TOOLKIT ]
-
-  - group: "Diff Reports"
-    steps:
-      - label: 'Dependency diff'
-        if: build.pull_request.id != null
-        command: comment_with_dependency_diff 'app' 'releaseRuntimeClasspath'
-        plugins: [ $CI_TOOLKIT ]
-        artifact_paths:
-          - "**/build/reports/diff/*"
-
-      - label: "Merged Manifest Diff"
-        command: ".buildkite/commands/diff-merged-manifest.sh release"
-        if: build.pull_request.id != null
-        plugins: [ $CI_TOOLKIT ]
-        artifact_paths:
-          - "**/build/reports/diff_manifest/**/**/*"
-
-  - label: 'Spotless formatting check'
-    command: |
-      if .buildkite/commands/should-skip-job.sh --job-type validation; then
-        exit 0
-      fi
-
-      echo "--- 🔎 Checking formatting with Spotless"
-      ./gradlew spotlessCheck
-    plugins: [ $CI_TOOLKIT ]
-
-  - label: "Instrumented tests"
-    command: ".buildkite/commands/run-instrumented-tests.sh"
+  - label: ":android: Validate build lane with prechecks ON (no Play Store upload)"
+    key: validate_build_lane
+    command: ".buildkite/commands/validate-build-lane.sh"
     plugins: [ $CI_TOOLKIT ]
     artifact_paths:
-      - "**/build/instrumented-tests/**/*"
-
-  - group: "Assemble release APKs"
-    steps:
-      - label: "Assemble app release APK"
-        command: ".buildkite/commands/assemble-release-apk.sh app"
-        plugins: [ $CI_TOOLKIT ]
-        artifact_paths:
-          - "**/build/outputs/apk/**/*"
-
-      - label: "Assemble automotive release APK"
-        command: ".buildkite/commands/assemble-release-apk.sh automotive"
-        plugins: [ $CI_TOOLKIT ]
-        artifact_paths:
-          - "**/build/outputs/apk/**/*"
-
-      - label: "Assemble wear release APK"
-        command: ".buildkite/commands/assemble-release-apk.sh wear"
-        plugins: [ $CI_TOOLKIT ]
-        artifact_paths:
-          - "**/build/outputs/apk/**/*"
-
-    ##########
-    # Optional Prototype Builds
-    #
-    # Builds all modules, uploads app to FAD and Wear and Automotive to S3
-    ##########
-  - group: Prototype Builds
-    if: "build.pull_request.id != null || build.branch == 'main'"
-    steps:
-      - input: "🚀 Generate Prototype Builds?"
-        prompt: Generate Prototype Builds?
-        key: prototype_builds_triggered
-      - label: ":rocket: Prototype Builds"
-        depends_on: prototype_builds_triggered
-        command: .buildkite/commands/prototype-build.sh
-        plugins: [ $CI_TOOLKIT ]
-        artifact_paths:
-          - "**/build/outputs/apk/**/*"
-        # No notify node to avoid GitHub checks status being stuck on yellow.
-        # This step being optional, chances are it will never be triggered.
+      - "artifacts/*.aab"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -546,36 +546,18 @@ platform :android do
 
       # Check local repo status
       ensure_git_status_clean unless is_ci
+
+      # THROW AWAY: prove the prechecks block still runs after `android_build_preflight` is gone.
+      UI.success('VALIDATION: prechecks block completed without android_build_preflight')
     end
 
-    release_assets = []
-
-    APPS.each do |app|
-      build_bundle(app: app, version: version, build_code: build_code)
-
-      aab_artifact_path = aab_artifact_path(app, version)
-      UI.error("Unable to find a build artifact at #{aab_artifact_path}") unless File.exist? aab_artifact_path
-
-      track = play_store_track(app: app, is_beta: is_beta)
-      upload_to_play_store(
-        **UPLOAD_TO_PLAY_STORE_COMMON_OPTIONS,
-        aab: aab_artifact_path,
-        track: track,
-        release_status: 'draft'
-      )
-      release_assets << aab_artifact_path
-
-      signed_apk_artifact_path = signed_apk_artifact_path(app, version)
-      download_universal_apk_from_google_play(
-        package_name: APP_PACKAGE_NAME,
-        version_code: version_code_for_app(app: app, version_code: build_code),
-        destination: signed_apk_artifact_path,
-        json_key: UPLOAD_TO_PLAY_STORE_JSON_KEY
-      )
-      release_assets << signed_apk_artifact_path
-    end
-
-    create_gh_release(version: version, prerelease: is_beta, release_assets: release_assets.compact) if create_gh_release
+    # THROW AWAY: build one bundle and stop. The uploads that normally follow are deleted on this branch.
+    UI.message("VALIDATION: is_beta=#{is_beta}, create_gh_release=#{create_gh_release}; both are ignored here")
+    build_bundle(app: APPS_APP, version: version, build_code: build_code)
+    aab_artifact_path = aab_artifact_path(APPS_APP, version)
+    UI.user_error!("VALIDATION: expected AAB at #{aab_artifact_path}") unless File.exist?(aab_artifact_path)
+    UI.user_error!("VALIDATION: AAB at #{aab_artifact_path} is empty") if File.empty?(aab_artifact_path)
+    UI.success("VALIDATION: bundle built (#{File.size(aab_artifact_path)} bytes at #{aab_artifact_path}); stopping before Play Store upload")
   end
 
   # Builds and bundles the given app


### PR DESCRIPTION
## Validation only — do not merge

Stacked on #5767 ([AINFRA-2965](https://linear.app/a8c/issue/AINFRA-2965)).
Close this PR once the job has answered; never merge it.

## Why the ordinary pipeline misses this

#5767 removes `android_build_preflight` from `build_and_upload_to_play_store`, and now also drops the `skip_prechecks` parameter that gated the block it sat in.

Two things keep that code away from PR CI. The lane is only reached from `.buildkite/commands/release-build.sh`, which the release pipeline triggers — PR jobs run `build_and_upload_prototype_build` instead. And until #5767 that script passed `skip_prechecks:true`, so the block never executed even on the release pipeline. It has effectively never run on CI.

## Which job to read

**Validate build lane with prechecks ON (no Play Store upload)** is expected to **pass**.
Red means #5767 actually broke the lane — do not "fix" this PR.

The step runs `build_and_upload_to_play_store skip_confirm:true`. The prechecks are unconditional now, so invoking the lane is enough to exercise them.

Assertions:

- The lane prints `VALIDATION: prechecks block completed` — the code the PR edited ran end to end.
- The lane prints `VALIDATION: bundle built` with a non-zero size — a signed Release AAB was produced, so nothing downstream depended on the `configure_apply` that `android_build_preflight` used to run.

The AAB is attached as a build artifact.

Note that every check now left in that block is guarded by `unless is_ci` or by `skip_confirm`, so on CI this job exercises the path rather than the checks themselves. Its value is proving the lane still runs end to end and still produces a bundle.

## What CI still cannot answer

Whether the Play Store would accept the bundle. On this branch the loop over `APPS` is replaced by a single `app` build, and `upload_to_play_store`, `download_universal_apk_from_google_play` and `create_gh_release` are deleted rather than exercised.
