### PR TITLE
[TV] Auth parity: silent QR expiry rotation, account-creation-failed, gated create_account_shown

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
@@ -256,7 +256,7 @@ class SyncManagerImpl @Inject constructor(
                 message = tokenError?.errorDescription ?: context.resources.getString(LR.string.error_login_failed),
                 messageId = tokenError?.error,
             )
-            if (tokenError?.error != "authorization_pending") {
+            if (tokenError?.error != "authorization_pending" && tokenError?.error != "expired_token") {
                 trackSignIn(result, signInSource, LoginIdentity.QrCode)
             }
             result

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
@@ -257,13 +257,13 @@ class SyncManagerImpl @Inject constructor(
                 messageId = tokenError?.error,
             )
             if (tokenError?.error != "authorization_pending" && tokenError?.error != "expired_token") {
-                trackSignIn(result, signInSource, LoginIdentity.QrCode)
+                trackSignIn(result, signInSource, LoginIdentity.QrCode, isNewAccount)
             }
             result
         } catch (ex: Exception) {
             Timber.e(ex, "Device auth failed")
             val result = exceptionToAuthResult(exception = ex, fallbackMessage = LR.string.error_login_failed)
-            trackSignIn(result, signInSource, LoginIdentity.QrCode)
+            trackSignIn(result, signInSource, LoginIdentity.QrCode, isNewAccount)
             result
         }
     }
@@ -569,6 +569,7 @@ class SyncManagerImpl @Inject constructor(
         loginResult: LoginResult,
         signInSource: SignInSource,
         loginIdentity: LoginIdentity,
+        isNewAccount: Boolean = false,
     ) {
         val event = when (loginResult) {
             is LoginResult.Success -> {
@@ -607,11 +608,17 @@ class SyncManagerImpl @Inject constructor(
                     }
 
                     is SignInSource.UserInitiated -> {
-                        UserSigninFailedEvent(
-                            source = loginIdentity.analyticsValue,
-                            sourceInCode = signInSource.analyticsValue,
-                            errorCode = errorCodeValue,
-                        )
+                        if (isNewAccount) {
+                            UserAccountCreationFailedEvent(
+                                errorCode = errorCodeValue,
+                            )
+                        } else {
+                            UserSigninFailedEvent(
+                                source = loginIdentity.analyticsValue,
+                                sourceInCode = signInSource.analyticsValue,
+                                errorCode = errorCodeValue,
+                            )
+                        }
                     }
                 }
             }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
@@ -86,6 +86,7 @@ import java.io.File
 import java.net.HttpURLConnection
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.rx2.rxSingle
@@ -260,6 +261,8 @@ class SyncManagerImpl @Inject constructor(
                 trackSignIn(result, signInSource, LoginIdentity.QrCode, isNewAccount)
             }
             result
+        } catch (ex: CancellationException) {
+            throw ex
         } catch (ex: Exception) {
             Timber.e(ex, "Device auth failed")
             val result = exceptionToAuthResult(exception = ex, fallbackMessage = LR.string.error_login_failed)

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImplTest.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.repositories.sync
 
 import android.content.Context
+import android.content.res.Resources
 import au.com.shiftyjelly.pocketcasts.analytics.testing.TestEventSink
 import au.com.shiftyjelly.pocketcasts.preferences.AccessToken
 import au.com.shiftyjelly.pocketcasts.preferences.RefreshToken
@@ -15,7 +16,9 @@ import com.automattic.eventhorizon.LoginIdentityType
 import com.automattic.eventhorizon.OnboardingFlowType
 import com.automattic.eventhorizon.SignInSourceType
 import com.automattic.eventhorizon.UserAccountCreatedEvent
+import com.automattic.eventhorizon.UserAccountCreationFailedEvent
 import com.automattic.eventhorizon.UserSignedInEvent
+import com.automattic.eventhorizon.UserSigninFailedEvent
 import com.squareup.moshi.Moshi
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -27,6 +30,7 @@ import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -125,6 +129,28 @@ class SyncManagerImplTest {
         )
         assertTrue(eventSink.isEmpty())
         verifyNotificationNotCalled()
+    }
+
+    @Test
+    fun `device auth failure as new account fires account creation failed event`() = runTest {
+        stubResources()
+        whenever(syncServiceManager.deviceToken(any(), any())).thenThrow(RuntimeException("boom"))
+        syncManager.loginWithDeviceAuth("device-code", SignInSource.UserInitiated.Onboarding, isNewAccount = true)
+        assertTrue(eventSink.pollEvent() is UserAccountCreationFailedEvent)
+    }
+
+    @Test
+    fun `device auth failure as existing account fires signin failed event`() = runTest {
+        stubResources()
+        whenever(syncServiceManager.deviceToken(any(), any())).thenThrow(RuntimeException("boom"))
+        syncManager.loginWithDeviceAuth("device-code", SignInSource.UserInitiated.Onboarding, isNewAccount = false)
+        assertTrue(eventSink.pollEvent() is UserSigninFailedEvent)
+    }
+
+    private fun stubResources() {
+        val resources = mock<Resources>()
+        whenever(context.resources).thenReturn(resources)
+        whenever(resources.getString(any())).thenReturn("error")
     }
 
     private fun createDeviceTokenResponse() = DeviceTokenResponse(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/createaccount/TvCreateAccountModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/createaccount/TvCreateAccountModal.kt
@@ -16,9 +16,11 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.component.TvModal
+import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.compose.loading.LoadingView
 import au.com.shiftyjelly.pocketcasts.onboarding.signin.TvSignInErrorContent
 import au.com.shiftyjelly.pocketcasts.onboarding.signin.TvSignInQrContent
@@ -34,7 +36,11 @@ fun TvCreateAccountModal(
     onRetry: () -> Unit,
     onDismissRequest: () -> Unit,
     modifier: Modifier = Modifier,
+    viewModel: TvCreateAccountModalViewModel = hiltViewModel(),
 ) {
+    CallOnce {
+        viewModel.trackShown()
+    }
     TvModal(
         onDismissRequest = onDismissRequest,
         width = ModalWidth,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/createaccount/TvCreateAccountModalViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/createaccount/TvCreateAccountModalViewModel.kt
@@ -1,0 +1,18 @@
+package au.com.shiftyjelly.pocketcasts.onboarding.createaccount
+
+import androidx.lifecycle.ViewModel
+import com.automattic.eventhorizon.CreateAccountShownEvent
+import com.automattic.eventhorizon.EventHorizon
+import com.automattic.eventhorizon.OnboardingFlowType
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class TvCreateAccountModalViewModel @Inject constructor(
+    private val eventHorizon: EventHorizon,
+) : ViewModel() {
+
+    fun trackShown() {
+        eventHorizon.track(CreateAccountShownEvent(flow = OnboardingFlowType.AccountEncouragement))
+    }
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvDeviceAuth.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvDeviceAuth.kt
@@ -10,46 +10,52 @@ import kotlinx.coroutines.flow.flow
 import timber.log.Timber
 
 private const val AUTHORIZATION_PENDING = "authorization_pending"
+private const val EXPIRED_TOKEN = "expired_token"
 private const val MIN_POLL_INTERVAL_SECONDS = 5L
 
 fun deviceAuthFlow(syncManager: SyncManager, isNewAccount: Boolean): Flow<TvSignInUiState> = flow {
     emit(TvSignInUiState.Loading)
-    val response = try {
-        syncManager.deviceAuthorize()
-    } catch (e: CancellationException) {
-        throw e
-    } catch (e: Exception) {
-        Timber.e(e, "Failed to request device code")
-        emit(TvSignInUiState.Error)
-        return@flow
-    }
-    emit(
-        TvSignInUiState.Ready(
-            userCode = response.userCode.map { it.toString() },
-            verificationUri = response.verificationUri,
-            verificationUriComplete = response.verificationUriComplete,
-        ),
-    )
-    val intervalSeconds = response.interval.toLong().coerceAtLeast(MIN_POLL_INTERVAL_SECONDS)
     while (true) {
-        delay(intervalSeconds * 1000)
-        val result = syncManager.loginWithDeviceAuth(
-            deviceCode = response.deviceCode,
-            signInSource = SignInSource.UserInitiated.Onboarding,
-            isNewAccount = isNewAccount,
+        val response = try {
+            syncManager.deviceAuthorize()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to request device code")
+            emit(TvSignInUiState.Error)
+            return@flow
+        }
+        emit(
+            TvSignInUiState.Ready(
+                userCode = response.userCode.map { it.toString() },
+                verificationUri = response.verificationUri,
+                verificationUriComplete = response.verificationUriComplete,
+            ),
         )
-        when {
-            result is LoginResult.Success -> {
-                emit(TvSignInUiState.Complete)
-                return@flow
-            }
+        val intervalSeconds = response.interval.toLong().coerceAtLeast(MIN_POLL_INTERVAL_SECONDS)
+        var codeExpired = false
+        while (!codeExpired) {
+            delay(intervalSeconds * 1000)
+            val result = syncManager.loginWithDeviceAuth(
+                deviceCode = response.deviceCode,
+                signInSource = SignInSource.UserInitiated.Onboarding,
+                isNewAccount = isNewAccount,
+            )
+            when {
+                result is LoginResult.Success -> {
+                    emit(TvSignInUiState.Complete)
+                    return@flow
+                }
 
-            result is LoginResult.Failed && result.messageId == AUTHORIZATION_PENDING -> Unit
+                result is LoginResult.Failed && result.messageId == AUTHORIZATION_PENDING -> Unit
 
-            else -> {
-                Timber.w("Device auth polling stopped: ${(result as? LoginResult.Failed)?.message}")
-                emit(TvSignInUiState.Error)
-                return@flow
+                result is LoginResult.Failed && result.messageId == EXPIRED_TOKEN -> codeExpired = true
+
+                else -> {
+                    Timber.w("Device auth polling stopped: ${(result as? LoginResult.Failed)?.message}")
+                    emit(TvSignInUiState.Error)
+                    return@flow
+                }
             }
         }
     }

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/onboarding/TvCreateAccountModalViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/onboarding/TvCreateAccountModalViewModelTest.kt
@@ -1,0 +1,21 @@
+package au.com.shiftyjelly.pocketcasts.onboarding
+
+import au.com.shiftyjelly.pocketcasts.onboarding.createaccount.TvCreateAccountModalViewModel
+import com.automattic.eventhorizon.CreateAccountShownEvent
+import com.automattic.eventhorizon.EventHorizon
+import com.automattic.eventhorizon.OnboardingFlowType
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+class TvCreateAccountModalViewModelTest {
+
+    private val eventHorizon = mock<EventHorizon>()
+
+    @Test
+    fun `trackShown fires create account shown with the account encouragement flow`() {
+        TvCreateAccountModalViewModel(eventHorizon).trackShown()
+
+        verify(eventHorizon).track(CreateAccountShownEvent(flow = OnboardingFlowType.AccountEncouragement))
+    }
+}

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/onboarding/TvSignInViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/onboarding/TvSignInViewModelTest.kt
@@ -125,7 +125,7 @@ class TvSignInViewModelTest {
     fun `non-pending error stops polling`() = runTest {
         whenever(syncManager.deviceAuthorize()).thenReturn(createDeviceAuthorizeResponse())
         whenever(syncManager.loginWithDeviceAuth(eq("device-code-123"), any(), any()))
-            .thenReturn(LoginResult.Failed(message = "Token expired", messageId = "expired_token"))
+            .thenReturn(LoginResult.Failed(message = "Access denied", messageId = "access_denied"))
 
         val viewModel = createViewModel()
 
@@ -137,6 +137,27 @@ class TvSignInViewModelTest {
             assertTrue(states.any { it is TvSignInUiState.Ready })
             assertEquals(TvSignInUiState.Error, states.last())
         }
+    }
+
+    @Test
+    fun `expired code requests a fresh code and keeps polling`() = runTest {
+        whenever(syncManager.deviceAuthorize()).thenReturn(createDeviceAuthorizeResponse())
+        whenever(syncManager.loginWithDeviceAuth(eq("device-code-123"), any(), any()))
+            .thenReturn(LoginResult.Failed(message = "Token expired", messageId = "expired_token"))
+            .thenReturn(createLoginSuccess())
+
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val states = mutableListOf(awaitItem())
+            while (states.last() !is TvSignInUiState.Complete) {
+                states.add(awaitItem())
+            }
+            assertFalse(states.any { it is TvSignInUiState.Error })
+            assertEquals(TvSignInUiState.Complete, states.last())
+        }
+
+        verify(syncManager, times(2)).deviceAuthorize()
     }
 
     @Test


### PR DESCRIPTION
## Description

**Android TV parity — Section B / PR 4: auth parity fixes.** Brings the device-auth QR flow in line with tvOS across code expiry, and makes account-creation failures + the gated-modal open visible.

Commits:
1. **Silent code rotation on expiry.** tvOS treats `EXPIRED_TOKEN` as retryable — it transparently requests a fresh device code and re-renders the QR. Android's `deviceAuthFlow` treated anything but `authorization_pending` as terminal → the screen dropped to the error state and the shared sign-in path emitted a spurious `user_signin_failed{error_code=expired_token}` per expiry. Now, on `expired_token`, `deviceAuthFlow` requests a new code and keeps polling (no `Error`, no failure event), and `SyncManagerImpl` skips `trackSignIn` for `expired_token` (same as `authorization_pending`). Fixes both the Sign In and Create Account consumers. (Device auth is TV-only on Android, so this shared change has no phone impact.)
2. **`user_account_creation_failed`.** Shared `trackSignIn` emitted `user_signin_failed` regardless of `isNewAccount`. It now branches: a failed device-auth **create-account** emits `UserAccountCreationFailedEvent(error_code)`; sign-in failures keep `UserSigninFailedEvent`. Also rethrows `CancellationException` in `loginWithDeviceAuth`'s catch so a cancel mid-poll can't fire a stray failure event.
3. **`create_account_shown` for the gated Follow modal.** The account-gated Follow modal (`TvCreateAccountModal`, opened from podcast details) tracked nothing; it now fires `create_account_shown{flow=account_encouragement}` on open via `CallOnce` + a tiny `TvCreateAccountModalViewModel`. `account_encouragement` distinguishes the modal from the full-screen create-account (`initial_onboarding`).

**Deliberate non-goal:** the modal completion still emits `user_signed_in` (via `isNewAccount=false`) where iOS emits `user_account_created` — a reviewed decision on #5784 (device pairing can't truly distinguish create-vs-login). Left as-is.

## Testing Instructions

1. `debugProd` TV build + `adb logcat` on `LoggingAnalyticsListener`.
2. Open Sign In (QR). Leave the code past its expiry (minutes) → the QR **visibly rotates** to a new code and keeps polling; no error screen, no `user_signin_failed{expired_token}` in logcat.
3. Create Account → force a pairing failure → `user_account_creation_failed` (not `user_signin_failed`).
4. From a podcast, tap Follow while signed out → the account modal opens → `create_account_shown{flow=account_encouragement}`.

Unit tests: expiry → fresh code requested (deviceAuthorize called twice), no Error, no failure event; create-account failure → creation-failed event; sign-in failure → signin-failed event; modal open → shown event.

Fixes POC-857 https://linear.app/a8c/issue/POC-875/qr-code-exipration-account-creation-failed-event-reporting

## Screenshots or Screencast

_QR rotation is time-based (minutes) — best verified on device per the steps above; no static UI change to screenshot._

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md — n/a
- [x] Ensure the linter passes (`./gradlew spotlessApply`)
- [x] I have considered whether it makes sense to add tests for my changes — ViewModel + SyncManager unit tests added
- [x] All strings that need to be localized are in localization — n/a
- [x] Any jetpack compose components I added or changed are covered by compose previews — n/a
- [x] I have updated the Event Horizon schema to reflect any new or changed analytics — n/a (all events already exist)

> Depends on #5801 (TV analytics foundation) landing first, so these events carry `platform=tv`.
