### PR TITLE
Improve the Claude code review workflow

### DIFF
--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -23,7 +23,11 @@ Commits on this branch:
 2. Read the diff with `git diff main...HEAD` to understand all changes.
 3. Create the PR using `gh pr create --draft --base main` using the
 template below. Fill in every section:
-- **Description**: Summarize what changed and why (not just *what* files changed).
+- **Description**: Start with a one-sentence plain-language summary of what the change
+does, written for someone who has not seen the code: no file names, class names, or
+API names. Then, in following paragraphs, explain why the change was needed and how it
+works (not just *what* files changed). Keep the whole description proportionate to the
+size of the change: a small change needs little more than the opening sentence.
 - **Fixes**: Link the Linear/GitHub issue. If unknown, ask the user.
 - **Testing Instructions**: Concrete numbered steps someone can follow to verify.
 - **Screenshots**: Note whether screenshots are applicable. If UI changed, ask the user to add them.
@@ -40,6 +44,22 @@ template below. Fill in every section:
 5. Add an `[Area]` label that matches the changes. Run `gh label list --search "[Area]"` to find the best match, then apply with `gh pr edit --add-label`.
 6. Set the milestone to the current one (not past its due date). Run `gh api repos/Automattic/pocket-casts-android/milestones --jq '[.[] | select(.due_on) | select((.due_on | fromdateiso8601) >= now)] | sort_by(.due_on) | .[0].title'` to find it, then apply with `gh pr edit --milestone`.
 7. After creating the PR, output the PR URL.
+
+## Description Examples
+
+Too much detail up front, the reader has to decode the code to learn what changed:
+
+> On Android TV, episode rows (`TvEpisodeListItem`) forward `onClick` to the underlying
+> TV `Card`, which fires on the remote's DPAD-center / SELECT (ENTER). The Podcast
+> Details and Playlist Details screens passed `onClick = {}`, so ...
+
+Same PR, opening with the plain-language sentence first:
+
+> On Android TV, pressing SELECT on an episode in a podcast or playlist now plays it and
+> opens the Now Playing screen, instead of doing nothing.
+>
+> Episode rows (`TvEpisodeListItem`) forward `onClick` to the underlying TV `Card`, but
+> the Podcast Details and Playlist Details screens passed `onClick = {}`, so ...
 
 ## PR Template
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Checkout repository
         if: steps.workflow-changes.outputs.skip != 'true'
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
           persist-credentials: false
@@ -62,13 +62,56 @@ jobs:
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            Please review this pull request with a focus on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Security implications
-            - Performance considerations
+            Read AGENTS.md first - it carries this repo's conventions.
 
-            Provide detailed feedback using inline comments for specific issues.
+            Priorities, in order:
+            1. Correctness - bugs reachable from real user flows: wrong logic,
+               unhandled states, races and threading violations, object lifetime
+               and retain issues, leaks.
+            2. Unintended behaviour change - anything the diff changes that the
+               description does not claim to change.
+            3. Security and privacy - untrusted input reaching queries, parsers or
+               the filesystem; secrets or user data in logs.
+            4. Performance - only where the impact is user-visible.
+
+            Comments:
+            - Keep comments short by default - a few sentences stating the problem
+              and the fix, not the reasoning that led you there. Spend more words
+              only where the finding needs them to be actionable: a subtle race, a
+              non-obvious call path, a concrete repro.
+            - Start a comment with "(nit)" for a trivial suggestion, and
+              "(non-blocking)" for something worth knowing that should not hold up
+              the merge. An unprefixed comment means it blocks.
+            - At most three "(nit)"/"(non-blocking)" comments between them. Blocking
+              findings are uncapped.
+            - Raise a pre-existing issue only if this PR makes it reachable, more
+              likely, or harder to fix later - and say which.
+            - Never comment to confirm code is correct, restate the diff, or praise it.
+            - Never describe a command you did not run or a file you did not read.
+
+            Do not comment on what other CI already checks: formatting and lint, PR
+            hygiene (labels, milestone, description, CHANGELOG presence), or whether
+            tests pass.
+
+            Output:
+            - Inline comments for anything anchored to a line.
+            - One summary comment:
+              - Two to four sentences of verdict. No preamble, no restating the PR.
+              - Then the findings grouped under `### Blocking`, `### Non-blocking`,
+                `### Nits`. Skip a group that is empty; skip the section entirely if
+                there are no findings, leaving the verdict as the whole summary.
+              - One line per finding: `path/File.swift:123` followed by a single
+                sentence naming the problem and the fix - enough to act on without
+                opening the thread. Add the inline comment's URL when you have one.
+              - A finding with no line to anchor to takes the same shape with just
+                the path, or no path when it is repo-wide.
+            - No tables, no re-analysis, no checklist of what you read, no praise.
+
+            If new commits arrived since your last review on this PR:
+            - Review only what changed since then.
+            - Re-raise an earlier finding only if it is still open - one line, linking
+              the existing thread rather than restating it.
+            - If nothing new and nothing open, say so in one sentence and stop.
 
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## Description

Automated pull request reviews now produce short, prioritised, actionable feedback instead of long general-purpose commentary, and the PR-creation helper asks for a plain-language opening sentence in every description.

The review prompt previously asked for "detailed feedback" across four broad areas, which produced verbose reviews that restated the diff, praised code, duplicated what other CI checks already report (formatting, lint, PR hygiene), and buried the real problems. The new prompt replaces that with an explicit priority order (correctness, unintended behaviour change, security/privacy, then user-visible performance), rules on comment length and tone, a `(nit)` / `(non-blocking)` prefix convention with a cap of three such comments so blocking findings stand out, a fixed shape for the summary comment, and instructions to only re-review what changed when new commits arrive. It also points the reviewer at `AGENTS.md` so it applies this repo's conventions.

The `create-pr` skill change asks for a one-sentence, jargon-free summary at the top of the description (no file, class or API names) followed by the why and how, with two worked examples showing the difference.

Also bumps the pinned `actions/checkout` SHA to v7.0.1.

Fixes # N/A

## Testing Instructions

1. Open a pull request against `main` that contains a deliberate bug (for example an off-by-one or an unhandled null) in a Kotlin file.
2. Wait for the `claude-code-review` workflow to run and confirm it succeeds in the Actions tab.
3. Check the review it posts:
   - Inline comments are short and anchored to the relevant lines.
   - There is a single summary comment starting with a two-to-four-sentence verdict, followed by findings grouped under `### Blocking` / `### Non-blocking` / `### Nits` (empty groups omitted).
   - No comments about formatting, lint, labels, milestone, CHANGELOG, or whether tests pass.
   - No praise or restatement of the diff.
4. Push another commit to the same PR and confirm the follow-up review only covers what changed since the previous review.
5. Run `/create-pr` on a branch and confirm the generated description opens with a plain-language sentence containing no file or class names.

## Screenshots or Screencast

Not applicable, no UI changes.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
