### PR TITLE
[TV] Start playback on episode card taps

### DIFF
--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffoldViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffoldViewModel.kt
@@ -8,10 +8,12 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -33,13 +35,18 @@ class TvScaffoldViewModel @Inject constructor(
         .stateIn(viewModelScope, SharingStarted.Eagerly, false)
 
     init {
-        viewModelScope.launch {
-            hasCurrentEpisode.collect { hasEpisode ->
+        viewModelScope.launch { leaveNowPlayingWhenEpisodeCleared() }
+    }
+
+    @OptIn(FlowPreview::class)
+    private suspend fun leaveNowPlayingWhenEpisodeCleared() {
+        hasCurrentEpisode
+            .debounce(NOW_PLAYING_EMPTY_DEBOUNCE_MS)
+            .collect { hasEpisode ->
                 if (!hasEpisode && selectedTab.value == TvTab.NowPlaying) {
                     selectedTab.value = TvTab.Home
                 }
             }
-        }
     }
 
     val uiState: StateFlow<TvScaffoldUiState> = combine(
@@ -79,6 +86,8 @@ class TvScaffoldViewModel @Inject constructor(
         TvProfileState.SignedOut
     }
 }
+
+private const val NOW_PLAYING_EMPTY_DEBOUNCE_MS = 500L
 
 data class TvScaffoldUiState(
     val tabs: List<TvTab> = TvTab.entries,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffoldViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffoldViewModel.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -34,21 +35,6 @@ class TvScaffoldViewModel @Inject constructor(
         .map { state -> state is UpNextQueue.State.Loaded }
         .stateIn(viewModelScope, SharingStarted.Eagerly, false)
 
-    init {
-        viewModelScope.launch { leaveNowPlayingWhenEpisodeCleared() }
-    }
-
-    @OptIn(FlowPreview::class)
-    private suspend fun leaveNowPlayingWhenEpisodeCleared() {
-        hasCurrentEpisode
-            .debounce(NOW_PLAYING_EMPTY_DEBOUNCE_MS)
-            .collect { hasEpisode ->
-                if (!hasEpisode && selectedTab.value == TvTab.NowPlaying) {
-                    selectedTab.value = TvTab.Home
-                }
-            }
-    }
-
     val uiState: StateFlow<TvScaffoldUiState> = combine(
         selectedTab,
         hasCurrentEpisode,
@@ -66,6 +52,10 @@ class TvScaffoldViewModel @Inject constructor(
         initialValue = TvScaffoldUiState(profile = currentProfileState()),
     )
 
+    init {
+        viewModelScope.launch { leaveNowPlayingWhenEpisodeCleared() }
+    }
+
     fun selectTab(tab: TvTab) {
         selectedTab.value = tab
     }
@@ -76,6 +66,18 @@ class TvScaffoldViewModel @Inject constructor(
 
     fun signOut() {
         signOutManager.signOutAndWipeData()
+    }
+
+    @OptIn(FlowPreview::class)
+    private suspend fun leaveNowPlayingWhenEpisodeCleared() {
+        hasCurrentEpisode
+            .drop(1)
+            .debounce(NOW_PLAYING_EMPTY_DEBOUNCE_MS)
+            .collect { hasEpisode ->
+                if (!hasEpisode && selectedTab.value == TvTab.NowPlaying) {
+                    selectedTab.value = TvTab.Home
+                }
+            }
     }
 
     private fun currentProfileState() = profileState(syncManager.isLoggedIn(), syncManager.getEmail())

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
@@ -83,13 +83,13 @@ fun TvPlaylistDetailsScreen(
         key = playlistUuid,
         creationCallback = { factory -> factory.create(playlistUuid, playlistType) },
     ),
+    episodeActions: TvEpisodeActionsViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     var openedPodcastUuid by rememberSaveable { mutableStateOf<String?>(null) }
     var isReplaceUpNextConfirmationVisible by rememberSaveable { mutableStateOf(false) }
 
     val openNowPlaying = LocalOpenNowPlaying.current
-    val episodeActions = hiltViewModel<TvEpisodeActionsViewModel>()
     val toastHostState = LocalTvToastHostState.current
     val upNextName = stringResource(LR.string.up_next)
     val savedToast = stringResource(LR.string.up_next_as_playlist_saved)

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
@@ -43,6 +43,7 @@ import au.com.shiftyjelly.pocketcasts.component.LocalOpenNowPlaying
 import au.com.shiftyjelly.pocketcasts.component.LocalTvToastHostState
 import au.com.shiftyjelly.pocketcasts.component.TvArchivedFilterButton
 import au.com.shiftyjelly.pocketcasts.component.TvEpisodeActionContext
+import au.com.shiftyjelly.pocketcasts.component.TvEpisodeActions
 import au.com.shiftyjelly.pocketcasts.component.TvEpisodeActionsModal
 import au.com.shiftyjelly.pocketcasts.component.TvEpisodeActionsViewModel
 import au.com.shiftyjelly.pocketcasts.component.TvEpisodeInfoModal
@@ -83,7 +84,7 @@ fun TvPlaylistDetailsScreen(
         key = playlistUuid,
         creationCallback = { factory -> factory.create(playlistUuid, playlistType) },
     ),
-    episodeActions: TvEpisodeActionsViewModel = hiltViewModel(),
+    episodeActions: TvEpisodeActions = hiltViewModel<TvEpisodeActionsViewModel>(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     var openedPodcastUuid by rememberSaveable { mutableStateOf<String?>(null) }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
@@ -44,6 +44,7 @@ import au.com.shiftyjelly.pocketcasts.component.LocalTvToastHostState
 import au.com.shiftyjelly.pocketcasts.component.TvArchivedFilterButton
 import au.com.shiftyjelly.pocketcasts.component.TvEpisodeActionContext
 import au.com.shiftyjelly.pocketcasts.component.TvEpisodeActionsModal
+import au.com.shiftyjelly.pocketcasts.component.TvEpisodeActionsViewModel
 import au.com.shiftyjelly.pocketcasts.component.TvEpisodeInfoModal
 import au.com.shiftyjelly.pocketcasts.component.TvEpisodeListItem
 import au.com.shiftyjelly.pocketcasts.component.TvModal
@@ -88,6 +89,7 @@ fun TvPlaylistDetailsScreen(
     var isReplaceUpNextConfirmationVisible by rememberSaveable { mutableStateOf(false) }
 
     val openNowPlaying = LocalOpenNowPlaying.current
+    val episodeActions = hiltViewModel<TvEpisodeActionsViewModel>()
     val toastHostState = LocalTvToastHostState.current
     val upNextName = stringResource(LR.string.up_next)
     val savedToast = stringResource(LR.string.up_next_as_playlist_saved)
@@ -128,6 +130,10 @@ fun TvPlaylistDetailsScreen(
             onToggleArchiveFilter = viewModel::toggleArchiveFilter,
             onOpenPodcast = { openedPodcastUuid = it },
             onPlayAll = viewModel::playAll,
+            onPlayEpisode = { episode ->
+                episodeActions.play(episode, TvEpisodeActionContext.Playlist.source)
+                openNowPlaying()
+            },
             modifier = modifier,
         )
     }
@@ -158,6 +164,7 @@ private fun TvPlaylistDetailsContent(
     onToggleArchiveFilter: () -> Unit,
     onOpenPodcast: (String) -> Unit,
     onPlayAll: () -> Unit,
+    onPlayEpisode: (PodcastEpisode) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Box(modifier = modifier.fillMaxSize()) {
@@ -193,6 +200,7 @@ private fun TvPlaylistDetailsContent(
                             onSortTap = onSortTap,
                             onToggleArchiveFilter = onToggleArchiveFilter,
                             onOpenPodcast = onOpenPodcast,
+                            onPlayEpisode = onPlayEpisode,
                             playAllFocusRequester = playAllFocusRequester,
                             modifier = Modifier.weight(1f),
                         )
@@ -210,6 +218,7 @@ private fun SortableEpisodeList(
     onSortTap: () -> Unit,
     onToggleArchiveFilter: () -> Unit,
     onOpenPodcast: (String) -> Unit,
+    onPlayEpisode: (PodcastEpisode) -> Unit,
     playAllFocusRequester: FocusRequester,
     modifier: Modifier = Modifier,
 ) {
@@ -252,6 +261,7 @@ private fun SortableEpisodeList(
             EpisodeList(
                 episodes = uiState.episodes,
                 onOpenPodcast = onOpenPodcast,
+                onPlayEpisode = onPlayEpisode,
                 playAllFocusRequester = playAllFocusRequester,
                 listState = listState,
                 modifier = Modifier.weight(1f),
@@ -288,6 +298,7 @@ private fun AllEpisodesArchived(
 private fun EpisodeList(
     episodes: List<PodcastEpisode>,
     onOpenPodcast: (String) -> Unit,
+    onPlayEpisode: (PodcastEpisode) -> Unit,
     playAllFocusRequester: FocusRequester,
     listState: LazyListState,
     modifier: Modifier = Modifier,
@@ -309,7 +320,7 @@ private fun EpisodeList(
             TvEpisodeListItem(
                 episode = episode,
                 dateFormatter = dateFormatter,
-                onClick = {},
+                onClick = { onPlayEpisode(episode) },
                 onOpenActions = {
                     focus.watchForRemoval(episodes, index)
                     actionsEpisode = episode
@@ -508,6 +519,7 @@ private fun TvPlaylistDetailsPreview() {
             onToggleArchiveFilter = {},
             onOpenPodcast = {},
             onPlayAll = {},
+            onPlayEpisode = {},
         )
     }
 }
@@ -541,6 +553,7 @@ private fun TvPlaylistDetailsLoadedPreview() {
             onToggleArchiveFilter = {},
             onOpenPodcast = {},
             onPlayAll = {},
+            onPlayEpisode = {},
         )
     }
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
@@ -43,11 +43,13 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.Button
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.component.LocalOpenNowPlaying
 import au.com.shiftyjelly.pocketcasts.component.TvArchivedFilterButton
 import au.com.shiftyjelly.pocketcasts.component.TvArtworkImage
 import au.com.shiftyjelly.pocketcasts.component.TvEmptyState
 import au.com.shiftyjelly.pocketcasts.component.TvEpisodeActionContext
 import au.com.shiftyjelly.pocketcasts.component.TvEpisodeActionsModal
+import au.com.shiftyjelly.pocketcasts.component.TvEpisodeActionsViewModel
 import au.com.shiftyjelly.pocketcasts.component.TvEpisodeInfoModal
 import au.com.shiftyjelly.pocketcasts.component.TvEpisodeListItem
 import au.com.shiftyjelly.pocketcasts.component.TvPodcastInfoModal
@@ -83,6 +85,8 @@ fun TvPodcastDetailsScreen(
     ),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val openNowPlaying = LocalOpenNowPlaying.current
+    val episodeActions = hiltViewModel<TvEpisodeActionsViewModel>()
 
     LaunchedEffect(uiState, onClose) {
         if (uiState is TvPodcastDetailsUiState.NotFound) {
@@ -99,6 +103,10 @@ fun TvPodcastDetailsScreen(
         onRetryAccountAuth = viewModel::retryAccountAuth,
         onChangeSortType = viewModel::changeSortType,
         onToggleArchiveFilter = viewModel::toggleArchiveFilter,
+        onPlayEpisode = { episode ->
+            episodeActions.play(episode, TvEpisodeActionContext.PodcastDetails.source)
+            openNowPlaying()
+        },
         modifier = modifier,
     )
 }
@@ -113,6 +121,7 @@ private fun TvPodcastDetailsContent(
     onRetryAccountAuth: () -> Unit,
     onChangeSortType: (EpisodesSortType) -> Unit,
     onToggleArchiveFilter: () -> Unit,
+    onPlayEpisode: (PodcastEpisode) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Box(modifier = modifier.fillMaxSize()) {
@@ -158,6 +167,7 @@ private fun TvPodcastDetailsContent(
                             isShowingArchived = uiState.isShowingArchived,
                             onChangeSortType = onChangeSortType,
                             onToggleArchiveFilter = onToggleArchiveFilter,
+                            onPlayEpisode = onPlayEpisode,
                             leftFocusRequester = followFocusRequester,
                             modifier = Modifier.weight(1f - INFO_PANE_WEIGHT),
                         )
@@ -260,6 +270,7 @@ private fun EpisodeList(
     isShowingArchived: Boolean,
     onChangeSortType: (EpisodesSortType) -> Unit,
     onToggleArchiveFilter: () -> Unit,
+    onPlayEpisode: (PodcastEpisode) -> Unit,
     leftFocusRequester: FocusRequester,
     modifier: Modifier = Modifier,
 ) {
@@ -316,7 +327,7 @@ private fun EpisodeList(
                     TvEpisodeListItem(
                         episode = episode,
                         dateFormatter = dateFormatter,
-                        onClick = {},
+                        onClick = { onPlayEpisode(episode) },
                         onOpenActions = {
                             focus.watchForRemoval(episodes, index)
                             actionsEpisode = episode
@@ -430,6 +441,7 @@ private fun TvPodcastDetailsContentPreview(
             onRetryAccountAuth = {},
             onChangeSortType = {},
             onToggleArchiveFilter = {},
+            onPlayEpisode = {},
         )
     }
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
@@ -83,10 +83,10 @@ fun TvPodcastDetailsScreen(
         key = podcastUuid,
         creationCallback = { factory -> factory.create(podcastUuid) },
     ),
+    episodeActions: TvEpisodeActionsViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val openNowPlaying = LocalOpenNowPlaying.current
-    val episodeActions = hiltViewModel<TvEpisodeActionsViewModel>()
 
     LaunchedEffect(uiState, onClose) {
         if (uiState is TvPodcastDetailsUiState.NotFound) {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
@@ -48,6 +48,7 @@ import au.com.shiftyjelly.pocketcasts.component.TvArchivedFilterButton
 import au.com.shiftyjelly.pocketcasts.component.TvArtworkImage
 import au.com.shiftyjelly.pocketcasts.component.TvEmptyState
 import au.com.shiftyjelly.pocketcasts.component.TvEpisodeActionContext
+import au.com.shiftyjelly.pocketcasts.component.TvEpisodeActions
 import au.com.shiftyjelly.pocketcasts.component.TvEpisodeActionsModal
 import au.com.shiftyjelly.pocketcasts.component.TvEpisodeActionsViewModel
 import au.com.shiftyjelly.pocketcasts.component.TvEpisodeInfoModal
@@ -83,7 +84,7 @@ fun TvPodcastDetailsScreen(
         key = podcastUuid,
         creationCallback = { factory -> factory.create(podcastUuid) },
     ),
-    episodeActions: TvEpisodeActionsViewModel = hiltViewModel(),
+    episodeActions: TvEpisodeActions = hiltViewModel<TvEpisodeActionsViewModel>(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val openNowPlaying = LocalOpenNowPlaying.current

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/TvScaffoldViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/TvScaffoldViewModelTest.kt
@@ -154,10 +154,27 @@ class TvScaffoldViewModelTest {
             assertEquals(TvTab.NowPlaying, awaitItem().selectedTab)
 
             queueChanges.onNext(UpNextQueue.State.Empty)
+            coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
 
             val state = expectMostRecentItem()
             assertEquals(TvTab.Home, state.selectedTab)
             assertEquals(TvTab.entries, state.tabs)
+        }
+    }
+
+    @Test
+    fun `stays on now playing when the queue empties only transiently while switching episodes`() = runTest {
+        queueChanges.onNext(loadedQueue)
+
+        viewModel.uiState.test {
+            assertEquals(TvTab.Home, awaitItem().selectedTab)
+
+            viewModel.selectTab(TvTab.NowPlaying)
+            queueChanges.onNext(UpNextQueue.State.Empty)
+            queueChanges.onNext(loadedQueue)
+            coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+            assertEquals(TvTab.NowPlaying, expectMostRecentItem().selectedTab)
         }
     }
 

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/TvScaffoldViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/TvScaffoldViewModelTest.kt
@@ -179,6 +179,20 @@ class TvScaffoldViewModelTest {
     }
 
     @Test
+    fun `keeps now playing selected when the queue reports later than the debounce window`() = runTest {
+        viewModel.uiState.test {
+            assertEquals(TvTab.Home, awaitItem().selectedTab)
+
+            viewModel.openNowPlaying()
+            coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+            queueChanges.onNext(loadedQueue)
+            coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+            assertEquals(TvTab.NowPlaying, expectMostRecentItem().selectedTab)
+        }
+    }
+
+    @Test
     fun `profile is signed out without an account`() = runTest {
         viewModel.uiState.test {
             assertEquals(TvProfileState.SignedOut, awaitItem().profile)


### PR DESCRIPTION
## Description

On Android TV, episode rows (`TvEpisodeListItem`) forward `onClick` to the underlying TV `Card`, which fires on the remote's DPAD-center / SELECT (ENTER). The **Podcast Details** and **Playlist Details** screens passed `onClick = {}`, so highlighting an episode and pressing SELECT did nothing — the only way to start playback was to DPAD-right to the ellipsis "More" button and choose *Play* from the actions modal.

This wires SELECT on a row to start playback of that episode and open the Now Playing screen, matching what the **Up Next** and **Search** screens already do on Android TV, and matching the tvOS app (where SELECT on a row calls `model.play()` and presents the full-screen player).

Implementation reuses the existing shared `TvEpisodeActionsViewModel` (`play(episode, source)`) — the exact same path the actions modal's *Play* button uses — plus `LocalOpenNowPlaying`. The action is resolved at the screen-level composable (as a `hiltViewModel()` default parameter) and threaded down as an `onPlayEpisode` lambda so the `@Preview`-rendered list composables never touch Hilt. The analytics `SourceView` per screen is unchanged (`PODCAST_SCREEN` / `FILTERS`), matching each screen's actions modal.

The ellipsis "More" button behaviour is unchanged — it still opens the full actions modal (Play, Play Next, Details, Mark as Played, Archive, …).

Fixes PCDROID-733 https://linear.app/a8c/issue/PCDROID-733/start-playback-on-episode-row-enter

## Testing Instructions

1. On an Android TV device/emulator, open a **Podcast** (from Home or Your Podcasts), move focus onto an episode row, and press **SELECT / center** → playback starts and the **Now Playing** screen opens (it does not jump to Home).
2. Repeat on a **Playlist/Filter** detail screen.
3. Confirm the ellipsis **More** button (DPAD-right on a focused row) still opens the actions modal.
4. Confirm **Up Next** and **Search** episode rows still play on SELECT (unchanged).

Device-verified on an Android TV emulator: SELECT on both Podcast Details and Playlist Details rows starts playback and lands on Now Playing.

## Screenshots or Screencast

https://github.com/user-attachments/assets/732478c8-31f3-4015-b96c-a116b0f28060



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md <!-- Android TV app; not covered by the mobile CHANGELOG -->
- [x] Ensure the linter passes (`./gradlew spotlessApply`)
- [x] I have considered whether it makes sense to add tests for my changes <!-- added TvScaffoldViewModelTest coverage for the transient-empty guard; playback path exercised by TvEpisodeActionsViewModelTest -->
- [x] All strings that need to be localized are in `modules/services/localization/...` <!-- no new strings -->
- [x] Any jetpack compose components I added or changed are covered by compose previews <!-- existing previews retained/updated -->
- [x] I have updated (or requested that someone edit) the Event Horizon schema to reflect any new or changed analytics. <!-- no new/changed analytics; reuses existing sources -->

