### PR TITLE
[TV] Align onboarding copies with Apple TV

### DIFF
--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -272,7 +272,8 @@
     <string name="tv_sign_in_title">Log in to Pocket Casts</string>
     <string name="tv_sign_in_step_scan">Scan the QR code or go to %1$s</string>
     <string name="tv_sign_in_step_login">Log in to your account</string>
-    <string name="tv_sign_in_step_confirm_code">If asked, confirm with the code below</string>
+    <string name="tv_sign_in_step_confirm_code">If asked, confirm the code below</string>
+    <string name="tv_sign_in_qr_error">Couldn\'t get your log in code</string>
     <string name="tv_account_signed_out_alert_title">You\'ve been logged out</string>
     <string name="tv_account_signed_out_alert_message">There was a problem and you\'ve been logged out.\nSelect the button below to log in to your Pocket Casts account again.</string>
     <string name="tv_create_account_modal_title">Your podcasts deserve a home</string>
@@ -2926,14 +2927,14 @@
     <!-- TV Onboarding -->
     <string name="tv_onboarding_welcome">Welcome to Pocket Casts</string>
     <string name="tv_onboarding_welcome_tv">Welcome to Pocket Casts TV</string>
-    <string name="tv_onboarding_subtitle">Your podcasts, on the big screen</string>
+    <string name="tv_onboarding_subtitle">Your podcasts. On the big screen. Obviously.</string>
     <string name="tv_onboarding_create_free_account">Create free account</string>
     <string name="tv_onboarding_browse_without_account">Browse without an account</string>
     <string name="tv_onboarding_sign_in_title">Sign in with your phone</string>
     <string name="tv_onboarding_sign_in_instructions">Open the camera and point to this QR code</string>
     <string name="tv_onboarding_syncing">Syncing your podcasts\u2026</string>
-    <string name="tv_onboarding_welcome_back">Welcome back!</string>
-    <string name="tv_onboarding_syncing_subtitle">Your podcasts are syncing, we\'ll sign you in soon!</string>
+    <string name="tv_onboarding_welcome_back">Good to see you</string>
+    <string name="tv_onboarding_syncing_subtitle">Loading your podcasts now.</string>
     <string name="tv_create_account_title">Create your free account</string>
     <string name="tv_create_account_subtitle">Scan this code to get started on your phone, it only takes a minute.</string>
     <string name="tv_create_account_come_back">Once you\'ve created your account, come back and sign in</string>

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/createaccount/TvCreateAccountModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/createaccount/TvCreateAccountModal.kt
@@ -1,14 +1,11 @@
 package au.com.shiftyjelly.pocketcasts.onboarding.createaccount
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
@@ -16,23 +13,19 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.tv.material3.Button
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.component.TvModal
 import au.com.shiftyjelly.pocketcasts.compose.loading.LoadingView
+import au.com.shiftyjelly.pocketcasts.onboarding.signin.TvSignInErrorContent
 import au.com.shiftyjelly.pocketcasts.onboarding.signin.TvSignInQrContent
 import au.com.shiftyjelly.pocketcasts.onboarding.signin.TvSignInUiState
 import au.com.shiftyjelly.pocketcasts.onboarding.signin.verificationDisplayUrl
-import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
 import au.com.shiftyjelly.pocketcasts.theme.tvColors
 import au.com.shiftyjelly.pocketcasts.theme.tvTypography
-import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
@@ -112,7 +105,7 @@ private fun LoadingContent(modifier: Modifier = Modifier) {
         contentAlignment = Alignment.Center,
         modifier = modifier
             .fillMaxWidth()
-            .height(LoadingHeight)
+            .height(ContentHeight)
             .focusRequester(focusRequester)
             .focusable(),
     ) {
@@ -129,40 +122,13 @@ private fun ErrorContent(
     onRetry: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val focusRequester = remember { FocusRequester() }
-    Column(
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center,
+    TvSignInErrorContent(
+        onRetry = onRetry,
         modifier = modifier
             .fillMaxWidth()
-            .height(LoadingHeight),
-    ) {
-        Image(
-            painter = painterResource(IR.drawable.ic_waitingforwifi),
-            contentDescription = null,
-            colorFilter = ColorFilter.tint(MaterialTheme.tvColors.textSecondary),
-            modifier = Modifier.size(48.dp),
-        )
-        Spacer(modifier = Modifier.height(16.dp))
-        Text(
-            text = stringResource(LR.string.tv_sign_in_qr_error),
-            color = MaterialTheme.tvColors.textPrimary,
-            style = MaterialTheme.tvTypography.body.copy(textAlign = TextAlign.Center),
-        )
-        Spacer(modifier = Modifier.height(24.dp))
-        Button(
-            onClick = onRetry,
-            colors = TvButtonDefaults.filledButtonColors(),
-            modifier = Modifier.focusRequester(focusRequester),
-        ) {
-            Text(text = stringResource(LR.string.try_again))
-        }
-    }
-
-    LaunchedEffect(Unit) {
-        focusRequester.requestFocus()
-    }
+            .height(ContentHeight),
+    )
 }
 
 private val ModalWidth = 760.dp
-private val LoadingHeight = 220.dp
+private val ContentHeight = 220.dp

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/createaccount/TvCreateAccountModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/createaccount/TvCreateAccountModal.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.onboarding.createaccount
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -7,6 +8,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
@@ -14,6 +16,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -28,6 +32,7 @@ import au.com.shiftyjelly.pocketcasts.onboarding.signin.verificationDisplayUrl
 import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
 import au.com.shiftyjelly.pocketcasts.theme.tvColors
 import au.com.shiftyjelly.pocketcasts.theme.tvTypography
+import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
@@ -132,9 +137,16 @@ private fun ErrorContent(
             .fillMaxWidth()
             .height(LoadingHeight),
     ) {
+        Image(
+            painter = painterResource(IR.drawable.ic_waitingforwifi),
+            contentDescription = null,
+            colorFilter = ColorFilter.tint(MaterialTheme.tvColors.textSecondary),
+            modifier = Modifier.size(48.dp),
+        )
+        Spacer(modifier = Modifier.height(16.dp))
         Text(
-            text = stringResource(LR.string.error_generic_message),
-            color = MaterialTheme.tvColors.textSecondary,
+            text = stringResource(LR.string.tv_sign_in_qr_error),
+            color = MaterialTheme.tvColors.textPrimary,
             style = MaterialTheme.tvTypography.body.copy(textAlign = TextAlign.Center),
         )
         Spacer(modifier = Modifier.height(24.dp))
@@ -143,7 +155,7 @@ private fun ErrorContent(
             colors = TvButtonDefaults.filledButtonColors(),
             modifier = Modifier.focusRequester(focusRequester),
         ) {
-            Text(text = stringResource(LR.string.retry))
+            Text(text = stringResource(LR.string.try_again))
         }
     }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -118,14 +119,15 @@ private fun TvSignInError(
     ) {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
             Image(
-                painter = painterResource(IR.drawable.ic_pocket_casts_logo),
+                painter = painterResource(IR.drawable.ic_waitingforwifi),
                 contentDescription = null,
-                modifier = Modifier.size(36.dp),
+                colorFilter = ColorFilter.tint(MaterialTheme.tvColors.textSecondary),
+                modifier = Modifier.size(48.dp),
             )
             Spacer(modifier = Modifier.height(16.dp))
             Text(
-                text = stringResource(LR.string.error_generic_message),
-                color = MaterialTheme.tvColors.textSecondary,
+                text = stringResource(LR.string.tv_sign_in_qr_error),
+                color = MaterialTheme.tvColors.textPrimary,
                 style = MaterialTheme.tvTypography.body.copy(textAlign = TextAlign.Center),
             )
             Spacer(modifier = Modifier.height(24.dp))
@@ -134,7 +136,7 @@ private fun TvSignInError(
                 colors = TvButtonDefaults.filledButtonColors(),
                 modifier = Modifier.focusRequester(focusRequester),
             ) {
-                Text(text = stringResource(LR.string.retry))
+                Text(text = stringResource(LR.string.try_again))
             }
         }
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInScreen.kt
@@ -109,35 +109,47 @@ private fun TvSignInError(
     onRetry: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val focusRequester = remember { FocusRequester() }
-
     Box(
         contentAlignment = Alignment.Center,
         modifier = modifier
             .fillMaxSize()
             .background(MaterialTheme.tvColors.backgroundSunken),
     ) {
-        Column(horizontalAlignment = Alignment.CenterHorizontally) {
-            Image(
-                painter = painterResource(IR.drawable.ic_waitingforwifi),
-                contentDescription = null,
-                colorFilter = ColorFilter.tint(MaterialTheme.tvColors.textSecondary),
-                modifier = Modifier.size(48.dp),
-            )
-            Spacer(modifier = Modifier.height(16.dp))
-            Text(
-                text = stringResource(LR.string.tv_sign_in_qr_error),
-                color = MaterialTheme.tvColors.textPrimary,
-                style = MaterialTheme.tvTypography.body.copy(textAlign = TextAlign.Center),
-            )
-            Spacer(modifier = Modifier.height(24.dp))
-            Button(
-                onClick = onRetry,
-                colors = TvButtonDefaults.filledButtonColors(),
-                modifier = Modifier.focusRequester(focusRequester),
-            ) {
-                Text(text = stringResource(LR.string.try_again))
-            }
+        TvSignInErrorContent(onRetry = onRetry)
+    }
+}
+
+@Composable
+internal fun TvSignInErrorContent(
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val focusRequester = remember { FocusRequester() }
+
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+        modifier = modifier,
+    ) {
+        Image(
+            painter = painterResource(IR.drawable.ic_waitingforwifi),
+            contentDescription = null,
+            colorFilter = ColorFilter.tint(MaterialTheme.tvColors.textSecondary),
+            modifier = Modifier.size(48.dp),
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = stringResource(LR.string.tv_sign_in_qr_error),
+            color = MaterialTheme.tvColors.textPrimary,
+            style = MaterialTheme.tvTypography.body.copy(textAlign = TextAlign.Center),
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+        Button(
+            onClick = onRetry,
+            colors = TvButtonDefaults.filledButtonColors(),
+            modifier = Modifier.focusRequester(focusRequester),
+        ) {
+            Text(text = stringResource(LR.string.try_again))
         }
     }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/welcome/TvWelcomeScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/welcome/TvWelcomeScreen.kt
@@ -132,7 +132,7 @@ private fun TvWelcomeContent(
                     colors = TvButtonDefaults.filledButtonColors(),
                     modifier = Modifier.focusRequester(focusRequester),
                 ) {
-                    Text(text = stringResource(LR.string.sign_in))
+                    Text(text = stringResource(LR.string.log_in))
                 }
                 Button(
                     onClick = onCreateAccount,


### PR DESCRIPTION
## Description

Aligns the Android TV onboarding copy with the Apple TV app, which is the source of truth (`Pocket Casts TV App` in the iOS repo). Discovery compared each Android onboarding screen string against the resolved `L10n` values in the tvOS views (`WelcomeView`, `SignInView`, `CreateAccountView`, `SigningInView`).

Changes:
- **Welcome** subtitle → "Your podcasts. On the big screen. Obviously.", and login button "Sign in" → "Log in" (matches `tvWelcomeLogIn`).
- **Sign in** — QR error now shows the wifi icon + "Couldn't get your log in code" (matches `tvLogInQrCodeErrorTitle`), step copy "confirm with the code below" → "confirm the code below", and retry button "Retry" → "Try again" (matches `tryAgain`).
- **Create account** — error state now mirrors the sign-in error (wifi icon + "Couldn't get your log in code" + "Try again") instead of the generic "Something went wrong" message.
- **Syncing** — "Welcome back!" → "Good to see you" (matches `tvSigningInTitleNew`) and subtitle → "Loading your podcasts now."

Two Android-only strings with no tvOS parity were intentionally left as-is (sign-in loading title "Sign in with your phone", and the create-account full-screen subtitle/"come back and sign in") — changing those would be a layout change, not a copy swap.

Fixes #

## Testing Instructions

1. Launch the TV app **signed out** → the Welcome screen shows the subtitle "Your podcasts. On the big screen. Obviously." and a **Log in** button (previously "Sign in").
2. Choose **Log in** → the QR sign-in screen; confirm the step reads "If asked, confirm the code below".
3. Force the pairing request to fail (e.g. no network) on the sign-in screen → error shows a wifi icon, "Couldn't get your log in code", and a **Try again** button.
4. Open **Create free account** and force the pairing request to fail → same wifi-icon error + "Try again" (previously a generic "Something went wrong" message with no icon).
5. Complete a sign-in → the Syncing screen reads "Good to see you" / "Loading your podcasts now."

## Screenshots or Screencast

_Not included — the changed states (signed-out Welcome, plus two network-failure error states) aren't reliably reproducible on the connected device. Copy verified against the tvOS source._

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md <!-- TV onboarding copy tweak; not tracked in the phone CHANGELOG -->
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes <!-- copy-only, no logic changed -->
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews <!-- existing sign-in previews cover the loading/content states -->
- [x] I have updated (or requested that someone edit) the Event Horizon schema to reflect any new or changed analytics. <!-- no analytics changes -->
