### PR TITLE
[TV] Fix focus order on search

### DIFF
--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvTabBar.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvTabBar.kt
@@ -21,8 +21,8 @@ import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -83,7 +83,9 @@ fun TvTabBar(
     ) {
         TabRow(
             selectedTabIndex = selectedTabIndex,
-            modifier = Modifier.focusRestorer(),
+            modifier = Modifier.focusProperties {
+                onEnter = { runCatching { focusRequester.requestFocus() } }
+            },
             containerColor = Color.Transparent,
             indicator = @Composable { tabPositions, doesTabRowHaveFocus ->
                 tabPositions.getOrNull(selectedTabIndex)?.let { currentTabPosition ->

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvTabBar.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvTabBar.kt
@@ -54,10 +54,11 @@ fun TvTabBar(
     onConsumeFocusRequest: () -> Unit = {},
 ) {
     val focusRequester = remember { FocusRequester() }
+    val requestSelectedTabFocus = remember { { runCatching { focusRequester.requestFocus() }.isSuccess } }
     val currentOnSelectedTabFocus by rememberUpdatedState(onSelectedTabFocus)
     LaunchedEffect(autoFocusSelectedTab) {
         if (autoFocusSelectedTab) {
-            runCatching { focusRequester.requestFocus() }
+            requestSelectedTabFocus()
             currentOnSelectedTabFocus()
         }
     }
@@ -67,7 +68,7 @@ fun TvTabBar(
             // Retry across frames so the request is not consumed before the revealed tab bar has attached.
             repeat(FOCUS_REQUEST_MAX_FRAMES) {
                 withFrameNanos { }
-                if (runCatching { focusRequester.requestFocus() }.isSuccess) {
+                if (requestSelectedTabFocus()) {
                     currentOnConsumeFocusRequest()
                     return@LaunchedEffect
                 }
@@ -84,7 +85,7 @@ fun TvTabBar(
         TabRow(
             selectedTabIndex = selectedTabIndex,
             modifier = Modifier.focusProperties {
-                onEnter = { runCatching { focusRequester.requestFocus() } }
+                onEnter = { requestSelectedTabFocus() }
             },
             containerColor = Color.Transparent,
             indicator = @Composable { tabPositions, doesTabRowHaveFocus ->

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchFilters.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchFilters.kt
@@ -11,9 +11,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.focusRestorer
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Devices
@@ -35,6 +38,7 @@ internal fun TvSearchFilters(
     selected: TvSearchFilter,
     onFilterSelect: (TvSearchFilter) -> Unit,
     modifier: Modifier = Modifier,
+    upFocusRequester: FocusRequester? = null,
 ) {
     Row(
         modifier = modifier.fillMaxWidth(),
@@ -42,7 +46,11 @@ internal fun TvSearchFilters(
     ) {
         FilterDivider(modifier = Modifier.weight(1f))
         Spacer(modifier = Modifier.width(20.dp))
-        TvSearchFilterPills(selected = selected, onFilterSelect = onFilterSelect)
+        TvSearchFilterPills(
+            selected = selected,
+            onFilterSelect = onFilterSelect,
+            upFocusRequester = upFocusRequester,
+        )
         Spacer(modifier = Modifier.width(20.dp))
         FilterDivider(modifier = Modifier.weight(1f))
     }
@@ -52,8 +60,10 @@ internal fun TvSearchFilters(
 private fun TvSearchFilterPills(
     selected: TvSearchFilter,
     onFilterSelect: (TvSearchFilter) -> Unit,
+    upFocusRequester: FocusRequester? = null,
 ) {
     val selectedIndex = TvSearchFilter.entries.indexOf(selected)
+    val focusRequester = remember { FocusRequester() }
     Box(
         modifier = Modifier
             .background(MaterialTheme.tvColors.backgroundSunken, RoundedCornerShape(percent = 50))
@@ -61,7 +71,9 @@ private fun TvSearchFilterPills(
     ) {
         TabRow(
             selectedTabIndex = selectedIndex,
-            modifier = Modifier.focusRestorer(),
+            modifier = Modifier.focusProperties {
+                onEnter = { runCatching { focusRequester.requestFocus() } }
+            },
             containerColor = Color.Transparent,
             indicator = @Composable { tabPositions, doesTabRowHaveFocus ->
                 tabPositions.getOrNull(selectedIndex)?.let { currentTabPosition ->
@@ -81,7 +93,9 @@ private fun TvSearchFilterPills(
                     onClick = { onFilterSelect(filter) },
                     modifier = Modifier
                         .height(44.dp)
-                        .padding(horizontal = 21.dp),
+                        .padding(horizontal = 21.dp)
+                        .then(upFocusRequester?.let { Modifier.focusProperties { up = it } } ?: Modifier)
+                        .then(if (index == selectedIndex) Modifier.focusRequester(focusRequester) else Modifier),
                     colors = TabDefaults.pillIndicatorTabColors(
                         contentColor = MaterialTheme.tvColors.textPrimary,
                         selectedContentColor = MaterialTheme.tvColors.textPrimary,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchFilters.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchFilters.kt
@@ -94,7 +94,7 @@ private fun TvSearchFilterPills(
                     modifier = Modifier
                         .height(44.dp)
                         .padding(horizontal = 21.dp)
-                        .then(upFocusRequester?.let { Modifier.focusProperties { up = it } } ?: Modifier)
+                        .focusProperties { upFocusRequester?.let { up = it } }
                         .then(if (index == selectedIndex) Modifier.focusRequester(focusRequester) else Modifier),
                     colors = TabDefaults.pillIndicatorTabColors(
                         contentColor = MaterialTheme.tvColors.textPrimary,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
@@ -233,7 +233,9 @@ private fun TvSearchContent(
                     }
                     isEditing = editing
                 },
-                modifier = Modifier.focusRequester(searchFieldFocusRequester),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .focusRequester(searchFieldFocusRequester),
             )
             Spacer(modifier = Modifier.height(24.dp))
         }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
@@ -252,6 +252,7 @@ private fun TvSearchContent(
                 selected = filter,
                 onFilterSelect = onFilterSelect,
                 modifier = Modifier.padding(ContentPadding),
+                upFocusRequester = searchFieldFocusRequester,
             )
             Spacer(modifier = Modifier.height(24.dp))
         }


### PR DESCRIPTION
## Description

Fixes a set of related Android TV D-pad focus bugs where a tab/pill row grabbed the _geometrically nearest_ item on entry (silently switching the active tab/filter) or where vertical navigation skipped the element the user expected.

**Top tab bar** — moving focus **up** from a horizontal content row landed on whichever tab sat above the focused item, and because focusing a tab selects it, this switched tabs. Replaced `focusRestorer()` on the `TabRow` with `focusProperties { onEnter { … } }` that routes any entry into the tab-row focus group onto the currently **selected** tab. UP now preserves the tab; tabs change only via LEFT/RIGHT.

**Search screen — strict vertical order.** On a search-results screen the intended column is **top tabs ↕ search input ↕ filter pills ↕ results**. Three links were broken:

- **Down from the tab bar skipped the search input** and landed on the centered filter pills (the left-aligned input was outside the beam from the right-side Search tab). The search input now fills the content width, so it is the natural target directly below any tab. It stays visually identical (transparent container, no focus scale), only its focus bounds widen.
- **Down from the search input grabbed the leftmost "Top Results"** instead of the selected pill. `onEnter` → selected-pill fix on the filter `TabRow`.
- **Up from a filter pill skipped the search input** and escaped to the tab bar. Each pill now has an explicit `up` target pointing at the search field's `FocusRequester`. (Directional properties like `up` are resolved on the focused node itself, not inherited from the group — hence per-pill, matching the repo's existing `left`/`right` overrides.)

`onEnter` only fires when focus crosses into a group from outside, so navigation _within_ a tab/pill/content group is untouched.

Fixes # <!-- n/a -->

## Testing Instructions

Top tab bar:
1. On a tab with a horizontal content row (e.g. **Home**), press DOWN into a row and RIGHT to a center/end item.
2. Press UP — focus returns to the already-selected tab; it does **not** jump to the tab above the item.
3. LEFT/RIGHT still move between tabs.

Search screen (run a search so results + the Top Results / Podcasts / Episodes pills show):
1. From the **Search** tab in the top bar, press DOWN — the **search input** focuses (not the filter pills).
2. Press DOWN — focus moves to the selected filter pill (e.g. Top Results / Episodes), not always the leftmost.
3. Press DOWN — focus moves into the results; LEFT/RIGHT navigate the row normally.
4. Press UP repeatedly — results → filter pills → search input → top bar.

So DOWN traverses top tabs → search input → filter pills → results, and UP the reverse.

## Screenshots or Screencast

https://github.com/user-attachments/assets/64e1dc4e-de60-41dc-8797-0abc687c70c9



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md <!-- TV app is not tracked in the mobile CHANGELOG -->
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes <!-- D-pad focus behavior is not unit-testable; verified on-device -->
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml` <!-- no strings -->
- [x] Any jetpack compose components I added or changed are covered by compose previews <!-- TvTabBar / TvSearchFilters previews already exist -->
- [x] I have updated (or requested that someone edit) the Event Horizon schema to reflect any new or changed analytics. <!-- no analytics changes -->

#### I have tested any UI changes...
- [x] with different themes <!-- TV is dark-only -->
- [ ] with a landscape orientation <!-- TV is always landscape -->
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
