### PR TITLE
[TV] Analytics foundation: predefined properties, lifecycle events, crash reporting

### DIFF
--- a/tv/build.gradle.kts
+++ b/tv/build.gradle.kts
@@ -71,10 +71,12 @@ dependencies {
     implementation(libs.tv.material)
 
     implementation(platform(libs.firebase.bom))
+    implementation(libs.firebase.config)
 
     implementation(projects.modules.features.shared)
     implementation(projects.modules.services.analytics)
     implementation(projects.modules.services.compose)
+    implementation(projects.modules.services.crashlogging)
     implementation(projects.modules.services.images)
     implementation(projects.modules.services.localization)
     implementation(projects.modules.services.qr)

--- a/tv/build.gradle.kts
+++ b/tv/build.gradle.kts
@@ -63,6 +63,7 @@ dependencies {
     implementation(libs.hilt.work)
     implementation(libs.work.runtime)
     implementation(libs.navigation.compose)
+    implementation(libs.lifecycle.process)
     implementation(libs.lifecycle.runtime.compose)
     implementation(libs.lifecycle.viewmodel.compose)
     implementation(libs.timber)

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvAppLifecycleObserver.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvAppLifecycleObserver.kt
@@ -52,6 +52,8 @@ class TvAppLifecycleObserver(
         } else if (previousVersionCode < versionCode) {
             appLifecycleAnalytics.onApplicationUpgrade(previousVersionCode)
         }
-        settings.setMigratedVersionCode(versionCode)
+        if (previousVersionCode != versionCode) {
+            settings.setMigratedVersionCode(versionCode)
+        }
     }
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvAppLifecycleObserver.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvAppLifecycleObserver.kt
@@ -1,0 +1,45 @@
+package au.com.shiftyjelly.pocketcasts
+
+import android.content.Context
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
+import au.com.shiftyjelly.pocketcasts.analytics.AppLifecycleAnalytics
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.utils.getVersionCode
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+
+class TvAppLifecycleObserver @Inject constructor(
+    @ApplicationContext private val appContext: Context,
+    private val appLifecycleAnalytics: AppLifecycleAnalytics,
+    private val settings: Settings,
+    private val appLifecycleOwner: LifecycleOwner = ProcessLifecycleOwner.get(),
+) : DefaultLifecycleObserver {
+
+    fun setup() {
+        appLifecycleOwner.lifecycle.addObserver(this)
+        handleNewInstallOrUpgrade()
+    }
+
+    override fun onResume(owner: LifecycleOwner) {
+        super.onResume(owner)
+        appLifecycleAnalytics.onApplicationEnterForeground()
+    }
+
+    override fun onPause(owner: LifecycleOwner) {
+        super.onPause(owner)
+        appLifecycleAnalytics.onApplicationEnterBackground()
+    }
+
+    private fun handleNewInstallOrUpgrade() {
+        val versionCode = appContext.getVersionCode()
+        val previousVersionCode = settings.getMigratedVersionCode()
+        if (previousVersionCode == 0) {
+            appLifecycleAnalytics.onNewApplicationInstall()
+        } else if (previousVersionCode < versionCode) {
+            appLifecycleAnalytics.onApplicationUpgrade(previousVersionCode)
+        }
+        settings.setMigratedVersionCode(versionCode)
+    }
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvAppLifecycleObserver.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvAppLifecycleObserver.kt
@@ -10,12 +10,24 @@ import au.com.shiftyjelly.pocketcasts.utils.getVersionCode
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 
-class TvAppLifecycleObserver @Inject constructor(
-    @ApplicationContext private val appContext: Context,
+class TvAppLifecycleObserver(
+    private val appContext: Context,
     private val appLifecycleAnalytics: AppLifecycleAnalytics,
     private val settings: Settings,
-    private val appLifecycleOwner: LifecycleOwner = ProcessLifecycleOwner.get(),
+    private val appLifecycleOwner: LifecycleOwner,
 ) : DefaultLifecycleObserver {
+
+    @Inject
+    constructor(
+        @ApplicationContext appContext: Context,
+        appLifecycleAnalytics: AppLifecycleAnalytics,
+        settings: Settings,
+    ) : this(
+        appContext = appContext,
+        appLifecycleAnalytics = appLifecycleAnalytics,
+        settings = settings,
+        appLifecycleOwner = ProcessLifecycleOwner.get(),
+    )
 
     fun setup() {
         appLifecycleOwner.lifecycle.addObserver(this)

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvApplication.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvApplication.kt
@@ -45,6 +45,8 @@ class TvApplication :
 
     @Inject lateinit var userManager: UserManager
 
+    @Inject lateinit var appLifecycleObserver: TvAppLifecycleObserver
+
     private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     override fun onCreate() {
@@ -56,6 +58,7 @@ class TvApplication :
         setupFeatureFlags()
         setupAnalytics()
         notificationHelper.setupNotificationChannels()
+        appLifecycleObserver.setup()
         PlaybackServiceToggle.ensureCorrectServiceEnabled(this)
         // setup() subscribes the Up Next queue's sync pipeline itself, so there must be no
         // separate UpNextQueue.setupBlocking() call on TV.

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvApplication.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvApplication.kt
@@ -5,6 +5,7 @@ import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsController
 import au.com.shiftyjelly.pocketcasts.crashlogging.InitializeRemoteLogging
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationHelper
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackServiceToggle
@@ -25,6 +26,7 @@ import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.rx2.asFlow
@@ -50,6 +52,8 @@ class TvApplication :
     @Inject lateinit var analyticsController: AnalyticsController
 
     @Inject lateinit var syncManager: SyncManager
+
+    @Inject lateinit var settings: Settings
 
     @Inject lateinit var appLifecycleObserver: TvAppLifecycleObserver
 
@@ -93,7 +97,10 @@ class TvApplication :
         analyticsController.clearAllData()
         analyticsController.refreshMetadata()
         applicationScope.launch {
-            syncManager.isLoggedInObservable.asFlow()
+            combine(
+                syncManager.isLoggedInObservable.asFlow(),
+                settings.cachedSubscription.flow,
+            ) { isLoggedIn, subscription -> isLoggedIn to subscription }
                 .distinctUntilChanged()
                 .collect { analyticsController.refreshMetadata() }
         }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvApplication.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvApplication.kt
@@ -8,7 +8,7 @@ import au.com.shiftyjelly.pocketcasts.crashlogging.InitializeRemoteLogging
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationHelper
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackServiceToggle
-import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
+import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.utils.ChainedExceptionHandler
 import au.com.shiftyjelly.pocketcasts.utils.TimberDebugTree
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
@@ -49,7 +49,7 @@ class TvApplication :
 
     @Inject lateinit var analyticsController: AnalyticsController
 
-    @Inject lateinit var userManager: UserManager
+    @Inject lateinit var syncManager: SyncManager
 
     @Inject lateinit var appLifecycleObserver: TvAppLifecycleObserver
 
@@ -93,7 +93,7 @@ class TvApplication :
         analyticsController.clearAllData()
         analyticsController.refreshMetadata()
         applicationScope.launch {
-            userManager.getSignInState().toObservable().asFlow()
+            syncManager.isLoggedInObservable.asFlow()
                 .distinctUntilChanged()
                 .collect { analyticsController.refreshMetadata() }
         }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvApplication.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvApplication.kt
@@ -4,17 +4,23 @@ import android.app.Application
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsController
+import au.com.shiftyjelly.pocketcasts.crashlogging.InitializeRemoteLogging
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationHelper
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackServiceToggle
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
+import au.com.shiftyjelly.pocketcasts.utils.ChainedExceptionHandler
 import au.com.shiftyjelly.pocketcasts.utils.TimberDebugTree
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.providers.DefaultReleaseFeatureProvider
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.providers.FirebaseRemoteFeatureProvider
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.providers.PreferencesFeatureProvider
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBufferUncaughtExceptionHandler
 import au.com.shiftyjelly.pocketcasts.utils.log.RxJavaUncaughtExceptionHandling
+import com.google.firebase.FirebaseApp
 import dagger.hilt.android.HiltAndroidApp
+import java.io.File
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -47,6 +53,8 @@ class TvApplication :
 
     @Inject lateinit var appLifecycleObserver: TvAppLifecycleObserver
 
+    @Inject lateinit var initializeRemoteLogging: InitializeRemoteLogging
+
     private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     override fun onCreate() {
@@ -55,6 +63,7 @@ class TvApplication :
             Timber.plant(TimberDebugTree())
         }
         RxJavaUncaughtExceptionHandling.setUp()
+        setupCrashLogging()
         setupFeatureFlags()
         setupAnalytics()
         notificationHelper.setupNotificationChannels()
@@ -65,6 +74,19 @@ class TvApplication :
         applicationScope.launch {
             playbackManager.setup()
         }
+    }
+
+    private fun setupCrashLogging() {
+        LogBuffer.setup(File(filesDir, "logs").absolutePath)
+        val exceptionHandler = ChainedExceptionHandler(
+            listOfNotNull(
+                LogBufferUncaughtExceptionHandler(),
+                Thread.getDefaultUncaughtExceptionHandler(),
+            ),
+        )
+        Thread.setDefaultUncaughtExceptionHandler(exceptionHandler)
+        initializeRemoteLogging()
+        FirebaseApp.initializeApp(this)
     }
 
     private fun setupAnalytics() {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvApplication.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvApplication.kt
@@ -3,9 +3,11 @@ package au.com.shiftyjelly.pocketcasts
 import android.app.Application
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsController
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationHelper
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackServiceToggle
+import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.utils.TimberDebugTree
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.providers.DefaultReleaseFeatureProvider
@@ -17,7 +19,9 @@ import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.rx2.asFlow
 import timber.log.Timber
 
 @HiltAndroidApp
@@ -37,6 +41,10 @@ class TvApplication :
 
     @Inject lateinit var preferencesFeatureProvider: PreferencesFeatureProvider
 
+    @Inject lateinit var analyticsController: AnalyticsController
+
+    @Inject lateinit var userManager: UserManager
+
     private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     override fun onCreate() {
@@ -46,12 +54,23 @@ class TvApplication :
         }
         RxJavaUncaughtExceptionHandling.setUp()
         setupFeatureFlags()
+        setupAnalytics()
         notificationHelper.setupNotificationChannels()
         PlaybackServiceToggle.ensureCorrectServiceEnabled(this)
         // setup() subscribes the Up Next queue's sync pipeline itself, so there must be no
         // separate UpNextQueue.setupBlocking() call on TV.
         applicationScope.launch {
             playbackManager.setup()
+        }
+    }
+
+    private fun setupAnalytics() {
+        analyticsController.clearAllData()
+        analyticsController.refreshMetadata()
+        applicationScope.launch {
+            userManager.getSignInState().toObservable().asFlow()
+                .distinctUntilChanged()
+                .collect { analyticsController.refreshMetadata() }
         }
     }
 

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/TvAppLifecycleObserverTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/TvAppLifecycleObserverTest.kt
@@ -1,0 +1,92 @@
+package au.com.shiftyjelly.pocketcasts
+
+import android.content.Context
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import au.com.shiftyjelly.pocketcasts.analytics.AppLifecycleAnalytics
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.any
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+private const val PACKAGE_NAME = "au.com.shiftyjelly.pocketcasts.tv"
+private const val VERSION_CODE_FRESH_INSTALL = 0
+private const val VERSION_CODE_PREVIOUS = 1
+private const val VERSION_CODE_CURRENT = 2
+
+@RunWith(MockitoJUnitRunner::class)
+class TvAppLifecycleObserverTest {
+
+    @Mock private lateinit var context: Context
+
+    @Mock private lateinit var packageManager: PackageManager
+
+    @Mock private lateinit var appLifecycleAnalytics: AppLifecycleAnalytics
+
+    @Mock private lateinit var settings: Settings
+
+    @Mock private lateinit var appLifecycleOwner: LifecycleOwner
+
+    @Mock private lateinit var appLifecycle: Lifecycle
+
+    private lateinit var observer: TvAppLifecycleObserver
+
+    @Suppress("DEPRECATION")
+    @Before
+    fun setUp() {
+        whenever(context.packageName).thenReturn(PACKAGE_NAME)
+        whenever(context.packageManager).thenReturn(packageManager)
+        whenever(packageManager.getPackageInfo(PACKAGE_NAME, 0)).thenReturn(
+            PackageInfo().apply { versionCode = VERSION_CODE_CURRENT },
+        )
+        whenever(appLifecycleOwner.lifecycle).thenReturn(appLifecycle)
+
+        observer = TvAppLifecycleObserver(
+            appContext = context,
+            appLifecycleAnalytics = appLifecycleAnalytics,
+            settings = settings,
+            appLifecycleOwner = appLifecycleOwner,
+        )
+    }
+
+    @Test
+    fun handlesNewInstall() {
+        whenever(settings.getMigratedVersionCode()).thenReturn(VERSION_CODE_FRESH_INSTALL)
+
+        observer.setup()
+
+        verify(appLifecycleAnalytics).onNewApplicationInstall()
+        verify(appLifecycleAnalytics, never()).onApplicationUpgrade(any())
+        verify(settings).setMigratedVersionCode(VERSION_CODE_CURRENT)
+    }
+
+    @Test
+    fun handlesUpgrade() {
+        whenever(settings.getMigratedVersionCode()).thenReturn(VERSION_CODE_PREVIOUS)
+
+        observer.setup()
+
+        verify(appLifecycleAnalytics).onApplicationUpgrade(VERSION_CODE_PREVIOUS)
+        verify(appLifecycleAnalytics, never()).onNewApplicationInstall()
+        verify(settings).setMigratedVersionCode(VERSION_CODE_CURRENT)
+    }
+
+    @Test
+    fun sameVersionDoesNotTrackOrRewriteMigratedVersion() {
+        whenever(settings.getMigratedVersionCode()).thenReturn(VERSION_CODE_CURRENT)
+
+        observer.setup()
+
+        verify(appLifecycleAnalytics, never()).onNewApplicationInstall()
+        verify(appLifecycleAnalytics, never()).onApplicationUpgrade(any())
+        verify(settings, never()).setMigratedVersionCode(any())
+    }
+}


### PR DESCRIPTION
## Description

**Android TV parity — Section B / PR 1: analytics foundation.** Makes Android TV telemetry real. Before this, `TvApplication` did no analytics or crash wiring, so every TV event shipped with **zero predefined properties** — no `platform=tv`, no user properties — and, sharing the `pcandroid_` prefix, was indistinguishable from anonymous phone traffic in every dashboard. There were also no app-lifecycle/session events and no crash reporting. Closes the audit's three P0 infrastructure findings.

This must land **before** the other Section B analytics PRs (follow-funnel, episode-status, auth) — until `refreshMetadata()` runs on TV, their events ship without `platform=tv` and pollute phone dashboards.

Three commits:
1. **Predefined-properties bootstrap** — `analyticsController.clearAllData()` + `refreshMetadata()` at launch (mirrors phone/wear), and a side-effect-free subscription to `syncManager.isLoggedInObservable` that re-refreshes on login changes. This populates `platform=tv`, `user_is_logged_in`, the `plus_*` set, and the anonymous→account alias.
2. **App-lifecycle events** — a slim `TvAppLifecycleObserver` on `ProcessLifecycleOwner` firing `application_opened` / `application_closed{time_in_app}` / `application_installed` / `application_updated{previous_version}` via the existing `AppLifecycleAnalytics`. Deliberately does **not** reuse the shared `AppLifecycleObserver` (which would drag in Blaze ads, notification scheduling, network watching and duplicate TV's feature-flag init).
3. **Crash reporting** — `LogBuffer` + `ChainedExceptionHandler(LogBufferUncaughtExceptionHandler)` + `InitializeRemoteLogging` (Sentry) + `FirebaseApp.initializeApp`, mirroring the phone. Respects `sendCrashReports`/`linkCrashReportsToUser` (which already survive the TV sign-out wipe). Adds the `crashlogging`, `firebase-config` and `lifecycle-process` dependencies.

No new analytics *events* are defined here (only predefined properties + existing lifecycle events), so no EventHorizon schema change is needed.

### ⚠️ Flags for reviewers / ops
- **Release `google-services.json` for `tv/` — already provisioned (no action needed).** A raw `git checkout` shows only `debug`/`debugProd` configs, so `:tv:processReleaseGoogleServices` fails locally until secrets are applied. But `.configure` already maps `tv/google-services.json` to the same shared `android/pocket-casts/google-services.json` secret as `app`/`automotive`/`wear`, so CI's `configure apply` populates it (same Firebase app `au.com.shiftyjelly.pocketcasts`, project `singular-vector-91401`). Confirmed on `main`; `:tv:processReleaseGoogleServices` passes once the secret is in place. No new Firebase/Play Console app is needed — TV shares the phone's `applicationId`.
- **One-time `application_installed` for the existing TV base.** TV never ran `VersionMigrationsWorker`, so existing installs have `migratedVersionCode == 0` and will register as a fresh *install* (not *update*) on their first launch after this ships. It self-heals after that launch. Accepted deliberately: TV had no prior analytics baseline, and the alternatives (running full version-migrations on TV, or heuristic install detection) are out of scope and riskier. Analysts can attribute the one-time bump to the launch date.
- **Future TV migrations note:** this observer now advances `migratedVersionCode` each launch; whoever later wires `VersionMigrationsWorker` on TV must account for it (it would otherwise read an already-current code and skip migrations).

Fixes PCDROID-741 https://linear.app/a8c/issue/PCDROID-741/init-crashlitycs-analytics-global-init-track-lifecycle

## Testing Instructions

> **What's observable where:** debug/debugProd TV builds bind only `NoOpTracker` + `LoggingAnalyticsListener`, so logcat confirms events **fire** (with their own properties). The predefined properties (`platform=tv`, `user_is_logged_in`, `plus_*`) are attached inside `TracksAnalyticsTracker`, which is bound only in **release** — they are **not** visible in debug logcat. (`prototype` is disabled for `tv`.)

1. Build & install a `debugProd` TV build; `adb logcat -s Analytics` to watch `LoggingAnalyticsListener`.
2. Foreground/background the app → confirm `application_opened` and `application_closed` fire, with a sane `time_in_app`.
3. Confirm `refreshMetadata()` runs at launch and again on sign-in/sign-out (a log/breakpoint in `TvApplication.setupAnalytics` and its `isLoggedInObservable` collector).
4. To verify the predefined props themselves (`platform=tv`, user props): inspect the Tracks backend from a **release** build, or temporarily bind `TracksAnalyticsTracker` in a debug build and re-check logcat.

### Expected analytics events

Captured on `emulator-5554` from a **fresh install** of the `debug` build (tag `Analytics`, via `LoggingAnalyticsListener`):

| Trigger | Event | Notes |
|---|---|---|
| Fresh install → first launch | `application_installed` | fires once (`migratedVersionCode == 0`) |
| App to foreground | `application_opened` | on every `ProcessLifecycleOwner` resume |
| App to background | `application_closed` | carries `{time_in_app}` (seconds) |
| Return to foreground | `application_opened` | again |

## Screenshots or Screencast
<img width="1664" height="340" alt="pr1-analytics-logcat" src="https://github.com/user-attachments/assets/0a9920a3-5322-4427-816f-1167052e394d" />


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md — n/a (no user-facing change)
- [x] Ensure the linter passes (`./gradlew spotlessApply`)
- [x] I have considered whether it makes sense to add tests for my changes — infra wiring in `Application`; behavior verified via logcat
- [x] All strings that need to be localized are in localization — n/a
- [x] Any jetpack compose components I added or changed are covered by compose previews — n/a
- [x] I have updated the Event Horizon schema to reflect any new or changed analytics — n/a (no new/changed events; predefined properties + existing lifecycle events only)
