### PR TITLE
[TV] Show an alert when the server signs the user out

### DIFF
--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -273,6 +273,8 @@
     <string name="tv_sign_in_step_scan">Scan the QR code or go to %1$s</string>
     <string name="tv_sign_in_step_login">Log in to your account</string>
     <string name="tv_sign_in_step_confirm_code">If asked, confirm with the code below</string>
+    <string name="tv_account_signed_out_alert_title">You\'ve been logged out</string>
+    <string name="tv_account_signed_out_alert_message">There was a problem and you\'ve been logged out.\nTap the button below to log in to your Pocket Casts account again.</string>
     <string name="tv_create_account_modal_title">Your podcasts deserve a home</string>
     <string name="tv_create_account_modal_subtitle">Create a free account to follow podcasts, build your Up Next, and pick up right where you left off, on any device.</string>
     <string name="tv_create_account_modal_step_create">Create your account or log in</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -274,7 +274,7 @@
     <string name="tv_sign_in_step_login">Log in to your account</string>
     <string name="tv_sign_in_step_confirm_code">If asked, confirm with the code below</string>
     <string name="tv_account_signed_out_alert_title">You\'ve been logged out</string>
-    <string name="tv_account_signed_out_alert_message">There was a problem and you\'ve been logged out.\nTap the button below to log in to your Pocket Casts account again.</string>
+    <string name="tv_account_signed_out_alert_message">There was a problem and you\'ve been logged out.\nSelect the button below to log in to your Pocket Casts account again.</string>
     <string name="tv_create_account_modal_title">Your podcasts deserve a home</string>
     <string name="tv_create_account_modal_subtitle">Create a free account to follow podcasts, build your Up Next, and pick up right where you left off, on any device.</string>
     <string name="tv_create_account_modal_step_create">Create your account or log in</string>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/TokenErrorNotification.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/TokenErrorNotification.kt
@@ -27,6 +27,9 @@ open class TokenErrorNotification @Inject constructor(
     private var lastSignInErrorNotification: Long? = null
 
     fun show(intent: Intent) {
+        if (Util.isTv(context)) {
+            return
+        }
         onShowSignInErrorNotificationDebounced {
             eventHorizon.track(SignedOutAlertShownEvent)
         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
@@ -42,6 +42,9 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -53,6 +56,9 @@ import timber.log.Timber
 interface UserManager {
     fun beginMonitoringAccountManager(playbackManager: PlaybackManager)
     fun getSignInState(): Flowable<SignInState>
+
+    /** Emits when the user is signed out by the server rather than by their own action. */
+    val onServerSignOut: SharedFlow<Unit>
 
     /** Returns the job for the async credential sign out, or null when the sign out is skipped. */
     fun signOut(playbackManager: PlaybackManager, wasInitiatedByUser: Boolean): Job?
@@ -90,6 +96,9 @@ class UserManagerImpl @Inject constructor(
 
     override val coroutineContext: CoroutineContext
         get() = Dispatchers.Default
+
+    private val _onServerSignOut = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    override val onServerSignOut: SharedFlow<Unit> = _onServerSignOut.asSharedFlow()
 
     override fun beginMonitoringAccountManager(playbackManager: PlaybackManager) {
         val accountListener = OnAccountsUpdateListener {
@@ -163,6 +172,9 @@ class UserManagerImpl @Inject constructor(
     override fun signOut(playbackManager: PlaybackManager, wasInitiatedByUser: Boolean): Job? {
         var signOutJob: Job? = null
         if (wasInitiatedByUser || !settings.getFullySignedOut()) {
+            if (!wasInitiatedByUser) {
+                _onServerSignOut.tryEmit(Unit)
+            }
             LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Signing out")
             signOutJob = applicationScope.launch {
                 syncManager.signOut {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
@@ -171,10 +171,8 @@ class UserManagerImpl @Inject constructor(
 
     override fun signOut(playbackManager: PlaybackManager, wasInitiatedByUser: Boolean): Job? {
         var signOutJob: Job? = null
-        if (wasInitiatedByUser || !settings.getFullySignedOut()) {
-            if (!wasInitiatedByUser) {
-                _onServerSignOut.tryEmit(Unit)
-            }
+        val isSigningOut = wasInitiatedByUser || !settings.getFullySignedOut()
+        if (isSigningOut) {
             LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Signing out")
             signOutJob = applicationScope.launch {
                 syncManager.signOut {
@@ -203,6 +201,9 @@ class UserManagerImpl @Inject constructor(
             }
         }
         settings.setFullySignedOut(true)
+        if (isSigningOut && !wasInitiatedByUser) {
+            _onServerSignOut.tryEmit(Unit)
+        }
         return signOutJob
     }
 

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManagerImplTest.kt
@@ -7,6 +7,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -53,7 +54,7 @@ class UserManagerImplTest {
         }
     }
 
-    private fun createUserManager() = UserManagerImpl(
+    private fun TestScope.createUserManager() = UserManagerImpl(
         application = mock(),
         settings = settings,
         syncManager = syncManager,
@@ -65,7 +66,7 @@ class UserManagerImplTest {
         analyticsController = mock(),
         eventHorizon = mock(),
         accountStatusInfo = mock(),
-        applicationScope = CoroutineScope(StandardTestDispatcher()),
+        applicationScope = CoroutineScope(StandardTestDispatcher(testScheduler)),
         crashLogging = mock(),
         experimentProvider = mock(),
         endOfYearSync = mock(),

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManagerImplTest.kt
@@ -1,0 +1,74 @@
+package au.com.shiftyjelly.pocketcasts.repositories.user
+
+import app.cash.turbine.test
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class UserManagerImplTest {
+
+    private val settings = mock<Settings>()
+    private val syncManager = mock<SyncManager>()
+    private val playbackManager = mock<PlaybackManager>()
+
+    @Test
+    fun `server-forced sign out emits onServerSignOut`() = runTest {
+        whenever(settings.getFullySignedOut()).thenReturn(false)
+        val userManager = createUserManager()
+
+        userManager.onServerSignOut.test {
+            userManager.signOut(playbackManager, wasInitiatedByUser = false)
+            assertEquals(Unit, awaitItem())
+        }
+    }
+
+    @Test
+    fun `user-initiated sign out does not emit onServerSignOut`() = runTest {
+        whenever(settings.getFullySignedOut()).thenReturn(false)
+        val userManager = createUserManager()
+
+        userManager.onServerSignOut.test {
+            userManager.signOut(playbackManager, wasInitiatedByUser = true)
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `forced sign out does not emit when already fully signed out`() = runTest {
+        whenever(settings.getFullySignedOut()).thenReturn(true)
+        val userManager = createUserManager()
+
+        userManager.onServerSignOut.test {
+            userManager.signOut(playbackManager, wasInitiatedByUser = false)
+            expectNoEvents()
+        }
+    }
+
+    private fun createUserManager() = UserManagerImpl(
+        application = mock(),
+        settings = settings,
+        syncManager = syncManager,
+        subscriptionManager = mock(),
+        podcastManager = mock(),
+        userEpisodeManager = mock(),
+        playlistDao = mock(),
+        playlistsInitializer = mock(),
+        analyticsController = mock(),
+        eventHorizon = mock(),
+        accountStatusInfo = mock(),
+        applicationScope = CoroutineScope(StandardTestDispatcher()),
+        crashLogging = mock(),
+        experimentProvider = mock(),
+        endOfYearSync = mock(),
+        notificationScheduler = mock(),
+    )
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/auth/TvSignOutManager.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/auth/TvSignOutManager.kt
@@ -34,7 +34,7 @@ class TvSignOutManager @Inject constructor(
     @ApplicationScope private val applicationScope: CoroutineScope,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) {
-    fun signOutAndWipeData() {
+    fun signOutAndWipeData(wasInitiatedByUser: Boolean = true) {
         applicationScope.launch(ioDispatcher) {
             val signOutJob = runWipeStep("sign out and clear data") {
                 userManager.signOutAndClearData(
@@ -43,7 +43,7 @@ class TvSignOutManager @Inject constructor(
                     folderManager = folderManager.get(),
                     searchHistoryManager = searchHistoryManager.get(),
                     episodeManager = episodeManager.get(),
-                    wasInitiatedByUser = true,
+                    wasInitiatedByUser = wasInitiatedByUser,
                 )
             }
             if (signOutJob != null && withTimeoutOrNull(SIGN_OUT_TIMEOUT) { signOutJob.join() } == null) {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingNavHost.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingNavHost.kt
@@ -19,6 +19,7 @@ import au.com.shiftyjelly.pocketcasts.component.TvToastHost
 import au.com.shiftyjelly.pocketcasts.component.TvToastHostState
 import au.com.shiftyjelly.pocketcasts.home.TvScaffold
 import au.com.shiftyjelly.pocketcasts.onboarding.createaccount.TvCreateAccountScreen
+import au.com.shiftyjelly.pocketcasts.onboarding.signedout.TvSignedOutScreen
 import au.com.shiftyjelly.pocketcasts.onboarding.signin.TvSignInScreen
 import au.com.shiftyjelly.pocketcasts.onboarding.signin.TvSyncingScreen
 import au.com.shiftyjelly.pocketcasts.onboarding.welcome.TvWelcomeScreen
@@ -37,6 +38,11 @@ fun TvOnboardingNavHost(
     LaunchedEffect(Unit) {
         if (viewModel.startDestination == TvOnboardingRoutes.HOME) {
             viewModel.refreshOnLaunch()
+        }
+    }
+    LaunchedEffect(Unit) {
+        viewModel.onServerSignOut.collect {
+            navigateClearingBackStack(TvOnboardingRoutes.SIGNED_OUT)
         }
     }
     val toastHostState = remember { TvToastHostState() }
@@ -75,6 +81,11 @@ fun TvOnboardingNavHost(
                                 popUpTo(TvOnboardingRoutes.SYNCING) { inclusive = true }
                             }
                         },
+                    )
+                }
+                composable(TvOnboardingRoutes.SIGNED_OUT) {
+                    TvSignedOutScreen(
+                        onLogIn = { navigateClearingBackStack(TvOnboardingRoutes.LANDING) },
                     )
                 }
                 composable(TvOnboardingRoutes.HOME) {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingNavHost.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingNavHost.kt
@@ -42,7 +42,9 @@ fun TvOnboardingNavHost(
     }
     LaunchedEffect(Unit) {
         viewModel.onServerSignOut.collect {
-            navigateClearingBackStack(TvOnboardingRoutes.SIGNED_OUT)
+            if (navController.currentDestination?.route != TvOnboardingRoutes.SIGNED_OUT) {
+                navigateClearingBackStack(TvOnboardingRoutes.SIGNED_OUT)
+            }
         }
     }
     val toastHostState = remember { TvToastHostState() }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingRoutes.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingRoutes.kt
@@ -5,5 +5,6 @@ object TvOnboardingRoutes {
     const val CREATE_ACCOUNT = "tv_create_account"
     const val SIGN_IN = "tv_sign_in"
     const val SYNCING = "tv_syncing"
+    const val SIGNED_OUT = "tv_signed_out"
     const val HOME = "tv_home"
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingViewModel.kt
@@ -6,15 +6,18 @@ import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.UpNextSyncWorker
+import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
+import kotlinx.coroutines.flow.SharedFlow
 
 @HiltViewModel
 class TvOnboardingViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
     private val syncManager: SyncManager,
     private val podcastManager: PodcastManager,
+    userManager: UserManager,
     settings: Settings,
 ) : ViewModel() {
     val startDestination: String = if (syncManager.isLoggedIn() && !settings.getFullySignedOut()) {
@@ -22,6 +25,8 @@ class TvOnboardingViewModel @Inject constructor(
     } else {
         TvOnboardingRoutes.LANDING
     }
+
+    val onServerSignOut: SharedFlow<Unit> = userManager.onServerSignOut
 
     fun refreshOnLaunch() {
         podcastManager.refreshPodcasts("tv launch")

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signedout/TvSignedOutScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signedout/TvSignedOutScreen.kt
@@ -12,9 +12,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -43,14 +41,12 @@ fun TvSignedOutScreen(
     modifier: Modifier = Modifier,
     viewModel: TvSignedOutViewModel = hiltViewModel(),
 ) {
-    val currentOnLogIn by rememberUpdatedState(onLogIn)
-
     CallOnce { viewModel.trackShown() }
 
     TvSignedOutContent(
         onLogIn = {
             viewModel.logOut()
-            currentOnLogIn()
+            onLogIn()
         },
         modifier = modifier,
     )

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signedout/TvSignedOutScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signedout/TvSignedOutScreen.kt
@@ -82,12 +82,12 @@ private fun TvSignedOutContent(
             Text(
                 text = stringResource(LR.string.tv_account_signed_out_alert_title),
                 color = MaterialTheme.tvColors.textPrimary,
-                style = MaterialTheme.tvTypography.title1.copy(textAlign = TextAlign.Center),
+                style = MaterialTheme.tvTypography.title2.copy(textAlign = TextAlign.Center),
             )
             Text(
                 text = stringResource(LR.string.tv_account_signed_out_alert_message),
                 color = MaterialTheme.tvColors.textSecondary,
-                style = MaterialTheme.tvTypography.headline.copy(textAlign = TextAlign.Center),
+                style = MaterialTheme.tvTypography.body.copy(textAlign = TextAlign.Center),
             )
             Spacer(modifier = Modifier.height(16.dp))
             Button(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signedout/TvSignedOutScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signedout/TvSignedOutScreen.kt
@@ -1,0 +1,114 @@
+package au.com.shiftyjelly.pocketcasts.onboarding.signedout
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.tv.material3.Button
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.compose.CallOnce
+import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
+import au.com.shiftyjelly.pocketcasts.theme.TvTheme
+import au.com.shiftyjelly.pocketcasts.theme.tvColors
+import au.com.shiftyjelly.pocketcasts.theme.tvTypography
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+fun TvSignedOutScreen(
+    onLogIn: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: TvSignedOutViewModel = hiltViewModel(),
+) {
+    val currentOnLogIn by rememberUpdatedState(onLogIn)
+
+    CallOnce { viewModel.trackShown() }
+
+    TvSignedOutContent(
+        onLogIn = {
+            viewModel.logOut()
+            currentOnLogIn()
+        },
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun TvSignedOutContent(
+    onLogIn: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val focusRequester = remember { FocusRequester() }
+
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.tvColors.backgroundSunken),
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            modifier = Modifier.padding(horizontal = 48.dp),
+        ) {
+            Image(
+                painter = painterResource(IR.drawable.ic_pocket_casts_logo),
+                contentDescription = null,
+                modifier = Modifier.size(36.dp),
+            )
+            Text(
+                text = stringResource(LR.string.tv_account_signed_out_alert_title),
+                color = MaterialTheme.tvColors.textPrimary,
+                style = MaterialTheme.tvTypography.title1.copy(textAlign = TextAlign.Center),
+            )
+            Text(
+                text = stringResource(LR.string.tv_account_signed_out_alert_message),
+                color = MaterialTheme.tvColors.textSecondary,
+                style = MaterialTheme.tvTypography.headline.copy(textAlign = TextAlign.Center),
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Button(
+                onClick = onLogIn,
+                colors = TvButtonDefaults.filledButtonColors(),
+                modifier = Modifier.focusRequester(focusRequester),
+            ) {
+                Text(text = stringResource(LR.string.log_in))
+            }
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+}
+
+@Preview(device = Devices.TV_1080p)
+@Composable
+private fun TvSignedOutScreenPreview() {
+    TvTheme {
+        TvSignedOutContent(onLogIn = {})
+    }
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signedout/TvSignedOutViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signedout/TvSignedOutViewModel.kt
@@ -1,0 +1,23 @@
+package au.com.shiftyjelly.pocketcasts.onboarding.signedout
+
+import androidx.lifecycle.ViewModel
+import au.com.shiftyjelly.pocketcasts.auth.TvSignOutManager
+import com.automattic.eventhorizon.EventHorizon
+import com.automattic.eventhorizon.SignedOutAlertShownEvent
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class TvSignedOutViewModel @Inject constructor(
+    private val eventHorizon: EventHorizon,
+    private val signOutManager: TvSignOutManager,
+) : ViewModel() {
+
+    fun trackShown() {
+        eventHorizon.track(SignedOutAlertShownEvent)
+    }
+
+    fun logOut() {
+        signOutManager.signOutAndWipeData()
+    }
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signedout/TvSignedOutViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signedout/TvSignedOutViewModel.kt
@@ -18,6 +18,6 @@ class TvSignedOutViewModel @Inject constructor(
     }
 
     fun logOut() {
-        signOutManager.signOutAndWipeData()
+        signOutManager.signOutAndWipeData(wasInitiatedByUser = false)
     }
 }

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/auth/TvSignOutManagerTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/auth/TvSignOutManagerTest.kt
@@ -72,6 +72,23 @@ class TvSignOutManagerTest {
     }
 
     @Test
+    fun `a server-initiated wipe does not re-run the sign out analytics`() = runTest {
+        val manager = createManager(fileStorage = mock<FileStorage>())
+
+        manager.signOutAndWipeData(wasInitiatedByUser = false)
+        advanceUntilIdle()
+
+        verify(userManager).signOutAndClearData(
+            playbackManager = eq(playbackManager),
+            upNextQueue = eq(upNextQueue),
+            folderManager = eq(folderManager),
+            searchHistoryManager = eq(searchHistoryManager),
+            episodeManager = eq(episodeManager),
+            wasInitiatedByUser = eq(false),
+        )
+    }
+
+    @Test
     fun `sign out deletes the downloaded files`() = runTest {
         val episodesDir = temporaryFolder.newFolder("episodes")
         val imagesDir = temporaryFolder.newFolder("network_images")

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingViewModelTest.kt
@@ -1,20 +1,29 @@
 package au.com.shiftyjelly.pocketcasts.onboarding
 
 import android.content.Context
+import app.cash.turbine.test
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
+import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class TvOnboardingViewModelTest {
 
     private val context = mock<Context>()
     private val syncManager = mock<SyncManager>()
     private val podcastManager = mock<PodcastManager>()
     private val settings = mock<Settings>()
+    private val serverSignOut = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    private val userManager = mock<UserManager> { on { onServerSignOut } doReturn serverSignOut }
 
     @Test
     fun `start destination is landing when signed out`() {
@@ -36,5 +45,13 @@ class TvOnboardingViewModelTest {
         assertEquals(TvOnboardingRoutes.LANDING, viewModel().startDestination)
     }
 
-    private fun viewModel() = TvOnboardingViewModel(context, syncManager, podcastManager, settings)
+    @Test
+    fun `re-emits the server sign out signal`() = runTest {
+        viewModel().onServerSignOut.test {
+            serverSignOut.emit(Unit)
+            assertEquals(Unit, awaitItem())
+        }
+    }
+
+    private fun viewModel() = TvOnboardingViewModel(context, syncManager, podcastManager, userManager, settings)
 }

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/onboarding/TvSignedOutViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/onboarding/TvSignedOutViewModelTest.kt
@@ -24,7 +24,7 @@ class TvSignedOutViewModelTest {
     fun `logOut wipes the local data`() {
         viewModel().logOut()
 
-        verify(signOutManager).signOutAndWipeData()
+        verify(signOutManager).signOutAndWipeData(wasInitiatedByUser = false)
     }
 
     private fun viewModel() = TvSignedOutViewModel(eventHorizon, signOutManager)

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/onboarding/TvSignedOutViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/onboarding/TvSignedOutViewModelTest.kt
@@ -1,0 +1,31 @@
+package au.com.shiftyjelly.pocketcasts.onboarding
+
+import au.com.shiftyjelly.pocketcasts.auth.TvSignOutManager
+import au.com.shiftyjelly.pocketcasts.onboarding.signedout.TvSignedOutViewModel
+import com.automattic.eventhorizon.EventHorizon
+import com.automattic.eventhorizon.SignedOutAlertShownEvent
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+class TvSignedOutViewModelTest {
+
+    private val eventHorizon = mock<EventHorizon>()
+    private val signOutManager = mock<TvSignOutManager>()
+
+    @Test
+    fun `trackShown fires signed out alert shown event`() {
+        viewModel().trackShown()
+
+        verify(eventHorizon).track(SignedOutAlertShownEvent)
+    }
+
+    @Test
+    fun `logOut wipes the local data`() {
+        viewModel().logOut()
+
+        verify(signOutManager).signOutAndWipeData()
+    }
+
+    private fun viewModel() = TvSignedOutViewModel(eventHorizon, signOutManager)
+}


### PR DESCRIPTION
## Description

Adds a **server-forced sign-out alert** to the Android TV app, matching Apple TV. When a user is signed out by the **server** (token revoked / refresh failed / account removed) rather than by their own action, iOS shows a full-screen alert instead of silently dropping them; Android TV previously surfaced nothing (only a system notification, which is invisible on a TV). This closes functional gap #5 from the Android-TV-vs-iOS-tvOS onboarding parity audit and lands the deferred `signed_out_alert_shown` analytics event (one of the three events split out of the onboarding-analytics PR #5773).

### How it works
- **Signal at the source (shared):** `UserManager` gains `onServerSignOut: SharedFlow<Unit>`, emitted from `signOut()` only when `wasInitiatedByUser == false` (the Android equivalent of iOS's `user_initiated`). Transient (`replay = 0`) = in-session only, matching iOS.
- **TV observes it:** `TvOnboardingNavHost` collects the flow and navigates to a new `SIGNED_OUT` route from any screen.
- **Alert screen:** `TvSignedOutScreen` (Compose + tv-material3, styled like `TvWelcomeScreen`) shows "You've been logged out" + message + a **Log in** button; `signed_out_alert_shown` fires on appear. The button fully wipes local data (via `TvSignOutManager`) and returns to Welcome — matching iOS's `logout()`.
- **No double-count:** `TokenErrorNotification` (which already fires `SignedOutAlertShownEvent`) is suppressed on TV, so the in-app alert is the single event source.

A user-initiated Log Out (Profile) is unaffected — it passes `wasInitiatedByUser = true`, so no alert and no emit.

### Known limitation (conscious decision)
Because the TV token-error notification is suppressed, a forced sign-out that surfaces **only** via the OkHttp interceptor's swallowed `RefreshTokenExpiredException` (rather than `RefreshPodcastsThread` or the account-removed listener) won't show the alert until the next podcast refresh runs (`refreshOnLaunch` + periodic). The primary forced-sign-out paths are covered; this is a delay, not a permanent gap.

Fixes POC-867 https://linear.app/a8c/issue/POC-867/server-forced-signout-alerts

## Testing Instructions
1. Sign in on Android TV.
2. Trigger a server-forced sign-out (revoke the session server-side / let the refresh token expire so the next podcast refresh fails).
3. The **"You've been logged out"** alert appears over whatever screen you were on.
4. Press **Log in** → local data is wiped and you land on the **Welcome** screen.
5. Confirm a normal Profile → **Log Out** does **not** show the alert (it goes straight to Welcome as before).

## Screenshots or Screencast
<img width="1920" height="1080" alt="Screenshot_20260826_125009" src="https://github.com/user-attachments/assets/b600b70a-4d6b-493c-9036-edde0a2f2ffa" />


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply`)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) the Event Horizon schema to reflect any new or changed analytics. (`signed_out_alert_shown` already exists in the schema; no new events added.)

#### I have tested any UI changes...
- [ ] with different themes (TV is single dark theme)
- [ ] with a landscape orientation (TV is landscape-only)
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
