### PR TITLE
[TV] Fix overlapping elapsed and duration labels on Now Playing

### DIFF
--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvSeekBar.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvSeekBar.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -45,6 +46,9 @@ import au.com.shiftyjelly.pocketcasts.theme.TvTheme
 import au.com.shiftyjelly.pocketcasts.theme.tvColors
 import au.com.shiftyjelly.pocketcasts.theme.tvTypography
 import kotlin.math.roundToInt
+
+private val labelGap = 8.dp
+private val labelFadeRange = 16.dp
 
 @Composable
 fun TvSeekBar(
@@ -133,22 +137,32 @@ fun TvSeekBar(
         ) {
             val maxWidthPx = constraints.maxWidth.toFloat()
             val thumbSizePx = with(LocalDensity.current) { thumbSize.toPx() }
+            val gapPx = with(LocalDensity.current) { labelGap.toPx() }
+            val fadeRangePx = with(LocalDensity.current) { labelFadeRange.toPx() }
             var positionLabelWidth by remember { mutableIntStateOf(0) }
+            var durationLabelWidth by remember { mutableIntStateOf(0) }
+
+            val positionLabelX = run {
+                val thumbCenter = (maxWidthPx - thumbSizePx) * progress + thumbSizePx / 2f
+                (thumbCenter - positionLabelWidth / 2f)
+                    .coerceIn(0f, (maxWidthPx - positionLabelWidth).coerceAtLeast(0f))
+            }
+            val availableGap = (maxWidthPx - durationLabelWidth) - (positionLabelX + positionLabelWidth)
+            val durationAlpha = ((availableGap - gapPx) / fadeRangePx).coerceIn(0f, 1f)
+
             SeekBarLabel(
                 text = TimeHelper.formattedSeconds(positionMs / 1000.0),
                 modifier = Modifier
                     .align(Alignment.CenterStart)
                     .onSizeChanged { positionLabelWidth = it.width }
-                    .offset {
-                        val thumbCenter = (maxWidthPx - thumbSizePx) * progress + thumbSizePx / 2f
-                        val x = (thumbCenter - positionLabelWidth / 2f)
-                            .coerceIn(0f, (maxWidthPx - positionLabelWidth).coerceAtLeast(0f))
-                        IntOffset(x.roundToInt(), 0)
-                    },
+                    .offset { IntOffset(positionLabelX.roundToInt(), 0) },
             )
             SeekBarLabel(
                 text = if (hasDuration) TimeHelper.formattedSeconds(durationMs / 1000.0) else "-",
-                modifier = Modifier.align(Alignment.CenterEnd),
+                modifier = Modifier
+                    .align(Alignment.CenterEnd)
+                    .onSizeChanged { durationLabelWidth = it.width }
+                    .alpha(durationAlpha),
             )
         }
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvSeekBar.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvSeekBar.kt
@@ -21,22 +21,22 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.layout.onSizeChanged
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.ProgressBarRangeInfo
 import androidx.compose.ui.semantics.progressBarRangeInfo
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.MaterialTheme
@@ -47,8 +47,8 @@ import au.com.shiftyjelly.pocketcasts.theme.tvColors
 import au.com.shiftyjelly.pocketcasts.theme.tvTypography
 import kotlin.math.roundToInt
 
-private val labelGap = 8.dp
-private val labelFadeRange = 16.dp
+private val LabelGap = 8.dp
+private val LabelFadeRange = 16.dp
 
 @Composable
 fun TvSeekBar(
@@ -136,33 +136,31 @@ fun TvSeekBar(
                 .padding(top = 8.dp),
         ) {
             val maxWidthPx = constraints.maxWidth.toFloat()
-            val thumbSizePx = with(LocalDensity.current) { thumbSize.toPx() }
-            val gapPx = with(LocalDensity.current) { labelGap.toPx() }
-            val fadeRangePx = with(LocalDensity.current) { labelFadeRange.toPx() }
             var positionLabelWidth by remember { mutableIntStateOf(0) }
             var durationLabelWidth by remember { mutableIntStateOf(0) }
 
-            val positionLabelX = run {
-                val thumbCenter = (maxWidthPx - thumbSizePx) * progress + thumbSizePx / 2f
+            val positionLabelX: Density.() -> Float = {
+                val thumbCenter = (maxWidthPx - thumbSize.toPx()) * progress + thumbSize.toPx() / 2f
                 (thumbCenter - positionLabelWidth / 2f)
                     .coerceIn(0f, (maxWidthPx - positionLabelWidth).coerceAtLeast(0f))
             }
-            val availableGap = (maxWidthPx - durationLabelWidth) - (positionLabelX + positionLabelWidth)
-            val durationAlpha = ((availableGap - gapPx) / fadeRangePx).coerceIn(0f, 1f)
 
             SeekBarLabel(
                 text = TimeHelper.formattedSeconds(positionMs / 1000.0),
                 modifier = Modifier
                     .align(Alignment.CenterStart)
                     .onSizeChanged { positionLabelWidth = it.width }
-                    .offset { IntOffset(positionLabelX.roundToInt(), 0) },
+                    .offset { IntOffset(positionLabelX().roundToInt(), 0) },
             )
             SeekBarLabel(
                 text = if (hasDuration) TimeHelper.formattedSeconds(durationMs / 1000.0) else "-",
                 modifier = Modifier
                     .align(Alignment.CenterEnd)
                     .onSizeChanged { durationLabelWidth = it.width }
-                    .alpha(durationAlpha),
+                    .graphicsLayer {
+                        val availableGap = (maxWidthPx - durationLabelWidth) - (positionLabelX() + positionLabelWidth)
+                        alpha = ((availableGap - LabelGap.toPx()) / LabelFadeRange.toPx()).coerceIn(0f, 1f)
+                    },
             )
         }
     }


### PR DESCRIPTION
## Description

On the TV **Now Playing** screen, the seekbar shows the elapsed position as a label that floats horizontally to follow the scrubber thumb, and the total duration as a label fixed to the right edge. As playback nears the end of an episode, the floating elapsed label slid all the way to the right edge and overlapped the fixed duration label, rendering both times on top of each other.

This keeps the elapsed label glued under the thumb (its intended behaviour) and instead **fades the duration label out** as the two labels approach each other, so they never overlap. The duration fades back in when scrubbing away from the end. At the very end of an episode the total duration is redundant with the elapsed position anyway, so hiding it there reads cleanly.

The behaviour is measurement-based (it compares the actual rendered widths of the two labels rather than a fixed progress threshold), so it holds regardless of time-string length (e.g. `59:59` vs `1:59:59`). An 8dp gap is preserved and the fade happens over a 16dp range before the labels would touch.

This is a TV-only change, fully contained in `TvSeekBar.kt`.


## Testing Instructions

1. On an Android TV device/emulator, open the TV app and start playing an episode.
2. Open the **Now Playing** screen and move focus onto the seekbar (the elapsed-time label appears under the thumb).
3. Seek/scrub toward the **end** of the episode (hold right).
4. As the elapsed label approaches the right-hand duration label, confirm the duration label **fades out** instead of the two texts overlapping.
5. Scrub back toward the start and confirm the duration label **fades back in**.
6. Check an episode with no known duration (duration shows `-`) still renders correctly.

## Screenshots or Screencast

https://github.com/user-attachments/assets/c8b33b0c-8c17-4a95-820c-b5b7238e3b80


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md — N/A: TV app is not in public release; the CHANGELOG tracks the mobile/Automotive apps only.
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes — this is a layout-only change to a Compose UI element; behaviour is covered by the existing preview.
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml` — no new strings.
- [x] Any jetpack compose components I added or changed are covered by compose previews — `TvSeekBarPreview` exists.
- [x] I have updated (or requested that someone edit) the Event Horizon schema to reflect any new or changed analytics — no analytics changes.

