### PR TITLE
[TV] Episode-status analytics: played/unplayed and archived/unarchived

### DIFF
--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionsModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionsModal.kt
@@ -127,8 +127,8 @@ private fun ColumnScope.TvEpisodeActionsModalContent(
             onCancel = ::cancelConfirmation,
         )
     } else {
-        val markAsPlayed = perform(playedToast) { actions.markAsPlayed(episode) }
-        val archiveEpisode = perform(archiveToast) { actions.archive(episode) }
+        val markAsPlayed = perform(playedToast) { actions.markAsPlayed(episode, source) }
+        val archiveEpisode = perform(archiveToast) { actions.archive(episode, source) }
 
         val buttons = tvEpisodeActionTypes(actionContext, showGoToPodcast = onGoToPodcast != null).map { button ->
             when (button) {
@@ -154,7 +154,7 @@ private fun ColumnScope.TvEpisodeActionsModalContent(
                 }
 
                 TvEpisodeActionType.TogglePlayed -> playedToggle to when {
-                    episode.isFinished -> perform(playedToast) { actions.markAsUnplayed(episode) }
+                    episode.isFinished -> perform(playedToast) { actions.markAsUnplayed(episode, source) }
 
                     tvEpisodeActionRequiresConfirmation(actionContext, button, episode) ->
                         confirm(markPlayedTitle, playedToggle, markAsPlayed)
@@ -163,7 +163,7 @@ private fun ColumnScope.TvEpisodeActionsModalContent(
                 }
 
                 TvEpisodeActionType.ToggleArchived -> archiveToggle to when {
-                    episode.isArchived -> perform(archiveToast) { actions.unarchive(episode) }
+                    episode.isArchived -> perform(archiveToast) { actions.unarchive(episode, source) }
 
                     tvEpisodeActionRequiresConfirmation(actionContext, button, episode) ->
                         confirm(archiveTitle, archiveToggle, archiveEpisode)
@@ -316,10 +316,10 @@ private object NoOpTvEpisodeActions : TvEpisodeActions {
     override fun play(episode: PodcastEpisode, source: SourceView) = Unit
     override fun playNext(episode: PodcastEpisode, source: SourceView) = Unit
     override fun playLast(episode: PodcastEpisode, source: SourceView) = Unit
-    override fun markAsPlayed(episode: PodcastEpisode) = Unit
-    override fun markAsUnplayed(episode: PodcastEpisode) = Unit
-    override fun archive(episode: PodcastEpisode) = Unit
-    override fun unarchive(episode: PodcastEpisode) = Unit
+    override fun markAsPlayed(episode: PodcastEpisode, source: SourceView) = Unit
+    override fun markAsUnplayed(episode: PodcastEpisode, source: SourceView) = Unit
+    override fun archive(episode: PodcastEpisode, source: SourceView) = Unit
+    override fun unarchive(episode: PodcastEpisode, source: SourceView) = Unit
     override fun removeFromUpNext(episode: PodcastEpisode, source: SourceView) = Unit
     override fun trackActionsShown(source: EpisodeViewSourceType) = Unit
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionsViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionsViewModel.kt
@@ -9,6 +9,10 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import com.automattic.eventhorizon.EpisodeActionsShownEvent
+import com.automattic.eventhorizon.EpisodeArchivedEvent
+import com.automattic.eventhorizon.EpisodeMarkedAsPlayedEvent
+import com.automattic.eventhorizon.EpisodeMarkedAsUnplayedEvent
+import com.automattic.eventhorizon.EpisodeUnarchivedEvent
 import com.automattic.eventhorizon.EpisodeViewSourceType
 import com.automattic.eventhorizon.EventHorizon
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -33,10 +37,10 @@ interface TvEpisodeActions {
     fun play(episode: PodcastEpisode, source: SourceView)
     fun playNext(episode: PodcastEpisode, source: SourceView)
     fun playLast(episode: PodcastEpisode, source: SourceView)
-    fun markAsPlayed(episode: PodcastEpisode)
-    fun markAsUnplayed(episode: PodcastEpisode)
-    fun archive(episode: PodcastEpisode)
-    fun unarchive(episode: PodcastEpisode)
+    fun markAsPlayed(episode: PodcastEpisode, source: SourceView)
+    fun markAsUnplayed(episode: PodcastEpisode, source: SourceView)
+    fun archive(episode: PodcastEpisode, source: SourceView)
+    fun unarchive(episode: PodcastEpisode, source: SourceView)
     fun removeFromUpNext(episode: PodcastEpisode, source: SourceView)
     fun trackActionsShown(source: EpisodeViewSourceType)
 }
@@ -64,20 +68,24 @@ class TvEpisodeActionsViewModel @Inject constructor(
         playbackManager.playLast(episode = episode, source = source)
     }
 
-    override fun markAsPlayed(episode: PodcastEpisode) = launchWrite {
+    override fun markAsPlayed(episode: PodcastEpisode, source: SourceView) = launchWrite {
         episodeManager.markAsPlayedBlocking(episode, playbackManager, podcastManager)
+        eventHorizon.track(EpisodeMarkedAsPlayedEvent(source = source.analyticsValue, episodeUuid = episode.uuid))
     }
 
-    override fun markAsUnplayed(episode: PodcastEpisode) = launchWrite {
+    override fun markAsUnplayed(episode: PodcastEpisode, source: SourceView) = launchWrite {
         episodeManager.markAsNotPlayedBlocking(episode)
+        eventHorizon.track(EpisodeMarkedAsUnplayedEvent(source = source.analyticsValue, episodeUuid = episode.uuid))
     }
 
-    override fun archive(episode: PodcastEpisode) = launchWrite {
+    override fun archive(episode: PodcastEpisode, source: SourceView) = launchWrite {
         episodeManager.archiveBlocking(episode, playbackManager)
+        eventHorizon.track(EpisodeArchivedEvent(source = source.analyticsValue, episodeUuid = episode.uuid))
     }
 
-    override fun unarchive(episode: PodcastEpisode) = launchWrite {
+    override fun unarchive(episode: PodcastEpisode, source: SourceView) = launchWrite {
         episodeManager.unarchiveBlocking(episode)
+        eventHorizon.track(EpisodeUnarchivedEvent(source = source.analyticsValue, episodeUuid = episode.uuid))
     }
 
     override fun removeFromUpNext(episode: PodcastEpisode, source: SourceView) {

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionsViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionsViewModelTest.kt
@@ -7,6 +7,10 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import com.automattic.eventhorizon.EpisodeActionsShownEvent
+import com.automattic.eventhorizon.EpisodeArchivedEvent
+import com.automattic.eventhorizon.EpisodeMarkedAsPlayedEvent
+import com.automattic.eventhorizon.EpisodeMarkedAsUnplayedEvent
+import com.automattic.eventhorizon.EpisodeUnarchivedEvent
 import com.automattic.eventhorizon.EpisodeViewSourceType
 import com.automattic.eventhorizon.EventHorizon
 import java.util.Date
@@ -75,31 +79,35 @@ class TvEpisodeActionsViewModelTest {
     }
 
     @Test
-    fun `markAsPlayed marks the episode as played`() = runTest {
-        viewModel().markAsPlayed(episode)
+    fun `markAsPlayed marks the episode as played and tracks the event with the source`() = runTest {
+        viewModel().markAsPlayed(episode, SourceView.PODCAST_SCREEN)
 
         verify(episodeManager).markAsPlayedBlocking(episode, playbackManager, podcastManager)
+        verify(eventHorizon).track(EpisodeMarkedAsPlayedEvent(source = SourceView.PODCAST_SCREEN.analyticsValue, episodeUuid = "episode-uuid"))
     }
 
     @Test
-    fun `markAsUnplayed marks the episode as not played`() = runTest {
-        viewModel().markAsUnplayed(episode)
+    fun `markAsUnplayed marks the episode as not played and tracks the event with the source`() = runTest {
+        viewModel().markAsUnplayed(episode, SourceView.LISTENING_HISTORY)
 
         verify(episodeManager).markAsNotPlayedBlocking(episode)
+        verify(eventHorizon).track(EpisodeMarkedAsUnplayedEvent(source = SourceView.LISTENING_HISTORY.analyticsValue, episodeUuid = "episode-uuid"))
     }
 
     @Test
-    fun `archive archives the episode`() = runTest {
-        viewModel().archive(episode)
+    fun `archive archives the episode and tracks the event with the source`() = runTest {
+        viewModel().archive(episode, SourceView.UP_NEXT)
 
         verify(episodeManager).archiveBlocking(episode, playbackManager)
+        verify(eventHorizon).track(EpisodeArchivedEvent(source = SourceView.UP_NEXT.analyticsValue, episodeUuid = "episode-uuid"))
     }
 
     @Test
-    fun `unarchive unarchives the episode`() = runTest {
-        viewModel().unarchive(episode)
+    fun `unarchive unarchives the episode and tracks the event with the source`() = runTest {
+        viewModel().unarchive(episode, SourceView.STARRED)
 
         verify(episodeManager).unarchiveBlocking(episode)
+        verify(eventHorizon).track(EpisodeUnarchivedEvent(source = SourceView.STARRED.analyticsValue, episodeUuid = "episode-uuid"))
     }
 
     @Test


### PR DESCRIPTION
## Description

**Android TV parity — Section B / PR 3: episode-status analytics.** On Android TV, marking an episode played/unplayed and archiving/unarchiving fire **no events** — the shared `EpisodeManagerImpl` doesn't track (only star/unstar do; phone fires these from its UI view-models), and `TvEpisodeActionsViewModel` added nothing. This wires them.

`TvEpisodeActionsViewModel` now fires, using its existing per-context `SourceView` (`TvEpisodeActionContext`: podcast_screen / filters / up_next / search_results / starred / listening_history / player):
- `episode_marked_as_played {source, episode_uuid}`
- `episode_marked_as_unplayed {source, episode_uuid}`
- `episode_archived {source, episode_uuid}`
- `episode_unarchived {source, episode_uuid}`

Because every surface (podcast details, playlists, up next, search, starred, listening history, player) routes through the shared `TvEpisodeActionsModal`, this covers them all in one place. The four action methods gained a `source: SourceView` parameter (matching the existing `play`/`playNext`/`playLast`); the modal passes `actionContext.source`. All event classes already exist — **no schema change needed**.

### Deliberately deferred from this PR
- **Reorder-vs-add detection** (Play next/last of an already-queued episode should fire `up_next_queue_reordered`, not `episode_added_to_up_next`). The add event is fired unconditionally inside the shared `PlaybackManager.playNext/playLast` for all platforms, so a TV-only reorder event would double-emit; the clean fix needs either a shared semantics change or a suppress flag, which is an explicit cross-platform decision. Split out to avoid shipping double-emission.
- **`podcast_uuid` on `episode_added_to_up_next`.** The event has no `podcastUuid` parameter in the current EventHorizon artifact — it needs an EventHorizonSchemas change first (draft raised separately). The Android wiring is a small follow-up once the artifact is bumped.

Fixes PCDROID-743 https://linear.app/a8c/issue/PCDROID-743/consolidate-episode-status-analytics

## Testing Instructions

1. `debugProd` TV build + `adb logcat` on `LoggingAnalyticsListener`.
2. Open an episode's actions from a podcast screen → Mark as played → `episode_marked_as_played {source=podcast_screen}`. Mark as unplayed → `episode_marked_as_unplayed`.
3. Repeat from Up Next, Starred, Listening History, Search, Playlist, Now Playing → confirm the `source` matches the surface.
4. Archive / unarchive → `episode_archived` / `episode_unarchived` with the right source.

Unit tests assert each action performs the manager call **and** emits the event with the correct source.

## Screenshots or Screencast
<img width="1860" height="1733" alt="pr5803_episode_status_events" src="https://github.com/user-attachments/assets/6a823bb9-cb08-493e-bef9-2386743285ed" />



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md — n/a
- [x] Ensure the linter passes (`./gradlew spotlessApply`)
- [x] I have considered whether it makes sense to add tests for my changes — ViewModel unit tests per action + source
- [x] All strings that need to be localized are in localization — n/a
- [x] Any jetpack compose components I added or changed are covered by compose previews — n/a
- [x] I have updated the Event Horizon schema to reflect any new or changed analytics — n/a (events already exist); `podcast_uuid` follow-up tracked via a separate EventHorizonSchemas PR

> Depends on #5801 (TV analytics foundation) landing first, so these events carry `platform=tv`.
