### PR TITLE
[TV] Now Playing analytics

### DIFF
--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -98,6 +99,18 @@ fun TvNowPlayingScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     var openedPodcastUuid by rememberSaveable { mutableStateOf<String?>(null) }
     val currentOnConsumeOpenRequest by rememberUpdatedState(onConsumeOpenRequest)
+
+    val isPlayerVisible = uiState is TvNowPlayingUiState.Loaded
+    DisposableEffect(isPlayerVisible) {
+        if (isPlayerVisible) {
+            viewModel.trackPlayerShown()
+        }
+        onDispose {
+            if (isPlayerVisible) {
+                viewModel.trackPlayerDismissed()
+            }
+        }
+    }
 
     val podcastUuid = openedPodcastUuid.takeUnless { isOpenRequested }
     if (podcastUuid != null) {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
@@ -100,13 +100,12 @@ fun TvNowPlayingScreen(
     var openedPodcastUuid by rememberSaveable { mutableStateOf<String?>(null) }
     val currentOnConsumeOpenRequest by rememberUpdatedState(onConsumeOpenRequest)
 
-    val isPlayerVisible = uiState is TvNowPlayingUiState.Loaded
-    DisposableEffect(isPlayerVisible) {
-        if (isPlayerVisible) {
+    // Keep this above the podcast-details early return, so opening a podcast from the player
+    // does not re-fire shown/dismissed on the way back.
+    if (uiState is TvNowPlayingUiState.Loaded) {
+        DisposableEffect(Unit) {
             viewModel.trackPlayerShown()
-        }
-        onDispose {
-            if (isPlayerVisible) {
+            onDispose {
                 viewModel.trackPlayerDismissed()
             }
         }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingViewModel.kt
@@ -15,8 +15,15 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.StreamVideoState
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import com.automattic.eventhorizon.EventHorizon
+import com.automattic.eventhorizon.PlaybackContentType
+import com.automattic.eventhorizon.PlaybackEffectSpeedChangedEvent
+import com.automattic.eventhorizon.PlaybackEffectTrimSilenceAmountChangedEvent
+import com.automattic.eventhorizon.PlaybackEffectVolumeBoostToggledEvent
 import com.automattic.eventhorizon.PlayerDismissedEvent
 import com.automattic.eventhorizon.PlayerShownEvent
+import com.automattic.eventhorizon.SettingType
+import com.automattic.eventhorizon.SourceViewType
+import com.automattic.eventhorizon.Trackable
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineDispatcher
@@ -101,18 +108,48 @@ class TvNowPlayingViewModel @Inject constructor(
         )
     }
 
-    fun setPlaybackSpeed(speed: Double) = updateEffects { it.copy(playbackSpeed = speed) }
+    fun setPlaybackSpeed(speed: Double) = updateEffects(
+        update = { it.copy(playbackSpeed = speed) },
+        track = { setting ->
+            trackEffectEvent { source, contentType ->
+                PlaybackEffectSpeedChangedEvent(speed = speed, settings = setting, source = source, contentType = contentType)
+            }
+        },
+    )
 
-    fun setTrimMode(trimMode: TrimMode) = updateEffects { it.copy(trimMode = trimMode) }
+    fun setTrimMode(trimMode: TrimMode) = updateEffects(
+        update = { it.copy(trimMode = trimMode) },
+        track = { setting ->
+            trackEffectEvent { source, contentType ->
+                PlaybackEffectTrimSilenceAmountChangedEvent(amount = trimMode.analyticsValue, settings = setting, source = source, contentType = contentType)
+            }
+        },
+    )
 
-    fun setVolumeBoost(isBoosted: Boolean) = updateEffects { it.copy(isVolumeBoosted = isBoosted) }
+    fun setVolumeBoost(isBoosted: Boolean) = updateEffects(
+        update = { it.copy(isVolumeBoosted = isBoosted) },
+        track = { setting ->
+            trackEffectEvent { source, contentType ->
+                PlaybackEffectVolumeBoostToggledEvent(enabled = isBoosted, settings = setting, source = source, contentType = contentType)
+            }
+        },
+    )
+
+    private fun trackEffectEvent(event: (SourceViewType, PlaybackContentType) -> Trackable) {
+        playbackManager.trackPlaybackEvent(SourceView.PLAYER_PLAYBACK_EFFECTS) { source, contentType ->
+            event(source.analyticsValue, contentType)
+        }
+    }
 
     private val effectsMutex = Mutex()
     private var pendingEffects: PlaybackEffectsData? = null
     private var pendingEffectsBaseline: PlaybackEffectsData? = null
     private var pendingEffectsEpisodeUuid: String? = null
 
-    private fun updateEffects(update: (PlaybackEffectsData) -> PlaybackEffectsData) {
+    private fun updateEffects(
+        update: (PlaybackEffectsData) -> PlaybackEffectsData,
+        track: (SettingType) -> Unit = {},
+    ) {
         viewModelScope.launch(ioDispatcher) {
             effectsMutex.withLock {
                 val playbackState = playbackManager.playbackStateFlow.first()
@@ -137,12 +174,14 @@ class TvNowPlayingViewModel @Inject constructor(
                 val effects = updatedEffects.toEffects()
                 val podcast = (currentEpisode as? PodcastEpisode)
                     ?.let { podcastManager.findPodcastByUuid(it.podcastUuid) }
+                val isLocal = podcast != null && podcast.overrideGlobalEffects
                 if (podcast != null && podcast.overrideGlobalEffects) {
                     podcastManager.updateEffectsBlocking(podcast, effects)
                 } else {
                     settings.globalPlaybackEffects.set(effects, updateModifiedAt = true)
                 }
                 playbackManager.updatePlayerEffects(effects)
+                track(if (isLocal) SettingType.Local else SettingType.Global)
             }
         }
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingViewModel.kt
@@ -14,6 +14,9 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.Player
 import au.com.shiftyjelly.pocketcasts.repositories.playback.StreamVideoState
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import com.automattic.eventhorizon.EventHorizon
+import com.automattic.eventhorizon.PlayerDismissedEvent
+import com.automattic.eventhorizon.PlayerShownEvent
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineDispatcher
@@ -32,6 +35,7 @@ class TvNowPlayingViewModel @Inject constructor(
     private val playbackManager: PlaybackManager,
     private val podcastManager: PodcastManager,
     private val settings: Settings,
+    private val eventHorizon: EventHorizon,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
 
@@ -70,6 +74,14 @@ class TvNowPlayingViewModel @Inject constructor(
         started = SharingStarted.WhileSubscribed(5_000),
         initialValue = TvNowPlayingUiState.Empty,
     )
+
+    fun trackPlayerShown() {
+        eventHorizon.track(PlayerShownEvent)
+    }
+
+    fun trackPlayerDismissed() {
+        eventHorizon.track(PlayerDismissedEvent)
+    }
 
     fun playPause() {
         playbackManager.playPause(sourceView = SourceView.PLAYER)

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingViewModel.kt
@@ -110,36 +110,29 @@ class TvNowPlayingViewModel @Inject constructor(
 
     fun setPlaybackSpeed(speed: Double) = updateEffects(
         update = { it.copy(playbackSpeed = speed) },
-        track = { setting ->
-            trackEffectEvent { source, contentType ->
-                PlaybackEffectSpeedChangedEvent(speed = speed, settings = setting, source = source, contentType = contentType)
-            }
+        event = { setting, source, contentType ->
+            PlaybackEffectSpeedChangedEvent(speed = speed, settings = setting, source = source, contentType = contentType)
         },
     )
 
     fun setTrimMode(trimMode: TrimMode) = updateEffects(
         update = { it.copy(trimMode = trimMode) },
-        track = { setting ->
-            trackEffectEvent { source, contentType ->
-                PlaybackEffectTrimSilenceAmountChangedEvent(amount = trimMode.analyticsValue, settings = setting, source = source, contentType = contentType)
-            }
+        event = { setting, source, contentType ->
+            PlaybackEffectTrimSilenceAmountChangedEvent(
+                amount = trimMode.analyticsValue,
+                settings = setting,
+                source = source,
+                contentType = contentType,
+            )
         },
     )
 
     fun setVolumeBoost(isBoosted: Boolean) = updateEffects(
         update = { it.copy(isVolumeBoosted = isBoosted) },
-        track = { setting ->
-            trackEffectEvent { source, contentType ->
-                PlaybackEffectVolumeBoostToggledEvent(enabled = isBoosted, settings = setting, source = source, contentType = contentType)
-            }
+        event = { setting, source, contentType ->
+            PlaybackEffectVolumeBoostToggledEvent(enabled = isBoosted, settings = setting, source = source, contentType = contentType)
         },
     )
-
-    private fun trackEffectEvent(event: (SourceViewType, PlaybackContentType) -> Trackable) {
-        playbackManager.trackPlaybackEvent(SourceView.PLAYER_PLAYBACK_EFFECTS) { source, contentType ->
-            event(source.analyticsValue, contentType)
-        }
-    }
 
     private val effectsMutex = Mutex()
     private var pendingEffects: PlaybackEffectsData? = null
@@ -148,7 +141,7 @@ class TvNowPlayingViewModel @Inject constructor(
 
     private fun updateEffects(
         update: (PlaybackEffectsData) -> PlaybackEffectsData,
-        track: (SettingType) -> Unit = {},
+        event: (SettingType, SourceViewType, PlaybackContentType) -> Trackable,
     ) {
         viewModelScope.launch(ioDispatcher) {
             effectsMutex.withLock {
@@ -181,7 +174,10 @@ class TvNowPlayingViewModel @Inject constructor(
                     settings.globalPlaybackEffects.set(effects, updateModifiedAt = true)
                 }
                 playbackManager.updatePlayerEffects(effects)
-                track(if (overridingPodcast != null) SettingType.Local else SettingType.Global)
+                val setting = if (overridingPodcast != null) SettingType.Local else SettingType.Global
+                playbackManager.trackPlaybackEvent(SourceView.PLAYER_PLAYBACK_EFFECTS) { source, contentType ->
+                    event(setting, source.analyticsValue, contentType)
+                }
             }
         }
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingViewModel.kt
@@ -172,16 +172,16 @@ class TvNowPlayingViewModel @Inject constructor(
                 pendingEffectsBaseline = stateEffects
                 pendingEffectsEpisodeUuid = currentEpisode.uuid
                 val effects = updatedEffects.toEffects()
-                val podcast = (currentEpisode as? PodcastEpisode)
+                val overridingPodcast = (currentEpisode as? PodcastEpisode)
                     ?.let { podcastManager.findPodcastByUuid(it.podcastUuid) }
-                val isLocal = podcast != null && podcast.overrideGlobalEffects
-                if (podcast != null && podcast.overrideGlobalEffects) {
-                    podcastManager.updateEffectsBlocking(podcast, effects)
+                    ?.takeIf { it.overrideGlobalEffects }
+                if (overridingPodcast != null) {
+                    podcastManager.updateEffectsBlocking(overridingPodcast, effects)
                 } else {
                     settings.globalPlaybackEffects.set(effects, updateModifiedAt = true)
                 }
                 playbackManager.updatePlayerEffects(effects)
-                track(if (isLocal) SettingType.Local else SettingType.Global)
+                track(if (overridingPodcast != null) SettingType.Local else SettingType.Global)
             }
         }
     }

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/discover/TvDiscoverFeedAnalyticsTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/discover/TvDiscoverFeedAnalyticsTest.kt
@@ -1,0 +1,185 @@
+package au.com.shiftyjelly.pocketcasts.discover
+
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
+import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
+import com.automattic.eventhorizon.BannerRowTappedEvent
+import com.automattic.eventhorizon.DiscoverAdCategoryTappedEvent
+import com.automattic.eventhorizon.DiscoverCategoriesPillTappedEvent
+import com.automattic.eventhorizon.DiscoverFeaturedPodcastTappedEvent
+import com.automattic.eventhorizon.DiscoverListEpisodePlayEvent
+import com.automattic.eventhorizon.DiscoverListEpisodeTappedEvent
+import com.automattic.eventhorizon.DiscoverListImpressionEvent
+import com.automattic.eventhorizon.DiscoverListPodcastTappedEvent
+import com.automattic.eventhorizon.EventHorizon
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+
+class TvDiscoverFeedAnalyticsTest {
+
+    private val eventHorizon = mock<EventHorizon>()
+    private val discoverCountryCode = mock<UserSetting<String>> {
+        whenever(it.value).thenReturn("us")
+    }
+    private val settings = mock<Settings> {
+        whenever(it.discoverCountryCode).thenReturn(discoverCountryCode)
+    }
+
+    private fun analytics(source: String = "home", localRowIds: Set<String> = emptySet()) = TvDiscoverFeedAnalytics(eventHorizon, settings, source, localRowIds)
+
+    @Test
+    fun `list impression is tracked with the row id and source`() {
+        analytics(source = "search").trackListImpression(podcastsRow(id = "trending"))
+
+        verify(eventHorizon).track(DiscoverListImpressionEvent(listId = "trending", source = "search"))
+    }
+
+    @Test
+    fun `list impression is not tracked for a local row`() {
+        analytics(localRowIds = setOf("trending")).trackListImpression(podcastsRow(id = "trending"))
+
+        verifyNoInteractions(eventHorizon)
+    }
+
+    @Test
+    fun `list impression is not tracked for a banner row`() {
+        analytics().trackListImpression(
+            TvDiscoverRow.Banner(id = "create_account", title = "", banner = TvDiscoverBanner.CreateAccount),
+        )
+
+        verifyNoInteractions(eventHorizon)
+    }
+
+    @Test
+    fun `list impression is not tracked for a categories row`() {
+        analytics().trackListImpression(
+            TvDiscoverRow.Categories(id = "categories", title = "Browse", categories = emptyList()),
+        )
+
+        verifyNoInteractions(eventHorizon)
+    }
+
+    @Test
+    fun `podcast tapped is tracked with the list id, podcast uuid and source`() {
+        analytics(source = "search").trackPodcastTapped(podcastsRow(id = "trending"), podcast("podcast-1"))
+
+        verify(eventHorizon).track(
+            DiscoverListPodcastTappedEvent(listId = "trending", podcastUuid = "podcast-1", source = "search"),
+        )
+        verify(eventHorizon, never()).track(any<DiscoverFeaturedPodcastTappedEvent>())
+    }
+
+    @Test
+    fun `a featured podcast tap also tracks the featured podcast event`() {
+        val row = TvDiscoverRow.FeaturedPodcasts(id = "featured", title = "Featured", podcasts = emptyList())
+
+        analytics().trackPodcastTapped(row, podcast("podcast-1"))
+
+        verify(eventHorizon).track(DiscoverListPodcastTappedEvent(listId = "featured", podcastUuid = "podcast-1", source = "home"))
+        verify(eventHorizon).track(DiscoverFeaturedPodcastTappedEvent(podcastUuid = "podcast-1"))
+    }
+
+    @Test
+    fun `a sponsored podcast tap also tracks an ad category event with the unknown name`() {
+        analytics().trackPodcastTapped(podcastsRow(id = "trending"), podcast("podcast-1", isSponsored = true))
+
+        verify(eventHorizon).track(DiscoverListPodcastTappedEvent(listId = "trending", podcastUuid = "podcast-1", source = "home"))
+        verify(eventHorizon).track(
+            DiscoverAdCategoryTappedEvent(name = "unknown", region = "us", id = 0, podcastId = "podcast-1"),
+        )
+    }
+
+    @Test
+    fun `podcast tapped is not tracked for a local row`() {
+        analytics(localRowIds = setOf("trending")).trackPodcastTapped(podcastsRow(id = "trending"), podcast("podcast-1"))
+
+        verifyNoInteractions(eventHorizon)
+    }
+
+    @Test
+    fun `episode played tracks both the tapped and the play events`() {
+        analytics(source = "search").trackEpisodePlayed(podcastsRow(id = "trending"), episode())
+
+        verify(eventHorizon).track(
+            DiscoverListEpisodeTappedEvent(listId = "trending", podcastUuid = "podcast-1", episodeUuid = "episode-1", source = "search"),
+        )
+        verify(eventHorizon).track(DiscoverListEpisodePlayEvent(listId = "trending", podcastUuid = "podcast-1"))
+    }
+
+    @Test
+    fun `episode podcast tapped tracks the podcast tapped event`() {
+        analytics().trackEpisodePodcastTapped(podcastsRow(id = "trending"), episode())
+
+        verify(eventHorizon).track(
+            DiscoverListPodcastTappedEvent(listId = "trending", podcastUuid = "podcast-1", source = "home"),
+        )
+    }
+
+    @Test
+    fun `category podcast tap tracks the list podcast event when a list id is present`() {
+        analytics().trackCategoryPodcastTapped(openedCategory(), listId = "list-1", podcast("podcast-1"))
+
+        verify(eventHorizon).track(
+            DiscoverListPodcastTappedEvent(listId = "list-1", podcastUuid = "podcast-1", source = "home"),
+        )
+        verify(eventHorizon, never()).track(any<DiscoverAdCategoryTappedEvent>())
+    }
+
+    @Test
+    fun `category podcast tap without a list id tracks nothing for a non-sponsored podcast`() {
+        analytics().trackCategoryPodcastTapped(openedCategory(), listId = null, podcast("podcast-1"))
+
+        verifyNoInteractions(eventHorizon)
+    }
+
+    @Test
+    fun `a sponsored category podcast tap tracks an ad category event`() {
+        analytics().trackCategoryPodcastTapped(openedCategory(id = 7, name = "News"), listId = null, podcast("podcast-1", isSponsored = true))
+
+        verify(eventHorizon).track(
+            DiscoverAdCategoryTappedEvent(name = "News", region = "us", id = 7, podcastId = "podcast-1"),
+        )
+    }
+
+    @Test
+    fun `category pill tap tracks the pill event with the region, index and visit count`() {
+        val category = DiscoverCategory(id = 3, name = "Comedy", icon = "", source = "", totalVisits = 42, isSponsored = true)
+
+        analytics(source = "search").trackCategoryPillTapped(category, index = 2)
+
+        verify(eventHorizon).track(
+            DiscoverCategoriesPillTappedEvent(name = "Comedy", region = "us", index = 2, visits = 42, sponsored = true, source = "search"),
+        )
+    }
+
+    @Test
+    fun `banner tap tracks the banner row event with the banner id`() {
+        analytics().trackBannerTapped(TvDiscoverBanner.DiscoverMore)
+
+        verify(eventHorizon).track(BannerRowTappedEvent(type = "discover_more"))
+    }
+
+    private fun podcastsRow(id: String) = TvDiscoverRow.Podcasts(id = id, title = "Trending", podcasts = emptyList())
+
+    private fun podcast(uuid: String, isSponsored: Boolean = false) = TvDiscoverPodcast(
+        uuid = uuid,
+        title = "Podcast $uuid",
+        author = "Author",
+        description = "Description",
+        isSponsored = isSponsored,
+    )
+
+    private fun episode() = TvDiscoverEpisode(
+        episodeUuid = "episode-1",
+        episodeTitle = "Episode",
+        podcastUuid = "podcast-1",
+        podcastTitle = "Podcast",
+    )
+
+    private fun openedCategory(id: Int = 1, name: String = "Category") = TvOpenedCategory(id = id, name = name, source = "home")
+}

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingViewModelTest.kt
@@ -36,6 +36,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argThat
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -73,12 +74,13 @@ class TvNowPlayingViewModelTest {
     private var trackedEffectEvent: Trackable? = null
 
     init {
-        whenever(playbackManager.trackPlaybackEvent(any(), any())).thenAnswer { invocation ->
+        // The stub supplies the content type; the real derivation lives in PlaybackManager.playbackContentTypeFor.
+        doAnswer { invocation ->
             @Suppress("UNCHECKED_CAST")
             val builder = invocation.arguments[1] as (SourceView, PlaybackContentType) -> Trackable
             trackedEffectEvent = builder(invocation.arguments[0] as SourceView, PlaybackContentType.Audio)
             null
-        }
+        }.whenever(playbackManager).trackPlaybackEvent(any(), any())
     }
 
     private val skipForwardSetting = mock<UserSetting<Int>> { on { value } doReturn 30 }

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingViewModelTest.kt
@@ -16,6 +16,15 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.StreamVideoState
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import com.automattic.eventhorizon.EventHorizon
+import com.automattic.eventhorizon.PlaybackContentType
+import com.automattic.eventhorizon.PlaybackEffectSpeedChangedEvent
+import com.automattic.eventhorizon.PlaybackEffectTrimSilenceAmountChangedEvent
+import com.automattic.eventhorizon.PlaybackEffectVolumeBoostToggledEvent
+import com.automattic.eventhorizon.PlayerDismissedEvent
+import com.automattic.eventhorizon.PlayerShownEvent
+import com.automattic.eventhorizon.SettingType
+import com.automattic.eventhorizon.Trackable
 import io.reactivex.subjects.BehaviorSubject
 import java.util.Date
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -59,6 +68,18 @@ class TvNowPlayingViewModelTest {
     }
 
     private val podcastManager = mock<PodcastManager>()
+    private val eventHorizon = mock<EventHorizon>()
+
+    private var trackedEffectEvent: Trackable? = null
+
+    init {
+        whenever(playbackManager.trackPlaybackEvent(any(), any())).thenAnswer { invocation ->
+            @Suppress("UNCHECKED_CAST")
+            val builder = invocation.arguments[1] as (SourceView, PlaybackContentType) -> Trackable
+            trackedEffectEvent = builder(invocation.arguments[0] as SourceView, PlaybackContentType.Audio)
+            null
+        }
+    }
 
     private val skipForwardSetting = mock<UserSetting<Int>> { on { value } doReturn 30 }
     private val skipBackSetting = mock<UserSetting<Int>> { on { value } doReturn 10 }
@@ -73,7 +94,7 @@ class TvNowPlayingViewModelTest {
     private val videoEpisode = PodcastEpisode(uuid = "video", publishedDate = Date(0), fileType = "video/mp4")
 
     private val viewModel by lazy {
-        TvNowPlayingViewModel(playbackManager, podcastManager, settings, coroutineRule.testDispatcher)
+        TvNowPlayingViewModel(playbackManager, podcastManager, settings, eventHorizon, coroutineRule.testDispatcher)
     }
 
     @Test
@@ -344,6 +365,101 @@ class TvNowPlayingViewModelTest {
         verify(playbackManager, never()).updatePlayerEffects(any())
         verifyNoInteractions(podcastManager)
         verify(globalPlaybackEffectsSetting, never()).set(any(), any(), any(), any())
+    }
+
+    @Test
+    fun `showing the player tracks a player shown event`() = runTest {
+        viewModel.trackPlayerShown()
+
+        verify(eventHorizon).track(PlayerShownEvent)
+    }
+
+    @Test
+    fun `dismissing the player tracks a player dismissed event`() = runTest {
+        viewModel.trackPlayerDismissed()
+
+        verify(eventHorizon).track(PlayerDismissedEvent)
+    }
+
+    @Test
+    fun `a global speed change tracks a speed changed event with global settings`() = runTest {
+        playbackStates.value = PlaybackState(episodeUuid = audioEpisode.uuid)
+        whenever(playbackManager.getCurrentEpisode()).thenReturn(audioEpisode)
+        whenever(podcastManager.findPodcastByUuid(audioEpisode.podcastUuid)).thenReturn(Podcast(uuid = "podcast"))
+
+        viewModel.setPlaybackSpeed(1.5)
+        runCurrent()
+
+        assertEquals(
+            PlaybackEffectSpeedChangedEvent(
+                speed = 1.5,
+                settings = SettingType.Global,
+                source = SourceView.PLAYER_PLAYBACK_EFFECTS.analyticsValue,
+                contentType = PlaybackContentType.Audio,
+            ),
+            trackedEffectEvent,
+        )
+    }
+
+    @Test
+    fun `a podcast override speed change tracks local settings`() = runTest {
+        playbackStates.value = PlaybackState(episodeUuid = audioEpisode.uuid)
+        whenever(playbackManager.getCurrentEpisode()).thenReturn(audioEpisode)
+        whenever(podcastManager.findPodcastByUuid(audioEpisode.podcastUuid)).thenReturn(Podcast(uuid = "podcast", overrideGlobalEffects = true))
+
+        viewModel.setPlaybackSpeed(2.0)
+        runCurrent()
+
+        assertEquals(SettingType.Local, (trackedEffectEvent as PlaybackEffectSpeedChangedEvent).settings)
+    }
+
+    @Test
+    fun `a trim change tracks a trim silence amount changed event`() = runTest {
+        playbackStates.value = PlaybackState(episodeUuid = audioEpisode.uuid)
+        whenever(playbackManager.getCurrentEpisode()).thenReturn(audioEpisode)
+
+        viewModel.setTrimMode(TrimMode.HIGH)
+        runCurrent()
+
+        assertEquals(
+            PlaybackEffectTrimSilenceAmountChangedEvent(
+                amount = TrimMode.HIGH.analyticsValue,
+                settings = SettingType.Global,
+                source = SourceView.PLAYER_PLAYBACK_EFFECTS.analyticsValue,
+                contentType = PlaybackContentType.Audio,
+            ),
+            trackedEffectEvent,
+        )
+    }
+
+    @Test
+    fun `a volume boost change tracks a volume boost toggled event`() = runTest {
+        playbackStates.value = PlaybackState(episodeUuid = audioEpisode.uuid)
+        whenever(playbackManager.getCurrentEpisode()).thenReturn(audioEpisode)
+
+        viewModel.setVolumeBoost(true)
+        runCurrent()
+
+        assertEquals(
+            PlaybackEffectVolumeBoostToggledEvent(
+                enabled = true,
+                settings = SettingType.Global,
+                source = SourceView.PLAYER_PLAYBACK_EFFECTS.analyticsValue,
+                contentType = PlaybackContentType.Audio,
+            ),
+            trackedEffectEvent,
+        )
+    }
+
+    @Test
+    fun `a skipped effect change does not track an effect event`() = runTest {
+        playbackStates.value = PlaybackState(episodeUuid = "previous")
+        whenever(playbackManager.getCurrentEpisode()).thenReturn(audioEpisode)
+
+        viewModel.setPlaybackSpeed(2.0)
+        runCurrent()
+
+        assertEquals(null, trackedEffectEvent)
     }
 
     private fun effectsWith(speed: Double, trimMode: TrimMode, isVolumeBoosted: Boolean) = argThat<PlaybackEffects> {


### PR DESCRIPTION
## Description

Brings the Android TV **Now Playing / Player** screen to analytics parity with the Apple TV app (`Pocket Casts TV App/UI/Player/NowPlayingView.swift`). The TV player previously fired no screen analytics.

Apple TV is the source of truth for which events fire and when; each maps to the existing generated EventHorizon Kotlin class (no schema change — all events already include the `android` platform).

Stacked on **#5769** ([TV] Search analytics) — review/merge that first.

### Events

| Event | Properties | Trigger |
|---|---|---|
| `player_shown` | — | The player (Loaded state) becomes visible |
| `player_dismissed` | — | The player goes away (switch tabs / queue empties) |
| `playback_effect_speed_changed` | speed, settings, source, content_type | A playback speed is selected |
| `playback_effect_volume_boost_toggled` | enabled, settings, source, content_type | Volume boost is toggled |
| `playback_effect_trim_silence_amount_changed` | amount, settings, source, content_type | A trim-silence mode is selected (incl. Off) |

- `player_shown`/`player_dismissed` are bare events, wired via a `DisposableEffect` in `TvNowPlayingScreen` keyed on the `Loaded` state (placed above the podcast-details early-return so opening a podcast from the player does not over-fire). Injects `EventHorizon` into `TvNowPlayingViewModel`.
- The three effect events reuse the shared **`playbackManager.trackPlaybackEvent(SourceView.PLAYER_PLAYBACK_EFFECTS)`** helper — the same path the phone's `EffectsFragment` uses — which supplies `source` + `content_type` (audio/video); `settings` (global vs local) is derived from `podcast.overrideGlobalEffects`. They fire from the single `updateEffects` choke point, only after the effect is actually applied.

Fixes PCDROID-725 https://linear.app/a8c/issue/PCDROID-725/now-playing-analytics

### Notable parity decisions

- **`playback_effect_trim_silence_toggled` is deliberately not fired** — the TV UI collapses on/off and amount into one trim-mode list, and Apple TV does the same: its `NowPlayingView.swift` menu (built from `TrimSilenceAmount.allCases`, which includes `off`) only ever fires `trimSilenceAmountChanged`, never `trimSilenceToggled`. TV enable/disable therefore shows up as `amount_changed` with `amount=off`/non-off, on both platforms — queries built on the `toggled` event won't see TV traffic.

## Testing Instructions

1. Build & install the TV debug app: `./gradlew :tv:installDebug`.
2. Play an episode to open Now Playing; watch logcat (`adb logcat -s Analytics`) for the 🔵 events (debug builds log every EventHorizon event).
3. Verify:
   - Opening the player logs `player_shown`; leaving it (switch tabs) logs `player_dismissed`.
   - Opening a podcast from the player and coming back does **not** re-fire shown/dismissed.
   - Changing speed logs `playback_effect_speed_changed`; toggling volume boost logs `playback_effect_volume_boost_toggled`; picking a trim mode logs `playback_effect_trim_silence_amount_changed` — each with `source=player_playback_effects`, the right `content_type`, and `settings=global` (or `local` for a podcast with custom effects).

## Screenshots or Screencast
<img width="1500" height="462" alt="logcat_nowplaying_analytics" src="https://github.com/user-attachments/assets/9c9ea6f8-7496-4252-8387-b4906741c11d" />


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md — _n/a, analytics only_
- [x] Ensure the linter passes (`./gradlew spotlessApply`)
- [x] I have considered whether it makes sense to add tests for my changes — _added VM unit tests for every new event_
- [x] All strings that need to be localized are in `modules/services/localization` — _n/a, no new strings_
- [x] Any jetpack compose components I added or changed are covered by compose previews — _n/a, no new composables_
- [x] I have updated (or requested that someone edit) the Event Horizon schema — _n/a, all events already include the `android` platform_

