### PR TITLE
[TV] Add a TV case to AppPlatform

### DIFF
--- a/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserver.kt
+++ b/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserver.kt
@@ -138,6 +138,9 @@ class AppLifecycleObserver(
                 // do nothing because feature has not been enabled on Wear OS yet
                 AppPlatform.WearOs -> {}
 
+                // do nothing because feature has not been enabled on TV yet
+                AppPlatform.Tv -> {}
+
                 AppPlatform.Phone -> {
                     // For new users we want to auto play when the queue is empty by default
                     settings.autoPlayNextEpisodeOnEmpty.set(true, updateModifiedAt = false)

--- a/modules/features/shared/src/test/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserverTest.kt
+++ b/modules/features/shared/src/test/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserverTest.kt
@@ -176,6 +176,27 @@ class AppLifecycleObserverTest {
     }
 
     @Test
+    fun handlesNewInstallTv() = runTest {
+        whenever(settings.getMigratedVersionCode()).thenReturn(VERSION_CODE_DEFAULT)
+
+        appLifecycleObserver = spy(appLifecycleObserver)
+        doReturn(AppPlatform.Tv).whenever(appLifecycleObserver).getAppPlatform()
+
+        appLifecycleObserver.setup()
+
+        verify(appLifecycleAnalytics).onNewApplicationInstall()
+
+        verify(autoPlayNextEpisodeSetting, never()).set(any(), any(), any(), any())
+        verify(autoDownloadOnFollowPodcastSetting, never()).set(any(), any(), any(), any())
+        verify(dailyRemindersNotificationSetting, never()).set(any(), any(), any(), any())
+        verify(useUpNextDarkThemeSetting).set(false, updateModifiedAt = false)
+        verify(appLifecycleAnalytics, never()).onApplicationUpgrade(any())
+        verify(notificationScheduler, never()).setupOnboardingNotifications()
+        verify(notificationScheduler, times(1)).setupReEngagementNotification()
+        verify(notificationScheduler, times(1)).setupTrendingAndRecommendationsNotifications()
+    }
+
+    @Test
     fun handlesNewInstallAutomotive() = runTest {
         whenever(settings.getMigratedVersionCode()).thenReturn(VERSION_CODE_DEFAULT)
 

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/TracksAnalyticsTracker.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/TracksAnalyticsTracker.kt
@@ -101,14 +101,11 @@ class TracksAnalyticsTracker @Inject constructor(
             PredefinedEventProperty.THEME_DARK_PREFERENCE to settings.darkThemePreference.value.analyticsValue,
             PredefinedEventProperty.THEME_LIGHT_PREFERENCE to settings.lightThemePreference.value.analyticsValue,
             PredefinedEventProperty.THEME_USE_SYSTEM_SETTINGS to settings.useSystemTheme.value,
-            PredefinedEventProperty.PLATFORM to when {
-                Util.isTv(appContext) -> "tv"
-
-                else -> when (Util.getAppPlatform(appContext)) {
-                    AppPlatform.Automotive -> "automotive"
-                    AppPlatform.Phone -> "phone"
-                    AppPlatform.WearOs -> "watch"
-                }
+            PredefinedEventProperty.PLATFORM to when (Util.getAppPlatform(appContext)) {
+                AppPlatform.Automotive -> "automotive"
+                AppPlatform.Phone -> "phone"
+                AppPlatform.WearOs -> "watch"
+                AppPlatform.Tv -> "tv"
             },
         ).mapKeys { it.key.analyticsKey }
     }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -1078,6 +1078,7 @@ class SettingsImpl @Inject constructor(
 
             AppPlatform.Phone,
             AppPlatform.WearOs,
+            AppPlatform.Tv,
             -> false
         },
         sharedPrefs = sharedPreferences,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1803,7 +1803,7 @@ open class PlaybackManager @Inject constructor(
         return when (Util.getAppPlatform(application)) {
             AppPlatform.Automotive -> episodeWithSource?.first ?: episodeManager.findLatestEpisodeToPlayBlocking()
 
-            AppPlatform.WearOs -> episodeWithSource?.first
+            AppPlatform.WearOs, AppPlatform.Tv -> episodeWithSource?.first
 
             AppPlatform.Phone -> {
                 if (episodeWithSource != null) {

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/AppPlatform.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/AppPlatform.kt
@@ -14,4 +14,7 @@ enum class AppPlatform(
     WearOs(
         analyticsValue = DeviceType.Watch,
     ),
+    Tv(
+        analyticsValue = DeviceType.Tv,
+    ),
 }

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/Util.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/Util.kt
@@ -11,7 +11,6 @@ import android.view.accessibility.AccessibilityManager
 import androidx.car.app.connection.CarConnection
 import androidx.lifecycle.asFlow
 import androidx.lifecycle.map
-import au.com.shiftyjelly.pocketcasts.utils.Util.isAutomotive
 import java.util.Locale
 
 object Util {
@@ -38,6 +37,7 @@ object Util {
         val value = when {
             isAutomotive(context) -> AppPlatform.Automotive
             isWearOs(context) -> AppPlatform.WearOs
+            isTv(context) -> AppPlatform.Tv
             else -> AppPlatform.Phone
         }
         appPlatform = value


### PR DESCRIPTION
## Description

`Util.getAppPlatform()` had no TV case, so TV devices fell through to `AppPlatform.Phone`. Anywhere in the app that branches on the platform was therefore treating the TV app as a phone and applying phone behaviour to it.

For example, in [SimplePlayer.kt:367](https://github.com/Automattic/pocket-casts-android/blob/philip/tv-platform/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt#L367) `fingerprintTapEnabled` is gated on `getAppPlatform(context) == AppPlatform.Phone`, which currently evaluates to `true` on TV when it should almost certainly be `false`.

This adds `AppPlatform.Tv`, returns it from `Util.getAppPlatform()`, and handles the new case in the existing exhaustive `when` blocks. `TracksAnalyticsTracker` no longer needs its separate `Util.isTv()` check now that the enum carries the information.

Two behaviour changes ride along with the enum addition, both intended: `AppLifecycleObserver` no longer applies the phone new-user defaults on TV, and the `SettingsImpl` setting that was defaulting to the phone value now resolves to `false` on TV.

## Testing Instructions

1. Run the app on a TV device or emulator and confirm playback and settings behave as expected.
2. Run the app on a phone, Wear OS, and Automotive and confirm there are no behaviour changes.
3. Confirm the `platform` analytics property still reports `tv` on TV.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
