### PR TITLE
[TV] Don't focus the search field when entering the Search tab

### DIFF
--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
@@ -290,10 +290,6 @@ private fun TvSearchContent(
     var isEditing by remember { mutableStateOf(false) }
     var suggestionsFocused by remember { mutableStateOf(false) }
     val showSuggestions = (isEditing || suggestionsFocused) && suggestions.isNotEmpty()
-    LaunchedEffect(Unit) {
-        withFrameNanos {}
-        runCatching { searchFieldFocusRequester.requestFocus() }
-    }
     Column(modifier = modifier.fillMaxSize()) {
         Column(modifier = Modifier.padding(ContentPadding)) {
             Spacer(modifier = Modifier.height(40.dp))


### PR DESCRIPTION
## Description

Navigating to the Search tab jumped straight to the search input box. The behaviour now matches Apple TV, so you can navigate left and right in the tab bar without the focus changing to the page.

Entering the tab previously ran a one-shot effect that focused the search field as soon as the first frame was drawn. On a remote-driven UI this is the wrong default: it puts the screen into text-entry mode before the user has asked for it, and the discover content underneath (which is what most people are there to browse) starts out unfocused and one extra DPAD press away. Apple TV's Search screen behaves the same way as this change.

## Testing Instructions

1. Install the TV app on an Android TV device or emulator.
2. From Home, navigate to the **Search** tab.
3. Verify the search field is **not** focused and the on-screen keyboard does not appear.
4. Navigate to the search input box and check you can still search

## Screenshots or Screencast

**Android TV**

https://github.com/user-attachments/assets/fc755a93-d9be-4394-80f2-6185e194b0c6

**Apple TV**

https://github.com/user-attachments/assets/e51a39a7-2cf8-456f-97f1-12bda53b0100

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

#### I have tested any UI changes...
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
