### PR TITLE
[TV] Consolidate follow event analytics

### DIFF
--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/discover/TvDiscoverFeedAnalytics.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/discover/TvDiscoverFeedAnalytics.kt
@@ -17,6 +17,7 @@ class TvDiscoverFeedAnalytics(
     private val settings: Settings,
     private val source: String,
     private val localRowIds: Set<String>,
+    private val attribution: TvDiscoverPodcastAttribution,
 ) {
     fun trackListImpression(row: TvDiscoverRow) {
         val listId = row.discoverListId() ?: return
@@ -24,9 +25,11 @@ class TvDiscoverFeedAnalytics(
     }
 
     fun trackPodcastTapped(row: TvDiscoverRow, podcast: TvDiscoverPodcast) {
+        val isFeatured = row is TvDiscoverRow.FeaturedPodcasts
+        attribution.record(podcast.uuid, listId = row.discoverListId(), listDatetime = row.discoverListDatetime(), isFeatured = isFeatured)
         val listId = row.discoverListId() ?: return
         eventHorizon.track(DiscoverListPodcastTappedEvent(listId = listId, podcastUuid = podcast.uuid, listDatetime = row.discoverListDatetime(), source = source))
-        if (row is TvDiscoverRow.FeaturedPodcasts) {
+        if (isFeatured) {
             eventHorizon.track(DiscoverFeaturedPodcastTappedEvent(podcastUuid = podcast.uuid))
         } else if (podcast.isSponsored) {
             trackSponsoredPodcastTapped(podcast.uuid)
@@ -42,11 +45,13 @@ class TvDiscoverFeedAnalytics(
     }
 
     fun trackEpisodePodcastTapped(row: TvDiscoverRow, episode: TvDiscoverEpisode) {
+        attribution.record(episode.podcastUuid, listId = row.discoverListId(), listDatetime = row.discoverListDatetime(), isFeatured = false)
         val listId = row.discoverListId() ?: return
         eventHorizon.track(DiscoverListPodcastTappedEvent(listId = listId, podcastUuid = episode.podcastUuid, listDatetime = row.discoverListDatetime(), source = source))
     }
 
     fun trackCategoryPodcastTapped(category: TvOpenedCategory, listId: String?, podcast: TvDiscoverPodcast) {
+        attribution.record(podcast.uuid, listId = listId, listDatetime = null, isFeatured = false)
         if (listId != null) {
             eventHorizon.track(DiscoverListPodcastTappedEvent(listId = listId, podcastUuid = podcast.uuid, source = source))
         }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/discover/TvDiscoverPodcastAttribution.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/discover/TvDiscoverPodcastAttribution.kt
@@ -1,0 +1,28 @@
+package au.com.shiftyjelly.pocketcasts.discover
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class TvDiscoverPodcastAttribution @Inject constructor() {
+
+    data class Attribution(
+        val listId: String?,
+        val listDatetime: String?,
+        val isFeatured: Boolean,
+    )
+
+    private val attributions = mutableMapOf<String, Attribution>()
+
+    @Synchronized
+    fun record(podcastUuid: String, listId: String?, listDatetime: String?, isFeatured: Boolean) {
+        if (listId == null && !isFeatured) {
+            attributions.remove(podcastUuid)
+        } else {
+            attributions[podcastUuid] = Attribution(listId, listDatetime, isFeatured)
+        }
+    }
+
+    @Synchronized
+    fun consume(podcastUuid: String): Attribution? = attributions.remove(podcastUuid)
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/discover/TvDiscoverPodcastAttribution.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/discover/TvDiscoverPodcastAttribution.kt
@@ -25,4 +25,9 @@ class TvDiscoverPodcastAttribution @Inject constructor() {
 
     @Synchronized
     fun consume(podcastUuid: String): Attribution? = attributions.remove(podcastUuid)
+
+    @Synchronized
+    fun clear(podcastUuid: String) {
+        attributions.remove(podcastUuid)
+    }
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeScreen.kt
@@ -30,6 +30,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.OutlinedButton
 import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.component.LocalOpenNowPlaying
 import au.com.shiftyjelly.pocketcasts.component.LocalTvToastHostState
 import au.com.shiftyjelly.pocketcasts.component.TvDetailOverlay
@@ -141,6 +142,7 @@ fun TvHomeScreen(
         ) { uuid ->
             TvPodcastDetailsScreen(
                 podcastUuid = uuid,
+                source = SourceView.DISCOVER,
                 onClose = { openedPodcastUuid = null },
             )
         }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModel.kt
@@ -10,6 +10,7 @@ import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverEpisode
 import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverFeedAnalytics
 import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverFeedLoader
 import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverPodcast
+import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverPodcastAttribution
 import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverRow
 import au.com.shiftyjelly.pocketcasts.discover.TvOpenedCategory
 import au.com.shiftyjelly.pocketcasts.models.db.dao.PodcastDao
@@ -59,6 +60,7 @@ class TvHomeViewModel @Inject constructor(
     private val playbackManager: PlaybackManager,
     private val eventHorizon: EventHorizon,
     private val settings: Settings,
+    private val discoverPodcastAttribution: TvDiscoverPodcastAttribution,
     @ApplicationContext private val context: Context,
 ) : ViewModel() {
 
@@ -71,7 +73,7 @@ class TvHomeViewModel @Inject constructor(
     private val _playFailures = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
     val playFailures: SharedFlow<Unit> = _playFailures.asSharedFlow()
 
-    private val discoverFeedAnalytics = TvDiscoverFeedAnalytics(eventHorizon, settings, SOURCE_HOME, LOCAL_ROW_IDS)
+    private val discoverFeedAnalytics = TvDiscoverFeedAnalytics(eventHorizon, settings, SOURCE_HOME, LOCAL_ROW_IDS, discoverPodcastAttribution)
 
     private var loadJob: Job? = null
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
@@ -62,6 +62,7 @@ import androidx.tv.material3.Icon
 import androidx.tv.material3.IconButton
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.component.HideTvTopBar
 import au.com.shiftyjelly.pocketcasts.component.LocalFocusTvTopBar
 import au.com.shiftyjelly.pocketcasts.component.TvArtworkImage
@@ -117,6 +118,7 @@ fun TvNowPlayingScreen(
         BackHandler { openedPodcastUuid = null }
         TvPodcastDetailsScreen(
             podcastUuid = podcastUuid,
+            source = SourceView.PLAYER,
             onClose = { openedPodcastUuid = null },
             modifier = modifier,
         )

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
@@ -39,6 +39,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.Button
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.component.LocalOpenNowPlaying
 import au.com.shiftyjelly.pocketcasts.component.LocalTvToastHostState
 import au.com.shiftyjelly.pocketcasts.component.TvArchivedFilterButton
@@ -120,6 +121,7 @@ fun TvPlaylistDetailsScreen(
         BackHandler { openedPodcastUuid = null }
         TvPodcastDetailsScreen(
             podcastUuid = podcastUuid,
+            source = SourceView.FILTERS,
             onClose = { openedPodcastUuid = null },
             modifier = modifier,
         )

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
@@ -43,6 +43,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.Button
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.component.LocalOpenNowPlaying
 import au.com.shiftyjelly.pocketcasts.component.TvArchivedFilterButton
 import au.com.shiftyjelly.pocketcasts.component.TvArtworkImage
@@ -56,6 +57,7 @@ import au.com.shiftyjelly.pocketcasts.component.TvEpisodeListItem
 import au.com.shiftyjelly.pocketcasts.component.TvPodcastInfoModal
 import au.com.shiftyjelly.pocketcasts.component.TvSortButton
 import au.com.shiftyjelly.pocketcasts.component.rememberTvEpisodeListFocus
+import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.compose.components.displayLabel
 import au.com.shiftyjelly.pocketcasts.compose.loading.LoadingView
 import au.com.shiftyjelly.pocketcasts.localization.helper.RelativeDateFormatter
@@ -78,16 +80,21 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 @Composable
 fun TvPodcastDetailsScreen(
     podcastUuid: String,
+    source: SourceView,
     onClose: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: TvPodcastDetailsViewModel = hiltViewModel<TvPodcastDetailsViewModel, TvPodcastDetailsViewModel.Factory>(
         key = podcastUuid,
-        creationCallback = { factory -> factory.create(podcastUuid) },
+        creationCallback = { factory -> factory.create(podcastUuid, source) },
     ),
     episodeActions: TvEpisodeActions = hiltViewModel<TvEpisodeActionsViewModel>(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val openNowPlaying = LocalOpenNowPlaying.current
+
+    CallOnce {
+        viewModel.trackScreenShown()
+    }
 
     LaunchedEffect(uiState, onClose) {
         if (uiState is TvPodcastDetailsUiState.NotFound) {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
@@ -85,7 +85,7 @@ fun TvPodcastDetailsScreen(
     modifier: Modifier = Modifier,
     viewModel: TvPodcastDetailsViewModel = hiltViewModel<TvPodcastDetailsViewModel, TvPodcastDetailsViewModel.Factory>(
         key = podcastUuid,
-        creationCallback = { factory -> factory.create(podcastUuid, source) },
+        creationCallback = { factory -> factory.create(podcastUuid) },
     ),
     episodeActions: TvEpisodeActions = hiltViewModel<TvEpisodeActionsViewModel>(),
 ) {
@@ -93,7 +93,7 @@ fun TvPodcastDetailsScreen(
     val openNowPlaying = LocalOpenNowPlaying.current
 
     CallOnce {
-        viewModel.trackScreenShown()
+        viewModel.onScreenOpened(source)
     }
 
     LaunchedEffect(uiState, onClose) {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
@@ -111,6 +111,7 @@ fun TvPodcastDetailsScreen(
         onRetryAccountAuth = viewModel::retryAccountAuth,
         onChangeSortType = viewModel::changeSortType,
         onToggleArchiveFilter = viewModel::toggleArchiveFilter,
+        onMoreInfo = viewModel::trackSummaryExpanded,
         onPlayEpisode = { episode ->
             episodeActions.play(episode, TvEpisodeActionContext.PodcastDetails.source)
             openNowPlaying()
@@ -129,6 +130,7 @@ private fun TvPodcastDetailsContent(
     onRetryAccountAuth: () -> Unit,
     onChangeSortType: (EpisodesSortType) -> Unit,
     onToggleArchiveFilter: () -> Unit,
+    onMoreInfo: () -> Unit,
     onPlayEpisode: (PodcastEpisode) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -158,7 +160,10 @@ private fun TvPodcastDetailsContent(
                                 isShowingAccountModal = true
                             }
                         },
-                        onMoreInfo = { isShowingInfoModal = true },
+                        onMoreInfo = {
+                            onMoreInfo()
+                            isShowingInfoModal = true
+                        },
                         modifier = Modifier.weight(INFO_PANE_WEIGHT),
                     )
                     if (uiState.episodes.isEmpty() && uiState.archivedEpisodeCount == 0) {
@@ -449,6 +454,7 @@ private fun TvPodcastDetailsContentPreview(
             onRetryAccountAuth = {},
             onChangeSortType = {},
             onToggleArchiveFilter = {},
+            onMoreInfo = {},
             onPlayEpisode = {},
         )
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsViewModel.kt
@@ -17,6 +17,13 @@ import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import com.automattic.eventhorizon.EventHorizon
 import com.automattic.eventhorizon.PodcastScreenShownEvent
+import com.automattic.eventhorizon.PodcastScreenSubscribeTappedEvent
+import com.automattic.eventhorizon.PodcastScreenToggleArchivedEvent
+import com.automattic.eventhorizon.PodcastScreenToggleSummaryEvent
+import com.automattic.eventhorizon.PodcastScreenUnsubscribeTappedEvent
+import com.automattic.eventhorizon.PodcastSubscribedEvent
+import com.automattic.eventhorizon.PodcastUnsubscribedEvent
+import com.automattic.eventhorizon.PodcastsScreenSortOrderChangedEvent
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -104,6 +111,10 @@ class TvPodcastDetailsViewModel @AssistedInject constructor(
         eventHorizon.track(PodcastScreenShownEvent(source = source.analyticsValue))
     }
 
+    fun trackSummaryExpanded() {
+        eventHorizon.track(PodcastScreenToggleSummaryEvent(isExpanded = true))
+    }
+
     fun startAccountAuth() {
         accountAuthJob?.cancel()
         _accountAuthState.value = TvSignInUiState.Loading
@@ -112,6 +123,7 @@ class TvPodcastDetailsViewModel @AssistedInject constructor(
                 _accountAuthState.value = state
                 if (state is TvSignInUiState.Complete) {
                     podcastManager.subscribeToPodcast(podcastUuid, sync = true)
+                    trackSubscribed()
                     // Sibling of accountAuthJob so the modal dismiss cancel doesn't kill the refresh.
                     viewModelScope.launch {
                         try {
@@ -139,15 +151,24 @@ class TvPodcastDetailsViewModel @AssistedInject constructor(
     fun toggleSubscribe() {
         val podcast = (uiState.value as? TvPodcastDetailsUiState.Loaded)?.podcast ?: return
         if (podcast.isSubscribed) {
+            eventHorizon.track(PodcastScreenUnsubscribeTappedEvent)
+            eventHorizon.track(PodcastUnsubscribedEvent(uuid = podcastUuid, source = SourceView.PODCAST_SCREEN.analyticsValue))
             viewModelScope.launch(ioDispatcher) {
                 podcastManager.unsubscribe(podcastUuid, SourceView.PODCAST_SCREEN)
             }
         } else {
+            eventHorizon.track(PodcastScreenSubscribeTappedEvent)
             podcastManager.subscribeToPodcast(podcastUuid, sync = true)
+            trackSubscribed()
         }
     }
 
+    private fun trackSubscribed() {
+        eventHorizon.track(PodcastSubscribedEvent(uuid = podcastUuid, source = SourceView.PODCAST_SCREEN.analyticsValue))
+    }
+
     fun changeSortType(sortType: EpisodesSortType) {
+        eventHorizon.track(PodcastsScreenSortOrderChangedEvent(sortOrder = sortType.analyticsValue))
         viewModelScope.launch(ioDispatcher) {
             podcastManager.updateEpisodesSortTypeBlocking(Podcast(uuid = podcastUuid), sortType)
         }
@@ -155,6 +176,7 @@ class TvPodcastDetailsViewModel @AssistedInject constructor(
 
     fun toggleArchiveFilter() {
         val isShowingArchived = !isShowingArchivedFlow.value
+        eventHorizon.track(PodcastScreenToggleArchivedEvent(showArchived = isShowingArchived))
         preferences.setPodcastShowingArchived(podcastUuid, isShowingArchived)
         isShowingArchivedFlow.value = isShowingArchived
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsViewModel.kt
@@ -15,6 +15,8 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
+import com.automattic.eventhorizon.EventHorizon
+import com.automattic.eventhorizon.PodcastScreenShownEvent
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -46,10 +48,12 @@ import kotlinx.coroutines.rx2.await
 @HiltViewModel(assistedFactory = TvPodcastDetailsViewModel.Factory::class)
 class TvPodcastDetailsViewModel @AssistedInject constructor(
     @Assisted private val podcastUuid: String,
+    @Assisted private val source: SourceView,
     private val podcastManager: PodcastManager,
     private val episodeManager: EpisodeManager,
     private val syncManager: SyncManager,
     private val preferences: TvPreferences,
+    private val eventHorizon: EventHorizon,
     @DefaultDispatcher private val defaultDispatcher: CoroutineDispatcher,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
@@ -95,6 +99,10 @@ class TvPodcastDetailsViewModel @AssistedInject constructor(
             SharingStarted.WhileSubscribed(stopTimeout = 300.milliseconds, replayExpiration = Duration.ZERO),
             TvPodcastDetailsUiState.Loading,
         )
+
+    fun trackScreenShown() {
+        eventHorizon.track(PodcastScreenShownEvent(source = source.analyticsValue))
+    }
 
     fun startAccountAuth() {
         accountAuthJob?.cancel()
@@ -153,7 +161,7 @@ class TvPodcastDetailsViewModel @AssistedInject constructor(
 
     @AssistedFactory
     interface Factory {
-        fun create(podcastUuid: String): TvPodcastDetailsViewModel
+        fun create(podcastUuid: String, source: SourceView): TvPodcastDetailsViewModel
     }
 }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsViewModel.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.podcasts
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverPodcastAttribution
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodesSortType
@@ -15,6 +16,8 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
+import com.automattic.eventhorizon.DiscoverFeaturedPodcastSubscribedEvent
+import com.automattic.eventhorizon.DiscoverListPodcastSubscribedEvent
 import com.automattic.eventhorizon.EventHorizon
 import com.automattic.eventhorizon.PodcastScreenShownEvent
 import com.automattic.eventhorizon.PodcastScreenSubscribeTappedEvent
@@ -61,6 +64,7 @@ class TvPodcastDetailsViewModel @AssistedInject constructor(
     private val syncManager: SyncManager,
     private val preferences: TvPreferences,
     private val eventHorizon: EventHorizon,
+    private val discoverPodcastAttribution: TvDiscoverPodcastAttribution,
     @DefaultDispatcher private val defaultDispatcher: CoroutineDispatcher,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
@@ -165,6 +169,16 @@ class TvPodcastDetailsViewModel @AssistedInject constructor(
 
     private fun trackSubscribed() {
         eventHorizon.track(PodcastSubscribedEvent(uuid = podcastUuid, source = SourceView.PODCAST_SCREEN.analyticsValue))
+        if (source in DISCOVER_SOURCES) {
+            discoverPodcastAttribution.consume(podcastUuid)?.let { attribution ->
+                attribution.listId?.let { listId ->
+                    eventHorizon.track(DiscoverListPodcastSubscribedEvent(listId = listId, podcastUuid = podcastUuid, listDatetime = attribution.listDatetime))
+                }
+                if (attribution.isFeatured) {
+                    eventHorizon.track(DiscoverFeaturedPodcastSubscribedEvent(podcastUuid = podcastUuid))
+                }
+            }
+        }
     }
 
     fun changeSortType(sortType: EpisodesSortType) {
@@ -184,6 +198,10 @@ class TvPodcastDetailsViewModel @AssistedInject constructor(
     @AssistedFactory
     interface Factory {
         fun create(podcastUuid: String, source: SourceView): TvPodcastDetailsViewModel
+    }
+
+    private companion object {
+        val DISCOVER_SOURCES = setOf(SourceView.DISCOVER, SourceView.SEARCH_RESULTS)
     }
 }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsViewModel.kt
@@ -58,7 +58,6 @@ import kotlinx.coroutines.rx2.await
 @HiltViewModel(assistedFactory = TvPodcastDetailsViewModel.Factory::class)
 class TvPodcastDetailsViewModel @AssistedInject constructor(
     @Assisted private val podcastUuid: String,
-    @Assisted private val source: SourceView,
     private val podcastManager: PodcastManager,
     private val episodeManager: EpisodeManager,
     private val syncManager: SyncManager,
@@ -70,6 +69,8 @@ class TvPodcastDetailsViewModel @AssistedInject constructor(
 ) : ViewModel() {
 
     private val isShowingArchivedFlow = MutableStateFlow(preferences.isPodcastShowingArchived(podcastUuid))
+
+    private var discoverAttribution: TvDiscoverPodcastAttribution.Attribution? = null
 
     private val _accountAuthState = MutableStateFlow<TvSignInUiState>(TvSignInUiState.Loading)
     val accountAuthState: StateFlow<TvSignInUiState> = _accountAuthState.asStateFlow()
@@ -111,8 +112,14 @@ class TvPodcastDetailsViewModel @AssistedInject constructor(
             TvPodcastDetailsUiState.Loading,
         )
 
-    fun trackScreenShown() {
+    fun onScreenOpened(source: SourceView) {
         eventHorizon.track(PodcastScreenShownEvent(source = source.analyticsValue))
+        discoverAttribution = if (source in DISCOVER_SOURCES) {
+            discoverPodcastAttribution.consume(podcastUuid)
+        } else {
+            discoverPodcastAttribution.clear(podcastUuid)
+            null
+        }
     }
 
     fun trackSummaryExpanded() {
@@ -169,14 +176,12 @@ class TvPodcastDetailsViewModel @AssistedInject constructor(
 
     private fun trackSubscribed() {
         eventHorizon.track(PodcastSubscribedEvent(uuid = podcastUuid, source = SourceView.PODCAST_SCREEN.analyticsValue))
-        if (source in DISCOVER_SOURCES) {
-            discoverPodcastAttribution.consume(podcastUuid)?.let { attribution ->
-                attribution.listId?.let { listId ->
-                    eventHorizon.track(DiscoverListPodcastSubscribedEvent(listId = listId, podcastUuid = podcastUuid, listDatetime = attribution.listDatetime))
-                }
-                if (attribution.isFeatured) {
-                    eventHorizon.track(DiscoverFeaturedPodcastSubscribedEvent(podcastUuid = podcastUuid))
-                }
+        discoverAttribution?.let { attribution ->
+            attribution.listId?.let { listId ->
+                eventHorizon.track(DiscoverListPodcastSubscribedEvent(listId = listId, podcastUuid = podcastUuid, listDatetime = attribution.listDatetime))
+            }
+            if (attribution.isFeatured) {
+                eventHorizon.track(DiscoverFeaturedPodcastSubscribedEvent(podcastUuid = podcastUuid))
             }
         }
     }
@@ -197,7 +202,7 @@ class TvPodcastDetailsViewModel @AssistedInject constructor(
 
     @AssistedFactory
     interface Factory {
-        fun create(podcastUuid: String, source: SourceView): TvPodcastDetailsViewModel
+        fun create(podcastUuid: String): TvPodcastDetailsViewModel
     }
 
     private companion object {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvYourPodcastsScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.MaterialTheme
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.component.TvDetailOverlay
 import au.com.shiftyjelly.pocketcasts.component.TvEmptyState
 import au.com.shiftyjelly.pocketcasts.component.TvFolderCard
@@ -121,6 +122,7 @@ fun TvYourPodcastsScreen(
         ) { uuid ->
             TvPodcastDetailsScreen(
                 podcastUuid = uuid,
+                source = SourceView.PODCAST_LIST,
                 onClose = { openedPodcastUuid = null },
             )
         }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
@@ -44,6 +44,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.component.LocalOpenNowPlaying
 import au.com.shiftyjelly.pocketcasts.component.LocalTvToastHostState
 import au.com.shiftyjelly.pocketcasts.component.TvCategoryTile
@@ -235,6 +236,7 @@ fun TvSearchScreen(
         ) { uuid ->
             TvPodcastDetailsScreen(
                 podcastUuid = uuid,
+                source = SourceView.SEARCH_RESULTS,
                 onClose = { openedPodcastUuid = null },
             )
         }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
@@ -9,6 +9,7 @@ import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverEpisode
 import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverFeedAnalytics
 import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverFeedLoader
 import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverPodcast
+import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverPodcastAttribution
 import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverRow
 import au.com.shiftyjelly.pocketcasts.discover.TvOpenedCategory
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
@@ -70,9 +71,10 @@ class TvSearchViewModel @Inject constructor(
     private val folderManager: FolderManager,
     private val eventHorizon: EventHorizon,
     private val settings: Settings,
+    private val discoverPodcastAttribution: TvDiscoverPodcastAttribution,
 ) : ViewModel() {
 
-    private val discoverFeedAnalytics = TvDiscoverFeedAnalytics(eventHorizon, settings, SOURCE_SEARCH, localRowIds = emptySet())
+    private val discoverFeedAnalytics = TvDiscoverFeedAnalytics(eventHorizon, settings, SOURCE_SEARCH, localRowIds = emptySet(), attribution = discoverPodcastAttribution)
 
     private val _categories = MutableStateFlow<List<DiscoverCategory>>(emptyList())
     val categories: StateFlow<List<DiscoverCategory>> = _categories.asStateFlow()

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/starred/TvStarredScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/starred/TvStarredScreen.kt
@@ -33,6 +33,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.component.LocalOpenNowPlaying
 import au.com.shiftyjelly.pocketcasts.component.TvEmptyState
 import au.com.shiftyjelly.pocketcasts.component.TvEpisodeActionContext
@@ -69,6 +70,7 @@ fun TvStarredScreen(
         BackHandler { openedPodcastUuid = null }
         TvPodcastDetailsScreen(
             podcastUuid = podcastUuid,
+            source = SourceView.STARRED,
             onClose = { openedPodcastUuid = null },
             modifier = modifier,
         )

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextScreen.kt
@@ -33,6 +33,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.component.LocalOpenNowPlaying
 import au.com.shiftyjelly.pocketcasts.component.TvEmptyState
 import au.com.shiftyjelly.pocketcasts.component.TvEpisodeActionContext
@@ -70,6 +71,7 @@ fun TvUpNextScreen(
         BackHandler { openedPodcastUuid = null }
         TvPodcastDetailsScreen(
             podcastUuid = podcastUuid,
+            source = SourceView.UP_NEXT,
             onClose = { openedPodcastUuid = null },
             modifier = modifier,
         )

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/discover/TvDiscoverFeedAnalyticsTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/discover/TvDiscoverFeedAnalyticsTest.kt
@@ -12,6 +12,8 @@ import com.automattic.eventhorizon.DiscoverListEpisodeTappedEvent
 import com.automattic.eventhorizon.DiscoverListImpressionEvent
 import com.automattic.eventhorizon.DiscoverListPodcastTappedEvent
 import com.automattic.eventhorizon.EventHorizon
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
@@ -29,8 +31,9 @@ class TvDiscoverFeedAnalyticsTest {
     private val settings = mock<Settings> {
         whenever(it.discoverCountryCode).thenReturn(discoverCountryCode)
     }
+    private val attribution = TvDiscoverPodcastAttribution()
 
-    private fun analytics(source: String = "home", localRowIds: Set<String> = emptySet()) = TvDiscoverFeedAnalytics(eventHorizon, settings, source, localRowIds)
+    private fun analytics(source: String = "home", localRowIds: Set<String> = emptySet()) = TvDiscoverFeedAnalytics(eventHorizon, settings, source, localRowIds, attribution)
 
     @Test
     fun `list impression is tracked with the row id and source`() {
@@ -100,6 +103,27 @@ class TvDiscoverFeedAnalyticsTest {
 
         verify(eventHorizon).track(DiscoverListPodcastTappedEvent(listId = "featured", podcastUuid = "podcast-1", source = "home"))
         verify(eventHorizon).track(DiscoverFeaturedPodcastTappedEvent(podcastUuid = "podcast-1"))
+    }
+
+    @Test
+    fun `a featured podcast tap records the podcast attribution`() {
+        val row = TvDiscoverRow.FeaturedPodcasts(id = "featured", title = "Featured", podcasts = emptyList(), listId = "featured", listDatetime = "2026-08-27")
+
+        analytics().trackPodcastTapped(row, podcast("podcast-1"))
+
+        assertEquals(
+            TvDiscoverPodcastAttribution.Attribution(listId = "featured", listDatetime = "2026-08-27", isFeatured = true),
+            attribution.consume("podcast-1"),
+        )
+    }
+
+    @Test
+    fun `a local row podcast tap clears any recorded attribution`() {
+        attribution.record("podcast-1", listId = "stale", listDatetime = null, isFeatured = false)
+
+        analytics(localRowIds = setOf("trending")).trackPodcastTapped(podcastsRow(id = "trending"), podcast("podcast-1"))
+
+        assertNull(attribution.consume("podcast-1"))
     }
 
     @Test

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModelTest.kt
@@ -8,6 +8,7 @@ import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverBanner
 import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverEpisode
 import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverFeedLoader
 import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverPodcast
+import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverPodcastAttribution
 import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverRow
 import au.com.shiftyjelly.pocketcasts.discover.TvOpenedCategory
 import au.com.shiftyjelly.pocketcasts.models.db.dao.PodcastDao
@@ -1067,6 +1068,7 @@ class TvHomeViewModelTest {
         playbackManager = playbackManager,
         eventHorizon = eventHorizon,
         settings = settings,
+        discoverPodcastAttribution = TvDiscoverPodcastAttribution(),
         context = context,
     )
 

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsViewModelTest.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.podcasts
 
 import app.cash.turbine.test
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverPodcastAttribution
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodesSortType
@@ -15,6 +16,8 @@ import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.servers.model.AuthResultModel
 import au.com.shiftyjelly.pocketcasts.servers.sync.login.DeviceAuthorizeResponse
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import com.automattic.eventhorizon.DiscoverFeaturedPodcastSubscribedEvent
+import com.automattic.eventhorizon.DiscoverListPodcastSubscribedEvent
 import com.automattic.eventhorizon.EventHorizon
 import com.automattic.eventhorizon.PodcastScreenShownEvent
 import com.automattic.eventhorizon.PodcastScreenSubscribeTappedEvent
@@ -40,6 +43,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyBlocking
@@ -69,6 +73,7 @@ class TvPodcastDetailsViewModelTest {
         on { isLoggedInObservable } doReturn loggedIn
     }
     private val eventHorizon = mock<EventHorizon>()
+    private val discoverPodcastAttribution = TvDiscoverPodcastAttribution()
 
     @Test
     fun `archived episodes are hidden by default`() = runTest {
@@ -374,6 +379,44 @@ class TvPodcastDetailsViewModelTest {
     }
 
     @Test
+    fun `following a podcast opened from discover fires the list and featured subscribed events`() = runTest {
+        discoverPodcastAttribution.record("podcast-uuid", listId = "list-1", listDatetime = "2026-08-28", isFeatured = true)
+        val viewModel = createViewModel(source = SourceView.DISCOVER)
+
+        viewModel.uiState.test {
+            assertEquals(TvPodcastDetailsUiState.Loading, awaitItem())
+            episodes.emit(listOf(availableEpisode))
+            awaitItem() as TvPodcastDetailsUiState.Loaded
+
+            viewModel.toggleSubscribe()
+
+            cancelAndConsumeRemainingEvents()
+        }
+
+        verify(eventHorizon).track(DiscoverListPodcastSubscribedEvent(listId = "list-1", podcastUuid = "podcast-uuid", listDatetime = "2026-08-28"))
+        verify(eventHorizon).track(DiscoverFeaturedPodcastSubscribedEvent(podcastUuid = "podcast-uuid"))
+    }
+
+    @Test
+    fun `following a library opened podcast does not fire discover subscribed events`() = runTest {
+        discoverPodcastAttribution.record("podcast-uuid", listId = "list-1", listDatetime = null, isFeatured = false)
+        val viewModel = createViewModel(source = SourceView.PODCAST_LIST)
+
+        viewModel.uiState.test {
+            assertEquals(TvPodcastDetailsUiState.Loading, awaitItem())
+            episodes.emit(listOf(availableEpisode))
+            awaitItem() as TvPodcastDetailsUiState.Loaded
+
+            viewModel.toggleSubscribe()
+
+            cancelAndConsumeRemainingEvents()
+        }
+
+        verify(eventHorizon, never()).track(any<DiscoverListPodcastSubscribedEvent>())
+        verify(eventHorizon, never()).track(any<DiscoverFeaturedPodcastSubscribedEvent>())
+    }
+
+    @Test
     fun `starting account auth drives the account state to complete`() = runTest {
         whenever(syncManager.deviceAuthorize()).thenReturn(deviceAuthorizeResponse())
         whenever(syncManager.loginWithDeviceAuth(any(), any(), any())).thenReturn(loginSuccess())
@@ -435,6 +478,7 @@ class TvPodcastDetailsViewModelTest {
         syncManager = syncManager,
         preferences = prefs,
         eventHorizon = eventHorizon,
+        discoverPodcastAttribution = discoverPodcastAttribution,
         defaultDispatcher = coroutineRule.testDispatcher,
         ioDispatcher = coroutineRule.testDispatcher,
     )

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsViewModelTest.kt
@@ -17,6 +17,13 @@ import au.com.shiftyjelly.pocketcasts.servers.sync.login.DeviceAuthorizeResponse
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import com.automattic.eventhorizon.EventHorizon
 import com.automattic.eventhorizon.PodcastScreenShownEvent
+import com.automattic.eventhorizon.PodcastScreenSubscribeTappedEvent
+import com.automattic.eventhorizon.PodcastScreenToggleArchivedEvent
+import com.automattic.eventhorizon.PodcastScreenToggleSummaryEvent
+import com.automattic.eventhorizon.PodcastScreenUnsubscribeTappedEvent
+import com.automattic.eventhorizon.PodcastSubscribedEvent
+import com.automattic.eventhorizon.PodcastUnsubscribedEvent
+import com.automattic.eventhorizon.PodcastsScreenSortOrderChangedEvent
 import com.jakewharton.rxrelay2.BehaviorRelay
 import io.reactivex.Single
 import java.util.Date
@@ -275,6 +282,95 @@ class TvPodcastDetailsViewModelTest {
         advanceUntilIdle()
 
         verifyBlocking(podcastManager) { unsubscribe("podcast-uuid", SourceView.PODCAST_SCREEN) }
+    }
+
+    @Test
+    fun `following a podcast tracks the subscribe tapped and subscribed events`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            assertEquals(TvPodcastDetailsUiState.Loading, awaitItem())
+            episodes.emit(listOf(availableEpisode))
+            awaitItem() as TvPodcastDetailsUiState.Loaded
+
+            viewModel.toggleSubscribe()
+
+            cancelAndConsumeRemainingEvents()
+        }
+
+        verify(eventHorizon).track(PodcastScreenSubscribeTappedEvent)
+        verify(eventHorizon).track(PodcastSubscribedEvent(uuid = "podcast-uuid", source = SourceView.PODCAST_SCREEN.analyticsValue))
+    }
+
+    @Test
+    fun `unfollowing a podcast tracks the unsubscribe tapped and unsubscribed events`() = runTest {
+        val subscribedPodcast = podcast.copy(isSubscribed = true)
+        val podcastManager = mock<PodcastManager> {
+            on { findOrDownloadPodcastRxSingle(any(), any()) } doReturn Single.just(subscribedPodcast)
+            on { podcastByUuidFlow(any()) } doReturn MutableStateFlow(subscribedPodcast)
+        }
+        val viewModel = createViewModel(podcastManager = podcastManager)
+
+        viewModel.uiState.test {
+            assertEquals(TvPodcastDetailsUiState.Loading, awaitItem())
+            episodes.emit(listOf(availableEpisode))
+            awaitItem() as TvPodcastDetailsUiState.Loaded
+
+            viewModel.toggleSubscribe()
+
+            cancelAndConsumeRemainingEvents()
+        }
+
+        verify(eventHorizon).track(PodcastScreenUnsubscribeTappedEvent)
+        verify(eventHorizon).track(PodcastUnsubscribedEvent(uuid = "podcast-uuid", source = SourceView.PODCAST_SCREEN.analyticsValue))
+    }
+
+    @Test
+    fun `changing the sort type tracks the sort order changed event`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.changeSortType(EpisodesSortType.EPISODES_SORT_BY_TITLE_ASC)
+
+        verify(eventHorizon).track(PodcastsScreenSortOrderChangedEvent(sortOrder = EpisodesSortType.EPISODES_SORT_BY_TITLE_ASC.analyticsValue))
+    }
+
+    @Test
+    fun `toggling the archive filter tracks the toggle archived event`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.toggleArchiveFilter()
+
+        verify(eventHorizon).track(PodcastScreenToggleArchivedEvent(showArchived = true))
+    }
+
+    @Test
+    fun `expanding the summary tracks the toggle summary event`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.trackSummaryExpanded()
+
+        verify(eventHorizon).track(PodcastScreenToggleSummaryEvent(isExpanded = true))
+    }
+
+    @Test
+    fun `auto follow after account auth tracks the subscribed event`() = runTest {
+        whenever(syncManager.deviceAuthorize()).thenReturn(deviceAuthorizeResponse())
+        whenever(syncManager.loginWithDeviceAuth(any(), any(), any())).thenReturn(loginSuccess())
+        val viewModel = createViewModel()
+
+        viewModel.accountAuthState.test {
+            assertEquals(TvSignInUiState.Loading, awaitItem())
+
+            viewModel.startAccountAuth()
+
+            val states = mutableListOf<TvSignInUiState>()
+            while (states.lastOrNull() !is TvSignInUiState.Complete) {
+                states.add(awaitItem())
+            }
+        }
+        advanceUntilIdle()
+
+        verify(eventHorizon).track(PodcastSubscribedEvent(uuid = "podcast-uuid", source = SourceView.PODCAST_SCREEN.analyticsValue))
     }
 
     @Test

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsViewModelTest.kt
@@ -381,7 +381,8 @@ class TvPodcastDetailsViewModelTest {
     @Test
     fun `following a podcast opened from discover fires the list and featured subscribed events`() = runTest {
         discoverPodcastAttribution.record("podcast-uuid", listId = "list-1", listDatetime = "2026-08-28", isFeatured = true)
-        val viewModel = createViewModel(source = SourceView.DISCOVER)
+        val viewModel = createViewModel()
+        viewModel.onScreenOpened(SourceView.DISCOVER)
 
         viewModel.uiState.test {
             assertEquals(TvPodcastDetailsUiState.Loading, awaitItem())
@@ -400,7 +401,8 @@ class TvPodcastDetailsViewModelTest {
     @Test
     fun `following a library opened podcast does not fire discover subscribed events`() = runTest {
         discoverPodcastAttribution.record("podcast-uuid", listId = "list-1", listDatetime = null, isFeatured = false)
-        val viewModel = createViewModel(source = SourceView.PODCAST_LIST)
+        val viewModel = createViewModel()
+        viewModel.onScreenOpened(SourceView.PODCAST_LIST)
 
         viewModel.uiState.test {
             assertEquals(TvPodcastDetailsUiState.Loading, awaitItem())
@@ -441,10 +443,10 @@ class TvPodcastDetailsViewModelTest {
     }
 
     @Test
-    fun `showing the screen tracks the podcast screen shown event with its source`() = runTest {
-        val viewModel = createViewModel(source = SourceView.DISCOVER)
+    fun `opening the screen tracks the podcast screen shown event with its source`() = runTest {
+        val viewModel = createViewModel()
 
-        viewModel.trackScreenShown()
+        viewModel.onScreenOpened(SourceView.DISCOVER)
 
         verify(eventHorizon).track(PodcastScreenShownEvent(source = SourceView.DISCOVER.analyticsValue))
     }
@@ -469,10 +471,8 @@ class TvPodcastDetailsViewModelTest {
     private fun createViewModel(
         prefs: TvPreferences = preferences,
         podcastManager: PodcastManager = this.podcastManager,
-        source: SourceView = SourceView.PODCAST_SCREEN,
     ) = TvPodcastDetailsViewModel(
         podcastUuid = "podcast-uuid",
-        source = source,
         podcastManager = podcastManager,
         episodeManager = episodeManager,
         syncManager = syncManager,

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsViewModelTest.kt
@@ -15,6 +15,8 @@ import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.servers.model.AuthResultModel
 import au.com.shiftyjelly.pocketcasts.servers.sync.login.DeviceAuthorizeResponse
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import com.automattic.eventhorizon.EventHorizon
+import com.automattic.eventhorizon.PodcastScreenShownEvent
 import com.jakewharton.rxrelay2.BehaviorRelay
 import io.reactivex.Single
 import java.util.Date
@@ -59,6 +61,7 @@ class TvPodcastDetailsViewModelTest {
     private val syncManager = mock<SyncManager> {
         on { isLoggedInObservable } doReturn loggedIn
     }
+    private val eventHorizon = mock<EventHorizon>()
 
     @Test
     fun `archived episodes are hidden by default`() = runTest {
@@ -298,6 +301,15 @@ class TvPodcastDetailsViewModelTest {
         verify(podcastManager).refreshPodcastsAfterSignIn()
     }
 
+    @Test
+    fun `showing the screen tracks the podcast screen shown event with its source`() = runTest {
+        val viewModel = createViewModel(source = SourceView.DISCOVER)
+
+        viewModel.trackScreenShown()
+
+        verify(eventHorizon).track(PodcastScreenShownEvent(source = SourceView.DISCOVER.analyticsValue))
+    }
+
     private fun deviceAuthorizeResponse() = DeviceAuthorizeResponse(
         deviceCode = "device-code",
         userCode = "ABC123",
@@ -318,12 +330,15 @@ class TvPodcastDetailsViewModelTest {
     private fun createViewModel(
         prefs: TvPreferences = preferences,
         podcastManager: PodcastManager = this.podcastManager,
+        source: SourceView = SourceView.PODCAST_SCREEN,
     ) = TvPodcastDetailsViewModel(
         podcastUuid = "podcast-uuid",
+        source = source,
         podcastManager = podcastManager,
         episodeManager = episodeManager,
         syncManager = syncManager,
         preferences = prefs,
+        eventHorizon = eventHorizon,
         defaultDispatcher = coroutineRule.testDispatcher,
         ioDispatcher = coroutineRule.testDispatcher,
     )

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModelTest.kt
@@ -7,6 +7,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverEpisode
 import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverFeedLoader
 import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverPodcast
+import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverPodcastAttribution
 import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverRow
 import au.com.shiftyjelly.pocketcasts.models.entity.Folder
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
@@ -921,6 +922,7 @@ class TvSearchViewModelTest {
         folderManager = folderManager,
         eventHorizon = eventHorizon,
         settings = settings,
+        discoverPodcastAttribution = TvDiscoverPodcastAttribution(),
     )
 
     private fun folderEntity(name: String) = Folder(


### PR DESCRIPTION
## Description

**Android TV parity — Section B / PR 2: follow-funnel analytics.** Follows are the most important conversion signal on TV, and today the podcast-details screen fires **zero** events and the discover-attribution subscribe events can't fire (no uuid→list mapping). This wires the whole funnel.

All event classes already exist in the pinned EventHorizon artifact — **no schema change needed**.

Commits:
1. **Thread the entry source into podcast details.** The screen took no `source`; added a `SourceView` param passed from all 7 overlay call sites (home→`discover`, playlists→`filters`, now playing→`player`, up next→`up_next`, your podcasts→`podcast_list`, search→`search_results`, starred→`starred`), and fire `podcast_screen_shown{source}`. Per the Android schema, `podcast_screen_shown` carries `source`, not `uuid`.
2. **Podcast-details event set:** `podcast_screen_subscribe_tapped` + `podcast_subscribed{source=podcast_screen, uuid}` on follow (including the auto-follow-after-device-auth path); `podcast_screen_unsubscribe_tapped` + `podcast_unsubscribed`; `podcast_screen_toggle_archived`, `podcasts_screen_sort_order_changed`, `podcast_screen_toggle_summary{is_expanded=true}` on More-info.
3. **Discover follow attribution.** New `@Singleton TvDiscoverPodcastAttribution` (uuid→listId/datetime/featured), recorded when a podcast is opened from a Home/Search discover row or featured card. On follow, fires `discover_list_podcast_subscribed{list_id, podcast_uuid}` and/or `discover_featured_podcast_subscribed{podcast_uuid}`, using the corrected `list_id` semantics (never a row title).

### Design note (important)
The TV podcast-details ViewModel is `hiltViewModel(key = podcastUuid)` cached in the long-lived HOME `ViewModelStore` (the overlay keeps the parent composed and doesn't scope the VM), so **anything passed as an `@Assisted` constructor arg would freeze at the first open** and go stale when the same podcast is reopened from another surface. So `source` is delivered **per screen open** via `onScreenOpened(source)` (fired once per open by `CallOnce`), not as a constructor arg. The discover attribution is likewise **resolved at open time** — consumed for discover sources, cleared for library sources — which also drains the entry so a later plain-search-result open of the same podcast can't inherit a stale list attribution.

Fixes PCDROID-742 https://linear.app/a8c/issue/PCDROID-742/consolidate-follow-event-analytics

## Testing Instructions

1. `debugProd` TV build + `adb logcat` on `LoggingAnalyticsListener`.
2. From Home discover, open a podcast → `podcast_screen_shown{source=discover}`; tap Follow → `podcast_screen_subscribe_tapped` → `podcast_subscribed{source=podcast_screen}` → `discover_list_podcast_subscribed`/`discover_featured_podcast_subscribed`.
3. Open the same podcast from Your Podcasts → `podcast_screen_shown{source=podcast_list}`; follow → no discover-subscribed event.
4. Change sort / toggle archived / open More-info → the respective events. Unfollow → `podcast_screen_unsubscribe_tapped` + `podcast_unsubscribed`.

Unit tests cover every event, the source per-open, and the attribution map (recorded on discover open, consumed on follow, absent for library opens).

### Expected analytics events

| Trigger | Event(s) | Properties | Needs sign-in? |
|---|---|---|---|
| Open a podcast (any entry) | `podcast_screen_shown` | `source` = `discover` / `podcast_list` / `filters` / `up_next` / `player` / `search_results` / `starred` | no |
| Change episode sort | `podcasts_screen_sort_order_changed` | `sort_order` | no |
| Toggle archived filter | `podcast_screen_toggle_archived` | `show_archived` | no |
| Open More-info | `podcast_screen_toggle_summary` | `is_expanded=true` | no |
| Tap **Follow** | `podcast_screen_subscribe_tapped`, then `podcast_subscribed` | `{uuid, source=podcast_screen}` | **yes** |
| …when the podcast was opened from a **discover list** | + `discover_list_podcast_subscribed` | `{list_id, podcast_uuid}` | **yes** |
| …when opened from a **featured card** | + `discover_featured_podcast_subscribed` | `{podcast_uuid}` | **yes** |
| Tap **Unfollow** | `podcast_screen_unsubscribe_tapped`, then `podcast_unsubscribed` | `{uuid, source=podcast_screen}` | **yes** |
| Auto-follow after account creation (gated modal) | `podcast_subscribed` (+ discover events if attributed) | | n/a |

**Full funnel** (discover → follow): `podcast_screen_shown{source=discover}` → `podcast_screen_subscribe_tapped` → `podcast_subscribed{source=podcast_screen}` → `discover_list_podcast_subscribed{list_id}` and/or `discover_featured_podcast_subscribed`.

> The subscribe/unsubscribe + discover-attribution events fire only when **signed in** — signed-out, Follow opens the account modal instead. All of them are covered by `TvPodcastDetailsViewModelTest` (per-open source + the attribution map).

## Screenshots or Screencast
<img width="2252" height="448" alt="pr2-analytics-logcat" src="https://github.com/user-attachments/assets/87cc743c-6e5c-467c-8e3a-fa356ffb04a5" />



The `discover_list_podcast_subscribed` / `discover_featured_podcast_subscribed` attribution events additionally fire when following a podcast opened from a **discover row** (`source=discover`) — covered by `TvPodcastDetailsViewModelTest`.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md — n/a
- [x] Ensure the linter passes (`./gradlew spotlessApply`)
- [x] I have considered whether it makes sense to add tests for my changes — ViewModel + attribution unit tests added
- [x] All strings that need to be localized are in localization — n/a
- [x] Any jetpack compose components I added or changed are covered by compose previews — existing previews updated
- [x] I have updated the Event Horizon schema to reflect any new or changed analytics — n/a (all events already exist)

> Depends on #5801 (TV analytics foundation) landing first, so these events carry `platform=tv`.

