### PR TITLE
[TV] Add email/password sign-in option

### DIFF
--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -273,6 +273,9 @@
     <string name="tv_sign_in_step_scan">Scan the QR code or go to %1$s</string>
     <string name="tv_sign_in_step_login">Log in to your account</string>
     <string name="tv_sign_in_step_confirm_code">If asked, confirm with the code below</string>
+    <string name="tv_sign_in_tab_qr_code">QR code</string>
+    <string name="tv_sign_in_tab_email">Email</string>
+    <string name="tv_sign_in_signing_in">Signing in</string>
     <string name="tv_create_account_modal_title">Your podcasts deserve a home</string>
     <string name="tv_create_account_modal_subtitle">Create a free account to follow podcasts, build your Up Next, and pick up right where you left off, on any device.</string>
     <string name="tv_create_account_modal_step_create">Create your account or log in</string>

--- a/tv/src/main/AndroidManifest.xml
+++ b/tv/src/main/AndroidManifest.xml
@@ -44,7 +44,8 @@
         <activity
             android:name=".TvActivity"
             android:exported="true"
-            android:launchMode="singleTask">
+            android:launchMode="singleTask"
+            android:windowSoftInputMode="adjustNothing">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LEANBACK_LAUNCHER" />

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/createaccount/TvCreateAccountScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/createaccount/TvCreateAccountScreen.kt
@@ -94,7 +94,7 @@ private fun TvCreateAccountLoading(modifier: Modifier = Modifier) {
             Text(
                 text = stringResource(LR.string.tv_create_account_title),
                 color = MaterialTheme.tvColors.textPrimary,
-                style = MaterialTheme.tvTypography.title1.copy(textAlign = TextAlign.Center),
+                style = MaterialTheme.tvTypography.title2.copy(textAlign = TextAlign.Center),
             )
         }
     }
@@ -170,7 +170,7 @@ private fun TvCreateAccountContent(
             Text(
                 text = stringResource(LR.string.tv_create_account_title),
                 color = MaterialTheme.tvColors.textPrimary,
-                style = MaterialTheme.tvTypography.title1.copy(textAlign = TextAlign.Center),
+                style = MaterialTheme.tvTypography.title2.copy(textAlign = TextAlign.Center),
             )
             TvSignInQrContent(
                 userCode = userCode,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvEmailSignInForm.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvEmailSignInForm.kt
@@ -1,7 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.onboarding.signin
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -24,6 +23,7 @@ import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
@@ -70,7 +70,6 @@ internal fun TvEmailSignInForm(
             value = state.email,
             onValueChange = onEmailChange,
             placeholder = stringResource(LR.string.profile_email),
-            isError = state.showEmailError,
             errorText = if (state.showEmailError) stringResource(LR.string.onboarding_email_invalid_message) else null,
             keyboardOptions = KeyboardOptions(
                 capitalization = KeyboardCapitalization.None,
@@ -84,7 +83,6 @@ internal fun TvEmailSignInForm(
             value = state.password,
             onValueChange = onPasswordChange,
             placeholder = stringResource(LR.string.profile_password),
-            isError = state.showPasswordError,
             errorText = if (state.showPasswordError) {
                 stringResource(LR.string.profile_create_password_requirements)
             } else {
@@ -112,15 +110,20 @@ internal fun TvEmailSignInForm(
             colors = TvButtonDefaults.filledButtonColors(),
             modifier = Modifier.fillMaxWidth(),
         ) {
-            if (state.isSubmitting) {
-                LoadingView(
-                    color = LocalContentColor.current,
-                    modifier = Modifier
-                        .size(24.dp)
-                        .semantics { contentDescription = signingInDescription },
-                )
-            } else {
-                Text(text = stringResource(LR.string.log_in))
+            Box(
+                modifier = Modifier.fillMaxWidth(),
+                contentAlignment = Alignment.Center,
+            ) {
+                if (state.isSubmitting) {
+                    LoadingView(
+                        color = LocalContentColor.current,
+                        modifier = Modifier
+                            .size(24.dp)
+                            .semantics { contentDescription = signingInDescription },
+                    )
+                } else {
+                    Text(text = stringResource(LR.string.log_in))
+                }
             }
         }
     }
@@ -133,7 +136,6 @@ private fun TvSignInTextField(
     placeholder: String,
     keyboardOptions: KeyboardOptions,
     keyboardActions: KeyboardActions,
-    isError: Boolean = false,
     errorText: String? = null,
     visualTransformation: VisualTransformation = VisualTransformation.None,
     focusRequester: FocusRequester? = null,
@@ -141,19 +143,17 @@ private fun TvSignInTextField(
     val keyboardController = LocalSoftwareKeyboardController.current
     val focusManager = LocalFocusManager.current
     var isFocused by remember { mutableStateOf(false) }
-    val borderColor = when {
-        isError -> MaterialTheme.colorScheme.error
-        isFocused -> MaterialTheme.tvColors.backgroundActive
-        else -> MaterialTheme.tvColors.overlayBorder
-    }
+    val fieldColor = if (isFocused) Color.White else MaterialTheme.tvColors.backgroundActive20
+    val contentColor = if (isFocused) MaterialTheme.tvColors.backgroundSunken else MaterialTheme.tvColors.textPrimary
+    val placeholderColor = if (isFocused) contentColor.copy(alpha = 0.5f) else MaterialTheme.tvColors.textSecondary
 
     Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
         BasicTextField(
             value = value,
             onValueChange = onValueChange,
             singleLine = true,
-            textStyle = MaterialTheme.tvTypography.body.copy(color = MaterialTheme.tvColors.textPrimary),
-            cursorBrush = SolidColor(MaterialTheme.tvColors.textPrimary),
+            textStyle = MaterialTheme.tvTypography.body.copy(color = contentColor),
+            cursorBrush = SolidColor(contentColor),
             visualTransformation = visualTransformation,
             keyboardOptions = keyboardOptions,
             keyboardActions = keyboardActions,
@@ -185,15 +185,14 @@ private fun TvSignInTextField(
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .background(MaterialTheme.tvColors.backgroundActive20, RoundedCornerShape(8.dp))
-                        .border(1.dp, borderColor, RoundedCornerShape(8.dp))
-                        .padding(horizontal = 16.dp, vertical = 14.dp),
+                        .background(fieldColor, RoundedCornerShape(12.dp))
+                        .padding(horizontal = 20.dp, vertical = 18.dp),
                     contentAlignment = Alignment.CenterStart,
                 ) {
                     if (value.isEmpty()) {
                         Text(
                             text = placeholder,
-                            color = MaterialTheme.tvColors.textSecondary,
+                            color = placeholderColor,
                             style = MaterialTheme.tvTypography.body,
                         )
                     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvEmailSignInForm.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvEmailSignInForm.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -98,12 +99,19 @@ internal fun TvEmailSignInForm(
             keyboardActions = KeyboardActions(onDone = { onSubmit() }),
             focusRequester = passwordFocusRequester,
         )
-        state.serverError?.let { serverError ->
-            Text(
-                text = serverError,
-                color = MaterialTheme.colorScheme.error,
-                style = MaterialTheme.tvTypography.caption1,
-            )
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(min = 24.dp),
+            contentAlignment = Alignment.CenterStart,
+        ) {
+            state.serverError?.let { serverError ->
+                Text(
+                    text = serverError,
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.tvTypography.caption1,
+                )
+            }
         }
         Button(
             onClick = onSubmit,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvEmailSignInForm.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvEmailSignInForm.kt
@@ -61,6 +61,7 @@ internal fun TvEmailSignInForm(
     modifier: Modifier = Modifier,
 ) {
     val passwordFocusRequester = remember { FocusRequester() }
+    val keyboardController = LocalSoftwareKeyboardController.current
     val signingInDescription = stringResource(LR.string.tv_sign_in_signing_in)
 
     Column(
@@ -71,6 +72,7 @@ internal fun TvEmailSignInForm(
             value = state.email,
             onValueChange = onEmailChange,
             placeholder = stringResource(LR.string.profile_email),
+            enabled = !state.isSubmitting,
             errorText = if (state.showEmailError) stringResource(LR.string.onboarding_email_invalid_message) else null,
             keyboardOptions = KeyboardOptions(
                 capitalization = KeyboardCapitalization.None,
@@ -84,6 +86,7 @@ internal fun TvEmailSignInForm(
             value = state.password,
             onValueChange = onPasswordChange,
             placeholder = stringResource(LR.string.profile_password),
+            enabled = !state.isSubmitting,
             errorText = if (state.showPasswordError) {
                 stringResource(LR.string.profile_create_password_requirements)
             } else {
@@ -96,7 +99,12 @@ internal fun TvEmailSignInForm(
                 keyboardType = KeyboardType.Password,
                 imeAction = ImeAction.Done,
             ),
-            keyboardActions = KeyboardActions(onDone = { onSubmit() }),
+            keyboardActions = KeyboardActions(
+                onDone = {
+                    keyboardController?.hide()
+                    onSubmit()
+                },
+            ),
             focusRequester = passwordFocusRequester,
         )
         Box(
@@ -144,6 +152,7 @@ private fun TvSignInTextField(
     placeholder: String,
     keyboardOptions: KeyboardOptions,
     keyboardActions: KeyboardActions,
+    enabled: Boolean = true,
     errorText: String? = null,
     visualTransformation: VisualTransformation = VisualTransformation.None,
     focusRequester: FocusRequester? = null,
@@ -159,6 +168,7 @@ private fun TvSignInTextField(
         BasicTextField(
             value = value,
             onValueChange = onValueChange,
+            enabled = enabled,
             singleLine = true,
             textStyle = MaterialTheme.tvTypography.body.copy(color = contentColor),
             cursorBrush = SolidColor(contentColor),
@@ -172,20 +182,15 @@ private fun TvSignInTextField(
                     isFocused = it.isFocused
                     if (it.isFocused) {
                         keyboardController?.show()
+                    } else {
+                        keyboardController?.hide()
                     }
                 }
                 .onPreviewKeyEvent { event ->
                     when {
-                        event.type == KeyEventType.KeyDown && event.key == Key.DirectionDown -> {
-                            focusManager.moveFocus(FocusDirection.Down)
-                            true
-                        }
-
-                        event.type == KeyEventType.KeyDown && event.key == Key.DirectionUp -> {
-                            focusManager.moveFocus(FocusDirection.Up)
-                            true
-                        }
-
+                        event.type != KeyEventType.KeyDown -> false
+                        event.key == Key.DirectionDown -> focusManager.moveFocus(FocusDirection.Down)
+                        event.key == Key.DirectionUp -> focusManager.moveFocus(FocusDirection.Up)
                         else -> false
                     }
                 },

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvEmailSignInForm.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvEmailSignInForm.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.onboarding.signin
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -9,6 +10,8 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.relocation.BringIntoViewRequester
+import androidx.compose.foundation.relocation.bringIntoViewRequester
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
@@ -17,13 +20,16 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.autofill.ContentType
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.input.key.Key
@@ -31,16 +37,20 @@ import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.contentType
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.Button
 import androidx.tv.material3.LocalContentColor
@@ -50,6 +60,8 @@ import au.com.shiftyjelly.pocketcasts.compose.loading.LoadingView
 import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
 import au.com.shiftyjelly.pocketcasts.theme.tvColors
 import au.com.shiftyjelly.pocketcasts.theme.tvTypography
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
@@ -74,6 +86,7 @@ internal fun TvEmailSignInForm(
             placeholder = stringResource(LR.string.profile_email),
             enabled = !state.isSubmitting,
             errorText = if (state.showEmailError) stringResource(LR.string.onboarding_email_invalid_message) else null,
+            contentType = ContentType.Username + ContentType.EmailAddress,
             keyboardOptions = KeyboardOptions(
                 capitalization = KeyboardCapitalization.None,
                 autoCorrectEnabled = false,
@@ -92,6 +105,7 @@ internal fun TvEmailSignInForm(
             } else {
                 null
             },
+            contentType = ContentType.Password,
             visualTransformation = PasswordVisualTransformation(),
             keyboardOptions = KeyboardOptions(
                 capitalization = KeyboardCapitalization.None,
@@ -145,6 +159,7 @@ internal fun TvEmailSignInForm(
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun TvSignInTextField(
     value: String,
@@ -152,6 +167,7 @@ private fun TvSignInTextField(
     placeholder: String,
     keyboardOptions: KeyboardOptions,
     keyboardActions: KeyboardActions,
+    contentType: ContentType,
     enabled: Boolean = true,
     errorText: String? = null,
     visualTransformation: VisualTransformation = VisualTransformation.None,
@@ -159,6 +175,10 @@ private fun TvSignInTextField(
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
     val focusManager = LocalFocusManager.current
+    val bringIntoViewRequester = remember { BringIntoViewRequester() }
+    val coroutineScope = rememberCoroutineScope()
+    val keyboardInsetPx = with(LocalDensity.current) { TvSignInKeyboardInset.toPx() }
+    var fieldSize by remember { mutableStateOf(IntSize.Zero) }
     var isFocused by remember { mutableStateOf(false) }
     val fieldColor = if (isFocused) Color.White else MaterialTheme.tvColors.backgroundActive20
     val contentColor = if (isFocused) MaterialTheme.tvColors.backgroundSunken else MaterialTheme.tvColors.textPrimary
@@ -177,11 +197,24 @@ private fun TvSignInTextField(
             keyboardActions = keyboardActions,
             modifier = Modifier
                 .fillMaxWidth()
+                .semantics { this.contentType = contentType }
+                .onSizeChanged { fieldSize = it }
+                .bringIntoViewRequester(bringIntoViewRequester)
                 .then(focusRequester?.let { Modifier.focusRequester(it) } ?: Modifier)
                 .onFocusChanged {
                     isFocused = it.isFocused
                     if (it.isFocused) {
                         keyboardController?.show()
+                        coroutineScope.launch {
+                            delay(IME_SETTLE_MILLIS)
+                            val revealRect = Rect(
+                                left = 0f,
+                                top = 0f,
+                                right = fieldSize.width.toFloat(),
+                                bottom = fieldSize.height + keyboardInsetPx,
+                            )
+                            bringIntoViewRequester.bringIntoView(revealRect)
+                        }
                     } else {
                         keyboardController?.hide()
                     }
@@ -224,3 +257,7 @@ private fun TvSignInTextField(
 }
 
 private val FormWidth = 420.dp
+private const val IME_SETTLE_MILLIS = 250L
+
+/** Estimated height of the TV soft keyboard, which reports no window insets, used to lift a focused field clear of it. */
+internal val TvSignInKeyboardInset = 320.dp

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvEmailSignInForm.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvEmailSignInForm.kt
@@ -109,7 +109,6 @@ internal fun TvEmailSignInForm(
         }
         Button(
             onClick = onSubmit,
-            enabled = !state.isSubmitting,
             colors = TvButtonDefaults.filledButtonColors(),
             modifier = Modifier.fillMaxWidth(),
         ) {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvEmailSignInForm.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvEmailSignInForm.kt
@@ -17,10 +17,10 @@ import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -61,7 +61,6 @@ import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
 import au.com.shiftyjelly.pocketcasts.theme.tvColors
 import au.com.shiftyjelly.pocketcasts.theme.tvTypography
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
@@ -176,7 +175,6 @@ private fun TvSignInTextField(
     val keyboardController = LocalSoftwareKeyboardController.current
     val focusManager = LocalFocusManager.current
     val bringIntoViewRequester = remember { BringIntoViewRequester() }
-    val coroutineScope = rememberCoroutineScope()
     val keyboardInsetPx = with(LocalDensity.current) { TvSignInKeyboardInset.toPx() }
     var fieldSize by remember { mutableStateOf(IntSize.Zero) }
     var isFocused by remember { mutableStateOf(false) }
@@ -205,16 +203,6 @@ private fun TvSignInTextField(
                     isFocused = it.isFocused
                     if (it.isFocused) {
                         keyboardController?.show()
-                        coroutineScope.launch {
-                            delay(IME_SETTLE_MILLIS)
-                            val revealRect = Rect(
-                                left = 0f,
-                                top = 0f,
-                                right = fieldSize.width.toFloat(),
-                                bottom = fieldSize.height + keyboardInsetPx,
-                            )
-                            bringIntoViewRequester.bringIntoView(revealRect)
-                        }
                     } else {
                         keyboardController?.hide()
                     }
@@ -253,6 +241,14 @@ private fun TvSignInTextField(
                 style = MaterialTheme.tvTypography.caption1,
             )
         }
+    }
+
+    LaunchedEffect(isFocused) {
+        if (!isFocused) return@LaunchedEffect
+        delay(IME_SETTLE_MILLIS)
+        bringIntoViewRequester.bringIntoView(
+            Rect(0f, 0f, fieldSize.width.toFloat(), fieldSize.height + keyboardInsetPx),
+        )
     }
 }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvEmailSignInForm.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvEmailSignInForm.kt
@@ -1,0 +1,215 @@
+package au.com.shiftyjelly.pocketcasts.onboarding.signin
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
+import androidx.tv.material3.Button
+import androidx.tv.material3.LocalContentColor
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.compose.loading.LoadingView
+import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
+import au.com.shiftyjelly.pocketcasts.theme.tvColors
+import au.com.shiftyjelly.pocketcasts.theme.tvTypography
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+internal fun TvEmailSignInForm(
+    state: TvEmailSignInState,
+    onEmailChange: (String) -> Unit,
+    onPasswordChange: (String) -> Unit,
+    onSubmit: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val passwordFocusRequester = remember { FocusRequester() }
+    val signingInDescription = stringResource(LR.string.tv_sign_in_signing_in)
+
+    Column(
+        modifier = modifier.width(FormWidth),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        TvSignInTextField(
+            value = state.email,
+            onValueChange = onEmailChange,
+            placeholder = stringResource(LR.string.profile_email),
+            isError = state.showEmailError,
+            errorText = if (state.showEmailError) stringResource(LR.string.onboarding_email_invalid_message) else null,
+            keyboardOptions = KeyboardOptions(
+                capitalization = KeyboardCapitalization.None,
+                autoCorrectEnabled = false,
+                keyboardType = KeyboardType.Email,
+                imeAction = ImeAction.Next,
+            ),
+            keyboardActions = KeyboardActions(onNext = { runCatching { passwordFocusRequester.requestFocus() } }),
+        )
+        TvSignInTextField(
+            value = state.password,
+            onValueChange = onPasswordChange,
+            placeholder = stringResource(LR.string.profile_password),
+            isError = state.showPasswordError,
+            errorText = if (state.showPasswordError) {
+                stringResource(LR.string.profile_create_password_requirements)
+            } else {
+                null
+            },
+            visualTransformation = PasswordVisualTransformation(),
+            keyboardOptions = KeyboardOptions(
+                capitalization = KeyboardCapitalization.None,
+                autoCorrectEnabled = false,
+                keyboardType = KeyboardType.Password,
+                imeAction = ImeAction.Done,
+            ),
+            keyboardActions = KeyboardActions(onDone = { onSubmit() }),
+            focusRequester = passwordFocusRequester,
+        )
+        state.serverError?.let { serverError ->
+            Text(
+                text = serverError,
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.tvTypography.caption1,
+            )
+        }
+        Button(
+            onClick = onSubmit,
+            enabled = !state.isSubmitting,
+            colors = TvButtonDefaults.filledButtonColors(),
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            if (state.isSubmitting) {
+                LoadingView(
+                    color = LocalContentColor.current,
+                    modifier = Modifier
+                        .size(24.dp)
+                        .semantics { contentDescription = signingInDescription },
+                )
+            } else {
+                Text(text = stringResource(LR.string.log_in))
+            }
+        }
+    }
+}
+
+@Composable
+private fun TvSignInTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    placeholder: String,
+    keyboardOptions: KeyboardOptions,
+    keyboardActions: KeyboardActions,
+    isError: Boolean = false,
+    errorText: String? = null,
+    visualTransformation: VisualTransformation = VisualTransformation.None,
+    focusRequester: FocusRequester? = null,
+) {
+    val keyboardController = LocalSoftwareKeyboardController.current
+    val focusManager = LocalFocusManager.current
+    var isFocused by remember { mutableStateOf(false) }
+    val borderColor = when {
+        isError -> MaterialTheme.colorScheme.error
+        isFocused -> MaterialTheme.tvColors.backgroundActive
+        else -> MaterialTheme.tvColors.overlayBorder
+    }
+
+    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        BasicTextField(
+            value = value,
+            onValueChange = onValueChange,
+            singleLine = true,
+            textStyle = MaterialTheme.tvTypography.body.copy(color = MaterialTheme.tvColors.textPrimary),
+            cursorBrush = SolidColor(MaterialTheme.tvColors.textPrimary),
+            visualTransformation = visualTransformation,
+            keyboardOptions = keyboardOptions,
+            keyboardActions = keyboardActions,
+            modifier = Modifier
+                .fillMaxWidth()
+                .then(focusRequester?.let { Modifier.focusRequester(it) } ?: Modifier)
+                .onFocusChanged {
+                    isFocused = it.isFocused
+                    if (it.isFocused) {
+                        keyboardController?.show()
+                    }
+                }
+                .onPreviewKeyEvent { event ->
+                    when {
+                        event.type == KeyEventType.KeyDown && event.key == Key.DirectionDown -> {
+                            focusManager.moveFocus(FocusDirection.Down)
+                            true
+                        }
+
+                        event.type == KeyEventType.KeyDown && event.key == Key.DirectionUp -> {
+                            focusManager.moveFocus(FocusDirection.Up)
+                            true
+                        }
+
+                        else -> false
+                    }
+                },
+            decorationBox = { innerTextField ->
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(MaterialTheme.tvColors.backgroundActive20, RoundedCornerShape(8.dp))
+                        .border(1.dp, borderColor, RoundedCornerShape(8.dp))
+                        .padding(horizontal = 16.dp, vertical = 14.dp),
+                    contentAlignment = Alignment.CenterStart,
+                ) {
+                    if (value.isEmpty()) {
+                        Text(
+                            text = placeholder,
+                            color = MaterialTheme.tvColors.textSecondary,
+                            style = MaterialTheme.tvTypography.body,
+                        )
+                    }
+                    innerTextField()
+                }
+            },
+        )
+        errorText?.let {
+            Text(
+                text = it,
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.tvTypography.caption1,
+            )
+        }
+    }
+}
+
+private val FormWidth = 420.dp

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInScreen.kt
@@ -12,7 +12,9 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -91,12 +93,15 @@ private fun TvSignInContent(
     modifier: Modifier = Modifier,
 ) {
     Box(
-        contentAlignment = Alignment.Center,
+        contentAlignment = Alignment.TopCenter,
         modifier = modifier
             .fillMaxSize()
             .background(MaterialTheme.tvColors.backgroundSunken),
     ) {
         Column(
+            modifier = Modifier
+                .verticalScroll(rememberScrollState())
+                .padding(vertical = 48.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(20.dp),
         ) {
@@ -120,6 +125,9 @@ private fun TvSignInContent(
                     onPasswordChange = onPasswordChange,
                     onSubmit = onSubmitEmail,
                 )
+            }
+            if (mode == TvSignInMode.Email) {
+                Spacer(modifier = Modifier.height(TvSignInKeyboardInset))
             }
         }
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInScreen.kt
@@ -91,12 +91,13 @@ private fun TvSignInContent(
     modifier: Modifier = Modifier,
 ) {
     Box(
-        contentAlignment = Alignment.Center,
+        contentAlignment = Alignment.TopCenter,
         modifier = modifier
             .fillMaxSize()
             .background(MaterialTheme.tvColors.backgroundSunken),
     ) {
         Column(
+            modifier = Modifier.padding(top = 96.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(20.dp),
         ) {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInScreen.kt
@@ -227,6 +227,7 @@ private fun TvQrSignInError(
     onRetry: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val retryFocusRequester = remember { FocusRequester() }
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = modifier,
@@ -240,9 +241,14 @@ private fun TvQrSignInError(
         Button(
             onClick = onRetry,
             colors = TvButtonDefaults.filledButtonColors(),
+            modifier = Modifier.focusRequester(retryFocusRequester),
         ) {
             Text(text = stringResource(LR.string.retry))
         }
+    }
+
+    LaunchedEffect(Unit) {
+        runCatching { retryFocusRequester.requestFocus() }
     }
 }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInScreen.kt
@@ -2,14 +2,17 @@ package au.com.shiftyjelly.pocketcasts.onboarding.signin
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -18,7 +21,9 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -28,8 +33,14 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.Button
+import androidx.tv.material3.LocalContentColor
 import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Tab
+import androidx.tv.material3.TabDefaults
+import androidx.tv.material3.TabRow
+import androidx.tv.material3.TabRowDefaults
 import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.compose.loading.LoadingView
 import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
 import au.com.shiftyjelly.pocketcasts.theme.TvTheme
 import au.com.shiftyjelly.pocketcasts.theme.tvColors
@@ -44,6 +55,8 @@ fun TvSignInScreen(
     viewModel: TvSignInViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val mode by viewModel.mode.collectAsStateWithLifecycle()
+    val emailState by viewModel.emailState.collectAsStateWithLifecycle()
     val currentOnSignInComplete by rememberUpdatedState(onSignInComplete)
 
     LaunchedEffect(uiState) {
@@ -52,132 +65,185 @@ fun TvSignInScreen(
         }
     }
 
-    when (val state = uiState) {
-        is TvSignInUiState.Loading -> TvSignInLoading(modifier)
-
-        is TvSignInUiState.Ready -> TvSignInContent(
-            userCode = state.userCode,
-            verificationUri = state.verificationUri,
-            verificationUriComplete = state.verificationUriComplete,
-            modifier = modifier,
-        )
-
-        is TvSignInUiState.Error -> TvSignInError(onRetry = viewModel::retry, modifier = modifier)
-
-        is TvSignInUiState.Complete -> TvSignInLoading(modifier)
-    }
+    TvSignInContent(
+        mode = mode,
+        qrState = uiState,
+        emailState = emailState,
+        onSelectMode = viewModel::selectMode,
+        onEmailChange = viewModel::updateEmail,
+        onPasswordChange = viewModel::updatePassword,
+        onSubmitEmail = viewModel::submitEmailSignIn,
+        onRetryQr = viewModel::retry,
+        modifier = modifier,
+    )
 }
 
 @Composable
-private fun TvSignInLoading(modifier: Modifier = Modifier) {
-    val focusRequester = remember { FocusRequester() }
-
-    Box(
-        contentAlignment = Alignment.Center,
-        modifier = modifier
-            .fillMaxSize()
-            .background(MaterialTheme.tvColors.backgroundSunken)
-            .focusRequester(focusRequester)
-            .focusable(),
-    ) {
-        Column(horizontalAlignment = Alignment.CenterHorizontally) {
-            Image(
-                painter = painterResource(IR.drawable.ic_pocket_casts_logo),
-                contentDescription = null,
-                modifier = Modifier.size(36.dp),
-            )
-            Spacer(modifier = Modifier.height(16.dp))
-            Text(
-                text = stringResource(LR.string.tv_onboarding_sign_in_title),
-                color = MaterialTheme.tvColors.textPrimary,
-                style = MaterialTheme.tvTypography.title1.copy(textAlign = TextAlign.Center),
-            )
-        }
-    }
-
-    LaunchedEffect(Unit) {
-        focusRequester.requestFocus()
-    }
-}
-
-@Composable
-private fun TvSignInError(
-    onRetry: () -> Unit,
+private fun TvSignInContent(
+    mode: TvSignInMode,
+    qrState: TvSignInUiState,
+    emailState: TvEmailSignInState,
+    onSelectMode: (TvSignInMode) -> Unit,
+    onEmailChange: (String) -> Unit,
+    onPasswordChange: (String) -> Unit,
+    onSubmitEmail: () -> Unit,
+    onRetryQr: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val focusRequester = remember { FocusRequester() }
-
     Box(
         contentAlignment = Alignment.Center,
         modifier = modifier
             .fillMaxSize()
             .background(MaterialTheme.tvColors.backgroundSunken),
     ) {
-        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(32.dp),
+        ) {
             Image(
                 painter = painterResource(IR.drawable.ic_pocket_casts_logo),
                 contentDescription = null,
                 modifier = Modifier.size(36.dp),
             )
-            Spacer(modifier = Modifier.height(16.dp))
-            Text(
-                text = stringResource(LR.string.error_generic_message),
-                color = MaterialTheme.tvColors.textSecondary,
-                style = MaterialTheme.tvTypography.body.copy(textAlign = TextAlign.Center),
-            )
-            Spacer(modifier = Modifier.height(24.dp))
-            Button(
-                onClick = onRetry,
-                colors = TvButtonDefaults.filledButtonColors(),
-                modifier = Modifier.focusRequester(focusRequester),
-            ) {
-                Text(text = stringResource(LR.string.retry))
-            }
-        }
-    }
-
-    LaunchedEffect(Unit) {
-        focusRequester.requestFocus()
-    }
-}
-
-@Composable
-private fun TvSignInContent(
-    userCode: List<String>,
-    verificationUri: String,
-    verificationUriComplete: String,
-    modifier: Modifier = Modifier,
-) {
-    val focusRequester = remember { FocusRequester() }
-    val steps = signInSteps(verificationUri)
-
-    Box(
-        contentAlignment = Alignment.Center,
-        modifier = modifier
-            .fillMaxSize()
-            .background(MaterialTheme.tvColors.backgroundSunken)
-            .focusRequester(focusRequester)
-            .focusable(),
-    ) {
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(48.dp),
-        ) {
             Text(
                 text = stringResource(LR.string.tv_sign_in_title),
                 color = MaterialTheme.tvColors.textPrimary,
                 style = MaterialTheme.tvTypography.title1.copy(textAlign = TextAlign.Center),
             )
-            TvSignInQrContent(
-                userCode = userCode,
-                verificationUriComplete = verificationUriComplete,
-                steps = steps,
-            )
+            TvSignInModeTabs(selected = mode, onSelect = onSelectMode)
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier.heightIn(min = 320.dp),
+            ) {
+                when (mode) {
+                    TvSignInMode.QrCode -> TvQrSignIn(state = qrState, onRetry = onRetryQr)
+
+                    TvSignInMode.Email -> TvEmailSignInForm(
+                        state = emailState,
+                        onEmailChange = onEmailChange,
+                        onPasswordChange = onPasswordChange,
+                        onSubmit = onSubmitEmail,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TvSignInModeTabs(
+    selected: TvSignInMode,
+    onSelect: (TvSignInMode) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val selectedIndex = TvSignInMode.entries.indexOf(selected)
+    val selectedTabFocusRequester = remember { FocusRequester() }
+
+    Box(
+        modifier = modifier
+            .background(MaterialTheme.tvColors.backgroundSunken, RoundedCornerShape(percent = 50))
+            .padding(3.dp),
+    ) {
+        TabRow(
+            selectedTabIndex = selectedIndex,
+            modifier = Modifier.focusProperties {
+                onEnter = { runCatching { selectedTabFocusRequester.requestFocus() } }
+            },
+            containerColor = Color.Transparent,
+            indicator = @Composable { tabPositions, doesTabRowHaveFocus ->
+                tabPositions.getOrNull(selectedIndex)?.let { currentTabPosition ->
+                    TabRowDefaults.PillIndicator(
+                        currentTabPosition = currentTabPosition,
+                        doesTabRowHaveFocus = doesTabRowHaveFocus,
+                        activeColor = MaterialTheme.tvColors.backgroundActive,
+                        inactiveColor = MaterialTheme.tvColors.backgroundBase,
+                    )
+                }
+            },
+        ) {
+            TvSignInMode.entries.forEachIndexed { index, tabMode ->
+                Tab(
+                    selected = index == selectedIndex,
+                    onFocus = { onSelect(tabMode) },
+                    onClick = { onSelect(tabMode) },
+                    modifier = Modifier
+                        .height(44.dp)
+                        .padding(horizontal = 24.dp)
+                        .then(
+                            if (index == selectedIndex) Modifier.focusRequester(selectedTabFocusRequester) else Modifier,
+                        ),
+                    colors = TabDefaults.pillIndicatorTabColors(
+                        contentColor = MaterialTheme.tvColors.textPrimary,
+                        selectedContentColor = MaterialTheme.tvColors.textPrimary,
+                        focusedContentColor = MaterialTheme.tvColors.textPrimary,
+                        focusedSelectedContentColor = MaterialTheme.tvColors.textPrimaryActive,
+                        inactiveContentColor = MaterialTheme.tvColors.textPrimary,
+                    ),
+                ) {
+                    Box(
+                        modifier = Modifier.fillMaxHeight(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Text(
+                            text = stringResource(tabMode.labelRes()),
+                            color = LocalContentColor.current,
+                            style = MaterialTheme.tvTypography.caption1,
+                        )
+                    }
+                }
+            }
         }
     }
 
     LaunchedEffect(Unit) {
-        focusRequester.requestFocus()
+        runCatching { selectedTabFocusRequester.requestFocus() }
+    }
+}
+
+@Composable
+private fun TvQrSignIn(
+    state: TvSignInUiState,
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    when (state) {
+        is TvSignInUiState.Ready -> TvSignInQrContent(
+            userCode = state.userCode,
+            verificationUriComplete = state.verificationUriComplete,
+            steps = signInSteps(state.verificationUri),
+            modifier = modifier,
+        )
+
+        is TvSignInUiState.Error -> TvQrSignInError(onRetry = onRetry, modifier = modifier)
+
+        else -> LoadingView(
+            color = MaterialTheme.tvColors.textPrimary,
+            modifier = modifier,
+        )
+    }
+}
+
+@Composable
+private fun TvQrSignInError(
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier,
+    ) {
+        Text(
+            text = stringResource(LR.string.error_generic_message),
+            color = MaterialTheme.tvColors.textSecondary,
+            style = MaterialTheme.tvTypography.body.copy(textAlign = TextAlign.Center),
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+        Button(
+            onClick = onRetry,
+            colors = TvButtonDefaults.filledButtonColors(),
+        ) {
+            Text(text = stringResource(LR.string.retry))
+        }
     }
 }
 
@@ -191,30 +257,45 @@ private fun signInSteps(verificationUri: String): List<String> {
     )
 }
 
-@Preview(device = Devices.TV_1080p)
-@Composable
-private fun TvSignInScreenLoadingPreview() {
-    TvTheme {
-        TvSignInLoading()
-    }
+private fun TvSignInMode.labelRes() = when (this) {
+    TvSignInMode.QrCode -> LR.string.tv_sign_in_tab_qr_code
+    TvSignInMode.Email -> LR.string.tv_sign_in_tab_email
 }
 
 @Preview(device = Devices.TV_1080p)
 @Composable
-private fun TvSignInScreenErrorPreview() {
-    TvTheme {
-        TvSignInError(onRetry = {})
-    }
-}
-
-@Preview(device = Devices.TV_1080p)
-@Composable
-private fun TvSignInScreenContentPreview() {
+private fun TvSignInScreenQrPreview() {
     TvTheme {
         TvSignInContent(
-            userCode = listOf("J", "M", "R", "3", "W", "2"),
-            verificationUri = "https://pocketcasts.com/pair",
-            verificationUriComplete = "https://pocketcasts.com/pair?code=JMR3W2",
+            mode = TvSignInMode.QrCode,
+            qrState = TvSignInUiState.Ready(
+                userCode = listOf("J", "M", "R", "3", "W", "2"),
+                verificationUri = "https://pocketcasts.com/pair",
+                verificationUriComplete = "https://pocketcasts.com/pair?code=JMR3W2",
+            ),
+            emailState = TvEmailSignInState(),
+            onSelectMode = {},
+            onEmailChange = {},
+            onPasswordChange = {},
+            onSubmitEmail = {},
+            onRetryQr = {},
+        )
+    }
+}
+
+@Preview(device = Devices.TV_1080p)
+@Composable
+private fun TvSignInScreenEmailPreview() {
+    TvTheme {
+        TvSignInContent(
+            mode = TvSignInMode.Email,
+            qrState = TvSignInUiState.Loading,
+            emailState = TvEmailSignInState(email = "listener@pocketcasts.com"),
+            onSelectMode = {},
+            onEmailChange = {},
+            onPasswordChange = {},
+            onSubmitEmail = {},
+            onRetryQr = {},
         )
     }
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInScreen.kt
@@ -98,7 +98,7 @@ private fun TvSignInContent(
     ) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(32.dp),
+            verticalArrangement = Arrangement.spacedBy(20.dp),
         ) {
             Image(
                 painter = painterResource(IR.drawable.ic_pocket_casts_logo),
@@ -108,11 +108,11 @@ private fun TvSignInContent(
             Text(
                 text = stringResource(LR.string.tv_sign_in_title),
                 color = MaterialTheme.tvColors.textPrimary,
-                style = MaterialTheme.tvTypography.title1.copy(textAlign = TextAlign.Center),
+                style = MaterialTheme.tvTypography.title2.copy(textAlign = TextAlign.Center),
             )
             TvSignInModeTabs(selected = mode, onSelect = onSelectMode)
             Box(
-                contentAlignment = Alignment.Center,
+                contentAlignment = Alignment.TopCenter,
                 modifier = Modifier.heightIn(min = 320.dp),
             ) {
                 when (mode) {
@@ -156,7 +156,7 @@ private fun TvSignInModeTabs(
                         currentTabPosition = currentTabPosition,
                         doesTabRowHaveFocus = doesTabRowHaveFocus,
                         activeColor = MaterialTheme.tvColors.backgroundActive,
-                        inactiveColor = MaterialTheme.tvColors.backgroundBase,
+                        inactiveColor = MaterialTheme.tvColors.backgroundActive20,
                     )
                 }
             },
@@ -164,7 +164,7 @@ private fun TvSignInModeTabs(
             TvSignInMode.entries.forEachIndexed { index, tabMode ->
                 Tab(
                     selected = index == selectedIndex,
-                    onFocus = {},
+                    onFocus = { onSelect(tabMode) },
                     onClick = { onSelect(tabMode) },
                     modifier = Modifier
                         .height(44.dp)

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInScreen.kt
@@ -91,13 +91,12 @@ private fun TvSignInContent(
     modifier: Modifier = Modifier,
 ) {
     Box(
-        contentAlignment = Alignment.TopCenter,
+        contentAlignment = Alignment.Center,
         modifier = modifier
             .fillMaxSize()
             .background(MaterialTheme.tvColors.backgroundSunken),
     ) {
         Column(
-            modifier = Modifier.padding(top = 96.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(20.dp),
         ) {
@@ -112,20 +111,15 @@ private fun TvSignInContent(
                 style = MaterialTheme.tvTypography.title2.copy(textAlign = TextAlign.Center),
             )
             TvSignInModeTabs(selected = mode, onSelect = onSelectMode)
-            Box(
-                contentAlignment = Alignment.TopCenter,
-                modifier = Modifier.heightIn(min = 320.dp),
-            ) {
-                when (mode) {
-                    TvSignInMode.QrCode -> TvQrSignIn(state = qrState, onRetry = onRetryQr)
+            when (mode) {
+                TvSignInMode.QrCode -> TvQrSignIn(state = qrState, onRetry = onRetryQr)
 
-                    TvSignInMode.Email -> TvEmailSignInForm(
-                        state = emailState,
-                        onEmailChange = onEmailChange,
-                        onPasswordChange = onPasswordChange,
-                        onSubmit = onSubmitEmail,
-                    )
-                }
+                TvSignInMode.Email -> TvEmailSignInForm(
+                    state = emailState,
+                    onEmailChange = onEmailChange,
+                    onPasswordChange = onPasswordChange,
+                    onSubmit = onSubmitEmail,
+                )
             }
         }
     }
@@ -207,20 +201,24 @@ private fun TvQrSignIn(
     onRetry: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    when (state) {
-        is TvSignInUiState.Ready -> TvSignInQrContent(
-            userCode = state.userCode,
-            verificationUriComplete = state.verificationUriComplete,
-            steps = signInSteps(state.verificationUri),
-            modifier = modifier,
-        )
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = modifier.heightIn(min = 280.dp),
+    ) {
+        when (state) {
+            is TvSignInUiState.Ready -> TvSignInQrContent(
+                userCode = state.userCode,
+                verificationUriComplete = state.verificationUriComplete,
+                steps = signInSteps(state.verificationUri),
+            )
 
-        is TvSignInUiState.Error -> TvQrSignInError(onRetry = onRetry, modifier = modifier)
+            is TvSignInUiState.Error -> TvQrSignInError(onRetry = onRetry)
 
-        else -> LoadingView(
-            color = MaterialTheme.tvColors.textPrimary,
-            modifier = modifier,
-        )
+            else -> LoadingView(
+                color = MaterialTheme.tvColors.textPrimary,
+                modifier = Modifier.size(48.dp),
+            )
+        }
     }
 }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInScreen.kt
@@ -267,6 +267,10 @@ internal fun TvSignInErrorContent(
             Text(text = stringResource(LR.string.try_again))
         }
     }
+
+    LaunchedEffect(Unit) {
+        runCatching { focusRequester.requestFocus() }
+    }
 }
 
 @Composable

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInScreen.kt
@@ -141,7 +141,7 @@ private fun TvSignInModeTabs(
 
     Box(
         modifier = modifier
-            .background(MaterialTheme.tvColors.backgroundSunken, RoundedCornerShape(percent = 50))
+            .background(MaterialTheme.tvColors.backgroundBase, RoundedCornerShape(percent = 50))
             .padding(3.dp),
     ) {
         TabRow(
@@ -164,7 +164,7 @@ private fun TvSignInModeTabs(
             TvSignInMode.entries.forEachIndexed { index, tabMode ->
                 Tab(
                     selected = index == selectedIndex,
-                    onFocus = { onSelect(tabMode) },
+                    onFocus = {},
                     onClick = { onSelect(tabMode) },
                     modifier = Modifier
                         .height(44.dp)

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInViewModel.kt
@@ -2,26 +2,95 @@ package au.com.shiftyjelly.pocketcasts.onboarding.signin
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.repositories.sync.LoginResult
+import au.com.shiftyjelly.pocketcasts.repositories.sync.SignInSource
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
+import com.automattic.eventhorizon.EventHorizon
+import com.automattic.eventhorizon.SignInType
+import com.automattic.eventhorizon.SignInTypeTappedEvent
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 @HiltViewModel
 class TvSignInViewModel @Inject constructor(
     private val syncManager: SyncManager,
+    private val eventHorizon: EventHorizon,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<TvSignInUiState>(TvSignInUiState.Loading)
     val uiState: StateFlow<TvSignInUiState> = _uiState.asStateFlow()
 
+    private val _mode = MutableStateFlow(TvSignInMode.QrCode)
+    val mode: StateFlow<TvSignInMode> = _mode.asStateFlow()
+
+    private val _emailState = MutableStateFlow(TvEmailSignInState())
+    val emailState: StateFlow<TvEmailSignInState> = _emailState.asStateFlow()
+
     private var pollingJob: Job? = null
 
     init {
+        requestDeviceCode()
+    }
+
+    fun selectMode(mode: TvSignInMode) {
+        if (_mode.value == mode) return
+        _mode.value = mode
+        eventHorizon.track(SignInTypeTappedEvent(type = mode.analyticsType))
+        when (mode) {
+            TvSignInMode.QrCode -> requestDeviceCode()
+
+            TvSignInMode.Email -> {
+                pollingJob?.cancel()
+                _emailState.update { it.copy(showEmailError = false, showPasswordError = false, serverError = null) }
+            }
+        }
+    }
+
+    fun updateEmail(email: String) {
+        _emailState.update { it.copy(email = email, showEmailError = false, serverError = null) }
+    }
+
+    fun updatePassword(password: String) {
+        _emailState.update { it.copy(password = password, showPasswordError = false, serverError = null) }
+    }
+
+    fun submitEmailSignIn() {
+        val current = _emailState.value
+        if (current.isSubmitting) return
+
+        val emailValid = isEmailValid(current.email)
+        val passwordValid = isPasswordValid(current.password)
+        if (!emailValid || !passwordValid) {
+            _emailState.update { it.copy(showEmailError = !emailValid, showPasswordError = !passwordValid) }
+            return
+        }
+
+        _emailState.update {
+            it.copy(isSubmitting = true, showEmailError = false, showPasswordError = false, serverError = null)
+        }
+        viewModelScope.launch {
+            val result = syncManager.loginWithEmailAndPassword(
+                email = current.email,
+                password = current.password,
+                signInSource = SignInSource.UserInitiated.Onboarding,
+            )
+            when (result) {
+                is LoginResult.Success -> _uiState.value = TvSignInUiState.Complete
+
+                is LoginResult.Failed -> _emailState.update {
+                    it.copy(isSubmitting = false, serverError = result.message)
+                }
+            }
+        }
+    }
+
+    fun retry() {
         requestDeviceCode()
     }
 
@@ -33,10 +102,29 @@ class TvSignInViewModel @Inject constructor(
         }
     }
 
-    fun retry() {
-        requestDeviceCode()
+    private fun isEmailValid(email: String) = EMAIL_REGEX.matches(email)
+
+    private fun isPasswordValid(password: String) = password.length >= MIN_PASSWORD_LENGTH
+
+    private companion object {
+        const val MIN_PASSWORD_LENGTH = 6
+        val EMAIL_REGEX = Regex("[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}")
     }
 }
+
+enum class TvSignInMode(val analyticsType: SignInType) {
+    QrCode(SignInType.Qr),
+    Email(SignInType.Password),
+}
+
+data class TvEmailSignInState(
+    val email: String = "",
+    val password: String = "",
+    val isSubmitting: Boolean = false,
+    val showEmailError: Boolean = false,
+    val showPasswordError: Boolean = false,
+    val serverError: String? = null,
+)
 
 sealed interface TvSignInUiState {
     data object Loading : TvSignInUiState

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInViewModel.kt
@@ -69,7 +69,6 @@ class TvSignInViewModel @Inject constructor(
         _emailState.update {
             it.copy(isSubmitting = true, showEmailError = false, showPasswordError = false, serverError = null)
         }
-        pollingJob?.cancel()
         viewModelScope.launch {
             val result = syncManager.loginWithEmailAndPassword(
                 email = current.email,
@@ -78,6 +77,7 @@ class TvSignInViewModel @Inject constructor(
             )
             when (result) {
                 is LoginResult.Success -> {
+                    pollingJob?.cancel()
                     _emailState.update { it.copy(email = "", password = "", isSubmitting = false) }
                     _uiState.value = TvSignInUiState.Complete
                 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInViewModel.kt
@@ -48,7 +48,7 @@ class TvSignInViewModel @Inject constructor(
     }
 
     fun updateEmail(email: String) {
-        _emailState.update { it.copy(email = email, showEmailError = false, serverError = null) }
+        _emailState.update { it.copy(email = email.trim(), showEmailError = false, serverError = null) }
     }
 
     fun updatePassword(password: String) {
@@ -69,6 +69,7 @@ class TvSignInViewModel @Inject constructor(
         _emailState.update {
             it.copy(isSubmitting = true, showEmailError = false, showPasswordError = false, serverError = null)
         }
+        pollingJob?.cancel()
         viewModelScope.launch {
             val result = syncManager.loginWithEmailAndPassword(
                 email = current.email,
@@ -76,7 +77,10 @@ class TvSignInViewModel @Inject constructor(
                 signInSource = SignInSource.UserInitiated.Onboarding,
             )
             when (result) {
-                is LoginResult.Success -> _uiState.value = TvSignInUiState.Complete
+                is LoginResult.Success -> {
+                    _emailState.update { it.copy(email = "", password = "", isSubmitting = false) }
+                    _uiState.value = TvSignInUiState.Complete
+                }
 
                 is LoginResult.Failed -> _emailState.update {
                     it.copy(isSubmitting = false, serverError = result.message)
@@ -119,7 +123,11 @@ data class TvEmailSignInState(
     val showEmailError: Boolean = false,
     val showPasswordError: Boolean = false,
     val serverError: String? = null,
-)
+) {
+    override fun toString() = "TvEmailSignInState(email=$email, password=${if (password.isEmpty()) "" else "***"}, " +
+        "isSubmitting=$isSubmitting, showEmailError=$showEmailError, showPasswordError=$showPasswordError, " +
+        "serverError=$serverError)"
+}
 
 sealed interface TvSignInUiState {
     data object Loading : TvSignInUiState

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInViewModel.kt
@@ -42,13 +42,8 @@ class TvSignInViewModel @Inject constructor(
         if (_mode.value == mode) return
         _mode.value = mode
         eventHorizon.track(SignInTypeTappedEvent(type = mode.analyticsType))
-        when (mode) {
-            TvSignInMode.QrCode -> requestDeviceCode()
-
-            TvSignInMode.Email -> {
-                pollingJob?.cancel()
-                _emailState.update { it.copy(showEmailError = false, showPasswordError = false, serverError = null) }
-            }
+        if (mode == TvSignInMode.Email) {
+            _emailState.update { it.copy(showEmailError = false, showPasswordError = false, serverError = null) }
         }
     }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/welcome/TvWelcomeScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/welcome/TvWelcomeScreen.kt
@@ -116,13 +116,13 @@ private fun TvWelcomeContent(
             Text(
                 text = stringResource(LR.string.tv_onboarding_welcome_tv),
                 color = MaterialTheme.tvColors.textPrimary,
-                style = MaterialTheme.tvTypography.title1.copy(textAlign = TextAlign.Center),
+                style = MaterialTheme.tvTypography.title2.copy(textAlign = TextAlign.Center),
             )
             Spacer(modifier = Modifier.height(8.dp))
             Text(
                 text = stringResource(LR.string.tv_onboarding_subtitle),
                 color = MaterialTheme.tvColors.textSecondary,
-                style = MaterialTheme.tvTypography.headline.copy(textAlign = TextAlign.Center),
+                style = MaterialTheme.tvTypography.body.copy(textAlign = TextAlign.Center),
             )
             Spacer(modifier = Modifier.height(32.dp))
 

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/onboarding/TvSignInViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/onboarding/TvSignInViewModelTest.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -152,7 +153,7 @@ class TvSignInViewModelTest {
 
     @Test
     fun `switching to email mode tracks password sign in type`() = runTest {
-        val viewModel = createEmailViewModel()
+        val viewModel = createViewModelWithQrDisabled()
 
         viewModel.selectMode(TvSignInMode.Email)
 
@@ -161,7 +162,7 @@ class TvSignInViewModelTest {
 
     @Test
     fun `switching back to qr mode tracks qr sign in type`() = runTest {
-        val viewModel = createEmailViewModel()
+        val viewModel = createViewModelWithQrDisabled()
 
         viewModel.selectMode(TvSignInMode.Email)
         viewModel.selectMode(TvSignInMode.QrCode)
@@ -171,7 +172,7 @@ class TvSignInViewModelTest {
 
     @Test
     fun `reselecting the current mode does not track`() = runTest {
-        val viewModel = createEmailViewModel()
+        val viewModel = createViewModelWithQrDisabled()
 
         viewModel.selectMode(TvSignInMode.QrCode)
 
@@ -180,7 +181,7 @@ class TvSignInViewModelTest {
 
     @Test
     fun `successful email sign in transitions to Complete state`() = runTest {
-        val viewModel = createEmailViewModel()
+        val viewModel = createViewModelWithQrDisabled()
         whenever(syncManager.loginWithEmailAndPassword(any(), any(), any())).thenReturn(createLoginSuccess())
 
         viewModel.selectMode(TvSignInMode.Email)
@@ -199,7 +200,7 @@ class TvSignInViewModelTest {
 
     @Test
     fun `invalid email shows email error and does not attempt login`() = runTest {
-        val viewModel = createEmailViewModel()
+        val viewModel = createViewModelWithQrDisabled()
 
         viewModel.selectMode(TvSignInMode.Email)
         viewModel.updateEmail("not-an-email")
@@ -213,7 +214,7 @@ class TvSignInViewModelTest {
 
     @Test
     fun `short password shows password error and does not attempt login`() = runTest {
-        val viewModel = createEmailViewModel()
+        val viewModel = createViewModelWithQrDisabled()
 
         viewModel.selectMode(TvSignInMode.Email)
         viewModel.updateEmail("listener@pocketcasts.com")
@@ -227,7 +228,7 @@ class TvSignInViewModelTest {
 
     @Test
     fun `failed email sign in shows server error and clears submitting`() = runTest {
-        val viewModel = createEmailViewModel()
+        val viewModel = createViewModelWithQrDisabled()
         whenever(syncManager.loginWithEmailAndPassword(any(), any(), any()))
             .thenReturn(LoginResult.Failed(message = "Wrong password", messageId = "invalid_credentials"))
 
@@ -244,7 +245,7 @@ class TvSignInViewModelTest {
 
     @Test
     fun `submitting again while signing in only attempts one login`() = runTest {
-        val viewModel = createEmailViewModel()
+        val viewModel = createViewModelWithQrDisabled()
         whenever(syncManager.loginWithEmailAndPassword(any(), any(), any())).thenReturn(createLoginSuccess())
 
         viewModel.selectMode(TvSignInMode.Email)
@@ -257,9 +258,70 @@ class TvSignInViewModelTest {
         verify(syncManager, times(1)).loginWithEmailAndPassword(any(), any(), any())
     }
 
+    @Test
+    fun `updating email trims surrounding whitespace`() = runTest {
+        val viewModel = createViewModelWithQrDisabled()
+
+        viewModel.updateEmail("  listener@pocketcasts.com  ")
+
+        assertEquals("listener@pocketcasts.com", viewModel.emailState.value.email)
+    }
+
+    @Test
+    fun `switching to email mode clears field errors`() = runTest {
+        val viewModel = createViewModelWithQrDisabled()
+
+        viewModel.selectMode(TvSignInMode.Email)
+        viewModel.updateEmail("not-an-email")
+        viewModel.updatePassword("short")
+        viewModel.submitEmailSignIn()
+        advanceUntilIdle()
+        assertTrue(viewModel.emailState.value.showEmailError)
+
+        viewModel.selectMode(TvSignInMode.QrCode)
+        viewModel.selectMode(TvSignInMode.Email)
+
+        assertFalse(viewModel.emailState.value.showEmailError)
+        assertFalse(viewModel.emailState.value.showPasswordError)
+    }
+
+    @Test
+    fun `updating email clears the previous server error`() = runTest {
+        val viewModel = createViewModelWithQrDisabled()
+        whenever(syncManager.loginWithEmailAndPassword(any(), any(), any()))
+            .thenReturn(LoginResult.Failed(message = "Wrong password", messageId = "invalid_credentials"))
+
+        viewModel.selectMode(TvSignInMode.Email)
+        viewModel.updateEmail("listener@pocketcasts.com")
+        viewModel.updatePassword("hunter2")
+        viewModel.submitEmailSignIn()
+        advanceUntilIdle()
+        assertEquals("Wrong password", viewModel.emailState.value.serverError)
+
+        viewModel.updateEmail("listener@pocketcasts.com")
+
+        assertNull(viewModel.emailState.value.serverError)
+    }
+
+    @Test
+    fun `successful email sign in clears the credentials`() = runTest {
+        val viewModel = createViewModelWithQrDisabled()
+        whenever(syncManager.loginWithEmailAndPassword(any(), any(), any())).thenReturn(createLoginSuccess())
+
+        viewModel.selectMode(TvSignInMode.Email)
+        viewModel.updateEmail("listener@pocketcasts.com")
+        viewModel.updatePassword("hunter2")
+        viewModel.submitEmailSignIn()
+        advanceUntilIdle()
+
+        assertEquals("", viewModel.emailState.value.email)
+        assertEquals("", viewModel.emailState.value.password)
+        assertFalse(viewModel.emailState.value.isSubmitting)
+    }
+
     private fun createViewModel() = TvSignInViewModel(syncManager, eventHorizon)
 
-    private suspend fun createEmailViewModel(): TvSignInViewModel {
+    private suspend fun createViewModelWithQrDisabled(): TvSignInViewModel {
         whenever(syncManager.deviceAuthorize()).thenThrow(RuntimeException("qr disabled"))
         return createViewModel()
     }

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/onboarding/TvSignInViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/onboarding/TvSignInViewModelTest.kt
@@ -1,23 +1,32 @@
 package au.com.shiftyjelly.pocketcasts.onboarding
 
 import app.cash.turbine.test
+import au.com.shiftyjelly.pocketcasts.onboarding.signin.TvSignInMode
 import au.com.shiftyjelly.pocketcasts.onboarding.signin.TvSignInUiState
 import au.com.shiftyjelly.pocketcasts.onboarding.signin.TvSignInViewModel
 import au.com.shiftyjelly.pocketcasts.preferences.AccessToken
 import au.com.shiftyjelly.pocketcasts.repositories.sync.LoginResult
+import au.com.shiftyjelly.pocketcasts.repositories.sync.SignInSource
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.servers.model.AuthResultModel
 import au.com.shiftyjelly.pocketcasts.servers.sync.login.DeviceAuthorizeResponse
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import com.automattic.eventhorizon.EventHorizon
+import com.automattic.eventhorizon.SignInType
+import com.automattic.eventhorizon.SignInTypeTappedEvent
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -27,13 +36,14 @@ class TvSignInViewModelTest {
     val coroutineRule = MainCoroutineRule()
 
     private val syncManager = mock<SyncManager>()
+    private val eventHorizon = mock<EventHorizon>()
 
     @Test
     fun `successful device authorize transitions to Ready state`() = runTest {
         whenever(syncManager.deviceAuthorize()).thenReturn(createDeviceAuthorizeResponse())
         whenever(syncManager.loginWithDeviceAuth(any(), any())).thenReturn(createLoginSuccess())
 
-        val viewModel = TvSignInViewModel(syncManager)
+        val viewModel = createViewModel()
 
         viewModel.uiState.test {
             val state = awaitItem()
@@ -51,7 +61,7 @@ class TvSignInViewModelTest {
     fun `device authorize failure transitions to Error state`() = runTest {
         whenever(syncManager.deviceAuthorize()).thenThrow(RuntimeException("Network error"))
 
-        val viewModel = TvSignInViewModel(syncManager)
+        val viewModel = createViewModel()
 
         viewModel.uiState.test {
             assertEquals(TvSignInUiState.Error, awaitItem())
@@ -63,7 +73,7 @@ class TvSignInViewModelTest {
         whenever(syncManager.deviceAuthorize()).thenReturn(createDeviceAuthorizeResponse())
         whenever(syncManager.loginWithDeviceAuth(eq("device-code-123"), any())).thenReturn(createLoginSuccess())
 
-        val viewModel = TvSignInViewModel(syncManager)
+        val viewModel = createViewModel()
 
         viewModel.uiState.test {
             // May see Ready briefly before Complete, or jump straight to Complete
@@ -84,7 +94,7 @@ class TvSignInViewModelTest {
             .thenReturn(createAuthorizationPending())
             .thenReturn(createLoginSuccess())
 
-        val viewModel = TvSignInViewModel(syncManager)
+        val viewModel = createViewModel()
 
         viewModel.uiState.test {
             // Skip Ready, wait for Complete
@@ -103,7 +113,7 @@ class TvSignInViewModelTest {
         whenever(syncManager.loginWithDeviceAuth(eq("device-code-123"), any()))
             .thenReturn(LoginResult.Failed(message = "Token expired", messageId = "expired_token"))
 
-        val viewModel = TvSignInViewModel(syncManager)
+        val viewModel = createViewModel()
 
         viewModel.uiState.test {
             val states = mutableListOf(awaitItem())
@@ -122,7 +132,7 @@ class TvSignInViewModelTest {
             .thenReturn(createDeviceAuthorizeResponse())
         whenever(syncManager.loginWithDeviceAuth(any(), any())).thenReturn(createLoginSuccess())
 
-        val viewModel = TvSignInViewModel(syncManager)
+        val viewModel = createViewModel()
 
         viewModel.uiState.test {
             assertEquals(TvSignInUiState.Error, awaitItem())
@@ -137,6 +147,105 @@ class TvSignInViewModelTest {
             assertEquals(TvSignInUiState.Complete, states.last())
             cancelAndIgnoreRemainingEvents()
         }
+    }
+
+    @Test
+    fun `switching to email mode tracks password sign in type`() = runTest {
+        val viewModel = createEmailViewModel()
+
+        viewModel.selectMode(TvSignInMode.Email)
+
+        verify(eventHorizon).track(SignInTypeTappedEvent(type = SignInType.Password))
+    }
+
+    @Test
+    fun `switching back to qr mode tracks qr sign in type`() = runTest {
+        val viewModel = createEmailViewModel()
+
+        viewModel.selectMode(TvSignInMode.Email)
+        viewModel.selectMode(TvSignInMode.QrCode)
+
+        verify(eventHorizon).track(SignInTypeTappedEvent(type = SignInType.Qr))
+    }
+
+    @Test
+    fun `reselecting the current mode does not track`() = runTest {
+        val viewModel = createEmailViewModel()
+
+        viewModel.selectMode(TvSignInMode.QrCode)
+
+        verify(eventHorizon, never()).track(any())
+    }
+
+    @Test
+    fun `successful email sign in transitions to Complete state`() = runTest {
+        val viewModel = createEmailViewModel()
+        whenever(syncManager.loginWithEmailAndPassword(any(), any(), any())).thenReturn(createLoginSuccess())
+
+        viewModel.selectMode(TvSignInMode.Email)
+        viewModel.updateEmail("listener@pocketcasts.com")
+        viewModel.updatePassword("hunter2")
+        viewModel.submitEmailSignIn()
+        advanceUntilIdle()
+
+        assertEquals(TvSignInUiState.Complete, viewModel.uiState.value)
+        verify(syncManager).loginWithEmailAndPassword(
+            email = eq("listener@pocketcasts.com"),
+            password = eq("hunter2"),
+            signInSource = eq(SignInSource.UserInitiated.Onboarding),
+        )
+    }
+
+    @Test
+    fun `invalid email shows email error and does not attempt login`() = runTest {
+        val viewModel = createEmailViewModel()
+
+        viewModel.selectMode(TvSignInMode.Email)
+        viewModel.updateEmail("not-an-email")
+        viewModel.updatePassword("hunter2")
+        viewModel.submitEmailSignIn()
+        advanceUntilIdle()
+
+        assertTrue(viewModel.emailState.value.showEmailError)
+        verify(syncManager, never()).loginWithEmailAndPassword(any(), any(), any())
+    }
+
+    @Test
+    fun `short password shows password error and does not attempt login`() = runTest {
+        val viewModel = createEmailViewModel()
+
+        viewModel.selectMode(TvSignInMode.Email)
+        viewModel.updateEmail("listener@pocketcasts.com")
+        viewModel.updatePassword("short")
+        viewModel.submitEmailSignIn()
+        advanceUntilIdle()
+
+        assertTrue(viewModel.emailState.value.showPasswordError)
+        verify(syncManager, never()).loginWithEmailAndPassword(any(), any(), any())
+    }
+
+    @Test
+    fun `failed email sign in shows server error and clears submitting`() = runTest {
+        val viewModel = createEmailViewModel()
+        whenever(syncManager.loginWithEmailAndPassword(any(), any(), any()))
+            .thenReturn(LoginResult.Failed(message = "Wrong password", messageId = "invalid_credentials"))
+
+        viewModel.selectMode(TvSignInMode.Email)
+        viewModel.updateEmail("listener@pocketcasts.com")
+        viewModel.updatePassword("hunter2")
+        viewModel.submitEmailSignIn()
+        advanceUntilIdle()
+
+        assertEquals("Wrong password", viewModel.emailState.value.serverError)
+        assertFalse(viewModel.emailState.value.isSubmitting)
+        assertFalse(viewModel.uiState.value is TvSignInUiState.Complete)
+    }
+
+    private fun createViewModel() = TvSignInViewModel(syncManager, eventHorizon)
+
+    private suspend fun createEmailViewModel(): TvSignInViewModel {
+        whenever(syncManager.deviceAuthorize()).thenThrow(RuntimeException("qr disabled"))
+        return createViewModel()
     }
 
     private fun createDeviceAuthorizeResponse() = DeviceAuthorizeResponse(

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/onboarding/TvSignInViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/onboarding/TvSignInViewModelTest.kt
@@ -26,6 +26,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -239,6 +240,21 @@ class TvSignInViewModelTest {
         assertEquals("Wrong password", viewModel.emailState.value.serverError)
         assertFalse(viewModel.emailState.value.isSubmitting)
         assertFalse(viewModel.uiState.value is TvSignInUiState.Complete)
+    }
+
+    @Test
+    fun `submitting again while signing in only attempts one login`() = runTest {
+        val viewModel = createEmailViewModel()
+        whenever(syncManager.loginWithEmailAndPassword(any(), any(), any())).thenReturn(createLoginSuccess())
+
+        viewModel.selectMode(TvSignInMode.Email)
+        viewModel.updateEmail("listener@pocketcasts.com")
+        viewModel.updatePassword("hunter2")
+        viewModel.submitEmailSignIn()
+        viewModel.submitEmailSignIn()
+        advanceUntilIdle()
+
+        verify(syncManager, times(1)).loginWithEmailAndPassword(any(), any(), any())
     }
 
     private fun createViewModel() = TvSignInViewModel(syncManager, eventHorizon)


### PR DESCRIPTION
## Description

Adds a **manual email/password sign-in** option to the Android TV sign-in screen, which was previously QR-only. This closes an Apple TV parity gap found in an Android-TV-vs-iOS-tvOS onboarding audit: on tvOS the sign-in screen offers a segmented **QR / User-Pass** toggle, but on Android TV a user without their phone handy had **no way to log in at all**.

A `QR code` / `Email` segmented toggle (tv-material3 `TabRow` + `PillIndicator`, matching `TvSearchFilters`) is added to `TvSignInScreen`. The QR flow is unchanged. Selecting **Email** shows an email field, a password field and a **Log in** button that reuses the existing `SyncManager.loginWithEmailAndPassword(...)` machinery; on success it navigates to the syncing screen exactly like the QR path.

Notes:
- Sign-in success/failure analytics (`user_signed_in` / `user_signin_failed`, `source = password`) are emitted centrally by `SyncManagerImpl` (via `LoginIdentity.PocketCasts`) — the screen does not double-track them. Only the new `sign_in_type_tapped` event is fired from the ViewModel when the toggle is tapped.
- Field validation mirrors the phone login (valid email + password ≥ 6 chars) with inline errors; a bad login shows the server's localized error message.
- The mode toggle selects on **click** (not focus) so merely moving focus onto the QR tab doesn't mint a new device code or over-count the "tapped" event.
- The former "Sign in with your phone" loading title (`tv_onboarding_sign_in_title`) is no longer shown now that the toggle/QR layout is always present; the string is left in place to avoid GlotPress translation churn.

Fixes POC-865 https://linear.app/a8c/issue/POC-865/manual-sign-in

## Testing Instructions

1. Launch the Android TV app while **signed out**.
2. From **Welcome**, select **Sign in**.
3. Confirm the **QR code** tab is selected by default and the QR flow works as before.
4. Move focus to the **Email** tab and press OK — the email/password form appears.
5. Press **Log in** with empty/invalid fields → inline validation errors appear; no network call is made.
6. Enter valid credentials and **Log in** → button shows a spinner, then the app proceeds to the **syncing** screen and into Home.
7. Enter wrong credentials → the server error message appears inline and you can retry.

## Screenshots or Screencast

| Email login | Form validation |
| --- | --- |
| <img width="1920" height="1080" alt="Screenshot_20260826_113142" src="https://github.com/user-attachments/assets/c983ad82-f9ae-44b2-9aa8-f4c9432600df" /> | <img width="1920" height="1080" alt="Screenshot_20260826_113157" src="https://github.com/user-attachments/assets/d0606e57-fdd8-489a-98fb-0c4ae0ca657b" /> |


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) the Event Horizon schema to reflect any new or changed analytics. (`sign_in_type_tapped` already exists in the schema; no new events added.)
