### PR TITLE
[TV] Distribute TV prototype builds to S3 like wear and automotive

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -90,7 +90,7 @@ steps:
     ##########
     # Optional Prototype Builds
     #
-    # Builds all modules, uploads app to FAD and Wear and Automotive to S3
+    # Builds all modules, uploads app to FAD and Wear, Automotive and TV to S3
     ##########
   - group: Prototype Builds
     if: "build.pull_request.id != null || build.branch == 'main'"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -688,7 +688,7 @@ platform :android do
 
     UI.user_error!("'BUILDKITE_ARTIFACTS_S3_BUCKET' must be defined as an environment variable.") unless ENV['BUILDKITE_ARTIFACTS_S3_BUCKET']
 
-    other_platforms = %w[wear automotive]
+    other_platforms = %w[wear automotive tv]
 
     other_apks = []
     other_platforms.each do |platform|
@@ -747,7 +747,7 @@ platform :android do
 
   def get_app_display_name(apk_path:)
     key = get_app_key(apk_path: apk_path).to_sym
-    { app: '📱 Mobile', wear: '⌚ Wear', automotive: '🚗 Automotive' }.fetch(key, '❔ Unknown')
+    { app: '📱 Mobile', wear: '⌚ Wear', automotive: '🚗 Automotive', tv: '📺 TV' }.fetch(key, '❔ Unknown')
   end
 
   # Mimics the subset of ActiveSupport's `String#parameterize` we rely on.


### PR DESCRIPTION
## Description

Prototype (per-PR tester) builds currently cover only three of the four app modules: `app` is uploaded to Firebase App Distribution, and `wear` + `automotive` are built as **DebugProd** and uploaded to **S3** (with a download link posted on the PR). The `tv` module was never built or distributed.

This wires TV into the same S3 path as the other two non-phone form factors — the natural fit, since all four share the package name `au.com.shiftyjelly.pocketcasts` (so there is no TV-distinct Firebase app to target, which is exactly why wear/automotive use S3 rather than FAD).

Changes:
- **`fastlane/Fastfile`** — add `tv` to the `other_platforms` list in `build_and_upload_prototype_build`, so `:tv:assembleDebugProd` is built and uploaded to S3 alongside wear/automotive. The rest of the loop is already generic (`find { |p| p.include?("/#{platform}/") }`, S3 key from `get_app_key`, PR comment).
- **`fastlane/Fastfile`** — add `tv: '📺 TV'` to `get_app_display_name`, so the S3 PR comment renders "📺 TV" instead of the "❔ Unknown" fallback.
- **`.buildkite/pipeline.yml`** — update the Prototype Builds comment to reflect that TV also goes to S3.

Prototype builds are manual-triggered on PRs/`main`, so this adds one more DebugProd APK to that optional step.

Fixes #

## Testing Instructions

Prototype distribution runs on CI (needs S3 + Firebase CI credentials), but the build half is verifiable locally:

1. `./gradlew :tv:assembleDebugProd` → produces `tv/build/outputs/apk/debugProd/tv-debugProd.apk`. ✅ verified (BUILD SUCCESSFUL)
2. `get_app_key` derives `"tv"` from that filename, so the S3 object is `pocketcasts-tv-prototype-build-<n>.apk` and the PR comment shows "📺 TV". ✅
3. On a PR, trigger the optional **Prototype Builds** step and confirm a TV entry appears in the S3 download comment next to Wear and Automotive.

## Screenshots or Screencast

N/A — build/CI configuration only.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md <!-- N/A: CI/build tooling -->
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting) <!-- N/A: Ruby/YAML, outside spotless scope -->
- [x] I have considered whether it makes sense to add tests for my changes <!-- N/A: Fastlane lane wiring -->
- [x] All strings that need to be localized are in the localization module <!-- N/A -->
- [x] Any jetpack compose components I added or changed are covered by compose previews <!-- N/A -->
- [x] I have updated (or requested that someone edit) the Event Horizon schema to reflect any new or changed analytics. <!-- N/A -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
