### PR TITLE
Sync Claude workflows with the iOS and Web Player repos

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -75,6 +75,10 @@ jobs:
             4. Performance - only where the impact is user-visible.
 
             Comments:
+            - Open a blocking correctness or behaviour-change finding with its
+              user-facing impact in one plain sentence: what breaks, for which
+              user, and when, and then the code mechanism, the problem and the
+              fix.
             - Keep comments short by default - a few sentences stating the problem
               and the fix, not the reasoning that led you there. Spend more words
               only where the finding needs them to be actionable: a subtle race, a
@@ -100,9 +104,10 @@ jobs:
               - Then the findings grouped under `### Blocking`, `### Non-blocking`,
                 `### Nits`. Skip a group that is empty; skip the section entirely if
                 there are no findings, leaving the verdict as the whole summary.
-              - One line per finding: `path/File.swift:123` followed by a single
-                sentence naming the problem and the fix - enough to act on without
-                opening the thread. Add the inline comment's URL when you have one.
+              - One line per finding: `path/to/file:123` followed by a single
+                sentence that leads with the user-facing impact, then the fix -
+                enough to act on without opening the thread. Add the inline
+                comment's URL when you have one.
               - A finding with no line to anchor to takes the same shape with just
                 the path, or no path when it is repo-wide.
             - No tables, no re-analysis, no checklist of what you read, no praise.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Checkout repository
         if: steps.pr-origin.outputs.is_internal == 'true'
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
## Description

The automated Claude review that runs on every PR in this repo now behaves the same way it does on iOS and Web Player, instead of each repo quietly running its own slightly different version.

`claude.yml` and `claude-code-review.yml` are meant to be identical across pocket-casts-android, pocket-casts-ios and pocket-casts-webplayer, and the file header says as much. In practice nobody updates all three at once, so they drift. This PR is the result of a sync run across the three repos.

What changes here:

- **`claude.yml`**: bump `actions/checkout` v7.0.0 → v7.0.1, matching pocket-casts-ios. This repo's `claude-code-review.yml` was already on v7.0.1, so the two workflows were pinned to different versions of the same action.
- **`claude-code-review.yml`**: add the "lead with user-facing impact" rule to the review prompt, from pocket-casts-ios#5018. #5789 ported the tightened prompt to this repo at 02:10 UTC on 27 Aug, and iOS added this rule at 02:54 UTC the same morning, so it just missed the backport.
- **`claude-code-review.yml`**: change the example finding line from `path/File.swift:123` to `path/to/file:123`. The Swift path came over verbatim from the iOS prompt in #5789 and is misleading in a Kotlin repo.

This repo's `anthropics/claude-code-action` pin (v1.0.201) was the newest of the three and is propagating out to iOS and Web Player unchanged. Every pin in the sync was verified by resolving the tag to its commit SHA upstream, so the `# vX.Y.Z` comments match what is actually pinned.

## Testing Instructions

There is nothing to verify in the app; this touches `.github/workflows/*.yml` only.

1. Confirm CI is green on this PR.
2. Note that the Claude review will **not** run on this PR: `claude-code-review.yml` has a "Check workflow changes" step that deliberately skips the review whenever a PR modifies that file, because the Claude app token validation requires the workflow to match the default branch. The prompt change therefore takes effect on the first PR merged after this one.
3. Optionally, compare the two files against pocket-casts-ios after all three PRs merge; they should be byte-identical.

## Screenshots or Screencast

Not applicable, no UI change.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md (N/A - CI configuration, not user-facing)
- [x] Ensure the linter passes (N/A - no Kotlin or Gradle files touched)
- [x] I have considered whether it makes sense to add tests for my changes (considered - not applicable to workflow YAML)
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml` (N/A - no strings changed)
- [x] Any jetpack compose components I added or changed are covered by compose previews (N/A - no Compose changes)
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics. (N/A - no analytics changes)
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
