### PR TITLE
[TV] Add the profile Settings sheet

### DIFF
--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -269,6 +269,13 @@
     <string name="tv_search_no_results_subtitle">Try more general or different keywords.</string>
     <string name="tv_search_error_subtitle">Check your connection and try again.</string>
     <string name="tv_profile_starred_episodes">Starred Episodes</string>
+    <string name="tv_settings_subscription_title">Subscription</string>
+    <string name="tv_settings_subscription_plan">Plan</string>
+    <string name="tv_settings_subscription_next_renewal">Next renewal</string>
+    <string name="tv_settings_subscription_lifetime">Lifetime</string>
+    <string name="tv_settings_subscription_other_platform">This subscription was made on another platform. Please use that platform to manage the subscription.</string>
+    <string name="tv_settings_privacy_policy_qr_message">Scan the QR code below, or open the URL on your phone to access the Privacy Policy.</string>
+    <string name="tv_settings_terms_of_use_qr_message">Scan the QR code below, or open the URL on your phone to access the Terms of Use.</string>
     <string name="tv_sign_in_title">Log in to Pocket Casts</string>
     <string name="tv_sign_in_step_scan">Scan the QR code or go to %1$s</string>
     <string name="tv_sign_in_step_login">Log in to your account</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -272,6 +272,7 @@
     <string name="tv_settings_subscription_title">Subscription</string>
     <string name="tv_settings_subscription_plan">Plan</string>
     <string name="tv_settings_subscription_next_renewal">Next renewal</string>
+    <string name="tv_settings_subscription_expires">Expires</string>
     <string name="tv_settings_subscription_lifetime">Lifetime</string>
     <string name="tv_settings_subscription_other_platform">This subscription was made on another platform. Please use that platform to manage the subscription.</string>
     <string name="tv_settings_privacy_policy_qr_message">Scan the QR code below, or open the URL on your phone to access the Privacy Policy.</string>

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeRow.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeRow.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -36,12 +37,17 @@ import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.localization.helper.RelativeDateFormatter
 import au.com.shiftyjelly.pocketcasts.localization.helper.TimeHelper
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory
+import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory.PlaceholderType
 import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImage
 import au.com.shiftyjelly.pocketcasts.theme.TvTheme
 import au.com.shiftyjelly.pocketcasts.theme.tvColors
 import au.com.shiftyjelly.pocketcasts.theme.tvTypography
 import java.util.Date
 import au.com.shiftyjelly.pocketcasts.images.R as IR
+
+/** Whether episode rows render episode artwork over podcast artwork; mirrors the shared appearance setting. */
+val LocalUseEpisodeArtwork = staticCompositionLocalOf { false }
 
 @Composable
 fun TvEpisodeRow(
@@ -77,7 +83,7 @@ fun TvEpisodeRow(
                 .fillMaxWidth()
                 .padding(12.dp),
         ) {
-            EpisodeArtwork(podcastUuid = episode.podcastUuid)
+            EpisodeArtwork(episode = episode)
             Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
@@ -134,11 +140,21 @@ fun TvEpisodeRow(
 
 @Composable
 private fun EpisodeArtwork(
-    podcastUuid: String,
+    episode: PodcastEpisode,
     modifier: Modifier = Modifier,
 ) {
+    val useEpisodeArtwork = LocalUseEpisodeArtwork.current
+    val context = LocalContext.current
+    val model = if (useEpisodeArtwork) {
+        remember(episode.uuid) {
+            PocketCastsImageRequestFactory(context, placeholderType = PlaceholderType.None)
+                .create(episode, useEpisodeArtwork = true)
+        }
+    } else {
+        PodcastImage.getMediumArtworkUrl(episode.podcastUuid)
+    }
     TvArtworkImage(
-        model = PodcastImage.getMediumArtworkUrl(podcastUuid),
+        model = model,
         modifier = modifier
             .size(82.dp)
             .clip(RoundedCornerShape(4.dp)),

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvProfileModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvProfileModal.kt
@@ -41,6 +41,7 @@ fun TvProfileModal(
     onCreateAccount: () -> Unit,
     onStarredEpisodes: () -> Unit,
     onListeningHistory: () -> Unit,
+    onSettings: () -> Unit,
     onLogOut: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -54,6 +55,7 @@ fun TvProfileModal(
             onCreateAccount = onCreateAccount,
             onStarredEpisodes = onStarredEpisodes,
             onListeningHistory = onListeningHistory,
+            onSettings = onSettings,
             onLogOut = onLogOut,
         )
     }
@@ -66,6 +68,7 @@ private fun ColumnScope.TvProfileModalContent(
     onCreateAccount: () -> Unit,
     onStarredEpisodes: () -> Unit,
     onListeningHistory: () -> Unit,
+    onSettings: () -> Unit,
     onLogOut: () -> Unit,
 ) {
     val focusRequester = remember { FocusRequester() }
@@ -94,6 +97,10 @@ private fun ColumnScope.TvProfileModalContent(
                 onClick = onListeningHistory,
             )
             TvModalButton(
+                text = stringResource(LR.string.settings),
+                onClick = onSettings,
+            )
+            TvModalButton(
                 text = stringResource(LR.string.log_out),
                 onClick = onLogOut,
             )
@@ -108,6 +115,10 @@ private fun ColumnScope.TvProfileModalContent(
             TvModalButton(
                 text = stringResource(LR.string.create_account),
                 onClick = onCreateAccount,
+            )
+            TvModalButton(
+                text = stringResource(LR.string.settings),
+                onClick = onSettings,
             )
         }
     }
@@ -170,6 +181,7 @@ private fun TvProfileModalSignedOutPreview() {
                 onCreateAccount = {},
                 onStarredEpisodes = {},
                 onListeningHistory = {},
+                onSettings = {},
                 onLogOut = {},
             )
         }
@@ -187,6 +199,7 @@ private fun TvProfileModalSignedInPreview() {
                 onCreateAccount = {},
                 onStarredEpisodes = {},
                 onListeningHistory = {},
+                onSettings = {},
                 onLogOut = {},
             )
         }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvProfileModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvProfileModal.kt
@@ -83,7 +83,7 @@ private fun ColumnScope.TvProfileModalContent(
                 Text(
                     text = profile.email,
                     color = MaterialTheme.tvColors.textPrimary,
-                    style = MaterialTheme.tvTypography.headline.copy(textAlign = TextAlign.Center),
+                    style = MaterialTheme.tvTypography.callout.copy(textAlign = TextAlign.Center),
                     modifier = Modifier.padding(bottom = 16.dp),
                 )
             }
@@ -163,12 +163,12 @@ private fun TvProfileModalAvatarPlaceholder(modifier: Modifier = Modifier) {
             painter = painterResource(IR.drawable.ic_profile),
             contentDescription = null,
             tint = MaterialTheme.tvColors.textPrimary,
-            modifier = Modifier.size(48.dp),
+            modifier = Modifier.size(36.dp),
         )
     }
 }
 
-private val AvatarSize = 107.dp
+private val AvatarSize = 80.dp
 
 @Preview
 @Composable

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
@@ -29,6 +29,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import au.com.shiftyjelly.pocketcasts.component.LocalFocusTvTopBar
 import au.com.shiftyjelly.pocketcasts.component.LocalOpenNowPlaying
 import au.com.shiftyjelly.pocketcasts.component.LocalTvTopBarVisibility
+import au.com.shiftyjelly.pocketcasts.component.LocalUseEpisodeArtwork
 import au.com.shiftyjelly.pocketcasts.component.TvDetailOverlay
 import au.com.shiftyjelly.pocketcasts.component.TvTopBarVisibility
 import au.com.shiftyjelly.pocketcasts.component.tvFocusInactiveWhen
@@ -82,6 +83,7 @@ fun TvScaffold(
         LocalTvTopBarVisibility provides topBarVisibility,
         LocalOpenNowPlaying provides openNowPlaying,
         LocalFocusTvTopBar provides focusTopBar,
+        LocalUseEpisodeArtwork provides uiState.useEpisodeArtwork,
     ) {
         Box(modifier = modifier.fillMaxSize()) {
             TvScaffoldContent(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
@@ -153,6 +153,9 @@ fun TvScaffold(
         }
 
         if (isProfileModalVisible) {
+            LaunchedEffect(Unit) {
+                viewModel.trackProfileShown()
+            }
             TvProfileModal(
                 profile = uiState.profile,
                 onDismissRequest = { isProfileModalVisible = false },

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
@@ -177,7 +177,10 @@ fun TvScaffold(
                     isProfileModalVisible = false
                     isListeningHistoryVisible = true
                 },
-                onSettings = { isSettingsModalVisible = true },
+                onSettings = {
+                    isProfileModalVisible = false
+                    isSettingsModalVisible = true
+                },
                 onLogOut = {
                     isProfileModalVisible = false
                     viewModel.signOut()

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
@@ -37,6 +37,7 @@ import au.com.shiftyjelly.pocketcasts.nowplaying.TvNowPlayingScreen
 import au.com.shiftyjelly.pocketcasts.playlists.TvPlaylistsScreen
 import au.com.shiftyjelly.pocketcasts.podcasts.TvYourPodcastsScreen
 import au.com.shiftyjelly.pocketcasts.search.TvSearchScreen
+import au.com.shiftyjelly.pocketcasts.settings.TvSettingsModal
 import au.com.shiftyjelly.pocketcasts.starred.TvStarredScreen
 import au.com.shiftyjelly.pocketcasts.theme.TvScreenBackgroundBrush
 import au.com.shiftyjelly.pocketcasts.theme.TvTheme
@@ -55,6 +56,7 @@ fun TvScaffold(
     var isProfileModalVisible by rememberSaveable { mutableStateOf(false) }
     var isStarredVisible by rememberSaveable { mutableStateOf(false) }
     var isListeningHistoryVisible by rememberSaveable { mutableStateOf(false) }
+    var isSettingsModalVisible by rememberSaveable { mutableStateOf(false) }
     val topBarVisibility = remember { TvTopBarVisibility() }
     var didFocusTopBar by rememberSaveable { mutableStateOf(false) }
     var isNowPlayingOpenRequested by remember { mutableStateOf(false) }
@@ -170,11 +172,18 @@ fun TvScaffold(
                     isProfileModalVisible = false
                     isListeningHistoryVisible = true
                 },
+                onSettings = { isSettingsModalVisible = true },
                 onLogOut = {
                     isProfileModalVisible = false
                     viewModel.signOut()
                     onSignedOut()
                 },
+            )
+        }
+
+        if (isSettingsModalVisible) {
+            TvSettingsModal(
+                onDismissRequest = { isSettingsModalVisible = false },
             )
         }
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffoldViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffoldViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.TvLaunchRequests
 import au.com.shiftyjelly.pocketcasts.auth.TvSignOutManager
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import com.automattic.eventhorizon.EventHorizon
@@ -27,6 +28,7 @@ class TvScaffoldViewModel @Inject constructor(
     private val syncManager: SyncManager,
     private val signOutManager: TvSignOutManager,
     private val eventHorizon: EventHorizon,
+    private val settings: Settings,
     launchRequests: TvLaunchRequests,
     upNextQueue: UpNextQueue,
 ) : ViewModel() {
@@ -43,16 +45,21 @@ class TvScaffoldViewModel @Inject constructor(
         hasCurrentEpisode,
         syncManager.isLoggedInObservable.asFlow(),
         syncManager.emailFlow(),
-    ) { tab, hasEpisode, isLoggedIn, email ->
+        settings.artworkConfiguration.flow,
+    ) { tab, hasEpisode, isLoggedIn, email, artworkConfiguration ->
         TvScaffoldUiState(
             tabs = TvTab.tabs(showNowPlaying = hasEpisode || tab == TvTab.NowPlaying),
             selectedTab = tab,
             profile = profileState(isLoggedIn, email),
+            useEpisodeArtwork = artworkConfiguration.useEpisodeArtwork,
         )
     }.stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(5_000),
-        initialValue = TvScaffoldUiState(profile = currentProfileState()),
+        initialValue = TvScaffoldUiState(
+            profile = currentProfileState(),
+            useEpisodeArtwork = settings.artworkConfiguration.value.useEpisodeArtwork,
+        ),
     )
 
     init {
@@ -102,6 +109,7 @@ data class TvScaffoldUiState(
     val tabs: List<TvTab> = TvTab.entries,
     val selectedTab: TvTab = TvTab.Home,
     val profile: TvProfileState = TvProfileState.SignedOut,
+    val useEpisodeArtwork: Boolean = false,
 ) {
     val selectedTabIndex: Int get() = tabs.indexOf(selectedTab).coerceAtLeast(0)
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffoldViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffoldViewModel.kt
@@ -6,6 +6,8 @@ import au.com.shiftyjelly.pocketcasts.TvLaunchRequests
 import au.com.shiftyjelly.pocketcasts.auth.TvSignOutManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
+import com.automattic.eventhorizon.EventHorizon
+import com.automattic.eventhorizon.ProfileShownEvent
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.FlowPreview
@@ -24,6 +26,7 @@ import kotlinx.coroutines.rx2.asFlow
 class TvScaffoldViewModel @Inject constructor(
     private val syncManager: SyncManager,
     private val signOutManager: TvSignOutManager,
+    private val eventHorizon: EventHorizon,
     launchRequests: TvLaunchRequests,
     upNextQueue: UpNextQueue,
 ) : ViewModel() {
@@ -66,6 +69,10 @@ class TvScaffoldViewModel @Inject constructor(
 
     fun signOut() {
         signOutManager.signOutAndWipeData()
+    }
+
+    fun trackProfileShown() {
+        eventHorizon.track(ProfileShownEvent)
     }
 
     @OptIn(FlowPreview::class)

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/TvPreferences.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/TvPreferences.kt
@@ -29,14 +29,6 @@ class TvPreferences @Inject constructor(
         prefs.edit().putBoolean(podcastArchivedKey(podcastUuid), isShowingArchived).apply()
     }
 
-    fun isUsingEpisodeArtwork(): Boolean {
-        return prefs.getBoolean(USE_EPISODE_ARTWORK_KEY, false)
-    }
-
-    fun setUsingEpisodeArtwork(isUsingEpisodeArtwork: Boolean) {
-        prefs.edit().putBoolean(USE_EPISODE_ARTWORK_KEY, isUsingEpisodeArtwork).apply()
-    }
-
     @SuppressLint("ApplySharedPref")
     fun clearAll() {
         prefs.edit().clear().commit()
@@ -45,8 +37,4 @@ class TvPreferences @Inject constructor(
     private fun playlistArchivedKey(playlistUuid: String) = "show_archived_playlist_$playlistUuid"
 
     private fun podcastArchivedKey(podcastUuid: String) = "show_archived_podcast_$podcastUuid"
-
-    private companion object {
-        const val USE_EPISODE_ARTWORK_KEY = "use_episode_artwork"
-    }
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/TvPreferences.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/TvPreferences.kt
@@ -29,6 +29,14 @@ class TvPreferences @Inject constructor(
         prefs.edit().putBoolean(podcastArchivedKey(podcastUuid), isShowingArchived).apply()
     }
 
+    fun isUsingEpisodeArtwork(): Boolean {
+        return prefs.getBoolean(USE_EPISODE_ARTWORK_KEY, false)
+    }
+
+    fun setUsingEpisodeArtwork(isUsingEpisodeArtwork: Boolean) {
+        prefs.edit().putBoolean(USE_EPISODE_ARTWORK_KEY, isUsingEpisodeArtwork).apply()
+    }
+
     @SuppressLint("ApplySharedPref")
     fun clearAll() {
         prefs.edit().clear().commit()
@@ -37,4 +45,8 @@ class TvPreferences @Inject constructor(
     private fun playlistArchivedKey(playlistUuid: String) = "show_archived_playlist_$playlistUuid"
 
     private fun podcastArchivedKey(podcastUuid: String) = "show_archived_podcast_$podcastUuid"
+
+    private companion object {
+        const val USE_EPISODE_ARTWORK_KEY = "use_episode_artwork"
+    }
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/settings/TvSettingsModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/settings/TvSettingsModal.kt
@@ -1,0 +1,392 @@
+package au.com.shiftyjelly.pocketcasts.settings
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.tv.material3.Button
+import androidx.tv.material3.Icon
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.component.TvModal
+import au.com.shiftyjelly.pocketcasts.component.TvModalButton
+import au.com.shiftyjelly.pocketcasts.component.TvModalSurface
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPlatform
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.qr.rememberQrPainter
+import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
+import au.com.shiftyjelly.pocketcasts.theme.TvTheme
+import au.com.shiftyjelly.pocketcasts.theme.tvColors
+import au.com.shiftyjelly.pocketcasts.theme.tvTypography
+import au.com.shiftyjelly.pocketcasts.payment.BillingCycle
+import au.com.shiftyjelly.pocketcasts.payment.SubscriptionTier
+import java.text.DateFormat
+import java.time.Instant
+import java.util.Date
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+fun TvSettingsModal(
+    onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: TvSettingsViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    var subScreen by remember { mutableStateOf<TvSettingsSubScreen?>(null) }
+
+    TvModal(
+        onDismissRequest = onDismissRequest,
+        modifier = modifier,
+    ) {
+        LaunchedEffect(Unit) {
+            viewModel.trackSettingsShown()
+        }
+        TvSettingsMenuContent(
+            isSignedIn = uiState.isSignedIn,
+            useEpisodeArtwork = uiState.useEpisodeArtwork,
+            onSubscription = { subScreen = TvSettingsSubScreen.Subscription },
+            onPrivacyPolicy = { subScreen = TvSettingsSubScreen.PrivacyPolicy },
+            onTermsOfUse = { subScreen = TvSettingsSubScreen.TermsOfUse },
+            onToggleEpisodeArtwork = { viewModel.setUseEpisodeArtwork(!uiState.useEpisodeArtwork) },
+        )
+    }
+
+    when (subScreen) {
+        TvSettingsSubScreen.Subscription -> TvSubscriptionInfoModal(
+            subscription = uiState.subscription,
+            onDismissRequest = { subScreen = null },
+            onShown = viewModel::trackSubscriptionShown,
+        )
+
+        TvSettingsSubScreen.PrivacyPolicy -> TvQrLinkModal(
+            title = stringResource(LR.string.profile_privacy_policy),
+            message = stringResource(LR.string.tv_settings_privacy_policy_qr_message),
+            url = Settings.INFO_PRIVACY_URL,
+            onDismissRequest = { subScreen = null },
+            onShown = viewModel::trackPrivacyPolicyShown,
+        )
+
+        TvSettingsSubScreen.TermsOfUse -> TvQrLinkModal(
+            title = stringResource(LR.string.profile_terms_of_use),
+            message = stringResource(LR.string.tv_settings_terms_of_use_qr_message),
+            url = Settings.INFO_TOS_URL,
+            onDismissRequest = { subScreen = null },
+            onShown = viewModel::trackTermsOfUseShown,
+        )
+
+        null -> Unit
+    }
+}
+
+private enum class TvSettingsSubScreen {
+    Subscription,
+    PrivacyPolicy,
+    TermsOfUse,
+}
+
+@Composable
+private fun ColumnScope.TvSettingsMenuContent(
+    isSignedIn: Boolean,
+    useEpisodeArtwork: Boolean,
+    onSubscription: () -> Unit,
+    onPrivacyPolicy: () -> Unit,
+    onTermsOfUse: () -> Unit,
+    onToggleEpisodeArtwork: () -> Unit,
+) {
+    val focusRequester = remember { FocusRequester() }
+    LaunchedEffect(isSignedIn) {
+        focusRequester.requestFocus()
+    }
+
+    if (isSignedIn) {
+        TvModalButton(
+            text = stringResource(LR.string.tv_settings_subscription_title),
+            onClick = onSubscription,
+            modifier = Modifier.focusRequester(focusRequester),
+        )
+    }
+    TvModalButton(
+        text = stringResource(LR.string.profile_privacy_policy),
+        onClick = onPrivacyPolicy,
+        modifier = if (isSignedIn) Modifier else Modifier.focusRequester(focusRequester),
+    )
+    TvModalButton(
+        text = stringResource(LR.string.profile_terms_of_use),
+        onClick = onTermsOfUse,
+    )
+    TvSettingsDivider()
+    TvSettingsToggleRow(
+        label = stringResource(LR.string.settings_use_episode_artwork),
+        checked = useEpisodeArtwork,
+        onClick = onToggleEpisodeArtwork,
+    )
+}
+
+@Composable
+private fun TvSettingsToggleRow(
+    label: String,
+    checked: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Button(
+        onClick = onClick,
+        colors = TvButtonDefaults.filledButtonColors(),
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(
+                text = label,
+                style = MaterialTheme.tvTypography.caption1,
+                modifier = Modifier.weight(1f),
+            )
+            if (checked) {
+                Icon(
+                    painter = painterResource(IR.drawable.ic_check),
+                    contentDescription = null,
+                    modifier = Modifier.size(20.dp),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun TvSettingsDivider() {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(1.dp)
+            .background(MaterialTheme.tvColors.overlayBorder),
+    )
+}
+
+@Composable
+private fun TvSubscriptionInfoModal(
+    subscription: Subscription?,
+    onDismissRequest: () -> Unit,
+    onShown: () -> Unit,
+) {
+    TvModal(onDismissRequest = onDismissRequest) {
+        LaunchedEffect(Unit) {
+            onShown()
+        }
+        Text(
+            text = stringResource(LR.string.tv_settings_subscription_title),
+            color = MaterialTheme.tvColors.textPrimary,
+            style = MaterialTheme.tvTypography.headline.copy(textAlign = TextAlign.Center),
+            modifier = Modifier.fillMaxWidth(),
+        )
+        if (subscription == null) {
+            Text(
+                text = stringResource(LR.string.profile_free_account),
+                color = MaterialTheme.tvColors.textSecondary,
+                style = MaterialTheme.tvTypography.caption1.copy(textAlign = TextAlign.Center),
+                modifier = Modifier.fillMaxWidth(),
+            )
+        } else {
+            TvSettingsInfoRow(
+                label = stringResource(LR.string.tv_settings_subscription_plan),
+                value = subscriptionPlanText(subscription),
+            )
+            TvSettingsInfoRow(
+                label = stringResource(LR.string.tv_settings_subscription_next_renewal),
+                value = subscriptionRenewalText(subscription),
+            )
+            if (subscription.platform != SubscriptionPlatform.Android) {
+                Text(
+                    text = stringResource(LR.string.tv_settings_subscription_other_platform),
+                    color = MaterialTheme.tvColors.textSecondary,
+                    style = MaterialTheme.tvTypography.caption1.copy(textAlign = TextAlign.Center),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun TvSettingsInfoRow(label: String, value: String) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Text(
+            text = label,
+            color = MaterialTheme.tvColors.textSecondary,
+            style = MaterialTheme.tvTypography.body,
+            modifier = Modifier.weight(1f),
+        )
+        Text(
+            text = value,
+            color = MaterialTheme.tvColors.textPrimary,
+            style = MaterialTheme.tvTypography.body.copy(textAlign = TextAlign.End),
+        )
+    }
+}
+
+@Composable
+private fun subscriptionPlanText(subscription: Subscription): String {
+    val tier = when (subscription.tier) {
+        SubscriptionTier.Plus -> stringResource(LR.string.pocket_casts_plus_short)
+        SubscriptionTier.Patron -> stringResource(LR.string.pocket_casts_patron_short)
+    }
+    val cycle = when (subscription.billingCycle) {
+        BillingCycle.Monthly -> stringResource(LR.string.profile_monthly)
+        BillingCycle.Yearly -> stringResource(LR.string.profile_yearly)
+        null -> null
+    }
+    return listOfNotNull(tier, cycle).joinToString(separator = " ")
+}
+
+@Composable
+private fun subscriptionRenewalText(subscription: Subscription): String {
+    if (subscription.isChampion) {
+        return stringResource(LR.string.tv_settings_subscription_lifetime)
+    }
+    return remember(subscription.expiryDate) {
+        DateFormat.getDateInstance(DateFormat.LONG).format(Date.from(subscription.expiryDate))
+    }
+}
+
+@Composable
+private fun TvQrLinkModal(
+    title: String,
+    message: String,
+    url: String,
+    onDismissRequest: () -> Unit,
+    onShown: () -> Unit,
+) {
+    TvModal(onDismissRequest = onDismissRequest) {
+        LaunchedEffect(Unit) {
+            onShown()
+        }
+        Text(
+            text = title,
+            color = MaterialTheme.tvColors.textPrimary,
+            style = MaterialTheme.tvTypography.title2.copy(textAlign = TextAlign.Center),
+            modifier = Modifier.fillMaxWidth(),
+        )
+        Text(
+            text = message,
+            color = MaterialTheme.tvColors.textSecondary,
+            style = MaterialTheme.tvTypography.body.copy(textAlign = TextAlign.Center),
+            modifier = Modifier.fillMaxWidth(),
+        )
+        TvQrCode(
+            content = url,
+            modifier = Modifier.align(Alignment.CenterHorizontally),
+        )
+        Text(
+            text = url,
+            color = MaterialTheme.tvColors.textSecondary,
+            style = MaterialTheme.tvTypography.caption1.copy(textAlign = TextAlign.Center),
+            modifier = Modifier.fillMaxWidth(),
+        )
+        TvModalButton(
+            text = stringResource(LR.string.done),
+            onClick = onDismissRequest,
+        )
+    }
+}
+
+@Composable
+private fun TvQrCode(content: String, modifier: Modifier = Modifier) {
+    val qrPainter = rememberQrPainter(content = content, size = QrSize)
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(8.dp))
+            .background(Color.White)
+            .padding(10.dp),
+    ) {
+        Image(
+            painter = qrPainter,
+            contentDescription = null,
+            modifier = Modifier.size(QrSize),
+        )
+    }
+}
+
+private val QrSize = 160.dp
+
+@Preview
+@Composable
+private fun TvSettingsMenuSignedInPreview() {
+    TvTheme {
+        TvModalSurface {
+            TvSettingsMenuContent(
+                isSignedIn = true,
+                useEpisodeArtwork = true,
+                onSubscription = {},
+                onPrivacyPolicy = {},
+                onTermsOfUse = {},
+                onToggleEpisodeArtwork = {},
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun TvSettingsMenuSignedOutPreview() {
+    TvTheme {
+        TvModalSurface {
+            TvSettingsMenuContent(
+                isSignedIn = false,
+                useEpisodeArtwork = false,
+                onSubscription = {},
+                onPrivacyPolicy = {},
+                onTermsOfUse = {},
+                onToggleEpisodeArtwork = {},
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun TvSubscriptionInfoPreview() {
+    TvTheme {
+        TvModalSurface {
+            TvSettingsInfoRow(
+                label = stringResource(LR.string.tv_settings_subscription_plan),
+                value = "Plus Yearly",
+            )
+            TvSettingsInfoRow(
+                label = stringResource(LR.string.tv_settings_subscription_next_renewal),
+                value = DateFormat.getDateInstance(DateFormat.LONG).format(Date.from(Instant.now())),
+            )
+        }
+    }
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/settings/TvSettingsModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/settings/TvSettingsModal.kt
@@ -226,10 +226,19 @@ private fun TvSubscriptionInfoModal(
                 label = stringResource(LR.string.tv_settings_subscription_plan),
                 value = subscriptionPlanText(subscription),
             )
-            TvSettingsInfoRow(
-                label = subscriptionRenewalLabel(subscription),
-                value = subscriptionRenewalText(subscription),
-            )
+            if (subscription.isChampion) {
+                Text(
+                    text = stringResource(LR.string.tv_settings_subscription_lifetime),
+                    color = MaterialTheme.tvColors.textSecondary,
+                    style = MaterialTheme.tvTypography.caption1.copy(textAlign = TextAlign.Center),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            } else {
+                TvSettingsInfoRow(
+                    label = subscriptionRenewalLabel(subscription),
+                    value = subscriptionRenewalText(subscription),
+                )
+            }
             if (subscription.isManagedOnAnotherPlatform) {
                 Text(
                     text = stringResource(LR.string.tv_settings_subscription_other_platform),
@@ -287,16 +296,13 @@ private fun subscriptionPlanText(subscription: Subscription): String {
 @Composable
 private fun subscriptionRenewalLabel(subscription: Subscription): String = stringResource(
     when {
-        subscription.isChampion || subscription.isAutoRenewing -> LR.string.tv_settings_subscription_next_renewal
+        subscription.isAutoRenewing -> LR.string.tv_settings_subscription_next_renewal
         else -> LR.string.tv_settings_subscription_expires
     },
 )
 
 @Composable
 private fun subscriptionRenewalText(subscription: Subscription): String {
-    if (subscription.isChampion) {
-        return stringResource(LR.string.tv_settings_subscription_lifetime)
-    }
     return remember(subscription.expiryDate) {
         Date.from(subscription.expiryDate).toLocalizedFormatLongStyle()
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/settings/TvSettingsModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/settings/TvSettingsModal.kt
@@ -248,7 +248,7 @@ private fun TvSubscriptionInfoModal(
 }
 
 private val Subscription.isManagedOnAnotherPlatform: Boolean
-    get() = platform == SubscriptionPlatform.iOS || platform == SubscriptionPlatform.Web
+    get() = platform != SubscriptionPlatform.Android
 
 @Composable
 private fun TvSettingsInfoRow(label: String, value: String) {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/settings/TvSettingsModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/settings/TvSettingsModal.kt
@@ -47,7 +47,7 @@ import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
 import au.com.shiftyjelly.pocketcasts.theme.TvTheme
 import au.com.shiftyjelly.pocketcasts.theme.tvColors
 import au.com.shiftyjelly.pocketcasts.theme.tvTypography
-import java.text.DateFormat
+import au.com.shiftyjelly.pocketcasts.utils.extensions.toLocalizedFormatLongStyle
 import java.time.Instant
 import java.util.Date
 import au.com.shiftyjelly.pocketcasts.images.R as IR
@@ -227,7 +227,7 @@ private fun TvSubscriptionInfoModal(
                 value = subscriptionPlanText(subscription),
             )
             TvSettingsInfoRow(
-                label = stringResource(LR.string.tv_settings_subscription_next_renewal),
+                label = subscriptionRenewalLabel(subscription),
                 value = subscriptionRenewalText(subscription),
             )
             if (subscription.isManagedOnAnotherPlatform) {
@@ -285,12 +285,20 @@ private fun subscriptionPlanText(subscription: Subscription): String {
 }
 
 @Composable
+private fun subscriptionRenewalLabel(subscription: Subscription): String = stringResource(
+    when {
+        subscription.isChampion || subscription.isAutoRenewing -> LR.string.tv_settings_subscription_next_renewal
+        else -> LR.string.tv_settings_subscription_expires
+    },
+)
+
+@Composable
 private fun subscriptionRenewalText(subscription: Subscription): String {
     if (subscription.isChampion) {
         return stringResource(LR.string.tv_settings_subscription_lifetime)
     }
     return remember(subscription.expiryDate) {
-        DateFormat.getDateInstance(DateFormat.LONG).format(Date.from(subscription.expiryDate))
+        Date.from(subscription.expiryDate).toLocalizedFormatLongStyle()
     }
 }
 
@@ -400,7 +408,7 @@ private fun TvSubscriptionInfoPreview() {
             )
             TvSettingsInfoRow(
                 label = stringResource(LR.string.tv_settings_subscription_next_renewal),
-                value = DateFormat.getDateInstance(DateFormat.LONG).format(Date.from(Instant.now())),
+                value = Date.from(Instant.now()).toLocalizedFormatLongStyle(),
             )
         }
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/settings/TvSettingsModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/settings/TvSettingsModal.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.settings
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -9,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -17,8 +19,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -35,21 +39,17 @@ import au.com.shiftyjelly.pocketcasts.component.TvModalButton
 import au.com.shiftyjelly.pocketcasts.component.TvModalSurface
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPlatform
+import au.com.shiftyjelly.pocketcasts.payment.BillingCycle
+import au.com.shiftyjelly.pocketcasts.payment.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.qr.rememberQrPainter
 import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
 import au.com.shiftyjelly.pocketcasts.theme.TvTheme
 import au.com.shiftyjelly.pocketcasts.theme.tvColors
 import au.com.shiftyjelly.pocketcasts.theme.tvTypography
-import au.com.shiftyjelly.pocketcasts.payment.BillingCycle
-import au.com.shiftyjelly.pocketcasts.payment.SubscriptionTier
 import java.text.DateFormat
 import java.time.Instant
 import java.util.Date
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -61,6 +61,15 @@ fun TvSettingsModal(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     var subScreen by remember { mutableStateOf<TvSettingsSubScreen?>(null) }
+
+    LaunchedEffect(subScreen) {
+        when (subScreen) {
+            TvSettingsSubScreen.Subscription -> viewModel.trackSubscriptionShown()
+            TvSettingsSubScreen.PrivacyPolicy -> viewModel.trackPrivacyPolicyShown()
+            TvSettingsSubScreen.TermsOfUse -> viewModel.trackTermsOfUseShown()
+            null -> Unit
+        }
+    }
 
     TvModal(
         onDismissRequest = onDismissRequest,
@@ -83,7 +92,6 @@ fun TvSettingsModal(
         TvSettingsSubScreen.Subscription -> TvSubscriptionInfoModal(
             subscription = uiState.subscription,
             onDismissRequest = { subScreen = null },
-            onShown = viewModel::trackSubscriptionShown,
         )
 
         TvSettingsSubScreen.PrivacyPolicy -> TvQrLinkModal(
@@ -91,7 +99,6 @@ fun TvSettingsModal(
             message = stringResource(LR.string.tv_settings_privacy_policy_qr_message),
             url = Settings.INFO_PRIVACY_URL,
             onDismissRequest = { subScreen = null },
-            onShown = viewModel::trackPrivacyPolicyShown,
         )
 
         TvSettingsSubScreen.TermsOfUse -> TvQrLinkModal(
@@ -99,7 +106,6 @@ fun TvSettingsModal(
             message = stringResource(LR.string.tv_settings_terms_of_use_qr_message),
             url = Settings.INFO_TOS_URL,
             onDismissRequest = { subScreen = null },
-            onShown = viewModel::trackTermsOfUseShown,
         )
 
         null -> Unit
@@ -196,12 +202,12 @@ private fun TvSettingsDivider() {
 private fun TvSubscriptionInfoModal(
     subscription: Subscription?,
     onDismissRequest: () -> Unit,
-    onShown: () -> Unit,
 ) {
+    val focusRequester = remember { FocusRequester() }
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
     TvModal(onDismissRequest = onDismissRequest) {
-        LaunchedEffect(Unit) {
-            onShown()
-        }
         Text(
             text = stringResource(LR.string.tv_settings_subscription_title),
             color = MaterialTheme.tvColors.textPrimary,
@@ -224,7 +230,7 @@ private fun TvSubscriptionInfoModal(
                 label = stringResource(LR.string.tv_settings_subscription_next_renewal),
                 value = subscriptionRenewalText(subscription),
             )
-            if (subscription.platform != SubscriptionPlatform.Android) {
+            if (subscription.isManagedOnAnotherPlatform) {
                 Text(
                     text = stringResource(LR.string.tv_settings_subscription_other_platform),
                     color = MaterialTheme.tvColors.textSecondary,
@@ -233,8 +239,16 @@ private fun TvSubscriptionInfoModal(
                 )
             }
         }
+        TvModalButton(
+            text = stringResource(LR.string.done),
+            onClick = onDismissRequest,
+            modifier = Modifier.focusRequester(focusRequester),
+        )
     }
 }
+
+private val Subscription.isManagedOnAnotherPlatform: Boolean
+    get() = platform == SubscriptionPlatform.iOS || platform == SubscriptionPlatform.Web
 
 @Composable
 private fun TvSettingsInfoRow(label: String, value: String) {
@@ -286,12 +300,12 @@ private fun TvQrLinkModal(
     message: String,
     url: String,
     onDismissRequest: () -> Unit,
-    onShown: () -> Unit,
 ) {
+    val focusRequester = remember { FocusRequester() }
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
     TvModal(onDismissRequest = onDismissRequest) {
-        LaunchedEffect(Unit) {
-            onShown()
-        }
         Text(
             text = title,
             color = MaterialTheme.tvColors.textPrimary,
@@ -317,6 +331,7 @@ private fun TvQrLinkModal(
         TvModalButton(
             text = stringResource(LR.string.done),
             onClick = onDismissRequest,
+            modifier = Modifier.focusRequester(focusRequester),
         )
     }
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/settings/TvSettingsModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/settings/TvSettingsModal.kt
@@ -248,7 +248,7 @@ private fun TvSubscriptionInfoModal(
 }
 
 private val Subscription.isManagedOnAnotherPlatform: Boolean
-    get() = platform != SubscriptionPlatform.Android
+    get() = platform == SubscriptionPlatform.iOS || platform == SubscriptionPlatform.Web
 
 @Composable
 private fun TvSettingsInfoRow(label: String, value: String) {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/settings/TvSettingsViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/settings/TvSettingsViewModel.kt
@@ -4,14 +4,17 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.TvPreferences
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import com.automattic.eventhorizon.AccountDetailsShowPrivacyPolicyEvent
 import com.automattic.eventhorizon.AccountDetailsShowTosEvent
 import com.automattic.eventhorizon.AccountDetailsSubscriptionEvent
 import com.automattic.eventhorizon.EventHorizon
+import com.automattic.eventhorizon.SettingsAppearanceUseEpisodeArtworkToggledEvent
 import com.automattic.eventhorizon.SettingsGeneralShownEvent
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
@@ -22,16 +25,19 @@ import kotlinx.coroutines.rx2.asFlow
 class TvSettingsViewModel @Inject constructor(
     private val settings: Settings,
     private val syncManager: SyncManager,
+    private val tvPreferences: TvPreferences,
     private val eventHorizon: EventHorizon,
 ) : ViewModel() {
+    private val useEpisodeArtwork = MutableStateFlow(tvPreferences.isUsingEpisodeArtwork())
+
     val uiState: StateFlow<TvSettingsUiState> = combine(
         syncManager.isLoggedInObservable.asFlow(),
-        settings.artworkConfiguration.flow,
+        useEpisodeArtwork,
         settings.cachedSubscription.flow,
-    ) { isSignedIn, artwork, subscription ->
+    ) { isSignedIn, useEpisodeArtwork, subscription ->
         TvSettingsUiState(
             isSignedIn = isSignedIn,
-            useEpisodeArtwork = artwork.useEpisodeArtwork,
+            useEpisodeArtwork = useEpisodeArtwork,
             subscription = subscription,
         )
     }.stateIn(
@@ -39,14 +45,15 @@ class TvSettingsViewModel @Inject constructor(
         started = SharingStarted.WhileSubscribed(STOP_TIMEOUT_MILLIS),
         initialValue = TvSettingsUiState(
             isSignedIn = syncManager.isLoggedIn(),
-            useEpisodeArtwork = settings.artworkConfiguration.value.useEpisodeArtwork,
+            useEpisodeArtwork = useEpisodeArtwork.value,
             subscription = settings.cachedSubscription.value,
         ),
     )
 
     fun setUseEpisodeArtwork(value: Boolean) {
-        val configuration = settings.artworkConfiguration.value
-        settings.artworkConfiguration.set(configuration.copy(useEpisodeArtwork = value), updateModifiedAt = true)
+        tvPreferences.setUsingEpisodeArtwork(value)
+        useEpisodeArtwork.value = value
+        eventHorizon.track(SettingsAppearanceUseEpisodeArtworkToggledEvent(enabled = value))
     }
 
     fun trackSettingsShown() {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/settings/TvSettingsViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/settings/TvSettingsViewModel.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.preferences.TvPreferences
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import com.automattic.eventhorizon.AccountDetailsShowPrivacyPolicyEvent
 import com.automattic.eventhorizon.AccountDetailsShowTosEvent
@@ -14,7 +13,6 @@ import com.automattic.eventhorizon.SettingsAppearanceUseEpisodeArtworkToggledEve
 import com.automattic.eventhorizon.SettingsGeneralShownEvent
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
@@ -25,19 +23,17 @@ import kotlinx.coroutines.rx2.asFlow
 class TvSettingsViewModel @Inject constructor(
     private val settings: Settings,
     private val syncManager: SyncManager,
-    private val tvPreferences: TvPreferences,
     private val eventHorizon: EventHorizon,
 ) : ViewModel() {
-    private val useEpisodeArtwork = MutableStateFlow(tvPreferences.isUsingEpisodeArtwork())
 
     val uiState: StateFlow<TvSettingsUiState> = combine(
         syncManager.isLoggedInObservable.asFlow(),
-        useEpisodeArtwork,
+        settings.artworkConfiguration.flow,
         settings.cachedSubscription.flow,
-    ) { isSignedIn, useEpisodeArtwork, subscription ->
+    ) { isSignedIn, artworkConfiguration, subscription ->
         TvSettingsUiState(
             isSignedIn = isSignedIn,
-            useEpisodeArtwork = useEpisodeArtwork,
+            useEpisodeArtwork = artworkConfiguration.useEpisodeArtwork,
             subscription = subscription,
         )
     }.stateIn(
@@ -45,14 +41,14 @@ class TvSettingsViewModel @Inject constructor(
         started = SharingStarted.WhileSubscribed(STOP_TIMEOUT_MILLIS),
         initialValue = TvSettingsUiState(
             isSignedIn = syncManager.isLoggedIn(),
-            useEpisodeArtwork = useEpisodeArtwork.value,
+            useEpisodeArtwork = settings.artworkConfiguration.value.useEpisodeArtwork,
             subscription = settings.cachedSubscription.value,
         ),
     )
 
     fun setUseEpisodeArtwork(value: Boolean) {
-        tvPreferences.setUsingEpisodeArtwork(value)
-        useEpisodeArtwork.value = value
+        val currentConfiguration = settings.artworkConfiguration.value
+        settings.artworkConfiguration.set(currentConfiguration.copy(useEpisodeArtwork = value), updateModifiedAt = true)
         eventHorizon.track(SettingsAppearanceUseEpisodeArtworkToggledEvent(enabled = value))
     }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/settings/TvSettingsViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/settings/TvSettingsViewModel.kt
@@ -1,0 +1,75 @@
+package au.com.shiftyjelly.pocketcasts.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
+import com.automattic.eventhorizon.AccountDetailsShowPrivacyPolicyEvent
+import com.automattic.eventhorizon.AccountDetailsShowTosEvent
+import com.automattic.eventhorizon.AccountDetailsSubscriptionEvent
+import com.automattic.eventhorizon.EventHorizon
+import com.automattic.eventhorizon.SettingsGeneralShownEvent
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.rx2.asFlow
+
+@HiltViewModel
+class TvSettingsViewModel @Inject constructor(
+    private val settings: Settings,
+    private val syncManager: SyncManager,
+    private val eventHorizon: EventHorizon,
+) : ViewModel() {
+    val uiState: StateFlow<TvSettingsUiState> = combine(
+        syncManager.isLoggedInObservable.asFlow(),
+        settings.artworkConfiguration.flow,
+        settings.cachedSubscription.flow,
+    ) { isSignedIn, artwork, subscription ->
+        TvSettingsUiState(
+            isSignedIn = isSignedIn,
+            useEpisodeArtwork = artwork.useEpisodeArtwork,
+            subscription = subscription,
+        )
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(STOP_TIMEOUT_MILLIS),
+        initialValue = TvSettingsUiState(
+            isSignedIn = syncManager.isLoggedIn(),
+            useEpisodeArtwork = settings.artworkConfiguration.value.useEpisodeArtwork,
+            subscription = settings.cachedSubscription.value,
+        ),
+    )
+
+    fun setUseEpisodeArtwork(value: Boolean) {
+        val configuration = settings.artworkConfiguration.value
+        settings.artworkConfiguration.set(configuration.copy(useEpisodeArtwork = value), updateModifiedAt = true)
+    }
+
+    fun trackSettingsShown() {
+        eventHorizon.track(SettingsGeneralShownEvent)
+    }
+
+    fun trackSubscriptionShown() {
+        eventHorizon.track(AccountDetailsSubscriptionEvent)
+    }
+
+    fun trackPrivacyPolicyShown() {
+        eventHorizon.track(AccountDetailsShowPrivacyPolicyEvent)
+    }
+
+    fun trackTermsOfUseShown() {
+        eventHorizon.track(AccountDetailsShowTosEvent)
+    }
+}
+
+private const val STOP_TIMEOUT_MILLIS = 5_000L
+
+data class TvSettingsUiState(
+    val isSignedIn: Boolean = false,
+    val useEpisodeArtwork: Boolean = false,
+    val subscription: Subscription? = null,
+)

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/TvScaffoldViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/TvScaffoldViewModelTest.kt
@@ -9,6 +9,8 @@ import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import com.automattic.eventhorizon.EventHorizon
+import com.automattic.eventhorizon.ProfileShownEvent
 import com.jakewharton.rxrelay2.BehaviorRelay
 import io.reactivex.subjects.BehaviorSubject
 import java.util.Date
@@ -52,9 +54,10 @@ class TvScaffoldViewModelTest {
     )
 
     private val launchRequests = TvLaunchRequests()
+    private val eventHorizon = mock<EventHorizon>()
 
     private val viewModel by lazy {
-        TvScaffoldViewModel(syncManager, signOutManager, launchRequests, upNextQueue)
+        TvScaffoldViewModel(syncManager, signOutManager, eventHorizon, launchRequests, upNextQueue)
     }
 
     @Test
@@ -262,5 +265,12 @@ class TvScaffoldViewModelTest {
         viewModel.signOut()
 
         verify(signOutManager).signOutAndWipeData()
+    }
+
+    @Test
+    fun `trackProfileShown tracks the profile shown event`() = runTest {
+        viewModel.trackProfileShown()
+
+        verify(eventHorizon).track(ProfileShownEvent)
     }
 }

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/TvScaffoldViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/TvScaffoldViewModelTest.kt
@@ -6,6 +6,9 @@ import au.com.shiftyjelly.pocketcasts.home.TvProfileState
 import au.com.shiftyjelly.pocketcasts.home.TvScaffoldViewModel
 import au.com.shiftyjelly.pocketcasts.home.TvTab
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
+import au.com.shiftyjelly.pocketcasts.preferences.model.ArtworkConfiguration
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
@@ -56,8 +59,16 @@ class TvScaffoldViewModelTest {
     private val launchRequests = TvLaunchRequests()
     private val eventHorizon = mock<EventHorizon>()
 
+    private val artworkConfigurationSetting = mock<UserSetting<ArtworkConfiguration>> {
+        on { flow } doReturn MutableStateFlow(ArtworkConfiguration(useEpisodeArtwork = false))
+        on { value } doReturn ArtworkConfiguration(useEpisodeArtwork = false)
+    }
+    private val settings = mock<Settings> {
+        on { artworkConfiguration } doReturn artworkConfigurationSetting
+    }
+
     private val viewModel by lazy {
-        TvScaffoldViewModel(syncManager, signOutManager, eventHorizon, launchRequests, upNextQueue)
+        TvScaffoldViewModel(syncManager, signOutManager, eventHorizon, settings, launchRequests, upNextQueue)
     }
 
     @Test

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/settings/TvSettingsViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/settings/TvSettingsViewModelTest.kt
@@ -1,0 +1,138 @@
+package au.com.shiftyjelly.pocketcasts.settings
+
+import app.cash.turbine.test
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPlatform
+import au.com.shiftyjelly.pocketcasts.payment.BillingCycle
+import au.com.shiftyjelly.pocketcasts.payment.SubscriptionTier
+import au.com.shiftyjelly.pocketcasts.preferences.ReadSetting
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
+import au.com.shiftyjelly.pocketcasts.preferences.model.ArtworkConfiguration
+import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
+import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import com.automattic.eventhorizon.AccountDetailsShowPrivacyPolicyEvent
+import com.automattic.eventhorizon.AccountDetailsShowTosEvent
+import com.automattic.eventhorizon.AccountDetailsSubscriptionEvent
+import com.automattic.eventhorizon.EventHorizon
+import com.automattic.eventhorizon.SettingsGeneralShownEvent
+import com.jakewharton.rxrelay2.BehaviorRelay
+import java.time.Instant
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TvSettingsViewModelTest {
+
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
+
+    private val isLoggedIn = BehaviorRelay.createDefault(false)
+    private val artworkFlow = MutableStateFlow(ArtworkConfiguration(useEpisodeArtwork = false))
+    private val subscriptionFlow = MutableStateFlow<Subscription?>(null)
+
+    private val artworkSetting = mock<UserSetting<ArtworkConfiguration>> {
+        on { flow } doReturn artworkFlow
+        on { value } doReturn ArtworkConfiguration(useEpisodeArtwork = false)
+    }
+    private val subscriptionSetting = mock<ReadSetting<Subscription?>> {
+        on { flow } doReturn subscriptionFlow
+        on { value } doReturn null
+    }
+    private val settings = mock<Settings> {
+        on { artworkConfiguration } doReturn artworkSetting
+        on { cachedSubscription } doReturn subscriptionSetting
+    }
+    private val syncManager = mock<SyncManager> {
+        on { isLoggedIn() } doReturn false
+        on { isLoggedInObservable } doReturn isLoggedIn
+    }
+    private val eventHorizon = mock<EventHorizon>()
+
+    @Test
+    fun `initial state reflects the current settings`() = runTest {
+        createViewModel().uiState.test {
+            val state = awaitItem()
+            assertEquals(false, state.isSignedIn)
+            assertEquals(false, state.useEpisodeArtwork)
+            assertEquals(null, state.subscription)
+        }
+    }
+
+    @Test
+    fun `state reflects sign in artwork and subscription changes`() = runTest {
+        val subscription = subscription(platform = SubscriptionPlatform.Android)
+
+        createViewModel().uiState.test {
+            skipItems(1)
+
+            isLoggedIn.accept(true)
+            assertEquals(true, awaitItem().isSignedIn)
+
+            artworkFlow.value = ArtworkConfiguration(useEpisodeArtwork = true)
+            assertEquals(true, awaitItem().useEpisodeArtwork)
+
+            subscriptionFlow.value = subscription
+            assertEquals(subscription, awaitItem().subscription)
+        }
+    }
+
+    @Test
+    fun `setUseEpisodeArtwork writes the artwork configuration`() = runTest {
+        createViewModel().setUseEpisodeArtwork(true)
+
+        verify(artworkSetting).set(eq(ArtworkConfiguration(useEpisodeArtwork = true)), eq(true), any(), any())
+    }
+
+    @Test
+    fun `showing the settings menu tracks the general shown event`() = runTest {
+        createViewModel().trackSettingsShown()
+
+        verify(eventHorizon).track(SettingsGeneralShownEvent)
+    }
+
+    @Test
+    fun `showing the subscription info tracks the subscription event`() = runTest {
+        createViewModel().trackSubscriptionShown()
+
+        verify(eventHorizon).track(AccountDetailsSubscriptionEvent)
+    }
+
+    @Test
+    fun `showing the privacy policy tracks the privacy policy event`() = runTest {
+        createViewModel().trackPrivacyPolicyShown()
+
+        verify(eventHorizon).track(AccountDetailsShowPrivacyPolicyEvent)
+    }
+
+    @Test
+    fun `showing the terms of use tracks the terms of use event`() = runTest {
+        createViewModel().trackTermsOfUseShown()
+
+        verify(eventHorizon).track(AccountDetailsShowTosEvent)
+    }
+
+    private fun createViewModel() = TvSettingsViewModel(
+        settings = settings,
+        syncManager = syncManager,
+        eventHorizon = eventHorizon,
+    )
+
+    private fun subscription(platform: SubscriptionPlatform) = Subscription(
+        tier = SubscriptionTier.Plus,
+        billingCycle = BillingCycle.Yearly,
+        platform = platform,
+        expiryDate = Instant.EPOCH,
+        isAutoRenewing = true,
+        giftDays = 0,
+    )
+}

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/settings/TvSettingsViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/settings/TvSettingsViewModelTest.kt
@@ -7,14 +7,14 @@ import au.com.shiftyjelly.pocketcasts.payment.BillingCycle
 import au.com.shiftyjelly.pocketcasts.payment.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.preferences.ReadSetting
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
-import au.com.shiftyjelly.pocketcasts.preferences.model.ArtworkConfiguration
+import au.com.shiftyjelly.pocketcasts.preferences.TvPreferences
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import com.automattic.eventhorizon.AccountDetailsShowPrivacyPolicyEvent
 import com.automattic.eventhorizon.AccountDetailsShowTosEvent
 import com.automattic.eventhorizon.AccountDetailsSubscriptionEvent
 import com.automattic.eventhorizon.EventHorizon
+import com.automattic.eventhorizon.SettingsAppearanceUseEpisodeArtworkToggledEvent
 import com.automattic.eventhorizon.SettingsGeneralShownEvent
 import com.jakewharton.rxrelay2.BehaviorRelay
 import java.time.Instant
@@ -24,9 +24,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
-import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 
@@ -37,24 +35,21 @@ class TvSettingsViewModelTest {
     val coroutineRule = MainCoroutineRule()
 
     private val isLoggedIn = BehaviorRelay.createDefault(false)
-    private val artworkFlow = MutableStateFlow(ArtworkConfiguration(useEpisodeArtwork = false))
     private val subscriptionFlow = MutableStateFlow<Subscription?>(null)
 
-    private val artworkSetting = mock<UserSetting<ArtworkConfiguration>> {
-        on { flow } doReturn artworkFlow
-        on { value } doReturn ArtworkConfiguration(useEpisodeArtwork = false)
-    }
     private val subscriptionSetting = mock<ReadSetting<Subscription?>> {
         on { flow } doReturn subscriptionFlow
         on { value } doReturn null
     }
     private val settings = mock<Settings> {
-        on { artworkConfiguration } doReturn artworkSetting
         on { cachedSubscription } doReturn subscriptionSetting
     }
     private val syncManager = mock<SyncManager> {
         on { isLoggedIn() } doReturn false
         on { isLoggedInObservable } doReturn isLoggedIn
+    }
+    private val tvPreferences = mock<TvPreferences> {
+        on { isUsingEpisodeArtwork() } doReturn false
     }
     private val eventHorizon = mock<EventHorizon>()
 
@@ -72,13 +67,14 @@ class TvSettingsViewModelTest {
     fun `state reflects sign in artwork and subscription changes`() = runTest {
         val subscription = subscription(platform = SubscriptionPlatform.Android)
 
-        createViewModel().uiState.test {
+        val viewModel = createViewModel()
+        viewModel.uiState.test {
             skipItems(1)
 
             isLoggedIn.accept(true)
             assertEquals(true, awaitItem().isSignedIn)
 
-            artworkFlow.value = ArtworkConfiguration(useEpisodeArtwork = true)
+            viewModel.setUseEpisodeArtwork(true)
             assertEquals(true, awaitItem().useEpisodeArtwork)
 
             subscriptionFlow.value = subscription
@@ -87,10 +83,11 @@ class TvSettingsViewModelTest {
     }
 
     @Test
-    fun `setUseEpisodeArtwork writes the artwork configuration`() = runTest {
+    fun `setUseEpisodeArtwork stores the value on device and tracks the toggle event`() = runTest {
         createViewModel().setUseEpisodeArtwork(true)
 
-        verify(artworkSetting).set(eq(ArtworkConfiguration(useEpisodeArtwork = true)), eq(true), any(), any())
+        verify(tvPreferences).setUsingEpisodeArtwork(true)
+        verify(eventHorizon).track(SettingsAppearanceUseEpisodeArtworkToggledEvent(enabled = true))
     }
 
     @Test
@@ -124,6 +121,7 @@ class TvSettingsViewModelTest {
     private fun createViewModel() = TvSettingsViewModel(
         settings = settings,
         syncManager = syncManager,
+        tvPreferences = tvPreferences,
         eventHorizon = eventHorizon,
     )
 

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/settings/TvSettingsViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/settings/TvSettingsViewModelTest.kt
@@ -7,7 +7,8 @@ import au.com.shiftyjelly.pocketcasts.payment.BillingCycle
 import au.com.shiftyjelly.pocketcasts.payment.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.preferences.ReadSetting
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.preferences.TvPreferences
+import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
+import au.com.shiftyjelly.pocketcasts.preferences.model.ArtworkConfiguration
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import com.automattic.eventhorizon.AccountDetailsShowPrivacyPolicyEvent
@@ -24,7 +25,10 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 
@@ -36,20 +40,27 @@ class TvSettingsViewModelTest {
 
     private val isLoggedIn = BehaviorRelay.createDefault(false)
     private val subscriptionFlow = MutableStateFlow<Subscription?>(null)
+    private val artworkConfigurationFlow = MutableStateFlow(ArtworkConfiguration(useEpisodeArtwork = false))
 
     private val subscriptionSetting = mock<ReadSetting<Subscription?>> {
         on { flow } doReturn subscriptionFlow
         on { value } doReturn null
     }
+    private val artworkConfigurationSetting = mock<UserSetting<ArtworkConfiguration>> {
+        on { flow } doReturn artworkConfigurationFlow
+        on { value } doAnswer { artworkConfigurationFlow.value }
+        on { set(any(), any(), any(), any()) } doAnswer {
+            artworkConfigurationFlow.value = it.getArgument(0)
+            Unit
+        }
+    }
     private val settings = mock<Settings> {
         on { cachedSubscription } doReturn subscriptionSetting
+        on { artworkConfiguration } doReturn artworkConfigurationSetting
     }
     private val syncManager = mock<SyncManager> {
         on { isLoggedIn() } doReturn false
         on { isLoggedInObservable } doReturn isLoggedIn
-    }
-    private val tvPreferences = mock<TvPreferences> {
-        on { isUsingEpisodeArtwork() } doReturn false
     }
     private val eventHorizon = mock<EventHorizon>()
 
@@ -83,10 +94,10 @@ class TvSettingsViewModelTest {
     }
 
     @Test
-    fun `setUseEpisodeArtwork stores the value on device and tracks the toggle event`() = runTest {
+    fun `setUseEpisodeArtwork updates the shared artwork setting and tracks the toggle event`() = runTest {
         createViewModel().setUseEpisodeArtwork(true)
 
-        verify(tvPreferences).setUsingEpisodeArtwork(true)
+        verify(artworkConfigurationSetting).set(eq(ArtworkConfiguration(useEpisodeArtwork = true)), eq(true), any(), any())
         verify(eventHorizon).track(SettingsAppearanceUseEpisodeArtworkToggledEvent(enabled = true))
     }
 
@@ -121,7 +132,6 @@ class TvSettingsViewModelTest {
     private fun createViewModel() = TvSettingsViewModel(
         settings = settings,
         syncManager = syncManager,
-        tvPreferences = tvPreferences,
         eventHorizon = eventHorizon,
     )
 


### PR DESCRIPTION
## Description

Adds the **Settings** sheet to the Android TV profile modal, bringing it to parity with the Apple TV app (`UI/Profile/SettingsMenuView.swift`). The TV app previously had no settings surface of any kind.

Opening the profile modal now shows a **Settings** entry (in both the signed-in and signed-out states, matching tvOS). It presents a settings menu with four items:

1. **Subscription** (signed-in only) — plan name (Plus/Patron + Monthly/Yearly), next renewal date (or **Lifetime** for Champion subscriptions), and a "manage on another platform" note for any subscription not purchased through Google Play (iOS/Web/Gift/Unknown). Free accounts show the free-account copy. No purchase/upsell flow (parity with tvOS).
2. **Privacy Policy** → a QR-link screen (title, message, QR code of the support URL, and the URL as text).
3. **Terms of Use** → the same QR-link screen for the ToS URL.
4. **Use episode artwork** toggle → stored **device-local** in `TvPreferences` (the Kotlin equivalent of iOS `Settings.loadEmbeddedImages`, which the tvOS app deliberately keeps in local `UserDefaults`), default off. See the follow-up note below.

Reuses existing TV components (`TvModal`, `TvModalButton`, the `qr` module's `rememberQrPainter`) and the existing legal URL constants (`Settings.INFO_PRIVACY_URL` / `Settings.INFO_TOS_URL`).

### Analytics

Fires the EventHorizon equivalents of the tvOS screen-view events, one-shot when each surface appears (all no-property):

- `SettingsGeneralShownEvent` — settings menu appears
- `AccountDetailsSubscriptionEvent` — subscription info appears
- `AccountDetailsShowPrivacyPolicyEvent` — privacy QR appears
- `AccountDetailsShowTosEvent` — terms QR appears
- `SettingsAppearanceUseEpisodeArtworkToggledEvent {enabled}` — fired on every flip of the Use episode artwork toggle (matches the phone's appearance setter)
- `ProfileShownEvent` — fired every time the profile modal opens (both signed-in and signed-out), matching tvOS `ProfileMenuView.onAppear`

All four events already exist in the generated EventHorizon catalog, so no schema PR is required.

## Follow-up parity fixes (audit v2)

Four ride-along commits from the v2 parity audit (Part 9):

1. **Device-local artwork toggle (bug fix).** The toggle previously wrote the **synced** `Settings.artworkConfiguration` with `updateModifiedAt = true`, so toggling it on the TV silently changed the user's phone setting. tvOS keeps this device-local. It now reads/writes `TvPreferences` instead. **Known gap:** no TV rendering path currently consumes this value — every TV episode row/cell renders podcast artwork (`PodcastImage.getMediumArtworkUrl`) regardless — so the toggle stores the preference but has no visible effect yet. Wiring TV episode-embedded artwork rendering is tracked as a separate follow-up (audit Part 5/8). This commit's purpose is to stop mutating the synced phone setting. (Because it now lives in the shared `tv_preferences`, it is also cleared on the TV sign-out data wipe, like the other TV device preferences.)
2. **Toggle analytics.** Fire `settings_appearance_use_episode_artwork_toggled {enabled}` on every flip, matching the phone appearance setter.
3. **`profile_shown`.** The profile modal previously tracked nothing. It now fires `profile_shown` on every open (signed-in and signed-out), matching tvOS `ProfileMenuView.onAppear` and the phone's `ProfileViewModel`.
4. **Other-platform note coverage.** The "managed on another platform" note now shows for any non-Google-Play subscription (previously only iOS/Web; now also Gift/Unknown), matching iOS which shows it for any non-own-platform sub.

Fixes PCDROID-737 https://linear.app/a8c/issue/PCDROID-737/profile-settings-sheet

## Testing Instructions

1. On an Android TV device/emulator, open the profile modal (top-bar profile icon).
2. Confirm a **Settings** entry appears (both signed-in and signed-out).
3. Open Settings:
   - Signed in with a paid subscription: **Subscription** shows plan + next renewal; iOS/Web subs also show the other-platform note; a free account shows "Free Account".
   - **Privacy Policy** / **Terms of Use**: a QR code + the URL render, Back or **Done** dismisses.
   - **Use episode artwork**: toggling flips the checkmark and persists across app restarts. It is device-local (does not change the phone's setting) and, via `LoggingAnalyticsListener` logcat, fires `settings_appearance_use_episode_artwork_toggled` with the new `enabled` value.
   - Reopening the profile modal fires `profile_shown` each time (check logcat), signed-in or signed-out.
4. Verify D-pad focus lands on a control in every screen and Back navigates out cleanly.

## Screenshots or Screencast

https://github.com/user-attachments/assets/e148a22e-4775-4cbb-8d0e-f9714a8972e2



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) the Event Horizon schema to reflect any new or changed analytics. (No change needed — all four events already exist in the catalog.)


