### PR TITLE
[TV] Add the Starred Episodes screen

### DIFF
--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -314,6 +314,8 @@
     <string name="tv_up_next_empty_title">Nothing queued up</string>
     <string name="tv_up_next_empty_subtitle">Add episodes to Up Next and they’ll play in order, back to back</string>
     <string name="tv_up_next_empty_action_title">Add episodes</string>
+    <string name="tv_starred_empty_title">No starred episodes</string>
+    <string name="tv_starred_empty_subtitle">Star episodes to keep them handy, and they’ll show up here</string>
     <string name="tv_nothing_playing_title">Nothing playing</string>
     <string name="tv_nothing_playing_subtitle">Play an episode and it’ll show up here.</string>
     <string name="tv_playback_speed_changed">Playback speed set to %1$s</string>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -275,8 +275,8 @@ abstract class EpisodeDao {
     ): Int
 
     @Transaction
-    @Query("SELECT * FROM podcast_episodes WHERE starred = 1 ORDER BY last_starred_date DESC LIMIT 1000")
-    abstract fun findStarredEpisodesFlow(): Flow<List<PodcastEpisode>>
+    @Query("SELECT * FROM podcast_episodes WHERE starred = 1 ORDER BY last_starred_date DESC LIMIT :limit")
+    abstract fun findStarredEpisodesFlow(limit: Int = Int.MAX_VALUE): Flow<List<PodcastEpisode>>
 
     @Transaction
     @Query("SELECT * FROM podcast_episodes WHERE starred = 1")

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -275,7 +275,7 @@ abstract class EpisodeDao {
     ): Int
 
     @Transaction
-    @Query("SELECT * FROM podcast_episodes WHERE starred = 1 ORDER BY last_starred_date DESC")
+    @Query("SELECT * FROM podcast_episodes WHERE starred = 1 ORDER BY last_starred_date DESC LIMIT 1000")
     abstract fun findStarredEpisodesFlow(): Flow<List<PodcastEpisode>>
 
     @Transaction

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -47,7 +47,7 @@ interface EpisodeManager {
 
     fun findDownloadEpisodesFlow(): Flow<List<PodcastEpisode>>
     fun findDownloadedEpisodesRxFlowable(): Flowable<List<PodcastEpisode>>
-    fun findStarredEpisodesFlow(): Flow<List<PodcastEpisode>>
+    fun findStarredEpisodesFlow(limit: Int = Int.MAX_VALUE): Flow<List<PodcastEpisode>>
     suspend fun findStarredEpisodes(): List<PodcastEpisode>
     suspend fun downloadedEpisodesThatHaveNotBeenPlayedCount(): Int
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -681,8 +681,8 @@ class EpisodeManagerImpl @Inject constructor(
         return episodeDao.downloadedEpisodesThatHaveNotBeenPlayedCount()
     }
 
-    override fun findStarredEpisodesFlow(): Flow<List<PodcastEpisode>> {
-        return episodeDao.findStarredEpisodesFlow()
+    override fun findStarredEpisodesFlow(limit: Int): Flow<List<PodcastEpisode>> {
+        return episodeDao.findStarredEpisodesFlow(limit)
     }
 
     override suspend fun findStarredEpisodes(): List<PodcastEpisode> {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionsViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionsViewModel.kt
@@ -25,6 +25,7 @@ enum class TvEpisodeActionContext(val source: SourceView, val episodeViewSource:
     Playlist(SourceView.FILTERS, EpisodeViewSourceType.Filters),
     UpNext(SourceView.UP_NEXT, EpisodeViewSourceType.UpNext),
     NowPlaying(SourceView.PLAYER, EpisodeViewSourceType.NowPlaying),
+    Starred(SourceView.STARRED, EpisodeViewSourceType.Starred),
 }
 
 interface TvEpisodeActions {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
@@ -29,11 +29,14 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import au.com.shiftyjelly.pocketcasts.component.LocalFocusTvTopBar
 import au.com.shiftyjelly.pocketcasts.component.LocalOpenNowPlaying
 import au.com.shiftyjelly.pocketcasts.component.LocalTvTopBarVisibility
+import au.com.shiftyjelly.pocketcasts.component.TvDetailOverlay
 import au.com.shiftyjelly.pocketcasts.component.TvTopBarVisibility
+import au.com.shiftyjelly.pocketcasts.component.tvFocusInactiveWhen
 import au.com.shiftyjelly.pocketcasts.nowplaying.TvNowPlayingScreen
 import au.com.shiftyjelly.pocketcasts.playlists.TvPlaylistsScreen
 import au.com.shiftyjelly.pocketcasts.podcasts.TvYourPodcastsScreen
 import au.com.shiftyjelly.pocketcasts.search.TvSearchScreen
+import au.com.shiftyjelly.pocketcasts.starred.TvStarredScreen
 import au.com.shiftyjelly.pocketcasts.theme.TvScreenBackgroundBrush
 import au.com.shiftyjelly.pocketcasts.theme.TvTheme
 import au.com.shiftyjelly.pocketcasts.theme.TvTopBarHeight
@@ -49,6 +52,7 @@ fun TvScaffold(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     var isProfileModalVisible by rememberSaveable { mutableStateOf(false) }
+    var isStarredVisible by rememberSaveable { mutableStateOf(false) }
     val topBarVisibility = remember { TvTopBarVisibility() }
     var didFocusTopBar by rememberSaveable { mutableStateOf(false) }
     var isNowPlayingOpenRequested by remember { mutableStateOf(false) }
@@ -73,50 +77,59 @@ fun TvScaffold(
         LocalOpenNowPlaying provides openNowPlaying,
         LocalFocusTvTopBar provides focusTopBar,
     ) {
-        TvScaffoldContent(
-            tabs = uiState.tabs,
-            selectedTabIndex = uiState.selectedTabIndex,
-            profile = uiState.profile,
-            isTopBarVisible = topBarVisibility.isVisible,
-            autoFocusSelectedTab = !didFocusTopBar,
-            onSelectedTabFocus = { didFocusTopBar = true },
-            focusSelectedTab = isTopBarFocusRequested,
-            onConsumeFocusRequest = { isTopBarFocusRequested = false },
-            onTabSelect = viewModel::selectTab,
-            onTabClick = { tab ->
-                if (tab == TvTab.NowPlaying) {
-                    isNowPlayingOpenRequested = true
+        Box(modifier = modifier.fillMaxSize()) {
+            TvScaffoldContent(
+                tabs = uiState.tabs,
+                selectedTabIndex = uiState.selectedTabIndex,
+                profile = uiState.profile,
+                isTopBarVisible = topBarVisibility.isVisible,
+                autoFocusSelectedTab = !didFocusTopBar,
+                onSelectedTabFocus = { didFocusTopBar = true },
+                focusSelectedTab = isTopBarFocusRequested,
+                onConsumeFocusRequest = { isTopBarFocusRequested = false },
+                onTabSelect = viewModel::selectTab,
+                onTabClick = { tab ->
+                    if (tab == TvTab.NowPlaying) {
+                        isNowPlayingOpenRequested = true
+                    }
+                },
+                onProfileClick = { isProfileModalVisible = true },
+                modifier = Modifier.tvFocusInactiveWhen(isStarredVisible),
+            ) { tab ->
+                val navigateToHome = { viewModel.selectTab(TvTab.Home) }
+                // Tabs without a detail screen sit below the bar; the detail-bearing tabs pad their own
+                // content so their overlays can fill the full height.
+                val belowTopBar = Modifier.fillMaxSize().padding(top = TvTopBarHeight)
+                when (tab) {
+                    is TvTab.Home -> TvHomeScreen(
+                        onNavigateToSearch = { viewModel.selectTab(TvTab.Search) },
+                        onCreateAccount = onCreateAccount,
+                    )
+
+                    is TvTab.YourPodcasts -> TvYourPodcastsScreen(
+                        onNavigateToHome = navigateToHome,
+                    )
+
+                    is TvTab.Playlists -> TvPlaylistsScreen()
+
+                    is TvTab.UpNext -> Box(modifier = belowTopBar) {
+                        TvUpNextScreen(onNavigateToHome = navigateToHome)
+                    }
+
+                    is TvTab.NowPlaying -> TvNowPlayingScreen(
+                        isOpenRequested = isNowPlayingOpenRequested,
+                        onConsumeOpenRequest = { isNowPlayingOpenRequested = false },
+                    )
+
+                    is TvTab.Search -> TvSearchScreen()
                 }
-            },
-            onProfileClick = { isProfileModalVisible = true },
-            modifier = modifier,
-        ) { tab ->
-            val navigateToHome = { viewModel.selectTab(TvTab.Home) }
-            // Tabs without a detail screen sit below the bar; the detail-bearing tabs pad their own
-            // content so their overlays can fill the full height.
-            val belowTopBar = Modifier.fillMaxSize().padding(top = TvTopBarHeight)
-            when (tab) {
-                is TvTab.Home -> TvHomeScreen(
-                    onNavigateToSearch = { viewModel.selectTab(TvTab.Search) },
-                    onCreateAccount = onCreateAccount,
-                )
+            }
 
-                is TvTab.YourPodcasts -> TvYourPodcastsScreen(
-                    onNavigateToHome = navigateToHome,
-                )
-
-                is TvTab.Playlists -> TvPlaylistsScreen()
-
-                is TvTab.UpNext -> Box(modifier = belowTopBar) {
-                    TvUpNextScreen(onNavigateToHome = navigateToHome)
-                }
-
-                is TvTab.NowPlaying -> TvNowPlayingScreen(
-                    isOpenRequested = isNowPlayingOpenRequested,
-                    onConsumeOpenRequest = { isNowPlayingOpenRequested = false },
-                )
-
-                is TvTab.Search -> TvSearchScreen()
+            TvDetailOverlay(
+                target = if (isStarredVisible) Unit else null,
+                onBack = { isStarredVisible = false },
+            ) {
+                TvStarredScreen()
             }
         }
 
@@ -132,8 +145,11 @@ fun TvScaffold(
                     isProfileModalVisible = false
                     onCreateAccount()
                 },
-                // TODO: wire up the Starred Episodes and Listening History destinations.
-                onStarredEpisodes = {},
+                onStarredEpisodes = {
+                    isProfileModalVisible = false
+                    isStarredVisible = true
+                },
+                // TODO: wire up the Listening History destination.
                 onListeningHistory = {},
                 onLogOut = {
                     isProfileModalVisible = false

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
@@ -64,6 +64,7 @@ fun TvScaffold(
         {
             viewModel.openNowPlaying()
             isNowPlayingOpenRequested = true
+            isStarredVisible = false
         }
     }
     LaunchedEffect(viewModel) {
@@ -128,6 +129,7 @@ fun TvScaffold(
             TvDetailOverlay(
                 target = if (isStarredVisible) Unit else null,
                 onBack = { isStarredVisible = false },
+                onHide = focusTopBar,
             ) {
                 TvStarredScreen()
             }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
@@ -128,8 +128,10 @@ fun TvScaffold(
 
             TvDetailOverlay(
                 target = if (isStarredVisible) Unit else null,
-                onBack = { isStarredVisible = false },
-                onHide = focusTopBar,
+                onBack = {
+                    isStarredVisible = false
+                    focusTopBar()
+                },
             ) {
                 TvStarredScreen()
             }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/starred/TvStarredScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/starred/TvStarredScreen.kt
@@ -122,7 +122,7 @@ private fun StarredList(
     val context = LocalContext.current
     val dateFormatter = remember(context) { RelativeDateFormatter(context) }
     val listState = rememberLazyListState()
-    val focus = rememberTvEpisodeListFocus(episodes, listState, requestInitialFocus = false)
+    val focus = rememberTvEpisodeListFocus(episodes, listState, requestInitialFocus = true)
     var actionsEpisode by remember { mutableStateOf<PodcastEpisode?>(null) }
     var detailsEpisode by remember { mutableStateOf<PodcastEpisode?>(null) }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/starred/TvStarredScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/starred/TvStarredScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
@@ -56,6 +57,7 @@ fun TvStarredScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     var openedPodcastUuid by rememberSaveable { mutableStateOf<String?>(null) }
+    val listState = rememberLazyListState()
 
     LaunchedEffect(Unit) {
         viewModel.trackStarredShown()
@@ -79,6 +81,7 @@ fun TvStarredScreen(
                 viewModel.play(episode)
                 openNowPlaying()
             },
+            listState = listState,
             modifier = modifier,
         )
     }
@@ -90,6 +93,7 @@ private fun TvStarredContent(
     onOpenPodcast: (String) -> Unit,
     onPlayEpisode: (PodcastEpisode) -> Unit,
     modifier: Modifier = Modifier,
+    listState: LazyListState = rememberLazyListState(),
 ) {
     Box(modifier = modifier.fillMaxSize()) {
         when (uiState) {
@@ -106,6 +110,7 @@ private fun TvStarredContent(
                     episodes = uiState.episodes,
                     onOpenPodcast = onOpenPodcast,
                     onPlayEpisode = onPlayEpisode,
+                    listState = listState,
                 )
             }
         }
@@ -118,10 +123,10 @@ private fun StarredList(
     onOpenPodcast: (String) -> Unit,
     onPlayEpisode: (PodcastEpisode) -> Unit,
     modifier: Modifier = Modifier,
+    listState: LazyListState = rememberLazyListState(),
 ) {
     val context = LocalContext.current
     val dateFormatter = remember(context) { RelativeDateFormatter(context) }
-    val listState = rememberLazyListState()
     val focus = rememberTvEpisodeListFocus(episodes, listState, requestInitialFocus = true)
     var actionsEpisode by remember { mutableStateOf<PodcastEpisode?>(null) }
     var detailsEpisode by remember { mutableStateOf<PodcastEpisode?>(null) }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/starred/TvStarredScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/starred/TvStarredScreen.kt
@@ -1,0 +1,235 @@
+package au.com.shiftyjelly.pocketcasts.starred
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.component.LocalOpenNowPlaying
+import au.com.shiftyjelly.pocketcasts.component.TvEmptyState
+import au.com.shiftyjelly.pocketcasts.component.TvEpisodeActionContext
+import au.com.shiftyjelly.pocketcasts.component.TvEpisodeActionsModal
+import au.com.shiftyjelly.pocketcasts.component.TvEpisodeInfoModal
+import au.com.shiftyjelly.pocketcasts.component.TvEpisodeListItem
+import au.com.shiftyjelly.pocketcasts.component.rememberTvEpisodeListFocus
+import au.com.shiftyjelly.pocketcasts.compose.loading.LoadingView
+import au.com.shiftyjelly.pocketcasts.localization.helper.RelativeDateFormatter
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.podcasts.TvPodcastDetailsScreen
+import au.com.shiftyjelly.pocketcasts.theme.TvTheme
+import au.com.shiftyjelly.pocketcasts.theme.tvColors
+import au.com.shiftyjelly.pocketcasts.theme.tvTypography
+import java.util.Date
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+fun TvStarredScreen(
+    modifier: Modifier = Modifier,
+    viewModel: TvStarredViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    var openedPodcastUuid by rememberSaveable { mutableStateOf<String?>(null) }
+
+    LaunchedEffect(Unit) {
+        viewModel.trackStarredShown()
+        viewModel.onShown()
+    }
+
+    val podcastUuid = openedPodcastUuid
+    if (podcastUuid != null) {
+        BackHandler { openedPodcastUuid = null }
+        TvPodcastDetailsScreen(
+            podcastUuid = podcastUuid,
+            onClose = { openedPodcastUuid = null },
+            modifier = modifier,
+        )
+    } else {
+        val openNowPlaying = LocalOpenNowPlaying.current
+        TvStarredContent(
+            uiState = uiState,
+            onOpenPodcast = { openedPodcastUuid = it },
+            onPlayEpisode = { episode ->
+                viewModel.play(episode)
+                openNowPlaying()
+            },
+            modifier = modifier,
+        )
+    }
+}
+
+@Composable
+private fun TvStarredContent(
+    uiState: TvStarredUiState,
+    onOpenPodcast: (String) -> Unit,
+    onPlayEpisode: (PodcastEpisode) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(modifier = modifier.fillMaxSize()) {
+        when (uiState) {
+            is TvStarredUiState.Loading -> {
+                LoadingView(color = MaterialTheme.tvColors.textPrimary, modifier = Modifier.fillMaxSize())
+            }
+
+            is TvStarredUiState.Empty -> {
+                StarredEmpty(modifier = Modifier.fillMaxSize())
+            }
+
+            is TvStarredUiState.Loaded -> {
+                StarredList(
+                    episodes = uiState.episodes,
+                    onOpenPodcast = onOpenPodcast,
+                    onPlayEpisode = onPlayEpisode,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun StarredList(
+    episodes: List<PodcastEpisode>,
+    onOpenPodcast: (String) -> Unit,
+    onPlayEpisode: (PodcastEpisode) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val dateFormatter = remember(context) { RelativeDateFormatter(context) }
+    val listState = rememberLazyListState()
+    val focus = rememberTvEpisodeListFocus(episodes, listState, requestInitialFocus = false)
+    var actionsEpisode by remember { mutableStateOf<PodcastEpisode?>(null) }
+    var detailsEpisode by remember { mutableStateOf<PodcastEpisode?>(null) }
+
+    Column(
+        modifier = modifier
+            .fillMaxHeight()
+            .fillMaxWidth(ROW_WIDTH_FRACTION)
+            .padding(start = 32.dp, top = 8.dp),
+    ) {
+        Text(
+            text = stringResource(LR.string.tv_profile_starred_episodes),
+            style = MaterialTheme.tvTypography.title3,
+            color = MaterialTheme.tvColors.textPrimary,
+        )
+        Spacer(Modifier.height(26.dp))
+        LazyColumn(
+            state = listState,
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            contentPadding = PaddingValues(bottom = 32.dp),
+            modifier = Modifier.weight(1f),
+        ) {
+            itemsIndexed(
+                items = episodes,
+                key = { _, episode -> episode.uuid },
+            ) { index, episode ->
+                TvEpisodeListItem(
+                    episode = episode,
+                    dateFormatter = dateFormatter,
+                    onClick = { onPlayEpisode(episode) },
+                    onOpenActions = {
+                        focus.watchForRemoval(episodes, index)
+                        actionsEpisode = episode
+                    },
+                    episodeFocusRequester = focus.requesterFor(episode.uuid),
+                )
+            }
+        }
+    }
+
+    actionsEpisode?.let { episode ->
+        TvEpisodeActionsModal(
+            episode = episode,
+            actionContext = TvEpisodeActionContext.Starred,
+            onDismissRequest = { actionsEpisode = null },
+            onShowEpisodeDetails = {
+                detailsEpisode = episode
+                actionsEpisode = null
+            },
+            onGoToPodcast = { onOpenPodcast(episode.podcastUuid) },
+        )
+    }
+    detailsEpisode?.let { episode ->
+        TvEpisodeInfoModal(
+            episode = episode,
+            actionContext = TvEpisodeActionContext.Starred,
+            onDismissRequest = { detailsEpisode = null },
+        )
+    }
+}
+
+@Composable
+private fun StarredEmpty(
+    modifier: Modifier = Modifier,
+) {
+    TvEmptyState(
+        title = stringResource(LR.string.tv_starred_empty_title),
+        subtitle = stringResource(LR.string.tv_starred_empty_subtitle),
+        modifier = modifier,
+    )
+}
+
+private const val ROW_WIDTH_FRACTION = 0.75f
+
+@Preview(device = Devices.TV_1080p)
+@Composable
+private fun TvStarredLoadedPreview() {
+    TvTheme {
+        Box(modifier = Modifier.background(MaterialTheme.tvColors.backgroundSunken)) {
+            TvStarredContent(
+                uiState = TvStarredUiState.Loaded(
+                    episodes = List(4) { index ->
+                        PodcastEpisode(
+                            uuid = "episode-$index",
+                            title = "Episode $index title that may span multiple lines to test the layout",
+                            duration = 3600.0,
+                            playedUpTo = 600.0,
+                            publishedDate = Date(0),
+                        )
+                    },
+                ),
+                onOpenPodcast = {},
+                onPlayEpisode = {},
+            )
+        }
+    }
+}
+
+@Preview(device = Devices.TV_1080p)
+@Composable
+private fun TvStarredEmptyPreview() {
+    TvTheme {
+        Box(modifier = Modifier.background(MaterialTheme.tvColors.backgroundSunken)) {
+            TvStarredContent(
+                uiState = TvStarredUiState.Empty,
+                onOpenPodcast = {},
+                onPlayEpisode = {},
+            )
+        }
+    }
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/starred/TvStarredViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/starred/TvStarredViewModel.kt
@@ -1,0 +1,80 @@
+package au.com.shiftyjelly.pocketcasts.starred
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import au.com.shiftyjelly.pocketcasts.repositories.sync.StarredSyncWorker
+import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
+import com.automattic.eventhorizon.EventHorizon
+import com.automattic.eventhorizon.StarredShownEvent
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.WhileSubscribed
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+@HiltViewModel
+class TvStarredViewModel @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val episodeManager: EpisodeManager,
+    private val syncManager: SyncManager,
+    private val playbackManager: PlaybackManager,
+    private val eventHorizon: EventHorizon,
+) : ViewModel() {
+
+    val uiState: StateFlow<TvStarredUiState> = episodeManager.findStarredEpisodesFlow()
+        .map { episodes ->
+            if (episodes.isEmpty()) {
+                TvStarredUiState.Empty
+            } else {
+                TvStarredUiState.Loaded(episodes)
+            }
+        }
+        .stateIn(
+            viewModelScope,
+            SharingStarted.WhileSubscribed(stopTimeout = 300.milliseconds, replayExpiration = Duration.ZERO),
+            TvStarredUiState.Loading,
+        )
+
+    fun onShown() {
+        StarredSyncWorker.enqueue(syncManager, context)
+    }
+
+    fun trackStarredShown() {
+        eventHorizon.track(StarredShownEvent)
+    }
+
+    fun play(episode: PodcastEpisode) {
+        viewModelScope.launch {
+            try {
+                playbackManager.playNowSuspend(episode = episode, sourceView = SourceView.STARRED)
+            } catch (exception: CancellationException) {
+                throw exception
+            } catch (exception: Exception) {
+                Timber.e(exception, "Failed to play episode from TV starred")
+            }
+        }
+    }
+}
+
+sealed interface TvStarredUiState {
+    data object Loading : TvStarredUiState
+
+    data object Empty : TvStarredUiState
+
+    data class Loaded(
+        val episodes: List<PodcastEpisode>,
+    ) : TvStarredUiState
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/starred/TvStarredViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/starred/TvStarredViewModel.kt
@@ -34,7 +34,7 @@ class TvStarredViewModel @Inject constructor(
     private val eventHorizon: EventHorizon,
 ) : ViewModel() {
 
-    val uiState: StateFlow<TvStarredUiState> = episodeManager.findStarredEpisodesFlow()
+    val uiState: StateFlow<TvStarredUiState> = episodeManager.findStarredEpisodesFlow(limit = STARRED_EPISODE_LIMIT)
         .map { episodes ->
             if (episodes.isEmpty()) {
                 TvStarredUiState.Empty
@@ -68,6 +68,8 @@ class TvStarredViewModel @Inject constructor(
         }
     }
 }
+
+private const val STARRED_EPISODE_LIMIT = 1000
 
 sealed interface TvStarredUiState {
     data object Loading : TvStarredUiState

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionTypeTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionTypeTest.kt
@@ -16,6 +16,7 @@ class TvEpisodeActionTypeTest {
             TvEpisodeActionContext.Playlist to (SourceView.FILTERS to EpisodeViewSourceType.Filters),
             TvEpisodeActionContext.UpNext to (SourceView.UP_NEXT to EpisodeViewSourceType.UpNext),
             TvEpisodeActionContext.NowPlaying to (SourceView.PLAYER to EpisodeViewSourceType.NowPlaying),
+            TvEpisodeActionContext.Starred to (SourceView.STARRED to EpisodeViewSourceType.Starred),
         )
 
         assertEquals(TvEpisodeActionContext.entries.toSet(), expected.keys)

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/starred/TvStarredViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/starred/TvStarredViewModelTest.kt
@@ -106,7 +106,7 @@ class TvStarredViewModelTest {
     }
 
     @Test
-    fun `showing the screen only syncs when signed in`() = runTest {
+    fun `showing the screen checks whether the user is signed in before syncing`() = runTest {
         createViewModel().onShown()
 
         verify(syncManager).isLoggedIn()

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/starred/TvStarredViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/starred/TvStarredViewModelTest.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
@@ -30,7 +31,7 @@ class TvStarredViewModelTest {
 
     private val starredEpisodes = MutableSharedFlow<List<PodcastEpisode>>(replay = 1)
     private val episodeManager = mock<EpisodeManager> {
-        on { findStarredEpisodesFlow() } doReturn starredEpisodes
+        on { findStarredEpisodesFlow(any()) } doReturn starredEpisodes
     }
     private val syncManager = mock<SyncManager>()
     private val context = mock<Context>()

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/starred/TvStarredViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/starred/TvStarredViewModelTest.kt
@@ -1,0 +1,124 @@
+package au.com.shiftyjelly.pocketcasts.starred
+
+import android.content.Context
+import app.cash.turbine.test
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
+import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import com.automattic.eventhorizon.EventHorizon
+import com.automattic.eventhorizon.StarredShownEvent
+import java.util.Date
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyBlocking
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TvStarredViewModelTest {
+
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
+
+    private val starredEpisodes = MutableSharedFlow<List<PodcastEpisode>>(replay = 1)
+    private val episodeManager = mock<EpisodeManager> {
+        on { findStarredEpisodesFlow() } doReturn starredEpisodes
+    }
+    private val syncManager = mock<SyncManager>()
+    private val context = mock<Context>()
+    private val playbackManager = mock<PlaybackManager>()
+    private val eventHorizon = mock<EventHorizon>()
+
+    @Test
+    fun `state starts as loading`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            assertEquals(TvStarredUiState.Loading, awaitItem())
+        }
+    }
+
+    @Test
+    fun `starred episodes load reactively`() = runTest {
+        val viewModel = createViewModel()
+        val episodes = listOf(episode("first"), episode("second"))
+
+        viewModel.uiState.test {
+            assertEquals(TvStarredUiState.Loading, awaitItem())
+
+            starredEpisodes.emit(episodes)
+
+            assertEquals(TvStarredUiState.Loaded(episodes), awaitItem())
+        }
+    }
+
+    @Test
+    fun `an empty starred list maps to the empty state`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            assertEquals(TvStarredUiState.Loading, awaitItem())
+
+            starredEpisodes.emit(emptyList())
+
+            assertEquals(TvStarredUiState.Empty, awaitItem())
+        }
+    }
+
+    @Test
+    fun `a starred list that empties maps back to the empty state`() = runTest {
+        val viewModel = createViewModel()
+        val episode = episode("starred")
+
+        viewModel.uiState.test {
+            assertEquals(TvStarredUiState.Loading, awaitItem())
+
+            starredEpisodes.emit(listOf(episode))
+            assertEquals(TvStarredUiState.Loaded(listOf(episode)), awaitItem())
+
+            starredEpisodes.emit(emptyList())
+            assertEquals(TvStarredUiState.Empty, awaitItem())
+        }
+    }
+
+    @Test
+    fun `play starts playback of the episode from the starred source`() = runTest {
+        val episode = episode("episode")
+
+        createViewModel().play(episode)
+
+        verifyBlocking(playbackManager) { playNowSuspend(episode = episode, sourceView = SourceView.STARRED) }
+    }
+
+    @Test
+    fun `showing the screen tracks the starred shown event`() = runTest {
+        createViewModel().trackStarredShown()
+
+        verify(eventHorizon).track(StarredShownEvent)
+    }
+
+    @Test
+    fun `showing the screen only syncs when signed in`() = runTest {
+        createViewModel().onShown()
+
+        verify(syncManager).isLoggedIn()
+    }
+
+    private fun createViewModel() = TvStarredViewModel(
+        context = context,
+        episodeManager = episodeManager,
+        syncManager = syncManager,
+        playbackManager = playbackManager,
+        eventHorizon = eventHorizon,
+    )
+
+    private fun episode(uuid: String) = PodcastEpisode(uuid = uuid, publishedDate = Date(0))
+}


### PR DESCRIPTION
## Description

Adds the **Starred Episodes** screen to the Android TV app, reaching parity with tvOS (`UI/Starred/StarredEpisodesView.swift`). The profile modal already rendered a "Starred Episodes" button, but it was wired to `{}` with a TODO — this PR builds the screen and wires the destination.

Behaviour mirrors tvOS:
- Opened full-screen from **Profile → Starred Episodes** via the shared `TvDetailOverlay` (top bar hidden, Back returns to the tab layer).
- When signed in, kicks a server refresh on open by enqueuing the existing `StarredSyncWorker` (which stars the returned episodes locally), then observes the local starred list reactively through `EpisodeManager.findStarredEpisodesFlow()`. Signed-out users see the local list only (the worker is a no-op when logged out). The list live-updates when episodes are starred/unstarred elsewhere.
- Standard episode rows (`TvEpisodeListItem`), reusing the episode-actions modal (`TvEpisodeActionsModal`) and episode-info modal. **View-only — there is no star/unstar action anywhere on TV**, matching tvOS.
- Empty state uses new `tv_starred_empty_title` / `tv_starred_empty_subtitle` strings (copy taken from tvOS).

A new `TvEpisodeActionContext.Starred` (source `starred` / `EpisodeViewSourceType.Starred`) attributes playback and episode-action analytics to the Starred screen, exactly as the podcast/search/playlist/up-next/now-playing contexts already do.

### Analytics
- Fires `StarredShownEvent` (no properties) when the screen appears — the Android equivalent of tvOS `starred_shown` — via `eventHorizon.track(...)`, following the same pattern as `TvUpNextViewModel`.
- Episode-action events (`playback_play`, etc.) flow through the shared managers/`PlaybackManager` with `source = starred` via the new action context.

## Follow-up refinements (parity audit v2)

Three small ride-along commits from the v2 parity audit (Part 7):

1. **Default focus on open.** The episode list now takes initial focus when the screen opens (`requestInitialFocus = true`), matching tvOS `prefersDefaultFocus` (`StarredEpisodesView.swift`) and the sibling overlay lists. Previously nothing was deterministically focused after the overlay appeared (the tab layer behind is focus-deactivated and the top bar is hidden).
2. **Bounded query.** `EpisodeDao.findStarredEpisodesFlow()` now caps at `LIMIT 1000` (ordered by `last_starred_date DESC`), matching tvOS (`StarredEpisodesViewModel` `LIMIT 1000`) and the existing playback-history query. **Note:** this DAO query is shared — the phone Starred list (`ProfileEpisodeListViewModel`) and Wear (`StarredScreenViewModel`) consume the same flow, so the 1000-row cap now applies on all three platforms, consistent with the history flow they already share. Unit tests mock the flow, so none are affected.
3. **Scroll survives Go-to-podcast.** The `LazyListState` is hoisted to the always-composed `TvStarredScreen` so opening a podcast (which swaps the list out) and returning restores the scroll position; combined with (1), returning re-focuses the first visible row instead of landing at the top with nothing focused.

Fixes PCDROID-735 https://linear.app/a8c/issue/PCDROID-735/starred-episodes-screen

## Testing Instructions
1. Sign in on the TV app.
2. Open the profile modal (top-right) → tap **Starred Episodes**.
3. With starred episodes present: they appear as standard rows; SELECT plays and opens Now Playing; the more button opens the actions modal (no star/unstar option).
4. Star/unstar an episode elsewhere and confirm the list live-updates.
5. With none starred: the "No starred episodes" empty state shows.
6. Sign out and reopen: only locally-starred episodes are shown (no server refresh).
7. Press Back to return to the previous tab.

## Screenshots or Screencast
| Screen | Analytics |
| --- | --- |
| <img width="1920" height="1080" alt="Screenshot_20260827_140241" src="https://github.com/user-attachments/assets/477926df-d8c3-4d1e-9809-7a48769e7b08" /> | <img width="389" height="52" alt="SCR-20260827-mnnn" src="https://github.com/user-attachments/assets/48d2504a-e57b-4367-ad27-4621c83401e1" /> |


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md <!-- TV-only feature; CHANGELOG tracks the phone app -->
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes <!-- added TvStarredViewModelTest + extended TvEpisodeActionTypeTest -->
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) the Event Horizon schema to reflect any new or changed analytics 

