### PR TITLE
[TV] Build the TV app in CI (lint + assemble + manifest diff)

### DIFF
--- a/.buildkite/commands/diff-merged-manifest.sh
+++ b/.buildkite/commands/diff-merged-manifest.sh
@@ -22,3 +22,6 @@ comment_with_manifest_diff "wear" ${BUILD_VARIANT}
 
 echo "--- 💾 Diff Merged Manifest (Module: automotive, Build Variant: ${BUILD_VARIANT})"
 comment_with_manifest_diff "automotive" ${BUILD_VARIANT}
+
+echo "--- 💾 Diff Merged Manifest (Module: tv, Build Variant: ${BUILD_VARIANT})"
+comment_with_manifest_diff "tv" ${BUILD_VARIANT}

--- a/.buildkite/commands/lint.sh
+++ b/.buildkite/commands/lint.sh
@@ -17,10 +17,10 @@ echo "--- 🧹 Linting"
 ./gradlew :app:lintRelease
 app_lint_exit_code=$?
 
-./gradlew :automotive:lintRelease :wear:lintRelease
-automotive_wear_lint_exit_code=$?
+./gradlew :automotive:lintRelease :tv:lintRelease :wear:lintRelease
+other_lint_exit_code=$?
 
-if [ $app_lint_exit_code -ne 0 ] || [ $automotive_wear_lint_exit_code -ne 0 ]; then
+if [ $app_lint_exit_code -ne 0 ] || [ $other_lint_exit_code -ne 0 ]; then
   lint_exit_code=1
 else
   lint_exit_code=0
@@ -28,6 +28,7 @@ fi
 
 upload_sarif_to_github 'app/build/reports/lint-results-release.sarif' 'app'
 upload_sarif_to_github 'automotive/build/reports/lint-results-release.sarif' 'automotive'
+upload_sarif_to_github 'tv/build/reports/lint-results-release.sarif' 'tv'
 upload_sarif_to_github 'wear/build/reports/lint-results-release.sarif' 'wear'
 
 exit $lint_exit_code

--- a/.buildkite/commands/lint.sh
+++ b/.buildkite/commands/lint.sh
@@ -17,7 +17,7 @@ echo "--- 🧹 Linting"
 ./gradlew :app:lintRelease
 app_lint_exit_code=$?
 
-./gradlew :automotive:lintRelease :tv:lintRelease :wear:lintRelease
+./gradlew --continue :automotive:lintRelease :tv:lintRelease :wear:lintRelease
 other_lint_exit_code=$?
 
 if [ $app_lint_exit_code -ne 0 ] || [ $other_lint_exit_code -ne 0 ]; then

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -87,6 +87,12 @@ steps:
         artifact_paths:
           - "**/build/outputs/apk/**/*"
 
+      - label: "Assemble tv release APK"
+        command: ".buildkite/commands/assemble-release-apk.sh tv"
+        plugins: [ $CI_TOOLKIT ]
+        artifact_paths:
+          - "**/build/outputs/apk/**/*"
+
     ##########
     # Optional Prototype Builds
     #

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -96,7 +96,7 @@ steps:
     ##########
     # Optional Prototype Builds
     #
-    # Builds all modules, uploads app to FAD and Wear and Automotive to S3
+    # Builds all modules, uploads app to FAD and Wear, Automotive and TV to S3
     ##########
   - group: Prototype Builds
     if: "build.pull_request.id != null || build.branch == 'main'"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -688,7 +688,7 @@ platform :android do
 
     UI.user_error!("'BUILDKITE_ARTIFACTS_S3_BUCKET' must be defined as an environment variable.") unless ENV['BUILDKITE_ARTIFACTS_S3_BUCKET']
 
-    other_platforms = %w[wear automotive]
+    other_platforms = %w[wear automotive tv]
 
     other_apks = []
     other_platforms.each do |platform|
@@ -747,7 +747,7 @@ platform :android do
 
   def get_app_display_name(apk_path:)
     key = get_app_key(apk_path: apk_path).to_sym
-    { app: '📱 Mobile', wear: '⌚ Wear', automotive: '🚗 Automotive' }.fetch(key, '❔ Unknown')
+    { app: '📱 Mobile', wear: '⌚ Wear', automotive: '🚗 Automotive', tv: '📺 TV' }.fetch(key, '❔ Unknown')
   end
 
   # Mimics the subset of ActiveSupport's `String#parameterize` we rely on.

--- a/tv/src/main/AndroidManifest.xml
+++ b/tv/src/main/AndroidManifest.xml
@@ -82,7 +82,8 @@
             android:exported="true"
             android:enabled="false"
             android:foregroundServiceType="mediaPlayback"
-            android:label="@string/app_name">
+            android:label="@string/app_name"
+            tools:ignore="Instantiatable">
             <intent-filter>
                 <action android:name="android.media.browse.MediaBrowserService" />
             </intent-filter>

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvVideoPreviewPlayer.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvVideoPreviewPlayer.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.component
 
 import android.content.Context
+import androidx.annotation.OptIn
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.runtime.Composable
@@ -17,6 +18,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.media3.common.MediaItem
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.ui.compose.PlayerSurface
 import androidx.media3.ui.compose.SURFACE_TYPE_TEXTURE_VIEW
@@ -29,6 +31,7 @@ private const val FADE_DURATION_MS = 300
 private const val FADE_STEPS = 20
 private const val PREVIEW_VOLUME = 0.5f
 
+@OptIn(UnstableApi::class)
 @Composable
 fun TvVideoPreviewPlayer(
     videoUrl: String,


### PR DESCRIPTION
## Description

The `:tv` module ships in the app (`settings.gradle.kts`) and is already wired into Gradle-level tooling — spotless, `buildHealth`, `aggregatedLintRelease`, the version-code offset, and release signing. Two PR-gate CI steps already cover it for free because they run **unscoped** Gradle tasks: unit tests (`testDebugUnitTest`) and Spotless (`spotlessCheck`).

But the Buildkite pipeline still treated only `app`/`automotive`/`wear` as first-class apps, so the TV app was **never lint-checked, never assembled (release/R8), never manifest-diffed, and never distributed as a prototype build** on PRs. A TV-only regression (R8/manifest/resource break) could sail through CI unnoticed.

This PR brings TV to parity with the other three app variants across the pipeline:

1. **`.buildkite/commands/lint.sh`** — run `:tv:lintRelease` (grouped with automotive/wear, now with `--continue` so one module's failure still lets the others produce their SARIFs) and upload its SARIF to GitHub. The second exit-code variable is renamed `other_lint_exit_code` since it now also covers tv. No lint config change needed: the shared `configureLint` already sets `baseline = tv/lint-baseline.xml`, `sarifReport = CI`, and `abortOnError = true` for every app module.
2. **`.buildkite/pipeline.yml`** — add an "Assemble tv release APK" step to the *Assemble release APKs* group (mirrors the wear step; `assemble-release-apk.sh` is already parameterized).
3. **`.buildkite/commands/diff-merged-manifest.sh`** — diff the TV merged manifest alongside app/wear/automotive.
4. **`fastlane/Fastfile`** — distribute TV prototype builds to **S3**, exactly like wear and automotive: add `tv` to `other_platforms` in `build_and_upload_prototype_build` (builds `:tv:assembleDebugProd` → S3 with a PR download link) and add `tv: '📺 TV'` to `get_app_display_name` so the PR comment renders "📺 TV" instead of the "❔ Unknown" fallback. (S3 rather than Firebase App Distribution because all four form factors share the package `au.com.shiftyjelly.pocketcasts`, so there is no TV-distinct Firebase app to target — which is why wear/automotive already use S3.)

### Lint fixes surfaced by enabling TV lint
Turning on `:tv:lintRelease` correctly surfaced three pre-existing, `abortOnError` errors in the TV module that CI had never run before. Fixed here:
- **`UnsafeOptInUsageError` ×2** in `TvVideoPreviewPlayer.kt` — media3's `PlayerSurface`/`SURFACE_TYPE_TEXTURE_VIEW` are `@UnstableApi`; added `@OptIn(UnstableApi::class)` (using `androidx.annotation.OptIn`, the marker media3 requires, matching the convention already used across `:repositories`).
- **`Instantiatable`** in `AndroidManifest.xml` — a false positive: `LegacyPlaybackService` extends `MediaBrowserServiceCompat → Service`, but with `checkDependencies = false` lint can't resolve that superclass (it lives in `androidx.media`, not on TV's lint classpath). Suppressed with `tools:ignore="Instantiatable"`, consistent with existing manifest `tools:ignore` usage.

**Out of scope (deliberate):** Fastlane → Play Store *release/delivery* for TV. That is a separate change that can only land once the `tv:beta`/`tv:production` tracks exist in Play Console — bundling it here would introduce an external prerequisite. This PR is intentionally self-contained.

Fixes POC-876 https://linear.app/a8c/issue/POC-876/extend-ci-steps-to-build-tv-apks

## Testing Instructions

CI/build configuration only — nothing to exercise in the app. To validate locally:

1. `CI=true ./gradlew :tv:lintRelease` → passes (0 error-level findings) and produces `tv/build/reports/lint-results-release.sarif` (the exact path `lint.sh` uploads). ✅ verified
2. `./gradlew :tv:assembleRelease -PskipSentryProguardMappingUpload=true` → builds a release-signed, R8-minified APK. ✅ verified
3. `./gradlew :tv:assembleDebugProd` → builds `tv/build/outputs/apk/debugProd/tv-debugProd.apk`; `get_app_key` derives `"tv"`, so the S3 object is `pocketcasts-tv-prototype-build-<n>.apk` and the PR comment shows "📺 TV". ✅ verified
4. `bash -n` on `lint.sh`/`diff-merged-manifest.sh`, `ruby -c fastlane/Fastfile`, and YAML parse of `.buildkite/pipeline.yml` → all OK. ✅
5. On the pipeline itself: TV lint runs in the Lint job, "Assemble tv release APK" appears in the *Assemble release APKs* group, the merged-manifest-diff job comments a TV section, and the optional Prototype Builds step uploads a TV APK to S3 next to Wear and Automotive.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md <!-- N/A: CI-only, not user-facing -->
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes <!-- N/A: shell/YAML/Ruby CI config -->
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml` <!-- N/A -->
- [x] Any jetpack compose components I added or changed are covered by compose previews <!-- N/A -->
- [x] I have updated (or requested that someone edit) the Event Horizon schema to reflect any new or changed analytics. <!-- N/A: no analytics changes -->
