### PR TITLE
[TV] Actively poll API in create account flow

### DIFF
--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2933,6 +2933,4 @@
     <string name="tv_onboarding_welcome_back">Welcome back!</string>
     <string name="tv_onboarding_syncing_subtitle">Your podcasts are syncing, we\'ll sign you in soon!</string>
     <string name="tv_create_account_title">Create your free account</string>
-    <string name="tv_create_account_subtitle">Scan this code to get started on your phone, it only takes a minute.</string>
-    <string name="tv_create_account_come_back">Once you\'ve created your account, come back and sign in</string>
 </resources>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManager.kt
@@ -68,7 +68,13 @@ interface SyncManager : NamedSettingsCaller {
     suspend fun loginWithEmailAndPassword(email: String, password: String, signInSource: SignInSource): LoginResult
     suspend fun loginWithToken(token: RefreshToken, loginIdentity: LoginIdentity, signInSource: SignInSource): LoginResult
     suspend fun deviceAuthorize(): DeviceAuthorizeResponse
-    suspend fun loginWithDeviceAuth(deviceCode: String, signInSource: SignInSource, isNewAccount: Boolean = false): LoginResult
+
+    /**
+     * [isNewAccount] is a caller assertion that this pairing is a signup, not server truth the way
+     * AuthResultModel.isNewAccount carries it elsewhere. It drives new-account analytics attribution
+     * (and the value stored in that field), so each caller must set it deliberately.
+     */
+    suspend fun loginWithDeviceAuth(deviceCode: String, signInSource: SignInSource, isNewAccount: Boolean): LoginResult
     suspend fun createUserWithEmailAndPassword(email: String, password: String, signInSource: SignInSource.UserInitiated): LoginResult
     suspend fun forgotPassword(email: String, onSuccess: () -> Unit, onError: (String) -> Unit)
     suspend fun getAccessToken(account: Account): AccessToken

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManager.kt
@@ -68,7 +68,7 @@ interface SyncManager : NamedSettingsCaller {
     suspend fun loginWithEmailAndPassword(email: String, password: String, signInSource: SignInSource): LoginResult
     suspend fun loginWithToken(token: RefreshToken, loginIdentity: LoginIdentity, signInSource: SignInSource): LoginResult
     suspend fun deviceAuthorize(): DeviceAuthorizeResponse
-    suspend fun loginWithDeviceAuth(deviceCode: String, signInSource: SignInSource): LoginResult
+    suspend fun loginWithDeviceAuth(deviceCode: String, signInSource: SignInSource, isNewAccount: Boolean = false): LoginResult
     suspend fun createUserWithEmailAndPassword(email: String, password: String, signInSource: SignInSource.UserInitiated): LoginResult
     suspend fun forgotPassword(email: String, onSuccess: () -> Unit, onError: (String) -> Unit)
     suspend fun getAccessToken(account: Account): AccessToken

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
@@ -227,6 +227,7 @@ class SyncManagerImpl @Inject constructor(
     override suspend fun loginWithDeviceAuth(
         deviceCode: String,
         signInSource: SignInSource,
+        isNewAccount: Boolean,
     ): LoginResult {
         return try {
             val response = syncServiceManager.deviceToken(deviceCode)
@@ -245,7 +246,7 @@ class SyncManagerImpl @Inject constructor(
             val result = AuthResultModel(
                 token = response.accessToken,
                 uuid = uuid,
-                isNewAccount = false,
+                isNewAccount = isNewAccount,
             )
             trackSignIn(LoginResult.Success(result), signInSource, LoginIdentity.QrCode)
             LoginResult.Success(result)

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImplTest.kt
@@ -11,8 +11,11 @@ import au.com.shiftyjelly.pocketcasts.servers.sync.SyncServiceManager
 import au.com.shiftyjelly.pocketcasts.servers.sync.login.DeviceTokenResponse
 import au.com.shiftyjelly.pocketcasts.servers.sync.login.LoginTokenResponse
 import com.automattic.eventhorizon.EventHorizon
+import com.automattic.eventhorizon.UserAccountCreatedEvent
+import com.automattic.eventhorizon.UserSignedInEvent
 import com.squareup.moshi.Moshi
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -46,13 +49,14 @@ class SyncManagerImplTest {
     private lateinit var notificationManager: NotificationManager
 
     private lateinit var syncManager: SyncManagerImpl
+    private val eventSink = TestEventSink()
 
     @Before
     fun setUp() {
         MockitoAnnotations.openMocks(this)
 
         syncManager = SyncManagerImpl(
-            eventHorizon = EventHorizon(TestEventSink()),
+            eventHorizon = EventHorizon(eventSink),
             context = context,
             settings = settings,
             syncAccountManager = syncAccountManager,
@@ -87,16 +91,18 @@ class SyncManagerImplTest {
     }
 
     @Test
-    fun `device auth login as new account updates sync feature interaction`() = runTest {
+    fun `device auth login as new account fires account created event`() = runTest {
         whenever(syncServiceManager.deviceToken(any(), any())).thenReturn(createDeviceTokenResponse())
         syncManager.loginWithDeviceAuth("device-code", SignInSource.UserInitiated.Onboarding, isNewAccount = true)
+        assertTrue(eventSink.pollEvent() is UserAccountCreatedEvent)
         verifyNotificationCalled()
     }
 
     @Test
-    fun `device auth login as existing account does not update sync feature interaction`() = runTest {
+    fun `device auth login as existing account fires signed in event`() = runTest {
         whenever(syncServiceManager.deviceToken(any(), any())).thenReturn(createDeviceTokenResponse())
         syncManager.loginWithDeviceAuth("device-code", SignInSource.UserInitiated.Onboarding, isNewAccount = false)
+        assertTrue(eventSink.pollEvent() is UserSignedInEvent)
         verifyNotificationNotCalled()
     }
 

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImplTest.kt
@@ -11,10 +11,14 @@ import au.com.shiftyjelly.pocketcasts.servers.sync.SyncServiceManager
 import au.com.shiftyjelly.pocketcasts.servers.sync.login.DeviceTokenResponse
 import au.com.shiftyjelly.pocketcasts.servers.sync.login.LoginTokenResponse
 import com.automattic.eventhorizon.EventHorizon
+import com.automattic.eventhorizon.LoginIdentityType
+import com.automattic.eventhorizon.OnboardingFlowType
+import com.automattic.eventhorizon.SignInSourceType
 import com.automattic.eventhorizon.UserAccountCreatedEvent
 import com.automattic.eventhorizon.UserSignedInEvent
 import com.squareup.moshi.Moshi
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -94,7 +98,16 @@ class SyncManagerImplTest {
     fun `device auth login as new account fires account created event`() = runTest {
         whenever(syncServiceManager.deviceToken(any(), any())).thenReturn(createDeviceTokenResponse())
         syncManager.loginWithDeviceAuth("device-code", SignInSource.UserInitiated.Onboarding, isNewAccount = true)
-        assertTrue(eventSink.pollEvent() is UserAccountCreatedEvent)
+        assertEquals(
+            UserAccountCreatedEvent(
+                source = LoginIdentityType.QrCode,
+                sourceInCode = SignInSourceType.Onboarding,
+                redirectPath = "none",
+                flow = OnboardingFlowType.Unknown,
+            ),
+            eventSink.pollEvent(),
+        )
+        assertTrue(eventSink.isEmpty())
         verifyNotificationCalled()
     }
 
@@ -102,7 +115,15 @@ class SyncManagerImplTest {
     fun `device auth login as existing account fires signed in event`() = runTest {
         whenever(syncServiceManager.deviceToken(any(), any())).thenReturn(createDeviceTokenResponse())
         syncManager.loginWithDeviceAuth("device-code", SignInSource.UserInitiated.Onboarding, isNewAccount = false)
-        assertTrue(eventSink.pollEvent() is UserSignedInEvent)
+        assertEquals(
+            UserSignedInEvent(
+                source = LoginIdentityType.QrCode,
+                sourceInCode = SignInSourceType.Onboarding,
+                redirectPath = "none",
+            ),
+            eventSink.pollEvent(),
+        )
+        assertTrue(eventSink.isEmpty())
         verifyNotificationNotCalled()
     }
 

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImplTest.kt
@@ -8,6 +8,7 @@ import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationManager
 import au.com.shiftyjelly.pocketcasts.repositories.notification.OnboardingNotificationType
 import au.com.shiftyjelly.pocketcasts.servers.sync.SyncServiceManager
+import au.com.shiftyjelly.pocketcasts.servers.sync.login.DeviceTokenResponse
 import au.com.shiftyjelly.pocketcasts.servers.sync.login.LoginTokenResponse
 import com.automattic.eventhorizon.EventHorizon
 import com.squareup.moshi.Moshi
@@ -84,6 +85,27 @@ class SyncManagerImplTest {
         syncManager.loginWithGoogle("google_token", SignInSource.UserInitiated.Onboarding)
         verifyNotificationNotCalled()
     }
+
+    @Test
+    fun `device auth login as new account updates sync feature interaction`() = runTest {
+        whenever(syncServiceManager.deviceToken(any(), any())).thenReturn(createDeviceTokenResponse())
+        syncManager.loginWithDeviceAuth("device-code", SignInSource.UserInitiated.Onboarding, isNewAccount = true)
+        verifyNotificationCalled()
+    }
+
+    @Test
+    fun `device auth login as existing account does not update sync feature interaction`() = runTest {
+        whenever(syncServiceManager.deviceToken(any(), any())).thenReturn(createDeviceTokenResponse())
+        syncManager.loginWithDeviceAuth("device-code", SignInSource.UserInitiated.Onboarding, isNewAccount = false)
+        verifyNotificationNotCalled()
+    }
+
+    private fun createDeviceTokenResponse() = DeviceTokenResponse(
+        accessToken = AccessToken("value"),
+        refreshToken = RefreshToken("value"),
+        email = "test@example.com",
+        uuid = "uuid",
+    )
 
     private fun createMockLoginResponse(isNew: Boolean): LoginTokenResponse {
         return LoginTokenResponse(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingNavHost.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingNavHost.kt
@@ -60,7 +60,7 @@ fun TvOnboardingNavHost(
                 }
                 composable(TvOnboardingRoutes.CREATE_ACCOUNT) {
                     TvCreateAccountScreen(
-                        onSignIn = { navController.navigate(TvOnboardingRoutes.SIGN_IN) },
+                        onCreateAccountComplete = { navigateClearingBackStack(TvOnboardingRoutes.SYNCING) },
                     )
                 }
                 composable(TvOnboardingRoutes.SIGN_IN) {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/createaccount/TvCreateAccountScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/createaccount/TvCreateAccountScreen.kt
@@ -197,6 +197,22 @@ private fun createAccountSteps(verificationUri: String): List<String> {
 
 @Preview(device = Devices.TV_1080p)
 @Composable
+private fun TvCreateAccountScreenLoadingPreview() {
+    TvTheme {
+        TvCreateAccountLoading()
+    }
+}
+
+@Preview(device = Devices.TV_1080p)
+@Composable
+private fun TvCreateAccountScreenErrorPreview() {
+    TvTheme {
+        TvCreateAccountError(onRetry = {})
+    }
+}
+
+@Preview(device = Devices.TV_1080p)
+@Composable
 private fun TvCreateAccountScreenContentPreview() {
     TvTheme {
         TvCreateAccountContent(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/createaccount/TvCreateAccountScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/createaccount/TvCreateAccountScreen.kt
@@ -2,22 +2,23 @@ package au.com.shiftyjelly.pocketcasts.onboarding.createaccount
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -25,12 +26,14 @@ import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.Button
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
-import au.com.shiftyjelly.pocketcasts.BuildConfig
 import au.com.shiftyjelly.pocketcasts.compose.CallOnce
-import au.com.shiftyjelly.pocketcasts.qr.rememberQrPainter
+import au.com.shiftyjelly.pocketcasts.onboarding.signin.TvSignInQrContent
+import au.com.shiftyjelly.pocketcasts.onboarding.signin.TvSignInUiState
+import au.com.shiftyjelly.pocketcasts.onboarding.signin.verificationDisplayUrl
 import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
 import au.com.shiftyjelly.pocketcasts.theme.TvTheme
 import au.com.shiftyjelly.pocketcasts.theme.tvColors
@@ -40,36 +43,48 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 fun TvCreateAccountScreen(
-    onSignIn: () -> Unit,
+    onCreateAccountComplete: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: TvCreateAccountViewModel = hiltViewModel(),
 ) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val currentOnComplete by rememberUpdatedState(onCreateAccountComplete)
+
     CallOnce { viewModel.trackShown() }
 
-    TvCreateAccountContent(
-        onSignIn = onSignIn,
-        modifier = modifier,
-    )
+    LaunchedEffect(uiState) {
+        if (uiState is TvSignInUiState.Complete) {
+            currentOnComplete()
+        }
+    }
+
+    when (val state = uiState) {
+        is TvSignInUiState.Loading, is TvSignInUiState.Complete -> TvCreateAccountLoading(modifier)
+
+        is TvSignInUiState.Ready -> TvCreateAccountContent(
+            userCode = state.userCode,
+            verificationUri = state.verificationUri,
+            verificationUriComplete = state.verificationUriComplete,
+            modifier = modifier,
+        )
+
+        is TvSignInUiState.Error -> TvCreateAccountError(onRetry = viewModel::retry, modifier = modifier)
+    }
 }
 
 @Composable
-private fun TvCreateAccountContent(
-    onSignIn: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
+private fun TvCreateAccountLoading(modifier: Modifier = Modifier) {
     val focusRequester = remember { FocusRequester() }
-    val createAccountUrl = remember { "https://${BuildConfig.WEB_BASE_HOST}/create" }
-    val qrPainter = rememberQrPainter(content = createAccountUrl, size = 118.dp)
 
     Box(
         contentAlignment = Alignment.Center,
         modifier = modifier
             .fillMaxSize()
-            .background(MaterialTheme.tvColors.backgroundSunken),
+            .background(MaterialTheme.tvColors.backgroundSunken)
+            .focusRequester(focusRequester)
+            .focusable(),
     ) {
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
             Image(
                 painter = painterResource(IR.drawable.ic_pocket_casts_logo),
                 contentDescription = null,
@@ -81,37 +96,46 @@ private fun TvCreateAccountContent(
                 color = MaterialTheme.tvColors.textPrimary,
                 style = MaterialTheme.tvTypography.title1.copy(textAlign = TextAlign.Center),
             )
-            Spacer(modifier = Modifier.height(8.dp))
-            Text(
-                text = stringResource(LR.string.tv_create_account_subtitle),
-                color = MaterialTheme.tvColors.textSecondary,
-                style = MaterialTheme.tvTypography.body.copy(textAlign = TextAlign.Center),
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+}
+
+@Composable
+private fun TvCreateAccountError(
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val focusRequester = remember { FocusRequester() }
+
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.tvColors.backgroundSunken),
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Image(
+                painter = painterResource(IR.drawable.ic_pocket_casts_logo),
+                contentDescription = null,
+                modifier = Modifier.size(36.dp),
             )
-            Spacer(modifier = Modifier.height(24.dp))
-            Box(
-                modifier = Modifier
-                    .background(Color.White, RoundedCornerShape(4.dp))
-                    .padding(4.dp),
-            ) {
-                Image(
-                    painter = qrPainter,
-                    contentDescription = stringResource(LR.string.tv_create_account_subtitle),
-                    modifier = Modifier.size(118.dp),
-                )
-            }
-            Spacer(modifier = Modifier.height(24.dp))
+            Spacer(modifier = Modifier.height(16.dp))
             Text(
-                text = stringResource(LR.string.tv_create_account_come_back),
+                text = stringResource(LR.string.error_generic_message),
                 color = MaterialTheme.tvColors.textSecondary,
                 style = MaterialTheme.tvTypography.body.copy(textAlign = TextAlign.Center),
             )
             Spacer(modifier = Modifier.height(24.dp))
             Button(
-                onClick = onSignIn,
-                colors = TvButtonDefaults.prominentButtonColors(),
+                onClick = onRetry,
+                colors = TvButtonDefaults.filledButtonColors(),
                 modifier = Modifier.focusRequester(focusRequester),
             ) {
-                Text(text = stringResource(LR.string.sign_in))
+                Text(text = stringResource(LR.string.retry))
             }
         }
     }
@@ -121,10 +145,64 @@ private fun TvCreateAccountContent(
     }
 }
 
+@Composable
+private fun TvCreateAccountContent(
+    userCode: List<String>,
+    verificationUri: String,
+    verificationUriComplete: String,
+    modifier: Modifier = Modifier,
+) {
+    val focusRequester = remember { FocusRequester() }
+    val steps = createAccountSteps(verificationUri)
+
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.tvColors.backgroundSunken)
+            .focusRequester(focusRequester)
+            .focusable(),
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(48.dp),
+        ) {
+            Text(
+                text = stringResource(LR.string.tv_create_account_title),
+                color = MaterialTheme.tvColors.textPrimary,
+                style = MaterialTheme.tvTypography.title1.copy(textAlign = TextAlign.Center),
+            )
+            TvSignInQrContent(
+                userCode = userCode,
+                verificationUriComplete = verificationUriComplete,
+                steps = steps,
+            )
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+}
+
+@Composable
+private fun createAccountSteps(verificationUri: String): List<String> {
+    val url = remember(verificationUri) { verificationDisplayUrl(verificationUri) }
+    return listOf(
+        stringResource(LR.string.tv_sign_in_step_scan, url),
+        stringResource(LR.string.tv_create_account_modal_step_create),
+        stringResource(LR.string.tv_sign_in_step_confirm_code),
+    )
+}
+
 @Preview(device = Devices.TV_1080p)
 @Composable
-private fun TvCreateAccountScreenPreview() {
+private fun TvCreateAccountScreenContentPreview() {
     TvTheme {
-        TvCreateAccountContent(onSignIn = {})
+        TvCreateAccountContent(
+            userCode = listOf("J", "M", "R", "3", "W", "2"),
+            verificationUri = "https://pocketcasts.com/pair",
+            verificationUriComplete = "https://pocketcasts.com/pair?code=JMR3W2",
+        )
     }
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/createaccount/TvCreateAccountViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/createaccount/TvCreateAccountViewModel.kt
@@ -1,18 +1,49 @@
 package au.com.shiftyjelly.pocketcasts.onboarding.createaccount
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.onboarding.signin.TvSignInUiState
+import au.com.shiftyjelly.pocketcasts.onboarding.signin.deviceAuthFlow
+import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import com.automattic.eventhorizon.CreateAccountShownEvent
 import com.automattic.eventhorizon.EventHorizon
 import com.automattic.eventhorizon.OnboardingFlowType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 
 @HiltViewModel
 class TvCreateAccountViewModel @Inject constructor(
+    private val syncManager: SyncManager,
     private val eventHorizon: EventHorizon,
 ) : ViewModel() {
 
+    private val _uiState = MutableStateFlow<TvSignInUiState>(TvSignInUiState.Loading)
+    val uiState: StateFlow<TvSignInUiState> = _uiState.asStateFlow()
+
+    private var pollingJob: Job? = null
+
+    init {
+        requestDeviceCode()
+    }
+
     fun trackShown() {
         eventHorizon.track(CreateAccountShownEvent(flow = OnboardingFlowType.InitialOnboarding))
+    }
+
+    private fun requestDeviceCode() {
+        pollingJob?.cancel()
+        _uiState.value = TvSignInUiState.Loading
+        pollingJob = viewModelScope.launch {
+            deviceAuthFlow(syncManager, isNewAccount = true).collect { _uiState.value = it }
+        }
+    }
+
+    fun retry() {
+        requestDeviceCode()
     }
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvDeviceAuth.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvDeviceAuth.kt
@@ -12,7 +12,7 @@ import timber.log.Timber
 private const val AUTHORIZATION_PENDING = "authorization_pending"
 private const val MIN_POLL_INTERVAL_SECONDS = 5L
 
-fun deviceAuthFlow(syncManager: SyncManager): Flow<TvSignInUiState> = flow {
+fun deviceAuthFlow(syncManager: SyncManager, isNewAccount: Boolean = false): Flow<TvSignInUiState> = flow {
     emit(TvSignInUiState.Loading)
     val response = try {
         syncManager.deviceAuthorize()
@@ -36,6 +36,7 @@ fun deviceAuthFlow(syncManager: SyncManager): Flow<TvSignInUiState> = flow {
         val result = syncManager.loginWithDeviceAuth(
             deviceCode = response.deviceCode,
             signInSource = SignInSource.UserInitiated.Onboarding,
+            isNewAccount = isNewAccount,
         )
         when {
             result is LoginResult.Success -> {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvDeviceAuth.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvDeviceAuth.kt
@@ -12,7 +12,7 @@ import timber.log.Timber
 private const val AUTHORIZATION_PENDING = "authorization_pending"
 private const val MIN_POLL_INTERVAL_SECONDS = 5L
 
-fun deviceAuthFlow(syncManager: SyncManager, isNewAccount: Boolean = false): Flow<TvSignInUiState> = flow {
+fun deviceAuthFlow(syncManager: SyncManager, isNewAccount: Boolean): Flow<TvSignInUiState> = flow {
     emit(TvSignInUiState.Loading)
     val response = try {
         syncManager.deviceAuthorize()

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInViewModel.kt
@@ -36,7 +36,7 @@ class TvSignInViewModel @Inject constructor(
         pollingJob?.cancel()
         _uiState.value = TvSignInUiState.Loading
         pollingJob = viewModelScope.launch {
-            deviceAuthFlow(syncManager).collect { _uiState.value = it }
+            deviceAuthFlow(syncManager, isNewAccount = false).collect { _uiState.value = it }
         }
     }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsViewModel.kt
@@ -100,7 +100,7 @@ class TvPodcastDetailsViewModel @AssistedInject constructor(
         accountAuthJob?.cancel()
         _accountAuthState.value = TvSignInUiState.Loading
         accountAuthJob = viewModelScope.launch {
-            deviceAuthFlow(syncManager, isNewAccount = true).collect { state ->
+            deviceAuthFlow(syncManager, isNewAccount = false).collect { state ->
                 _accountAuthState.value = state
                 if (state is TvSignInUiState.Complete) {
                     podcastManager.subscribeToPodcast(podcastUuid, sync = true)

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsViewModel.kt
@@ -100,7 +100,7 @@ class TvPodcastDetailsViewModel @AssistedInject constructor(
         accountAuthJob?.cancel()
         _accountAuthState.value = TvSignInUiState.Loading
         accountAuthJob = viewModelScope.launch {
-            deviceAuthFlow(syncManager).collect { state ->
+            deviceAuthFlow(syncManager, isNewAccount = true).collect { state ->
                 _accountAuthState.value = state
                 if (state is TvSignInUiState.Complete) {
                     podcastManager.subscribeToPodcast(podcastUuid, sync = true)

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/onboarding/TvCreateAccountViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/onboarding/TvCreateAccountViewModelTest.kt
@@ -1,22 +1,115 @@
 package au.com.shiftyjelly.pocketcasts.onboarding
 
+import app.cash.turbine.test
 import au.com.shiftyjelly.pocketcasts.onboarding.createaccount.TvCreateAccountViewModel
+import au.com.shiftyjelly.pocketcasts.onboarding.signin.TvSignInUiState
+import au.com.shiftyjelly.pocketcasts.preferences.AccessToken
+import au.com.shiftyjelly.pocketcasts.repositories.sync.LoginResult
+import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
+import au.com.shiftyjelly.pocketcasts.servers.model.AuthResultModel
+import au.com.shiftyjelly.pocketcasts.servers.sync.login.DeviceAuthorizeResponse
+import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import com.automattic.eventhorizon.CreateAccountShownEvent
 import com.automattic.eventhorizon.EventHorizon
 import com.automattic.eventhorizon.OnboardingFlowType
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
 import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class TvCreateAccountViewModelTest {
 
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
+
+    private val syncManager = mock<SyncManager>()
     private val eventHorizon = mock<EventHorizon>()
-    private val viewModel = TvCreateAccountViewModel(eventHorizon)
 
     @Test
-    fun `trackShown fires create account shown event`() {
-        viewModel.trackShown()
+    fun `trackShown fires create account shown event`() = runTest {
+        whenever(syncManager.deviceAuthorize()).thenThrow(RuntimeException("qr disabled"))
+
+        createViewModel().trackShown()
 
         verify(eventHorizon).track(CreateAccountShownEvent(flow = OnboardingFlowType.InitialOnboarding))
     }
+
+    @Test
+    fun `successful device authorize transitions to Ready state`() = runTest {
+        whenever(syncManager.deviceAuthorize()).thenReturn(createDeviceAuthorizeResponse())
+        whenever(syncManager.loginWithDeviceAuth(any(), any(), any())).thenReturn(createLoginSuccess())
+
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertTrue(state is TvSignInUiState.Ready || state is TvSignInUiState.Complete)
+            if (state is TvSignInUiState.Ready) {
+                assertEquals(listOf("A", "B", "C", "1", "2", "3"), state.userCode)
+            }
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `successful poll transitions to Complete state`() = runTest {
+        whenever(syncManager.deviceAuthorize()).thenReturn(createDeviceAuthorizeResponse())
+        whenever(syncManager.loginWithDeviceAuth(eq("device-code-123"), any(), any())).thenReturn(createLoginSuccess())
+
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val states = mutableListOf(awaitItem())
+            while (states.last() !is TvSignInUiState.Complete) {
+                states.add(awaitItem())
+            }
+            assertEquals(TvSignInUiState.Complete, states.last())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `create account polls device auth as a new account`() = runTest {
+        whenever(syncManager.deviceAuthorize()).thenReturn(createDeviceAuthorizeResponse())
+        whenever(syncManager.loginWithDeviceAuth(eq("device-code-123"), any(), any())).thenReturn(createLoginSuccess())
+
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            var state = awaitItem()
+            while (state !is TvSignInUiState.Complete) {
+                state = awaitItem()
+            }
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        verify(syncManager).loginWithDeviceAuth(eq("device-code-123"), any(), isNewAccount = eq(true))
+    }
+
+    private fun createViewModel() = TvCreateAccountViewModel(syncManager, eventHorizon)
+
+    private fun createDeviceAuthorizeResponse() = DeviceAuthorizeResponse(
+        deviceCode = "device-code-123",
+        userCode = "ABC123",
+        verificationUri = "https://pocketcasts.com/pair",
+        verificationUriComplete = "https://pocketcasts.com/pair?code=ABC123",
+        expiresIn = 1800,
+        interval = 1,
+    )
+
+    private fun createLoginSuccess() = LoginResult.Success(
+        AuthResultModel(
+            token = AccessToken("access-token"),
+            uuid = "user-uuid",
+            isNewAccount = true,
+        ),
+    )
 }

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/onboarding/TvCreateAccountViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/onboarding/TvCreateAccountViewModelTest.kt
@@ -15,7 +15,6 @@ import com.automattic.eventhorizon.OnboardingFlowType
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
@@ -45,16 +44,17 @@ class TvCreateAccountViewModelTest {
     @Test
     fun `successful device authorize transitions to Ready state`() = runTest {
         whenever(syncManager.deviceAuthorize()).thenReturn(createDeviceAuthorizeResponse())
-        whenever(syncManager.loginWithDeviceAuth(any(), any(), any())).thenReturn(createLoginSuccess())
+        whenever(syncManager.loginWithDeviceAuth(eq("device-code-123"), any(), any())).thenReturn(createLoginSuccess())
 
         val viewModel = createViewModel()
 
         viewModel.uiState.test {
-            val state = awaitItem()
-            assertTrue(state is TvSignInUiState.Ready || state is TvSignInUiState.Complete)
-            if (state is TvSignInUiState.Ready) {
-                assertEquals(listOf("A", "B", "C", "1", "2", "3"), state.userCode)
+            val states = mutableListOf(awaitItem())
+            while (states.last() !is TvSignInUiState.Complete) {
+                states.add(awaitItem())
             }
+            val ready = states.filterIsInstance<TvSignInUiState.Ready>().first()
+            assertEquals(listOf("A", "B", "C", "1", "2", "3"), ready.userCode)
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/onboarding/TvSignInViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/onboarding/TvSignInViewModelTest.kt
@@ -35,7 +35,7 @@ class TvSignInViewModelTest {
     @Test
     fun `trackShown fires sign in shown event`() = runTest {
         whenever(syncManager.deviceAuthorize()).thenReturn(createDeviceAuthorizeResponse())
-        whenever(syncManager.loginWithDeviceAuth(any(), any())).thenReturn(createLoginSuccess())
+        whenever(syncManager.loginWithDeviceAuth(any(), any(), any())).thenReturn(createLoginSuccess())
 
         val viewModel = createViewModel()
         viewModel.trackShown()
@@ -46,7 +46,7 @@ class TvSignInViewModelTest {
     @Test
     fun `successful device authorize transitions to Ready state`() = runTest {
         whenever(syncManager.deviceAuthorize()).thenReturn(createDeviceAuthorizeResponse())
-        whenever(syncManager.loginWithDeviceAuth(any(), any())).thenReturn(createLoginSuccess())
+        whenever(syncManager.loginWithDeviceAuth(any(), any(), any())).thenReturn(createLoginSuccess())
 
         val viewModel = createViewModel()
 
@@ -76,7 +76,7 @@ class TvSignInViewModelTest {
     @Test
     fun `successful poll transitions to Complete state`() = runTest {
         whenever(syncManager.deviceAuthorize()).thenReturn(createDeviceAuthorizeResponse())
-        whenever(syncManager.loginWithDeviceAuth(eq("device-code-123"), any())).thenReturn(createLoginSuccess())
+        whenever(syncManager.loginWithDeviceAuth(eq("device-code-123"), any(), any())).thenReturn(createLoginSuccess())
 
         val viewModel = createViewModel()
 
@@ -94,7 +94,7 @@ class TvSignInViewModelTest {
     @Test
     fun `authorization pending continues polling until success`() = runTest {
         whenever(syncManager.deviceAuthorize()).thenReturn(createDeviceAuthorizeResponse())
-        whenever(syncManager.loginWithDeviceAuth(eq("device-code-123"), any()))
+        whenever(syncManager.loginWithDeviceAuth(eq("device-code-123"), any(), any()))
             .thenReturn(createAuthorizationPending())
             .thenReturn(createAuthorizationPending())
             .thenReturn(createLoginSuccess())
@@ -115,7 +115,7 @@ class TvSignInViewModelTest {
     @Test
     fun `non-pending error stops polling`() = runTest {
         whenever(syncManager.deviceAuthorize()).thenReturn(createDeviceAuthorizeResponse())
-        whenever(syncManager.loginWithDeviceAuth(eq("device-code-123"), any()))
+        whenever(syncManager.loginWithDeviceAuth(eq("device-code-123"), any(), any()))
             .thenReturn(LoginResult.Failed(message = "Token expired", messageId = "expired_token"))
 
         val viewModel = createViewModel()
@@ -135,7 +135,7 @@ class TvSignInViewModelTest {
         whenever(syncManager.deviceAuthorize())
             .thenThrow(RuntimeException("Network error"))
             .thenReturn(createDeviceAuthorizeResponse())
-        whenever(syncManager.loginWithDeviceAuth(any(), any())).thenReturn(createLoginSuccess())
+        whenever(syncManager.loginWithDeviceAuth(any(), any(), any())).thenReturn(createLoginSuccess())
 
         val viewModel = createViewModel()
 

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsViewModelTest.kt
@@ -277,7 +277,7 @@ class TvPodcastDetailsViewModelTest {
     @Test
     fun `starting account auth drives the account state to complete`() = runTest {
         whenever(syncManager.deviceAuthorize()).thenReturn(deviceAuthorizeResponse())
-        whenever(syncManager.loginWithDeviceAuth(any(), any())).thenReturn(loginSuccess())
+        whenever(syncManager.loginWithDeviceAuth(any(), any(), any())).thenReturn(loginSuccess())
         val viewModel = createViewModel()
 
         viewModel.accountAuthState.test {


### PR DESCRIPTION
## Description

Brings the Android TV **Create Account** screen to iOS tvOS parity. Previously it was a degraded two-step flow: a static `/create` web QR, a "come back and sign in" message, and a **Sign in** button that dumped you into the separate device-auth screen. Now it runs the **device-auth pairing flow directly** (the same one the Sign In screen uses) and **auto-advances to Syncing** on success — one shot, no manual hand-off.

It also lands the deferred **`user_account_created`** analytics event (the last of the three events split out of #5773).

### How it works
- The create screen now runs `deviceAuthFlow(syncManager, isNewAccount = true)` and renders Loading / Ready (QR + steps + code digits) / Error / Complete, mirroring `TvSignInScreen`, with create-framed copy ("Create your free account" + "Create your account or log in"). On `Complete` it navigates to SYNCING.
- **Analytics:** `loginWithDeviceAuth` gained an explicit `isNewAccount: Boolean` (no default), plumbed into `AuthResultModel` (was hardcoded `false`; `DeviceTokenResponse` has no `isNew` field). The create screen passes `true`, so the existing `trackSignIn` fires `user_account_created (source = qr_code)` instead of `user_signed_in`. This is **screen-attributed**, exactly like iOS (both tvOS screens use the same pairing session and attribute the event by which screen you're on). `create_account_shown` still fires.
- The follow-podcast "Create your account or log in" modal (`TvPodcastDetailsViewModel`) passes `isNewAccount = false`. It's a mixed create/login surface — its own copy says "Create your account **or log in**", and existing users following a podcast are a normal path — so attributing every follow as a creation would inflate `user_account_created`. It emits `user_signed_in` instead, deliberately undercounting creations rather than inflating them.
- **`flow` on the created event:** `user_account_created` is emitted through `trackSignIn`, which hardcodes `flow = unknown` (platform-wide — password signup via `trackRegister` does the same). So although `create_account_shown` carries `flow = initial_onboarding`, the paired `user_account_created` lands with `flow = unknown`, and the two can't be joined on `flow`. Left as-is here to avoid changing shared mobile sign-in behavior.

### QR parity note
The create QR is the device-auth pairing URL (`pocketcasts.net/pair` on debug/staging, `.com` on release) — the **same** QR the Sign In screen shows. Verified against iOS: both `CreateAccountView` and `SignInView` encode `pairing.pairURLComplete` (the server's `verificationUriComplete`); the screens differ only in copy. The old distinct static `/create` QR was the non-parity bit removed here.

### Caveat (iOS-parity imprecision)
Because the server's device-token response carries no is-new-account signal, `user_account_created` is attributed by screen — a user who signs into an *existing* account from the dedicated create screen is still counted as a creation (iOS has the identical behavior). The follow-podcast modal, being a mixed create/login surface, deliberately attributes as sign-in instead. The paired Sync-onboarding-notification write is benign: that notification only schedules for signed-out users, so it's suppressed post-sign-in regardless.

## Stacking
#5773 (`feat/tv-onboarding-analytics`), which provided `create_account_shown` and the `qr_code` `LoginIdentity`, has now merged. This branch is rebased onto `main` and contains only the device-auth create-account commits.

## Testing Instructions
1. Signed out, on a **debug** build (staging): Welcome → **Create free account**.
2. You get "Create your free account" with a live QR, steps ("Scan… / Create your account or log in / confirm code"), and 6 user-code chips.
3. Scan the QR (or open `pocketcasts.net/pair` and enter the code) on your phone; **create a new account** (or log in) and confirm the code.
4. The TV auto-advances **Create account → Syncing → Home** — no "come back and sign in" step.
5. Error path (no network): "Something went wrong" + **Retry**.
6. Analytics: `create_account_shown` on appear; on success **`user_account_created (qr_code)`** (vs `user_signed_in (qr_code)` from the Sign In screen).

> Note: debug points at staging, so pair against `pocketcasts.net`; use a debugProd build for production (`pocketcasts.com`).

## Screenshots or Screencast
<!-- Drag this PNG into the box (CLI can't upload). Captured on the ATV emulator. -->
<!-- Create account (Ready): /private/tmp/claude-501/-Users-tszelezsan-work-repositories-pocket-casts-pocket-casts-android/1c1e1768-2bc9-445d-bd93-01b1cf672188/scratchpad/create_account_v1.png -->

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply`)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) the Event Horizon schema to reflect any new or changed analytics. (`user_account_created` / `create_account_shown` already exist in the schema; no new events added.)

#### I have tested any UI changes...
- [ ] with different themes (TV is single dark theme)
- [ ] with a landscape orientation (TV is landscape-only)
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
