### PR TITLE
Setup compose-preview diff workflow

### DIFF
--- a/.github/workflows/compose-preview-publish.yml
+++ b/.github/workflows/compose-preview-publish.yml
@@ -1,0 +1,60 @@
+name: Compose Preview Publish
+
+# The trusted half of the preview-diff surface: publishes renders and the sticky comment for fork
+# pull requests, running the base branch's code and reading the fork's render as data. Same-repo
+# runs publish inline and upload no handoff, so this usually fires with nothing to do.
+
+on:
+  workflow_run:
+    workflows: [Compose Preview]
+    types: [completed]
+
+permissions:
+  contents: write # renders are pushed to compose-preview/* branches
+  pull-requests: write # sticky comment upsert
+  actions: read # cross-run artifact download
+
+concurrency:
+  # Serialized per head branch. Not `cancel-in-progress`: a publisher mid-push should finish, and
+  # the next one supersedes it on the same branch anyway.
+  group: compose-preview-publish-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    # A failed render has nothing worth publishing.
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      # The base branch's code, never the pull request's.
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      # Only a fork run uploads a handoff. Decided from `head_repository` rather than the download's
+      # outcome, so a genuine artifact or auth failure still fails instead of publishing nothing.
+      - id: fork
+        run: |
+          if [ "${{ github.event.workflow_run.head_repository.full_name }}" = "${{ github.repository }}" ]; then
+            echo "is_fork=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_fork=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/download-artifact@v7
+        if: steps.fork.outputs.is_fork == 'true'
+        with:
+          name: compose-preview-handoff
+          path: _compose_preview_handoff
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: pr
+        if: steps.fork.outputs.is_fork == 'true'
+        run: echo "number=$(cat _compose_preview_handoff/_pr_number)" >> "$GITHUB_OUTPUT"
+
+      - uses: yschimke/compose-ai-tools/.github/actions/apply@v1.53.1
+        if: steps.pr.outputs.number != ''
+        with:
+          phase: publish
+          pr-number: ${{ steps.pr.outputs.number }}

--- a/.github/workflows/compose-preview.yml
+++ b/.github/workflows/compose-preview.yml
@@ -1,0 +1,84 @@
+name: Compose Preview
+
+# Renders the repository's `@Preview`s to PNG (Robolectric, no emulator) and posts a sticky
+# before/after comment on pull requests; a push to `main` refreshes the baseline. Modules opt in
+# with a `composePreview { }` block in their own build file.
+#
+# This half never publishes: a fork's pull request gets a read-only token, and the alternative
+# (`pull_request_target`) hands a write token to a job that builds untrusted code. See
+# compose-preview-publish.yml.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  # Per-PR so concurrent pull requests don't cancel each other. Without this an older render can
+  # finish last and overwrite the newer one's branches and comment with stale pixels.
+  group: compose-preview-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # A separate job, not a conditional `phase`: an org can enable write tokens for fork pull
+  # requests, and job-level `permissions` is what holds regardless of that setting.
+  render-fork:
+    name: Render (fork)
+    if: github.event.pull_request.head.repo.fork
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          # 21, not the version catalog's `java = "17"` — that is the bytecode target, not the JDK
+          # the build runs on. `com.automattic.android:crashlogging` ships class-file version 65,
+          # which javac 17 cannot read.
+          java-version: '21'
+      - uses: android-actions/setup-android@v3
+      - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+      - uses: yschimke/compose-ai-tools/.github/actions/apply@v1.53.1
+        with:
+          phase: render
+          # a11y and notifications are opt-in later by widening this.
+          only: compose,resources
+          # A few previews rendering nothing should report, not gate every pull request.
+          missing-renders: warn
+      - uses: actions/upload-artifact@v7
+        with:
+          name: compose-preview-handoff
+          path: _compose_preview_handoff/
+          if-no-files-found: error
+          retention-days: 1
+
+  # Same-repo pull requests and the baseline push already hold the write token they need.
+  apply:
+    name: Compose previews
+    if: ${{ !github.event.pull_request.head.repo.fork }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # renders are pushed to compose-preview/* branches
+      pull-requests: write # the before/after comparison is a sticky comment
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          # See the note on the render-fork job.
+          java-version: '21'
+      - uses: android-actions/setup-android@v3
+      - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+      - uses: yschimke/compose-ai-tools/.github/actions/apply@v1.53.1
+        with:
+          only: compose,resources
+          missing-renders: warn

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ android-gradle-plugin = "9.3.2"
 billing = "9.1.0"
 coil = "3.5.0"
 compose = "2026.05.01" # https://developer.android.com/jetpack/compose/bom/bom-mapping
+compose-ai-preview = "1.53.1" # Renders @Preview functions to PNG outside Android Studio, for CI preview diffs.
 datastore = "1.2.1"
 dependency-analysis = "3.18.0"
 firebase = "34.17.0"
@@ -330,3 +331,4 @@ room = { id = "androidx.room", version.ref = "room" }
 sentry = { id = "io.sentry.android.gradle", version.ref = "sentry-plugin" }
 spotless = "com.diffplug.spotless:8.9.0"
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+compose-ai-preview = { id = "ee.schimke.composeai.preview", version.ref = "compose-ai-preview" }

--- a/modules/features/settings/build.gradle.kts
+++ b/modules/features/settings/build.gradle.kts
@@ -6,6 +6,14 @@ plugins {
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.aboutlibraries)
     alias(libs.plugins.aboutlibraries.android)
+    alias(libs.plugins.compose.ai.preview)
+}
+
+// Renders this module's `@Preview`s to PNG on CI. `sdkVersion` matches :modules:services:compose so
+// the components the two share render identically.
+composePreview {
+    variant.set("debug")
+    sdkVersion.set(35)
 }
 
 android {

--- a/modules/services/compose/build.gradle.kts
+++ b/modules/services/compose/build.gradle.kts
@@ -3,6 +3,17 @@ plugins {
     alias(libs.plugins.kotlin.parcelize)
     alias(libs.plugins.ksp)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.compose.ai.preview)
+}
+
+// Renders this module's `@Preview`s to PNG on CI. `sdkVersion` is pinned because auto-detect
+// silently clamps compileSdk 37 to Robolectric's sdk=36 ceiling; `hostTheme` is required because
+// `HtmlText` resolves `?attr/primary_text_01`, which only our own themes define and a library
+// module's merged manifest does not supply — without it those previews render nothing.
+composePreview {
+    variant.set("debug")
+    sdkVersion.set(35)
+    hostTheme.set("@style/ThemeLight")
 }
 
 android {

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -8,6 +8,14 @@ plugins {
     alias(libs.plugins.sentry)
     alias(libs.plugins.google.services)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.compose.ai.preview)
+}
+
+// Renders this module's `@Preview`s to PNG on CI. `sdkVersion` is pinned rather than auto-detected
+// — see the note in modules/services/compose/build.gradle.kts.
+composePreview {
+    variant.set("debug")
+    sdkVersion.set(35)
 }
 
 sentry {


### PR DESCRIPTION
This renders every `@Preview` to PNG outside Android Studio and shows what a pull request did to them: a sticky before/after comment on the PR, and a refreshed baseline on every push to main. The renderer is Robolectric-based, so no emulator and no connected device.

Three modules opt in: `:modules:services:compose` (the shared design system, where one theme role reaches the whole app), `:wear`, and `:modules:features:settings`. A fourth is a `composePreview { }` block in its build file, not a change to the workflow.

No preview code changes here on purpose, so the first baseline reflects what main draws today rather than what a simultaneous refactor made it draw.

Two workflows rather than one because a pull request from a fork gets a read-only token, so the job that renders its code cannot publish the result. `pull_request_target` would fix the permissions by handing a write token and the repository's secrets to a job that builds the pull request's own code, so instead the render job holds no write scope and a `workflow_run` publisher — running the base branch's code, reading the render as data — pushes and comments.

CI runs on JDK 21. The version catalog's `java = "17"` is the bytecode target, not the JDK the build runs on: `com.automattic.android:crashlogging` ships class-file version 65, which javac 17 cannot read.
