### PR TITLE
[TV] Add the Listening History screen

### DIFF
--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -316,6 +316,8 @@
     <string name="tv_up_next_empty_action_title">Add episodes</string>
     <string name="tv_starred_empty_title">No starred episodes</string>
     <string name="tv_starred_empty_subtitle">Star episodes to keep them handy, and they’ll show up here</string>
+    <string name="tv_history_empty_title">No listening history</string>
+    <string name="tv_history_empty_subtitle">Episodes you play will show up here</string>
     <string name="tv_nothing_playing_title">Nothing playing</string>
     <string name="tv_nothing_playing_subtitle">Play an episode and it’ll show up here.</string>
     <string name="tv_playback_speed_changed">Playback speed set to %1$s</string>

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionsViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionsViewModel.kt
@@ -26,6 +26,7 @@ enum class TvEpisodeActionContext(val source: SourceView, val episodeViewSource:
     UpNext(SourceView.UP_NEXT, EpisodeViewSourceType.UpNext),
     NowPlaying(SourceView.PLAYER, EpisodeViewSourceType.NowPlaying),
     Starred(SourceView.STARRED, EpisodeViewSourceType.Starred),
+    ListeningHistory(SourceView.LISTENING_HISTORY, EpisodeViewSourceType.ListeningHistory),
 }
 
 interface TvEpisodeActions {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/history/TvListeningHistoryScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/history/TvListeningHistoryScreen.kt
@@ -1,0 +1,206 @@
+package au.com.shiftyjelly.pocketcasts.history
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.component.LocalOpenNowPlaying
+import au.com.shiftyjelly.pocketcasts.component.TvEmptyState
+import au.com.shiftyjelly.pocketcasts.component.TvEpisodeActionContext
+import au.com.shiftyjelly.pocketcasts.component.TvEpisodeActionsModal
+import au.com.shiftyjelly.pocketcasts.component.TvEpisodeInfoModal
+import au.com.shiftyjelly.pocketcasts.component.TvEpisodeListItem
+import au.com.shiftyjelly.pocketcasts.component.rememberTvEpisodeListFocus
+import au.com.shiftyjelly.pocketcasts.compose.loading.LoadingView
+import au.com.shiftyjelly.pocketcasts.localization.helper.RelativeDateFormatter
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.theme.TvTheme
+import au.com.shiftyjelly.pocketcasts.theme.tvColors
+import au.com.shiftyjelly.pocketcasts.theme.tvTypography
+import java.util.Date
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+fun TvListeningHistoryScreen(
+    modifier: Modifier = Modifier,
+    viewModel: TvListeningHistoryViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val openNowPlaying = LocalOpenNowPlaying.current
+
+    LaunchedEffect(Unit) {
+        viewModel.trackShown()
+    }
+
+    TvListeningHistoryContent(
+        uiState = uiState,
+        onPlayEpisode = { episode ->
+            viewModel.play(episode)
+            openNowPlaying()
+        },
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun TvListeningHistoryContent(
+    uiState: TvListeningHistoryUiState,
+    onPlayEpisode: (PodcastEpisode) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(modifier = modifier.fillMaxSize()) {
+        when (uiState) {
+            is TvListeningHistoryUiState.Loading -> {
+                LoadingView(color = MaterialTheme.tvColors.textPrimary, modifier = Modifier.fillMaxSize())
+            }
+
+            is TvListeningHistoryUiState.Empty -> {
+                TvEmptyState(
+                    title = stringResource(LR.string.tv_history_empty_title),
+                    subtitle = stringResource(LR.string.tv_history_empty_subtitle),
+                    modifier = Modifier.fillMaxSize(),
+                )
+            }
+
+            is TvListeningHistoryUiState.Loaded -> {
+                HistoryList(
+                    episodes = uiState.episodes,
+                    onPlayEpisode = onPlayEpisode,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun HistoryList(
+    episodes: List<PodcastEpisode>,
+    onPlayEpisode: (PodcastEpisode) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val dateFormatter = remember(context) { RelativeDateFormatter(context) }
+    val listState = rememberLazyListState()
+    val focus = rememberTvEpisodeListFocus(episodes, listState, requestInitialFocus = true)
+    var actionsEpisode by remember { mutableStateOf<PodcastEpisode?>(null) }
+    var detailsEpisode by remember { mutableStateOf<PodcastEpisode?>(null) }
+
+    Column(
+        modifier = modifier
+            .fillMaxHeight()
+            .fillMaxWidth(ROW_WIDTH_FRACTION)
+            .padding(start = 32.dp, top = 8.dp),
+    ) {
+        Text(
+            text = stringResource(LR.string.profile_navigation_listening_history),
+            style = MaterialTheme.tvTypography.title3,
+            color = MaterialTheme.tvColors.textPrimary,
+        )
+        Spacer(Modifier.height(26.dp))
+        LazyColumn(
+            state = listState,
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            contentPadding = PaddingValues(bottom = 32.dp),
+            modifier = Modifier.weight(1f),
+        ) {
+            itemsIndexed(
+                items = episodes,
+                key = { _, episode -> episode.uuid },
+            ) { index, episode ->
+                TvEpisodeListItem(
+                    episode = episode,
+                    dateFormatter = dateFormatter,
+                    onClick = { onPlayEpisode(episode) },
+                    onOpenActions = {
+                        focus.watchForRemoval(episodes, index)
+                        actionsEpisode = episode
+                    },
+                    episodeFocusRequester = focus.requesterFor(episode.uuid),
+                )
+            }
+        }
+    }
+
+    actionsEpisode?.let { episode ->
+        TvEpisodeActionsModal(
+            episode = episode,
+            actionContext = TvEpisodeActionContext.ListeningHistory,
+            onDismissRequest = { actionsEpisode = null },
+            onShowEpisodeDetails = {
+                detailsEpisode = episode
+                actionsEpisode = null
+            },
+        )
+    }
+    detailsEpisode?.let { episode ->
+        TvEpisodeInfoModal(
+            episode = episode,
+            actionContext = TvEpisodeActionContext.ListeningHistory,
+            onDismissRequest = { detailsEpisode = null },
+        )
+    }
+}
+
+private const val ROW_WIDTH_FRACTION = 0.75f
+
+@Preview(device = Devices.TV_1080p)
+@Composable
+private fun TvListeningHistoryLoadedPreview() {
+    TvTheme {
+        Box(modifier = Modifier.background(MaterialTheme.tvColors.backgroundSunken)) {
+            TvListeningHistoryContent(
+                uiState = TvListeningHistoryUiState.Loaded(
+                    episodes = List(4) { index ->
+                        PodcastEpisode(
+                            uuid = "episode-$index",
+                            title = "Episode $index title that may span multiple lines to test the layout",
+                            duration = 3600.0,
+                            playedUpTo = 600.0,
+                            publishedDate = Date(0),
+                        )
+                    },
+                ),
+                onPlayEpisode = {},
+            )
+        }
+    }
+}
+
+@Preview(device = Devices.TV_1080p)
+@Composable
+private fun TvListeningHistoryEmptyPreview() {
+    TvTheme {
+        Box(modifier = Modifier.background(MaterialTheme.tvColors.backgroundSunken)) {
+            TvListeningHistoryContent(
+                uiState = TvListeningHistoryUiState.Empty,
+                onPlayEpisode = {},
+            )
+        }
+    }
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/history/TvListeningHistoryViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/history/TvListeningHistoryViewModel.kt
@@ -1,0 +1,70 @@
+package au.com.shiftyjelly.pocketcasts.history
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import com.automattic.eventhorizon.EventHorizon
+import com.automattic.eventhorizon.ListeningHistoryShownEvent
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.WhileSubscribed
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+@HiltViewModel
+class TvListeningHistoryViewModel @Inject constructor(
+    private val episodeManager: EpisodeManager,
+    private val playbackManager: PlaybackManager,
+    private val eventHorizon: EventHorizon,
+) : ViewModel() {
+
+    val uiState: StateFlow<TvListeningHistoryUiState> = episodeManager.findPlaybackHistoryEpisodesFlow()
+        .map { episodes ->
+            if (episodes.isEmpty()) {
+                TvListeningHistoryUiState.Empty
+            } else {
+                TvListeningHistoryUiState.Loaded(episodes)
+            }
+        }
+        .stateIn(
+            viewModelScope,
+            SharingStarted.WhileSubscribed(stopTimeout = 300.milliseconds, replayExpiration = Duration.ZERO),
+            TvListeningHistoryUiState.Loading,
+        )
+
+    fun trackShown() {
+        eventHorizon.track(ListeningHistoryShownEvent)
+    }
+
+    fun play(episode: PodcastEpisode) {
+        viewModelScope.launch {
+            try {
+                playbackManager.playNowSuspend(episode = episode, sourceView = SourceView.LISTENING_HISTORY)
+            } catch (exception: CancellationException) {
+                throw exception
+            } catch (exception: Exception) {
+                Timber.e(exception, "Failed to play episode from TV listening history")
+            }
+        }
+    }
+}
+
+sealed interface TvListeningHistoryUiState {
+    data object Loading : TvListeningHistoryUiState
+
+    data object Empty : TvListeningHistoryUiState
+
+    data class Loaded(
+        val episodes: List<PodcastEpisode>,
+    ) : TvListeningHistoryUiState
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
@@ -141,8 +141,10 @@ fun TvScaffold(
 
             TvDetailOverlay(
                 target = if (isListeningHistoryVisible) Unit else null,
-                onBack = { isListeningHistoryVisible = false },
-                onHide = focusTopBar,
+                onBack = {
+                    isListeningHistoryVisible = false
+                    focusTopBar()
+                },
             ) {
                 TvListeningHistoryScreen()
             }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
@@ -67,6 +67,7 @@ fun TvScaffold(
             viewModel.openNowPlaying()
             isNowPlayingOpenRequested = true
             isStarredVisible = false
+            isListeningHistoryVisible = false
         }
     }
     LaunchedEffect(viewModel) {
@@ -141,6 +142,7 @@ fun TvScaffold(
             TvDetailOverlay(
                 target = if (isListeningHistoryVisible) Unit else null,
                 onBack = { isListeningHistoryVisible = false },
+                onHide = focusTopBar,
             ) {
                 TvListeningHistoryScreen()
             }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
@@ -32,6 +32,7 @@ import au.com.shiftyjelly.pocketcasts.component.LocalTvTopBarVisibility
 import au.com.shiftyjelly.pocketcasts.component.TvDetailOverlay
 import au.com.shiftyjelly.pocketcasts.component.TvTopBarVisibility
 import au.com.shiftyjelly.pocketcasts.component.tvFocusInactiveWhen
+import au.com.shiftyjelly.pocketcasts.history.TvListeningHistoryScreen
 import au.com.shiftyjelly.pocketcasts.nowplaying.TvNowPlayingScreen
 import au.com.shiftyjelly.pocketcasts.playlists.TvPlaylistsScreen
 import au.com.shiftyjelly.pocketcasts.podcasts.TvYourPodcastsScreen
@@ -53,6 +54,7 @@ fun TvScaffold(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     var isProfileModalVisible by rememberSaveable { mutableStateOf(false) }
     var isStarredVisible by rememberSaveable { mutableStateOf(false) }
+    var isListeningHistoryVisible by rememberSaveable { mutableStateOf(false) }
     val topBarVisibility = remember { TvTopBarVisibility() }
     var didFocusTopBar by rememberSaveable { mutableStateOf(false) }
     var isNowPlayingOpenRequested by remember { mutableStateOf(false) }
@@ -95,7 +97,7 @@ fun TvScaffold(
                     }
                 },
                 onProfileClick = { isProfileModalVisible = true },
-                modifier = Modifier.tvFocusInactiveWhen(isStarredVisible),
+                modifier = Modifier.tvFocusInactiveWhen(isStarredVisible || isListeningHistoryVisible),
             ) { tab ->
                 val navigateToHome = { viewModel.selectTab(TvTab.Home) }
                 // Tabs without a detail screen sit below the bar; the detail-bearing tabs pad their own
@@ -135,6 +137,13 @@ fun TvScaffold(
             ) {
                 TvStarredScreen()
             }
+
+            TvDetailOverlay(
+                target = if (isListeningHistoryVisible) Unit else null,
+                onBack = { isListeningHistoryVisible = false },
+            ) {
+                TvListeningHistoryScreen()
+            }
         }
 
         if (isProfileModalVisible) {
@@ -153,8 +162,10 @@ fun TvScaffold(
                     isProfileModalVisible = false
                     isStarredVisible = true
                 },
-                // TODO: wire up the Listening History destination.
-                onListeningHistory = {},
+                onListeningHistory = {
+                    isProfileModalVisible = false
+                    isListeningHistoryVisible = true
+                },
                 onLogOut = {
                     isProfileModalVisible = false
                     viewModel.signOut()

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionTypeTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionTypeTest.kt
@@ -17,6 +17,7 @@ class TvEpisodeActionTypeTest {
             TvEpisodeActionContext.UpNext to (SourceView.UP_NEXT to EpisodeViewSourceType.UpNext),
             TvEpisodeActionContext.NowPlaying to (SourceView.PLAYER to EpisodeViewSourceType.NowPlaying),
             TvEpisodeActionContext.Starred to (SourceView.STARRED to EpisodeViewSourceType.Starred),
+            TvEpisodeActionContext.ListeningHistory to (SourceView.LISTENING_HISTORY to EpisodeViewSourceType.ListeningHistory),
         )
 
         assertEquals(TvEpisodeActionContext.entries.toSet(), expected.keys)
@@ -93,6 +94,23 @@ class TvEpisodeActionTypeTest {
                 TvEpisodeActionType.TogglePlayed,
                 TvEpisodeActionType.ToggleArchived,
                 TvEpisodeActionType.GoToPodcast,
+            ),
+            actions,
+        )
+    }
+
+    @Test
+    fun `listening history shows played and archive toggles but no go to podcast`() {
+        val actions = tvEpisodeActionTypes(TvEpisodeActionContext.ListeningHistory, showGoToPodcast = false)
+
+        assertEquals(
+            listOf(
+                TvEpisodeActionType.Play,
+                TvEpisodeActionType.Details,
+                TvEpisodeActionType.PlayNext,
+                TvEpisodeActionType.PlayLast,
+                TvEpisodeActionType.TogglePlayed,
+                TvEpisodeActionType.ToggleArchived,
             ),
             actions,
         )

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/history/TvListeningHistoryViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/history/TvListeningHistoryViewModelTest.kt
@@ -1,0 +1,103 @@
+package au.com.shiftyjelly.pocketcasts.history
+
+import app.cash.turbine.test
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import com.automattic.eventhorizon.EventHorizon
+import com.automattic.eventhorizon.ListeningHistoryShownEvent
+import java.util.Date
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyBlocking
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TvListeningHistoryViewModelTest {
+
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
+
+    private val history = MutableSharedFlow<List<PodcastEpisode>>(replay = 1, extraBufferCapacity = 1)
+    private val episodeManager = mock<EpisodeManager> {
+        on { findPlaybackHistoryEpisodesFlow() } doReturn history
+    }
+    private val playbackManager = mock<PlaybackManager>()
+    private val eventHorizon = mock<EventHorizon>()
+
+    @Test
+    fun `an empty history maps to the empty state`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            assertEquals(TvListeningHistoryUiState.Loading, awaitItem())
+
+            history.emit(emptyList())
+
+            assertEquals(TvListeningHistoryUiState.Empty, awaitItem())
+        }
+    }
+
+    @Test
+    fun `history episodes are exposed in the loaded state`() = runTest {
+        val viewModel = createViewModel()
+        val first = episode("first")
+        val second = episode("second")
+
+        viewModel.uiState.test {
+            assertEquals(TvListeningHistoryUiState.Loading, awaitItem())
+
+            history.emit(listOf(first, second))
+
+            assertEquals(TvListeningHistoryUiState.Loaded(listOf(first, second)), awaitItem())
+        }
+    }
+
+    @Test
+    fun `history that empties maps back to the empty state`() = runTest {
+        val viewModel = createViewModel()
+        val played = episode("played")
+
+        viewModel.uiState.test {
+            assertEquals(TvListeningHistoryUiState.Loading, awaitItem())
+
+            history.emit(listOf(played))
+            assertEquals(TvListeningHistoryUiState.Loaded(listOf(played)), awaitItem())
+
+            history.emit(emptyList())
+            assertEquals(TvListeningHistoryUiState.Empty, awaitItem())
+        }
+    }
+
+    @Test
+    fun `play starts playback from the listening history source`() = runTest {
+        val episode = episode("episode")
+
+        createViewModel().play(episode)
+
+        verifyBlocking(playbackManager) { playNowSuspend(episode = episode, sourceView = SourceView.LISTENING_HISTORY) }
+    }
+
+    @Test
+    fun `showing the screen tracks the listening history shown event`() = runTest {
+        createViewModel().trackShown()
+
+        verify(eventHorizon).track(ListeningHistoryShownEvent)
+    }
+
+    private fun createViewModel() = TvListeningHistoryViewModel(
+        episodeManager = episodeManager,
+        playbackManager = playbackManager,
+        eventHorizon = eventHorizon,
+    )
+
+    private fun episode(uuid: String) = PodcastEpisode(uuid = uuid, publishedDate = Date(0))
+}


### PR DESCRIPTION
## Description

Adds the **Listening History** screen to the Android TV app, reaching parity with tvOS (`UI/History/ListeningHistoryView.swift`). The profile modal already rendered a "Listening History" button wired to `{}` with a TODO; this PR builds the screen and wires the action to open it.

- New `TvListeningHistoryScreen` + `TvListeningHistoryViewModel` under `tv/.../history/`.
- Data comes from the shared repositories layer via `EpisodeManager.findPlaybackHistoryEpisodesFlow()`, whose Room query matches tvOS exactly: `last_playback_interaction_date > 0 ORDER BY last_playback_interaction_date DESC LIMIT 1000`. It is observed reactively, so the list live-updates as playback interactions change (equivalent to tvOS `listeningHistoryChanged`/`playbackTrackChanged`/`playbackEnded`). No server-history fetch and no clear-history, matching tvOS.
- Reuses the existing TV building blocks: `TvEpisodeListItem`, `TvEpisodeActionsModal`/`TvEpisodeInfoModal`, `TvEmptyState`, `LoadingView`, and the `TvDetailOverlay` + `tvFocusInactiveWhen` presentation pattern used by the other full-screen destinations.
- New `TvEpisodeActionContext.ListeningHistory` (source `listening_history`). Episode actions omit **Go to podcast**, mirroring tvOS `.other(showGoToPodcast: false)`.
- Empty state uses new strings `tv_history_empty_title` / `tv_history_empty_subtitle` ("No listening history" / "Episodes you play will show up here"), matching the tvOS copy.

### Analytics
- Fires `ListeningHistoryShownEvent` (no properties) when the screen appears, matching tvOS `listening_history_shown`, using the same `EventHorizon.track` pattern as the other TV screens.
- Episode-action events continue to flow from the shared managers, now attributed to the `listening_history` source via the new action context.

Fixes PCDROID-736 https://linear.app/a8c/issue/PCDROID-736/listening-history-screen

## Testing Instructions
1. Sign in on the TV app.
2. Play (or partially play) a few episodes so they enter your listening history.
3. Open the profile modal (top bar) and choose **Listening History**.
4. The screen shows your played episodes, newest first; SELECT plays an episode and opens Now Playing; the ellipsis opens the actions modal (note there is no "Go to podcast" option).
5. With no history, the empty state ("No listening history") is shown.
6. Press Back to return to the tabs.

## Screenshots or Screencast
| Screen | Analytics |
| --- | --- |
| <img width="1920" height="1080" alt="Screenshot_20260827_140310" src="https://github.com/user-attachments/assets/d750aac0-2d3f-4b3c-9637-72044aab3f31" /> | <img width="389" height="52" alt="SCR-20260827-mnnn" src="https://github.com/user-attachments/assets/6b007720-9db6-408f-acd7-73831e156d2d" /> |


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) the Event Horizon schema to reflect any new or changed analytics. (`listening_history_shown` already exists in the schema for tvOS; this reuses it — Android already lists `ListeningHistoryShownEvent`.)

