### PR TITLE
[TV] Confirm before logging out from the profile modal

### DIFF
--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -269,6 +269,8 @@
     <string name="tv_search_no_results_subtitle">Try more general or different keywords.</string>
     <string name="tv_search_error_subtitle">Check your connection and try again.</string>
     <string name="tv_profile_starred_episodes">Starred Episodes</string>
+    <string name="tv_profile_log_out_confirmation_title">Log out?</string>
+    <string name="tv_profile_log_out_confirmation_message">This removes all downloaded podcasts and data from this device. You can log in again to restore them.</string>
     <string name="tv_settings_subscription_title">Subscription</string>
     <string name="tv_settings_subscription_plan">Plan</string>
     <string name="tv_settings_subscription_next_renewal">Next renewal</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -270,7 +270,7 @@
     <string name="tv_search_error_subtitle">Check your connection and try again.</string>
     <string name="tv_profile_starred_episodes">Starred Episodes</string>
     <string name="tv_profile_log_out_confirmation_title">Log out?</string>
-    <string name="tv_profile_log_out_confirmation_message">This removes all downloaded podcasts and data from this device. You can log in again to restore them.</string>
+    <string name="tv_profile_log_out_confirmation_message">This removes all downloaded podcasts and data from this device. You can log in again to sync your podcasts back.</string>
     <string name="tv_settings_subscription_title">Subscription</string>
     <string name="tv_settings_subscription_plan">Plan</string>
     <string name="tv_settings_subscription_next_renewal">Next renewal</string>

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvProfileModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvProfileModal.kt
@@ -8,7 +8,10 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -23,6 +26,7 @@ import androidx.tv.material3.Icon
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.BuildConfig
+import au.com.shiftyjelly.pocketcasts.component.TvConfirmationContent
 import au.com.shiftyjelly.pocketcasts.component.TvModal
 import au.com.shiftyjelly.pocketcasts.component.TvModalButton
 import au.com.shiftyjelly.pocketcasts.component.TvModalSurface
@@ -45,19 +49,36 @@ fun TvProfileModal(
     onLogOut: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    var isShowingLogoutConfirmation by remember { mutableStateOf(false) }
     TvModal(
-        onDismissRequest = onDismissRequest,
+        onDismissRequest = {
+            if (isShowingLogoutConfirmation) {
+                isShowingLogoutConfirmation = false
+            } else {
+                onDismissRequest()
+            }
+        },
         modifier = modifier,
     ) {
-        TvProfileModalContent(
-            profile = profile,
-            onLogIn = onLogIn,
-            onCreateAccount = onCreateAccount,
-            onStarredEpisodes = onStarredEpisodes,
-            onListeningHistory = onListeningHistory,
-            onSettings = onSettings,
-            onLogOut = onLogOut,
-        )
+        if (isShowingLogoutConfirmation) {
+            TvConfirmationContent(
+                title = stringResource(LR.string.tv_profile_log_out_confirmation_title),
+                message = stringResource(LR.string.tv_profile_log_out_confirmation_message),
+                confirmLabel = stringResource(LR.string.log_out),
+                onConfirm = onLogOut,
+                onCancel = { isShowingLogoutConfirmation = false },
+            )
+        } else {
+            TvProfileModalContent(
+                profile = profile,
+                onLogIn = onLogIn,
+                onCreateAccount = onCreateAccount,
+                onStarredEpisodes = onStarredEpisodes,
+                onListeningHistory = onListeningHistory,
+                onSettings = onSettings,
+                onLogOut = { isShowingLogoutConfirmation = true },
+            )
+        }
     }
 }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvProfileModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvProfileModal.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.home
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.ColumnScope
@@ -49,36 +50,19 @@ fun TvProfileModal(
     onLogOut: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    var isShowingLogoutConfirmation by remember { mutableStateOf(false) }
     TvModal(
-        onDismissRequest = {
-            if (isShowingLogoutConfirmation) {
-                isShowingLogoutConfirmation = false
-            } else {
-                onDismissRequest()
-            }
-        },
+        onDismissRequest = onDismissRequest,
         modifier = modifier,
     ) {
-        if (isShowingLogoutConfirmation) {
-            TvConfirmationContent(
-                title = stringResource(LR.string.tv_profile_log_out_confirmation_title),
-                message = stringResource(LR.string.tv_profile_log_out_confirmation_message),
-                confirmLabel = stringResource(LR.string.log_out),
-                onConfirm = onLogOut,
-                onCancel = { isShowingLogoutConfirmation = false },
-            )
-        } else {
-            TvProfileModalContent(
-                profile = profile,
-                onLogIn = onLogIn,
-                onCreateAccount = onCreateAccount,
-                onStarredEpisodes = onStarredEpisodes,
-                onListeningHistory = onListeningHistory,
-                onSettings = onSettings,
-                onLogOut = { isShowingLogoutConfirmation = true },
-            )
-        }
+        TvProfileModalContent(
+            profile = profile,
+            onLogIn = onLogIn,
+            onCreateAccount = onCreateAccount,
+            onStarredEpisodes = onStarredEpisodes,
+            onListeningHistory = onListeningHistory,
+            onSettings = onSettings,
+            onLogOut = onLogOut,
+        )
     }
 }
 
@@ -92,9 +76,29 @@ private fun ColumnScope.TvProfileModalContent(
     onSettings: () -> Unit,
     onLogOut: () -> Unit,
 ) {
+    var isShowingLogoutConfirmation by remember { mutableStateOf(false) }
+    var returnFocusToLogOut by remember { mutableStateOf(false) }
     val focusRequester = remember { FocusRequester() }
-    LaunchedEffect(profile is TvProfileState.SignedIn) {
-        focusRequester.requestFocus()
+    LaunchedEffect(profile is TvProfileState.SignedIn, isShowingLogoutConfirmation) {
+        if (!isShowingLogoutConfirmation) {
+            focusRequester.requestFocus()
+        }
+    }
+
+    if (isShowingLogoutConfirmation) {
+        fun cancel() {
+            returnFocusToLogOut = true
+            isShowingLogoutConfirmation = false
+        }
+        BackHandler(onBack = ::cancel)
+        TvConfirmationContent(
+            title = stringResource(LR.string.tv_profile_log_out_confirmation_title),
+            message = stringResource(LR.string.tv_profile_log_out_confirmation_message),
+            confirmLabel = stringResource(LR.string.log_out),
+            onConfirm = onLogOut,
+            onCancel = ::cancel,
+        )
+        return
     }
 
     when (profile) {
@@ -111,7 +115,7 @@ private fun ColumnScope.TvProfileModalContent(
             TvModalButton(
                 text = stringResource(LR.string.tv_profile_starred_episodes),
                 onClick = onStarredEpisodes,
-                modifier = Modifier.focusRequester(focusRequester),
+                modifier = if (returnFocusToLogOut) Modifier else Modifier.focusRequester(focusRequester),
             )
             TvModalButton(
                 text = stringResource(LR.string.profile_navigation_listening_history),
@@ -123,7 +127,8 @@ private fun ColumnScope.TvProfileModalContent(
             )
             TvModalButton(
                 text = stringResource(LR.string.log_out),
-                onClick = onLogOut,
+                onClick = { isShowingLogoutConfirmation = true },
+                modifier = if (returnFocusToLogOut) Modifier.focusRequester(focusRequester) else Modifier,
             )
         }
 


### PR DESCRIPTION
## Description

Adds a **confirmation dialog before logging out** from the Android TV profile modal, bringing it to parity with the Apple TV app. Previously tapping **Log out** signed the user out immediately, with no chance to cancel an accidental D-pad selection — a destructive action (it clears all downloaded podcasts and data from the device).

Now tapping **Log out** swaps the profile modal content for an in-place confirmation (`TvConfirmationContent`) with a title, an explanatory message, a **Log out** confirm button, and a **Cancel** button. Focus lands on **Cancel** by default (the safe choice for a destructive action). Pressing Back / dismissing while the confirmation is showing returns to the profile menu rather than closing the whole modal; only confirming actually signs out.

Reuses the existing shared `TvConfirmationContent` component (already used for other TV confirmations) and the existing `log_out` / `cancel` strings, so the change is a small state toggle inside `TvProfileModal` plus two new strings for the confirmation copy.

Fixes PCDROID-740 https://linear.app/a8c/issue/PCDROID-740/logout-confirmation-dialog

## Testing Instructions

1. On an Android TV device/emulator, sign in and open the profile modal (top-bar profile icon).
2. Move focus to **Log out** and press SELECT.
3. Confirm the modal now shows the **Log out?** confirmation with **Log out** and **Cancel** buttons, focus starting on **Cancel**.
4. Press Back (or select **Cancel**) → returns to the profile menu, still signed in.
5. Re-open, select **Log out**, then select the **Log out** confirm button → you are signed out and returned to the Welcome screen.

## Screenshots or Screencast
<img width="1920" height="1080" alt="Screenshot_20260827_143009" src="https://github.com/user-attachments/assets/15f90b6a-30a7-4d18-b40c-e604b2b69a87" />


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) the Event Horizon schema to reflect any new or changed analytics. (No change needed — no analytics in this PR.)
