### PR TITLE
[TV] Home/Discover robustness: per-row retry, region fallback, live local rows

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/lists/ListRepository.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/lists/ListRepository.kt
@@ -32,6 +32,14 @@ class ListRepository(
     }
 
     suspend fun getListFeed(url: String, authenticated: Boolean? = false): ListFeed? {
+        return getListFeedResult(url, authenticated)
+            .onFailure { exception ->
+                Timber.e(exception, "Failed to fetch list feed $url")
+            }
+            .getOrNull()
+    }
+
+    suspend fun getListFeedResult(url: String, authenticated: Boolean? = false): Result<ListFeed?> {
         return runCatching {
             if (authenticated == true) {
                 checkNotNull(syncManager) { "Sync Manager is null" }
@@ -43,10 +51,6 @@ class ListRepository(
                 listWebService.getListFeed(url)
             }
         }
-            .onFailure { exception ->
-                Timber.e(exception, "Failed to fetch list feed $url")
-            }
-            .getOrNull()
     }
 
     suspend fun getCategoriesList(url: String): List<DiscoverCategory> {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/discover/TvDiscoverFeedAnalytics.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/discover/TvDiscoverFeedAnalytics.kt
@@ -98,6 +98,7 @@ class TvDiscoverFeedAnalytics(
 
         is TvDiscoverRow.Banner,
         is TvDiscoverRow.Categories,
+        is TvDiscoverRow.Failed,
         -> null
     }?.takeUnless { it in localRowIds }
 
@@ -112,6 +113,7 @@ class TvDiscoverFeedAnalytics(
 
         is TvDiscoverRow.Banner,
         is TvDiscoverRow.Categories,
+        is TvDiscoverRow.Failed,
         -> null
     }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/discover/TvDiscoverFeedLoader.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/discover/TvDiscoverFeedLoader.kt
@@ -248,7 +248,10 @@ class TvDiscoverFeedLoader @Inject constructor(
     }
 
     private fun resolveRegion(discover: Discover): DiscoverRegion {
-        return resolveRegionOrNull(discover) ?: error("Could not resolve discover region")
+        return resolveRegionOrNull(discover)
+            ?: discover.regions[FALLBACK_REGION_CODE]
+            ?: discover.regions.values.firstOrNull()
+            ?: error("Could not resolve discover region")
     }
 
     private fun regionReplacements(discover: Discover, region: DiscoverRegion? = resolveRegionOrNull(discover)): Map<String, String> {
@@ -284,6 +287,7 @@ class TvDiscoverFeedLoader @Inject constructor(
 
     companion object {
         private const val BANNER_TYPE = "banner"
+        private const val FALLBACK_REGION_CODE = "us"
         private const val SPONSORED_CATEGORY_POSITION = 5
         private const val COVER_ARTWORK_SIZE = 200
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/discover/TvDiscoverFeedLoader.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/discover/TvDiscoverFeedLoader.kt
@@ -138,6 +138,23 @@ class TvDiscoverFeedLoader @Inject constructor(
             .distinctBy(TvDiscoverRow::id)
     }
 
+    suspend fun reloadHomeRow(rowId: String, isLoggedIn: Boolean): TvDiscoverRow? {
+        return reloadRow(listRepository.getHomeDiscoverFeed(isLoggedIn), rowId, includeHomeSections = true)
+    }
+
+    suspend fun reloadSearchRow(rowId: String, isLoggedIn: Boolean): TvDiscoverRow? {
+        return reloadRow(listRepository.getSearchDiscoverFeed(), rowId, includeHomeSections = false)
+    }
+
+    private suspend fun reloadRow(discover: Discover, rowId: String, includeHomeSections: Boolean): TvDiscoverRow? {
+        val region = resolveRegion(discover)
+        val replacements = regionReplacements(discover, region)
+        val row = discover.layout
+            .transformWithRegion(region, replacements, context.resources)
+            .firstOrNull { it.rowId() == rowId } ?: return null
+        return loadRow(row, includeHomeSections, replacements)
+    }
+
     private suspend fun loadRow(row: DiscoverRow, includeHomeSections: Boolean, replacements: Map<String, String>): TvDiscoverRow? {
         val bannerType = row.type
         if (bannerType is ListType.Unknown && bannerType.value == BANNER_TYPE) {
@@ -146,15 +163,26 @@ class TvDiscoverFeedLoader @Inject constructor(
             return TvDiscoverRow.Banner(id = banner.id, title = row.title, banner = banner)
         }
         return when (row.type) {
-            is ListType.PodcastList -> if (row.source.isBlank()) null else loadPodcastsRow(row)
-            is ListType.EpisodeList -> if (row.source.isBlank()) null else loadEpisodesRow(row)
+            is ListType.PodcastList -> if (row.source.isBlank()) null else loadRowOrFailed(row) { loadPodcastsRow(row) }
+            is ListType.EpisodeList -> if (row.source.isBlank()) null else loadRowOrFailed(row) { loadEpisodesRow(row) }
             is ListType.Categories -> if (includeHomeSections) loadCategoriesRow(row, replacements) else null
             is ListType.Unknown -> null
         }
     }
 
+    private suspend fun loadRowOrFailed(row: DiscoverRow, block: suspend () -> TvDiscoverRow?): TvDiscoverRow? {
+        return try {
+            block()
+        } catch (exception: CancellationException) {
+            throw exception
+        } catch (exception: Exception) {
+            Timber.e(exception, "Failed to load TV discover row ${row.rowId()}")
+            TvDiscoverRow.Failed(id = row.rowId(), title = row.title)
+        }
+    }
+
     private suspend fun loadPodcastsRow(row: DiscoverRow): TvDiscoverRow? = coroutineScope {
-        val feedDeferred = async { listRepository.getListFeed(row.source, row.authenticated) }
+        val feedDeferred = async { listRepository.getListFeedResult(row.source, row.authenticated).getOrThrow() }
         val insertionsDeferred = async { loadSponsoredInsertions(row) }
         val feed = feedDeferred.await() ?: return@coroutineScope null
         val basePodcasts = feed.podcasts.orEmpty()
@@ -206,7 +234,7 @@ class TvDiscoverFeedLoader @Inject constructor(
     }
 
     private suspend fun loadEpisodesRow(row: DiscoverRow): TvDiscoverRow? {
-        val feed = listRepository.getListFeed(row.source, row.authenticated) ?: return null
+        val feed = listRepository.getListFeedResult(row.source, row.authenticated).getOrThrow() ?: return null
         val playsVideoPreview = row.displayStyle is DisplayStyle.VideoPreviewList
         val episodes = feed.episodes.orEmpty()
             .distinctBy(DiscoverEpisode::uuid)

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/discover/TvDiscoverFeedLoader.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/discover/TvDiscoverFeedLoader.kt
@@ -105,7 +105,7 @@ class TvDiscoverFeedLoader @Inject constructor(
             Timber.e(exception, "Failed to load TV category sponsored ads")
             return@coroutineScope emptyList()
         }
-        val region = resolveRegionOrNull(discover) ?: return@coroutineScope emptyList()
+        val region = resolveRegionOrFallback(discover) ?: return@coroutineScope emptyList()
         val replacements = regionReplacements(discover, region)
         discover.layout
             .transformWithRegion(region, replacements, context.resources)
@@ -134,8 +134,12 @@ class TvDiscoverFeedLoader @Inject constructor(
             .map { row -> async { loadRow(row, includeHomeSections, replacements) } }
             .awaitAll()
             .filterNotNull()
-            // Dedup after loading so a duplicate id whose feed came back empty falls back to a populated one.
-            .distinctBy(TvDiscoverRow::id)
+            .let { rows ->
+                // Dedup after loading so a duplicate id whose feed failed or came back empty falls back to a populated one.
+                val populatedIds = rows.filterNot { it is TvDiscoverRow.Failed }.mapTo(mutableSetOf(), TvDiscoverRow::id)
+                rows.filterNot { it is TvDiscoverRow.Failed && it.id in populatedIds }
+                    .distinctBy(TvDiscoverRow::id)
+            }
     }
 
     suspend fun reloadHomeRow(rowId: String, isLoggedIn: Boolean): TvDiscoverRow? {
@@ -281,14 +285,18 @@ class TvDiscoverFeedLoader @Inject constructor(
             ?: discover.regions[discover.defaultRegionCode]
     }
 
-    private fun resolveRegion(discover: Discover): DiscoverRegion {
+    private fun resolveRegionOrFallback(discover: Discover): DiscoverRegion? {
         return resolveRegionOrNull(discover)
             ?: discover.regions[FALLBACK_REGION_CODE]
             ?: discover.regions.values.firstOrNull()
+    }
+
+    private fun resolveRegion(discover: Discover): DiscoverRegion {
+        return resolveRegionOrFallback(discover)
             ?: error("Could not resolve discover region")
     }
 
-    private fun regionReplacements(discover: Discover, region: DiscoverRegion? = resolveRegionOrNull(discover)): Map<String, String> {
+    private fun regionReplacements(discover: Discover, region: DiscoverRegion? = resolveRegionOrFallback(discover)): Map<String, String> {
         if (region == null) return emptyMap()
         return mapOf(
             discover.regionCodeToken to region.code,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/discover/TvDiscoverFeedLoader.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/discover/TvDiscoverFeedLoader.kt
@@ -164,9 +164,15 @@ class TvDiscoverFeedLoader @Inject constructor(
         }
         return when (row.type) {
             is ListType.PodcastList -> if (row.source.isBlank()) null else loadRowOrFailed(row) { loadPodcastsRow(row) }
+
             is ListType.EpisodeList -> if (row.source.isBlank()) null else loadRowOrFailed(row) { loadEpisodesRow(row) }
+
             is ListType.Categories -> if (includeHomeSections) loadCategoriesRow(row, replacements) else null
-            is ListType.Unknown -> null
+
+            is ListType.Unknown -> {
+                Timber.w("Dropping unknown TV discover row type '${(row.type as ListType.Unknown).value}' for ${row.rowId()}")
+                null
+            }
         }
     }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/discover/TvDiscoverModels.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/discover/TvDiscoverModels.kt
@@ -50,6 +50,11 @@ sealed interface TvDiscoverRow {
         val listId: String? = null,
         val listDatetime: String? = null,
     ) : TvDiscoverRow
+
+    data class Failed(
+        override val id: String,
+        override val title: String,
+    ) : TvDiscoverRow
 }
 
 enum class TvDiscoverBanner(val id: String) {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/discover/TvDiscoverRows.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/discover/TvDiscoverRows.kt
@@ -1,14 +1,21 @@
 package au.com.shiftyjelly.pocketcasts.discover
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.tv.material3.Button
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.component.TvBannerRow
 import au.com.shiftyjelly.pocketcasts.component.TvCategoryTile
 import au.com.shiftyjelly.pocketcasts.component.TvFeaturedTile
@@ -18,6 +25,10 @@ import au.com.shiftyjelly.pocketcasts.component.TvRow
 import au.com.shiftyjelly.pocketcasts.component.TvSinglePodcastTile
 import au.com.shiftyjelly.pocketcasts.component.TvVideoTile
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
+import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
+import au.com.shiftyjelly.pocketcasts.theme.tvColors
+import au.com.shiftyjelly.pocketcasts.theme.tvTypography
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 fun LazyListScope.tvDiscoverRow(
     row: TvDiscoverRow,
@@ -31,6 +42,7 @@ fun LazyListScope.tvDiscoverRow(
     contentPadding: PaddingValues = PaddingValues(horizontal = 32.dp),
     onTapBanner: (TvDiscoverBanner) -> Unit = {},
     onListImpression: (TvDiscoverRow) -> Unit = {},
+    onRetryRow: (TvDiscoverRow) -> Unit = {},
     loadCategoryCovers: (suspend (DiscoverCategory) -> List<String>)? = null,
     isPodcastPlaying: () -> Boolean = { false },
 ) {
@@ -149,6 +161,38 @@ fun LazyListScope.tvDiscoverRow(
                 onClick = { onTapBanner(row.banner) },
                 modifier = bannerModifier.padding(contentPadding),
             )
+        }
+
+        is TvDiscoverRow.Failed -> item(key = row.id) {
+            val failedModifier = if (focusRequester != null) modifier.focusRequester(focusRequester) else modifier
+            TvDiscoverFailedRow(
+                title = row.title,
+                onRetry = { onRetryRow(row) },
+                modifier = failedModifier.padding(contentPadding),
+            )
+        }
+    }
+}
+
+@Composable
+private fun TvDiscoverFailedRow(
+    title: String,
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp), modifier = modifier) {
+        if (title.isNotBlank()) {
+            Text(
+                text = title,
+                style = MaterialTheme.tvTypography.title3,
+                color = MaterialTheme.tvColors.textPrimary,
+            )
+        }
+        Button(
+            onClick = onRetry,
+            colors = TvButtonDefaults.filledButtonColors(),
+        ) {
+            Text(text = stringResource(LR.string.try_again))
         }
     }
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeScreen.kt
@@ -112,6 +112,7 @@ fun TvHomeScreen(
                 openedCategory = TvOpenedCategory(category.id, category.name, category.source)
             },
             onListImpression = viewModel::trackDiscoverListShown,
+            onRetryRow = viewModel::retryDiscoverRow,
             loadCategoryCovers = viewModel::categoryCoverUrls,
             isPodcastPlaying = viewModel::isPlaying,
             modifier = Modifier
@@ -162,6 +163,7 @@ private fun TvHomeContent(
     onEpisodePodcastClick: (TvDiscoverRow, TvDiscoverEpisode) -> Unit = { _, _ -> },
     onCategoryClick: (DiscoverCategory, Int) -> Unit = { _, _ -> },
     onListImpression: (TvDiscoverRow) -> Unit = {},
+    onRetryRow: (TvDiscoverRow) -> Unit = {},
     loadCategoryCovers: (suspend (DiscoverCategory) -> List<String>)? = null,
     isPodcastPlaying: () -> Boolean = { false },
     restoreFocusTrigger: Int = 0,
@@ -183,6 +185,7 @@ private fun TvHomeContent(
                 onEpisodePodcastClick = onEpisodePodcastClick,
                 onCategoryClick = onCategoryClick,
                 onListImpression = onListImpression,
+                onRetryRow = onRetryRow,
                 loadCategoryCovers = loadCategoryCovers,
                 isPodcastPlaying = isPodcastPlaying,
                 modifier = modifier,
@@ -226,6 +229,7 @@ private fun TvHomeRows(
     onEpisodePodcastClick: (TvDiscoverRow, TvDiscoverEpisode) -> Unit = { _, _ -> },
     onCategoryClick: (DiscoverCategory, Int) -> Unit = { _, _ -> },
     onListImpression: (TvDiscoverRow) -> Unit = {},
+    onRetryRow: (TvDiscoverRow) -> Unit = {},
     loadCategoryCovers: (suspend (DiscoverCategory) -> List<String>)? = null,
     isPodcastPlaying: () -> Boolean = { false },
     restoreFocusTrigger: Int = 0,
@@ -267,6 +271,7 @@ private fun TvHomeRows(
                 focusRequester = rowFocusRequester,
                 onTapBanner = onTapBanner,
                 onListImpression = onListImpression,
+                onRetryRow = onRetryRow,
                 loadCategoryCovers = loadCategoryCovers,
                 isPodcastPlaying = isPodcastPlaying,
             )

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModel.kt
@@ -47,6 +47,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.rx2.asFlow
 import kotlinx.coroutines.rx2.await
@@ -110,10 +111,16 @@ class TvHomeViewModel @Inject constructor(
     }
 
     private suspend fun refreshLocalRows() {
-        val current = _uiState.value as? TvHomeUiState.Ready ?: return
-        val nonLocalRows = current.rows.filterNot { it.id in LOCAL_ROW_IDS }
+        if (_uiState.value !is TvHomeUiState.Ready) return
         val localRows = loadLocalRows(syncManager.isLoggedIn())
-        _uiState.value = TvHomeUiState.Ready((localRows + nonLocalRows).distinctBy(TvDiscoverRow::id))
+        _uiState.update { current ->
+            if (current is TvHomeUiState.Ready) {
+                val nonLocalRows = current.rows.filterNot { it.id in LOCAL_ROW_IDS }
+                TvHomeUiState.Ready((localRows + nonLocalRows).distinctBy(TvDiscoverRow::id))
+            } else {
+                current
+            }
+        }
     }
 
     fun load() {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModel.kt
@@ -31,6 +31,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -40,8 +41,12 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.rx2.asFlow
 import kotlinx.coroutines.rx2.await
@@ -77,12 +82,38 @@ class TvHomeViewModel @Inject constructor(
 
     private var loadJob: Job? = null
 
+    @Volatile
+    private var playbackStartedThisSession = false
+
     init {
         viewModelScope.launch {
             syncManager.isLoggedInObservable.asFlow()
                 .distinctUntilChanged()
                 .collect { load() }
         }
+        observeLocalRowSignals()
+    }
+
+    @OptIn(FlowPreview::class)
+    private fun observeLocalRowSignals() {
+        viewModelScope.launch {
+            merge(
+                playbackManager.upNextQueue.changesObservable.asFlow().map {},
+                playbackManager.playbackStateFlow
+                    .onEach { if (it.isPlaying) playbackStartedThisSession = true }
+                    .map {},
+                playlistManager.smartEpisodesFlow(NEW_RELEASES_RULES).map {},
+            )
+                .debounce(LOCAL_ROWS_DEBOUNCE_MS)
+                .collect { refreshLocalRows() }
+        }
+    }
+
+    private suspend fun refreshLocalRows() {
+        val current = _uiState.value as? TvHomeUiState.Ready ?: return
+        val nonLocalRows = current.rows.filterNot { it.id in LOCAL_ROW_IDS }
+        val localRows = loadLocalRows(syncManager.isLoggedIn())
+        _uiState.value = TvHomeUiState.Ready((localRows + nonLocalRows).distinctBy(TvDiscoverRow::id))
     }
 
     fun load() {
@@ -141,14 +172,16 @@ class TvHomeViewModel @Inject constructor(
         val podcastTitles = findPodcastTitles(upNextEpisodes + newReleases)
 
         buildList {
-            upNextEpisodes.firstOrNull()?.let { current ->
-                add(
-                    TvDiscoverRow.Episodes(
-                        id = KEEP_LISTENING_ROW_ID,
-                        title = context.getString(LR.string.tv_home_keep_listening),
-                        episodes = listOf(current.toTvDiscoverEpisode(podcastTitles)),
-                    ),
-                )
+            if (!playbackStartedThisSession) {
+                upNextEpisodes.firstOrNull()?.let { current ->
+                    add(
+                        TvDiscoverRow.Episodes(
+                            id = KEEP_LISTENING_ROW_ID,
+                            title = context.getString(LR.string.tv_home_keep_listening),
+                            episodes = listOf(current.toTvDiscoverEpisode(podcastTitles)),
+                        ),
+                    )
+                }
             }
             if (isLoggedIn) {
                 val queue = upNextEpisodes.drop(1)
@@ -300,6 +333,7 @@ class TvHomeViewModel @Inject constructor(
         private const val UP_NEXT_LIMIT = 12
         private const val UP_NEXT_ROW_MIN = 2
         private const val NEW_RELEASES_LIMIT = 12
+        private const val LOCAL_ROWS_DEBOUNCE_MS = 1000L
 
         private val NEW_RELEASES_RULES = SmartPlaylistDraft.NewReleases.rules.copy(
             episodeStatus = SmartRules.EpisodeStatusRule(unplayed = true, inProgress = false, completed = false),

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModel.kt
@@ -174,6 +174,25 @@ class TvHomeViewModel @Inject constructor(
         }
     }
 
+    fun retryDiscoverRow(row: TvDiscoverRow) {
+        viewModelScope.launch {
+            val reloaded = try {
+                discoverFeedLoader.reloadHomeRow(row.id, syncManager.isLoggedIn())
+            } catch (exception: CancellationException) {
+                throw exception
+            } catch (exception: Exception) {
+                Timber.e(exception, "Failed to reload TV home row ${row.id}")
+                row
+            }
+            replaceRow(row.id, reloaded)
+        }
+    }
+
+    private fun replaceRow(rowId: String, newRow: TvDiscoverRow?) {
+        val current = _uiState.value as? TvHomeUiState.Ready ?: return
+        _uiState.value = TvHomeUiState.Ready(current.rows.mapNotNull { if (it.id == rowId) newRow else it })
+    }
+
     suspend fun categoryPodcasts(categoryId: Int, source: String): TvCategoryPodcasts {
         return discoverFeedLoader.loadCategoryPodcasts(source, categoryId, syncManager.isLoggedIn())
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModel.kt
@@ -152,7 +152,7 @@ class TvHomeViewModel @Inject constructor(
             }
             if (isLoggedIn) {
                 val queue = upNextEpisodes.drop(1)
-                if (queue.isNotEmpty()) {
+                if (queue.size >= UP_NEXT_ROW_MIN) {
                     add(
                         TvDiscoverRow.Episodes(
                             id = UP_NEXT_ROW_ID,
@@ -279,6 +279,7 @@ class TvHomeViewModel @Inject constructor(
         private val LOCAL_ROW_IDS = setOf(KEEP_LISTENING_ROW_ID, UP_NEXT_ROW_ID, NEW_RELEASES_ROW_ID)
 
         private const val UP_NEXT_LIMIT = 12
+        private const val UP_NEXT_ROW_MIN = 2
         private const val NEW_RELEASES_LIMIT = 12
 
         private val NEW_RELEASES_RULES = SmartPlaylistDraft.NewReleases.rules.copy(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModel.kt
@@ -102,8 +102,10 @@ class TvHomeViewModel @Inject constructor(
                 playbackManager.upNextQueue.changesObservable.asFlow().map {},
                 playbackManager.playbackStateFlow
                     .onEach { if (it.isPlaying) playbackStartedThisSession = true }
+                    .map { it.isPlaying to it.episodeUuid }
+                    .distinctUntilChanged()
                     .map {},
-                playlistManager.smartEpisodesFlow(NEW_RELEASES_RULES).map {},
+                playlistManager.smartEpisodesFlow(NEW_RELEASES_RULES).distinctUntilChanged().map {},
             )
                 .debounce(LOCAL_ROWS_DEBOUNCE_MS)
                 .collect { refreshLocalRows() }
@@ -112,9 +114,10 @@ class TvHomeViewModel @Inject constructor(
 
     private suspend fun refreshLocalRows() {
         if (_uiState.value !is TvHomeUiState.Ready) return
-        val localRows = loadLocalRows(syncManager.isLoggedIn())
+        val isLoggedIn = syncManager.isLoggedIn()
+        val localRows = loadLocalRows(isLoggedIn)
         _uiState.update { current ->
-            if (current is TvHomeUiState.Ready) {
+            if (current is TvHomeUiState.Ready && isLoggedIn == syncManager.isLoggedIn()) {
                 val nonLocalRows = current.rows.filterNot { it.id in LOCAL_ROW_IDS }
                 TvHomeUiState.Ready((localRows + nonLocalRows).distinctBy(TvDiscoverRow::id))
             } else {
@@ -217,7 +220,7 @@ class TvHomeViewModel @Inject constructor(
     fun retryDiscoverRow(row: TvDiscoverRow) {
         viewModelScope.launch {
             val reloaded = try {
-                discoverFeedLoader.reloadHomeRow(row.id, syncManager.isLoggedIn())
+                discoverFeedLoader.reloadHomeRow(row.id, syncManager.isLoggedIn()) ?: row
             } catch (exception: CancellationException) {
                 throw exception
             } catch (exception: Exception) {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
@@ -174,6 +174,7 @@ fun TvSearchScreen(
                 openedCategory = TvOpenedCategory(discoverCategory.id, discoverCategory.name, discoverCategory.source)
             },
             onDiscoverListImpression = viewModel::trackDiscoverListShown,
+            onDiscoverRetryRow = viewModel::retryDiscoverRow,
             onPlayEpisode = { episode ->
                 viewModel.trackEpisodeResultTapped(episode.uuid)
                 viewModel.playEpisode(episode)
@@ -287,6 +288,7 @@ private fun TvSearchContent(
     onOpenEpisodeActions: (ImprovedSearchResultItem.EpisodeItem) -> Unit,
     modifier: Modifier = Modifier,
     onDiscoverListImpression: (TvDiscoverRow) -> Unit = {},
+    onDiscoverRetryRow: (TvDiscoverRow) -> Unit = {},
     history: List<String> = emptyList(),
     onHistorySelect: (String) -> Unit = {},
     suggestions: List<String> = emptyList(),
@@ -358,6 +360,7 @@ private fun TvSearchContent(
                     onDiscoverPlayLatestEpisode = onDiscoverPlayLatestEpisode,
                     onDiscoverCategoryClick = onDiscoverCategoryClick,
                     onDiscoverListImpression = onDiscoverListImpression,
+                    onDiscoverRetryRow = onDiscoverRetryRow,
                     loadCategoryCovers = loadCategoryCovers,
                     restoreFocusTrigger = restoreFocusTrigger,
                 )
@@ -403,6 +406,7 @@ private fun TvSearchIdle(
     onDiscoverPlayLatestEpisode: (TvDiscoverRow, TvDiscoverPodcast) -> Unit,
     onDiscoverCategoryClick: (DiscoverCategory, Int) -> Unit,
     onDiscoverListImpression: (TvDiscoverRow) -> Unit,
+    onDiscoverRetryRow: (TvDiscoverRow) -> Unit,
     restoreFocusTrigger: Int,
     loadCategoryCovers: (suspend (DiscoverCategory) -> List<String>)? = null,
 ) {
@@ -434,6 +438,7 @@ private fun TvSearchIdle(
             onDiscoverPlayLatestEpisode = onDiscoverPlayLatestEpisode,
             onDiscoverCategoryClick = onDiscoverCategoryClick,
             onDiscoverListImpression = onDiscoverListImpression,
+            onDiscoverRetryRow = onDiscoverRetryRow,
             loadCategoryCovers = loadCategoryCovers,
             restoreFocusTrigger = restoreFocusTrigger,
             modifier = Modifier.weight(1f),
@@ -451,6 +456,7 @@ private fun TvSearchDiscover(
     onDiscoverPlayLatestEpisode: (TvDiscoverRow, TvDiscoverPodcast) -> Unit,
     onDiscoverCategoryClick: (DiscoverCategory, Int) -> Unit,
     onDiscoverListImpression: (TvDiscoverRow) -> Unit,
+    onDiscoverRetryRow: (TvDiscoverRow) -> Unit,
     restoreFocusTrigger: Int,
     modifier: Modifier = Modifier,
     loadCategoryCovers: (suspend (DiscoverCategory) -> List<String>)? = null,
@@ -514,6 +520,7 @@ private fun TvSearchDiscover(
                 onCategoryClick = onDiscoverCategoryClick,
                 onPlayLatestEpisode = onDiscoverPlayLatestEpisode,
                 onListImpression = onDiscoverListImpression,
+                onRetryRow = onDiscoverRetryRow,
                 contentPadding = ContentPadding,
                 focusRequester = rowFocusRequesters.getOrNull(rowIndex),
                 loadCategoryCovers = loadCategoryCovers,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
@@ -280,7 +280,7 @@ class TvSearchViewModel @Inject constructor(
     fun retryDiscoverRow(row: TvDiscoverRow) {
         viewModelScope.launch {
             val reloaded = try {
-                discoverFeedLoader.reloadSearchRow(row.id, syncManager.isLoggedIn())
+                discoverFeedLoader.reloadSearchRow(row.id, syncManager.isLoggedIn()) ?: row
             } catch (exception: CancellationException) {
                 throw exception
             } catch (exception: Exception) {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModel.kt
@@ -277,6 +277,20 @@ class TvSearchViewModel @Inject constructor(
         eventHorizon.track(SearchShownEvent(source = SourceViewType.Search))
     }
 
+    fun retryDiscoverRow(row: TvDiscoverRow) {
+        viewModelScope.launch {
+            val reloaded = try {
+                discoverFeedLoader.reloadSearchRow(row.id, syncManager.isLoggedIn())
+            } catch (exception: CancellationException) {
+                throw exception
+            } catch (exception: Exception) {
+                Timber.e(exception, "Failed to reload TV search row ${row.id}")
+                row
+            }
+            _discoverRows.value = _discoverRows.value.mapNotNull { if (it.id == row.id) reloaded else it }
+        }
+    }
+
     fun trackDiscoverListShown(row: TvDiscoverRow) = discoverFeedAnalytics.trackListImpression(row)
 
     fun trackDiscoverPodcastTapped(row: TvDiscoverRow, podcast: TvDiscoverPodcast) = discoverFeedAnalytics.trackPodcastTapped(row, podcast)

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/discover/TvDiscoverFeedLoaderTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/discover/TvDiscoverFeedLoaderTest.kt
@@ -27,6 +27,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.eq
@@ -41,7 +42,11 @@ class TvDiscoverFeedLoaderTest {
     @get:Rule
     val coroutineRule = MainCoroutineRule()
 
-    private val listRepository = mock<ListRepository>()
+    private val listRepository = mock<ListRepository> {
+        on { getListFeedResult(any(), anyOrNull()) } doSuspendableAnswer { invocation ->
+            Result.success((invocation.mock as ListRepository).getListFeed(invocation.getArgument(0), invocation.getArgument(1)))
+        }
+    }
     private val settings = mock<Settings>()
     private val context = mock<Context>()
 

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModelTest.kt
@@ -823,6 +823,25 @@ class TvHomeViewModelTest {
     }
 
     @Test
+    fun `up next row is hidden when only one episode is queued beyond the current one`() = runTest {
+        whenever(syncManager.isLoggedIn()).thenReturn(true)
+        whenever(listRepository.getHomeDiscoverFeed(isLoggedIn = true)).thenReturn(discover())
+        whenever(upNextDao.getUpNextBaseEpisodes(any())).thenReturn(
+            listOf(
+                episode(uuid = "episode-1", podcastUuid = "podcast-1"),
+                episode(uuid = "episode-2", podcastUuid = "podcast-1"),
+            ),
+        )
+
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val state = awaitItem() as TvHomeUiState.Ready
+            assertEquals(listOf(TvHomeViewModel.KEEP_LISTENING_ROW_ID), state.rows.map { it.id })
+        }
+    }
+
+    @Test
     fun `up next and new releases rows are hidden when signed out`() = runTest {
         whenever(syncManager.isLoggedIn()).thenReturn(false)
         whenever(listRepository.getHomeDiscoverFeed(isLoggedIn = false)).thenReturn(discover())
@@ -838,6 +857,30 @@ class TvHomeViewModelTest {
         viewModel.uiState.test {
             val state = awaitItem() as TvHomeUiState.Ready
             assertEquals(listOf(TvHomeViewModel.KEEP_LISTENING_ROW_ID), state.rows.map { it.id })
+        }
+    }
+
+    @Test
+    fun `discover feed falls back to a default region when the country cannot be resolved`() = runTest {
+        whenever(discoverCountryCode.value).thenReturn("zz")
+        whenever(syncManager.isLoggedIn()).thenReturn(false)
+        whenever(listRepository.getHomeDiscoverFeed(isLoggedIn = false)).thenReturn(
+            Discover(
+                layout = listOf(row(id = "trending", title = "Row Trending", source = "https://lists/trending.json")),
+                regions = mapOf("us" to DiscoverRegion(name = "United States", flag = "flag", code = "us")),
+                regionCodeToken = "[regionCode]",
+                regionNameToken = "[regionName]",
+                defaultRegionCode = "unknown",
+            ),
+        )
+        whenever(listRepository.getListFeed(eq("https://lists/trending.json"), any()))
+            .thenReturn(podcastFeed("podcast-trending"))
+
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val state = awaitItem() as TvHomeUiState.Ready
+            assertEquals(listOf("trending"), state.rows.map { it.id })
         }
     }
 

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModelTest.kt
@@ -13,6 +13,7 @@ import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverRow
 import au.com.shiftyjelly.pocketcasts.discover.TvOpenedCategory
 import au.com.shiftyjelly.pocketcasts.models.db.dao.PodcastDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.UpNextDao
+import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
@@ -21,6 +22,8 @@ import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
 import au.com.shiftyjelly.pocketcasts.repositories.lists.ListRepository
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
+import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
@@ -48,10 +51,13 @@ import com.automattic.eventhorizon.DiscoverListPodcastTappedEvent
 import com.automattic.eventhorizon.EventHorizon
 import com.automattic.eventhorizon.HomeShownEvent
 import com.jakewharton.rxrelay2.BehaviorRelay
+import com.jakewharton.rxrelay2.PublishRelay
+import io.reactivex.Observable
 import io.reactivex.Single
 import java.util.Date
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -111,7 +117,13 @@ class TvHomeViewModelTest {
     }
     private val episodeManager = mock<EpisodeManager>()
     private val podcastManager = mock<PodcastManager>()
-    private val playbackManager = mock<PlaybackManager>()
+    private val upNextQueue = mock<UpNextQueue> {
+        on { changesObservable } doReturn Observable.never()
+    }
+    private val playbackManager = mock<PlaybackManager> {
+        on { upNextQueue } doReturn this@TvHomeViewModelTest.upNextQueue
+        on { playbackStateFlow } doReturn emptyFlow()
+    }
     private val eventHorizon = mock<EventHorizon>()
 
     @Test
@@ -847,6 +859,57 @@ class TvHomeViewModelTest {
     }
 
     @Test
+    fun `keep listening row is hidden after playback starts in the session`() = runTest {
+        whenever(syncManager.isLoggedIn()).thenReturn(false)
+        whenever(listRepository.getHomeDiscoverFeed(isLoggedIn = false)).thenReturn(discover())
+        whenever(upNextDao.getUpNextBaseEpisodes(any())).thenReturn(
+            listOf(episode(uuid = "episode-1", podcastUuid = "podcast-1")),
+        )
+        val playingState = mock<PlaybackState> {
+            on { isPlaying } doReturn true
+        }
+        whenever(playbackManager.playbackStateFlow).thenReturn(flowOf(playingState))
+
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            assertEquals(
+                listOf(TvHomeViewModel.KEEP_LISTENING_ROW_ID),
+                (awaitItem() as TvHomeUiState.Ready).rows.map { it.id },
+            )
+            assertEquals(
+                emptyList<String>(),
+                (awaitItem() as TvHomeUiState.Ready).rows.map { it.id },
+            )
+        }
+    }
+
+    @Test
+    fun `an up next queue change rebuilds the local rows`() = runTest {
+        val changes = PublishRelay.create<UpNextQueue.State>()
+        whenever(upNextQueue.changesObservable).thenReturn(changes)
+        whenever(syncManager.isLoggedIn()).thenReturn(false)
+        whenever(listRepository.getHomeDiscoverFeed(isLoggedIn = false)).thenReturn(discover())
+        whenever(upNextDao.getUpNextBaseEpisodes(any())).thenReturn(emptyList())
+
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            assertEquals(emptyList<String>(), (awaitItem() as TvHomeUiState.Ready).rows.map { it.id })
+
+            whenever(upNextDao.getUpNextBaseEpisodes(any())).thenReturn(
+                listOf(episode(uuid = "episode-1", podcastUuid = "podcast-1")),
+            )
+            changes.accept(UpNextQueue.State.Empty)
+
+            assertEquals(
+                listOf(TvHomeViewModel.KEEP_LISTENING_ROW_ID),
+                (awaitItem() as TvHomeUiState.Ready).rows.map { it.id },
+            )
+        }
+    }
+
+    @Test
     fun `up next and new releases rows are hidden when signed out`() = runTest {
         whenever(syncManager.isLoggedIn()).thenReturn(false)
         whenever(listRepository.getHomeDiscoverFeed(isLoggedIn = false)).thenReturn(discover())
@@ -974,7 +1037,7 @@ class TvHomeViewModelTest {
             viewModel.playEpisode(homeEpisode())
 
             awaitItem()
-            verifyNoInteractions(playbackManager)
+            verifyBlocking(playbackManager, never()) { playNowSuspend(any<BaseEpisode>(), any(), any(), any()) }
         }
     }
 
@@ -1006,7 +1069,7 @@ class TvHomeViewModelTest {
             viewModel.playLatestEpisode(featuredRow(), discoverPodcast("podcast-1"))
 
             awaitItem()
-            verifyNoInteractions(playbackManager)
+            verifyBlocking(playbackManager, never()) { playNowSuspend(any<BaseEpisode>(), any(), any(), any()) }
         }
     }
 

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModelTest.kt
@@ -57,8 +57,11 @@ import io.reactivex.Single
 import java.util.Date
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -71,6 +74,7 @@ import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyBlocking
 import org.mockito.kotlin.verifyNoInteractions
@@ -989,6 +993,55 @@ class TvHomeViewModelTest {
 
             val reloaded = (awaitItem() as TvHomeUiState.Ready).rows.single { it.id == "trending" }
             assertTrue(reloaded is TvDiscoverRow.Podcasts)
+        }
+    }
+
+    @Test
+    fun `repeated playback updates for the same episode rebuild local rows only once`() = runTest {
+        whenever(syncManager.isLoggedIn()).thenReturn(false)
+        whenever(listRepository.getHomeDiscoverFeed(isLoggedIn = false)).thenReturn(discover())
+        whenever(upNextDao.getUpNextBaseEpisodes(any())).thenReturn(
+            listOf(episode(uuid = "episode-1", podcastUuid = "podcast-1")),
+        )
+        val playing = mock<PlaybackState> {
+            on { isPlaying } doReturn true
+            on { episodeUuid } doReturn "episode-1"
+        }
+        whenever(playbackManager.playbackStateFlow).thenReturn(
+            flow {
+                emit(playing)
+                delay(2_000)
+                emit(playing)
+                delay(2_000)
+                emit(playing)
+            },
+        )
+
+        createViewModel()
+        advanceUntilIdle()
+
+        verify(upNextDao, times(2)).getUpNextBaseEpisodes(any())
+    }
+
+    @Test
+    fun `a failed row does not shadow a populated row with the same id`() = runTest {
+        whenever(syncManager.isLoggedIn()).thenReturn(false)
+        whenever(listRepository.getHomeDiscoverFeed(isLoggedIn = false)).thenReturn(
+            discover(
+                row(id = "trending", title = "Row Trending", source = "https://lists/trending.json"),
+                row(id = "trending", title = "Row Trending Again", source = "https://lists/trending-2.json"),
+            ),
+        )
+        whenever(listRepository.getListFeedResult(eq("https://lists/trending.json"), any()))
+            .thenReturn(Result.failure(RuntimeException("boom")))
+        whenever(listRepository.getListFeed(eq("https://lists/trending-2.json"), any()))
+            .thenReturn(podcastFeed("podcast-2"))
+
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val row = (awaitItem() as TvHomeUiState.Ready).rows.single { it.id == "trending" }
+            assertTrue(row is TvDiscoverRow.Podcasts)
         }
     }
 

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModelTest.kt
@@ -61,6 +61,7 @@ import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -76,7 +77,11 @@ class TvHomeViewModelTest {
     @get:Rule
     val coroutineRule = MainCoroutineRule()
 
-    private val listRepository = mock<ListRepository>()
+    private val listRepository = mock<ListRepository> {
+        on { getListFeedResult(any(), anyOrNull()) } doSuspendableAnswer { invocation ->
+            Result.success((invocation.mock as ListRepository).getListFeed(invocation.getArgument(0), invocation.getArgument(1)))
+        }
+    }
     private val syncManager = mock<SyncManager> {
         on { isLoggedInObservable } doReturn BehaviorRelay.createDefault(false)
     }
@@ -881,6 +886,46 @@ class TvHomeViewModelTest {
         viewModel.uiState.test {
             val state = awaitItem() as TvHomeUiState.Ready
             assertEquals(listOf("trending"), state.rows.map { it.id })
+        }
+    }
+
+    @Test
+    fun `a discover row whose feed fails to load becomes a failed row instead of being dropped`() = runTest {
+        whenever(syncManager.isLoggedIn()).thenReturn(false)
+        whenever(listRepository.getHomeDiscoverFeed(isLoggedIn = false)).thenReturn(
+            discover(row(id = "trending", title = "Row Trending", source = "https://lists/trending.json")),
+        )
+        whenever(listRepository.getListFeedResult(eq("https://lists/trending.json"), any()))
+            .thenReturn(Result.failure(RuntimeException("boom")))
+
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val row = (awaitItem() as TvHomeUiState.Ready).rows.single { it.id == "trending" }
+            assertTrue(row is TvDiscoverRow.Failed)
+        }
+    }
+
+    @Test
+    fun `retrying a failed discover row reloads it`() = runTest {
+        whenever(syncManager.isLoggedIn()).thenReturn(false)
+        whenever(listRepository.getHomeDiscoverFeed(isLoggedIn = false)).thenReturn(
+            discover(row(id = "trending", title = "Row Trending", source = "https://lists/trending.json")),
+        )
+        whenever(listRepository.getListFeedResult(eq("https://lists/trending.json"), any()))
+            .thenReturn(Result.failure(RuntimeException("boom")))
+            .thenReturn(Result.success(podcastFeed("podcast-trending")))
+
+        val viewModel = createViewModel()
+
+        viewModel.uiState.test {
+            val failedRow = (awaitItem() as TvHomeUiState.Ready).rows.single { it.id == "trending" }
+            assertTrue(failedRow is TvDiscoverRow.Failed)
+
+            viewModel.retryDiscoverRow(failedRow)
+
+            val reloaded = (awaitItem() as TvHomeUiState.Ready).rows.single { it.id == "trending" }
+            assertTrue(reloaded is TvDiscoverRow.Podcasts)
         }
     }
 

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/search/TvSearchViewModelTest.kt
@@ -68,7 +68,9 @@ import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -84,7 +86,11 @@ class TvSearchViewModelTest {
     @get:Rule
     val coroutineRule = MainCoroutineRule()
 
-    private val listRepository = mock<ListRepository>()
+    private val listRepository = mock<ListRepository> {
+        on { getListFeedResult(any(), anyOrNull()) } doSuspendableAnswer { invocation ->
+            Result.success((invocation.mock as ListRepository).getListFeed(invocation.getArgument(0), invocation.getArgument(1)))
+        }
+    }
     private val syncManager = mock<SyncManager> {
         on { isLoggedIn() } doReturn false
     }


### PR DESCRIPTION
## Description

**Android TV parity — Section B / PR 5: Home/Discover robustness.** Makes the TV Home feed degrade and update like tvOS: failed rows are visible and retryable, the feed never hard-fails on region resolution, and local rows reflect reality without relogging.

- **Per-row failure → inline retry.** `ListRepository.getListFeed` swallowed errors to `null` and the loader dropped null rows, so on a flaky connection rows silently vanished. Added `ListRepository.getListFeedResult(): Result<ListFeed?>` (getListFeed now delegates to it — phone behavior byte-identical); the TV row loaders `getOrThrow()` so a genuine fetch **failure** becomes a `TvDiscoverRow.Failed` (title + "Try again"), while an empty feed is still dropped. Pressing Try again reloads just that row (`reloadHomeRow`/`reloadSearchRow`) and replaces it in place. iOS renders the same per-row retry (`DiscoverRetryView`).
- **Region fallback.** `resolveRegion` fell back to `error(...)`, error-screening the whole feed; it now falls back to `"us"` then any available region (matches iOS `DiscoverManager`).
- **Live local rows.** `TvHomeViewModel` rebuilt rows only on login-state change; it now observes Up Next queue changes, playback state, and the new-releases flow, and rebuilds **only** the local rows (Keep Listening / Up Next / New Releases) with a ~1 s debounce, reading the latest state atomically so a refresh can't clobber a concurrent retry or full reload. Discover (network) rows keep their load-once behavior.
- **Keep Listening session rule.** Shown only until playback first starts in the session (iOS `playbackNotYetStarted`), instead of permanently duplicating the Now Playing tab after listening begins.
- **Up Next row threshold.** Requires ≥2 queued beyond the current episode (iOS), was ≥1.
- Unknown discover row types are now logged instead of silently dropped.

## Testing Instructions

1. `debugProd` TV build.
2. **Retry:** with a flaky/offline connection, load Home → a failed discover row shows its title + "Try again"; restore connectivity and press it → the row loads in place.
3. **Region:** with an unresolvable country code, Home still loads (no error screen).
4. **Live rows:** add/remove Up Next episodes or start playback elsewhere → Keep Listening / Up Next / New Releases update within ~1 s without leaving Home.
5. **Keep Listening:** it shows on launch, then disappears once you start playing something this session.
6. **Up Next:** the row appears only with ≥2 queued beyond the current episode.

Unit tests in `TvHomeViewModelTest`: failed row → `Failed` (not dropped) + successful re-fetch; unresolvable region → us-fallback; queue change → local rows rebuilt; Keep Listening hidden after playback starts; Up Next hidden at 1 queued.

## Screenshots or Screencast

Reproduced on the Android TV emulator by forcing the discover feed's network fetches to fail, then restoring connectivity and pressing **Try again**. Both columns are the same emulator under the same failing-connection condition.

**Failed discover rows — before vs after**

| Before (`main`) | After (this PR) |
| --- | --- |
| Failed rows are silently dropped; Home skips straight to *Browse categories*. | Failed rows stay visible as their title + **Try again**, each individually retryable. |

<img width="1952" height="743" alt="pr5805_discover_retry_before_after" src="https://github.com/user-attachments/assets/49fe8445-0d45-46cf-9c94-b7152b1f4fed" />

**Per-row recovery**

| Pressing "Try again" reloads just that row in place (rows recover independently) |
| --- |
| <video src="https://github.com/user-attachments/assets/c6f67f50-6c07-49b0-a646-f4efe934ee4c" /> | 

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md — n/a (TV-only, no phone-facing change)
- [x] Ensure the linter passes (`./gradlew spotlessApply`)
- [x] I have considered whether it makes sense to add tests for my changes — `TvHomeViewModelTest` covers each item
- [x] All strings that need to be localized are in localization — reuses existing `try_again`
- [x] Any jetpack compose components I added or changed are covered by compose previews — the failed row is trivial; VM logic is unit-tested
- [x] I have updated the Event Horizon schema to reflect any new or changed analytics — n/a (no analytics change)


