### PR TITLE
[TV] Wire TV into Sentry crash tracking and Play Store release pipeline

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -21,6 +21,8 @@ PLAY_STORE_TRACK_AUTOMOTIVE_BETA = 'automotive:beta'
 PLAY_STORE_TRACK_AUTOMOTIVE_PRODUCTION = 'automotive:production'
 PLAY_STORE_TRACK_WEAR_BETA = 'wear:beta'
 PLAY_STORE_TRACK_WEAR_PRODUCTION = 'wear:production'
+PLAY_STORE_TRACK_TV_BETA = 'tv:beta'
+PLAY_STORE_TRACK_TV_PRODUCTION = 'tv:production'
 PLAY_STORE_TRACK_BETA = 'beta'
 PLAY_STORE_TRACK_PRODUCTION = 'production'
 GLOTPRESS_APP_STRINGS_PROJECT_URL = 'https://translate.wordpress.com/projects/pocket-casts/android/'
@@ -67,7 +69,8 @@ GITHUB_REPO = 'automattic/pocket-casts-android'
 APPS_APP = 'app'
 APPS_AUTOMOTIVE = 'automotive'
 APPS_WEAR = 'wear'
-APPS = [APPS_APP, APPS_AUTOMOTIVE, APPS_WEAR].freeze
+APPS_TV = 'tv'
+APPS = [APPS_APP, APPS_AUTOMOTIVE, APPS_WEAR, APPS_TV].freeze
 
 UPLOAD_TO_PLAY_STORE_JSON_KEY = File.join(PROJECT_ROOT_FOLDER, 'google-upload-credentials.json')
 UPLOAD_TO_PLAY_STORE_COMMON_OPTIONS = {
@@ -330,7 +333,7 @@ platform :android do
     end
   end
 
-  # Update the rollout of all 3 variants/form-factors (app, automotive, wear) of the latest builds of the given Google Play track to the given % value
+  # Update the rollout of all 4 variants/form-factors (app, automotive, wear, tv) of the latest builds of the given Google Play track to the given % value
   #
   # @param percent [Float] The rollout percentage, between 0 and 1
   # @param track [String] The Google Play track for which to update the rollout of. Must be either `beta` or `production`.
@@ -369,7 +372,7 @@ platform :android do
     not_found_variants.each do |message|
       UI.important(message)
     end
-    UI.user_error!('None of the 3 app variants were found in Google Play Console. We expected at least one') if not_found_variants.count == APPS.count
+    UI.user_error!('None of the app variants were found in Google Play Console. We expected at least one') if not_found_variants.count == APPS.count
   end
 
   # Downloads the latest translations from GlotPress and creates a PR to integrate them into the current `release/*` branch
@@ -579,7 +582,7 @@ platform :android do
   #
   # @param version [String] The version to create
   # @param build_code [String] The build code to create
-  # @param app [String] The Android app to build (i.e 'app', 'automotive', or 'wear')
+  # @param app [String] The Android app to build (i.e 'app', 'automotive', 'wear', or 'tv')
   lane :build_bundle do |app:, version: version_name_current, build_code: build_code_current|
     aab_artifact_path = aab_artifact_path(app, version)
     build_dir = 'artifacts/'
@@ -593,7 +596,8 @@ platform :android do
       build_type: 'Release',
       properties: {
         'IS_AUTOMOTIVE_BUILD' => app == APPS_AUTOMOTIVE,
-        'IS_WEAR_BUILD' => app == APPS_WEAR
+        'IS_WEAR_BUILD' => app == APPS_WEAR,
+        'IS_TV_BUILD' => app == APPS_TV
       }
     )
 
@@ -935,7 +939,7 @@ platform :android do
     BUILD_CODE_FORMATTER.build_code(build_code: build_code_next)
   end
 
-  # Returns the versionCode for a given app, adjusting for offset depending if it's the mobile, automotive or wear app
+  # Returns the versionCode for a given app, adjusting for offset depending if it's the mobile, automotive, wear or tv app
   #
   # See also `dependencies.gradle.kts` and its `versionCodeDifferenceBetweenAppAnd*` constants where those offsets are defined
   #
@@ -945,6 +949,8 @@ platform :android do
       (version_code.to_i + 50_000).to_s
     when APPS_WEAR
       (version_code.to_i + 100_000).to_s
+    when APPS_TV
+      (version_code.to_i + 150_000).to_s
     else
       version_code
     end
@@ -952,7 +958,7 @@ platform :android do
 
   # Returns the Play Store track for a given app, for Open Testing or Production
   #
-  # @param app [String] The type of app. One of `APPS_APP`, `APPS_AUTOMOTIVE`, `APPS_WEAR`
+  # @param app [String] The type of app. One of `APPS_APP`, `APPS_AUTOMOTIVE`, `APPS_WEAR`, `APPS_TV`
   # @param is_beta [Boolean] If we want the track for Open Testing. Otherwise, returns the track for Production
   # @return [String] The Play Store track to use in the `upload_to_play_store(track: …)` action call
   #
@@ -962,6 +968,8 @@ platform :android do
       is_beta ? PLAY_STORE_TRACK_AUTOMOTIVE_BETA : PLAY_STORE_TRACK_AUTOMOTIVE_PRODUCTION
     when APPS_WEAR
       is_beta ? PLAY_STORE_TRACK_WEAR_BETA : PLAY_STORE_TRACK_WEAR_PRODUCTION
+    when APPS_TV
+      is_beta ? PLAY_STORE_TRACK_TV_BETA : PLAY_STORE_TRACK_TV_PRODUCTION
     else
       is_beta ? PLAY_STORE_TRACK_BETA : PLAY_STORE_TRACK_PRODUCTION
     end

--- a/tv/build.gradle.kts
+++ b/tv/build.gradle.kts
@@ -4,6 +4,11 @@ plugins {
     alias(libs.plugins.hilt)
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.google.services)
+    alias(libs.plugins.sentry)
+}
+
+sentry {
+    projectName = project.findProperty("sentryTvProject")?.toString()
 }
 
 android {
@@ -31,6 +36,10 @@ android {
 
         named("release") {
             manifestPlaceholders["appIcon"] = "@mipmap/ic_launcher"
+
+            if (project.findProperty("sentryTvProject")?.toString().isNullOrBlank()) {
+                println("WARNING: Sentry configuration not found. The ProGuard mapping files won't be uploaded.")
+            }
         }
     }
 


### PR DESCRIPTION
## Description

Makes the Android **TV** app a first-class citizen in Sentry crash tracking and the Google Play release pipeline, mirroring exactly how the `wear` and `automotive` apps are already wired.

Most of the runtime plumbing already existed on the `ci/build-tv-app` branch: `TvApplication` initializes remote logging, the `tv` module depends on `crashlogging`/`shared`/`repositories` (so all DI bindings resolve), and `dependencies.gradle.kts` already derives `buildPlatform=tv`, a versionCode offset, and reads `sentryTvDsn`/`sentryTvProject`. The gaps this PR closes are the **build-time** and **release** pieces:

1. **`tv/build.gradle.kts`** — applies the Sentry Gradle plugin and adds the `sentry { projectName = project.findProperty("sentryTvProject") }` block (plus the release-build "configuration not found" warning), identical to `automotive`/`wear`. This uploads the ProGuard mapping + source context for TV release builds so crash stack traces are symbolicated instead of obfuscated.
2. **`fastlane/Fastfile`** — promotes TV to a release app:
   - `APPS_TV = 'tv'` added to the `APPS` array (this is what pulls TV into `build_and_upload_to_play_store` and `update_rollouts`).
   - `IS_TV_BUILD` passed in `build_bundle` (drives `buildPlatform=tv`, the TV versionCode, and routing to `sentryTvDsn`).
   - `version_code_for_app` gains the TV `+150_000` offset (matches `versionCodeDifferenceBetweenAppAndTv` in `dependencies.gradle.kts`).
   - `play_store_track` gains the TV case, backed by new `PLAY_STORE_TRACK_TV_BETA = 'tv:beta'` / `PLAY_STORE_TRACK_TV_PRODUCTION = 'tv:production'` constants.

The existing Fastlane path/app-key helpers and the S3 prototype lane were already TV-aware, so no changes were needed there.

## ⚠️ Blocked / external prerequisites

- **Waiting on the `mobile-secrets` commit hash.** A follow-up commit still needs to bump `.configure`'s `pinned_hash` to the `mobile-secrets` commit that adds `sentryTvDsn` and `sentryTvProject`. **This PR does _not_ include that bump yet** — until it lands, `sentryTvProject` is blank, the TV Gradle build prints the "Sentry configuration not found" warning, and `sentryTvDsn` falls back to the android DSN. Nothing breaks; TV symbolication + dedicated-project routing simply won't be active. Please provide the hash and I'll add the `.configure` commit.
- **Play Console** must have the TV form factor with `tv:beta` / `tv:production` tracks under package `au.com.shiftyjelly.pocketcasts`, or `upload_to_play_store(track: 'tv:…')` will fail at release time.
- **Sentry** must have the TV project created in the `a8c` org (source of the two secret values above).

## Testing Instructions

This is build/release configuration; there is no in-app UI change.

1. **Gradle config resolves:** `./gradlew :tv:help` (or any `:tv` task) configures cleanly and, with no `sentryTvProject` set locally, prints `WARNING: Sentry configuration not found…` — same behavior as `:automotive`/`:wear`.
2. **Fastlane syntax:** `ruby -c fastlane/Fastfile` → `Syntax OK`.
3. **Release wiring (dry-run reasoning):** confirm `version_code_for_app(app: 'tv', version_code: N)` returns `N + 150000`, and `play_store_track(app: 'tv', is_beta: true/false)` returns `tv:beta` / `tv:production`.
4. Once the secrets land and a TV release bundle is built in CI, confirm the Sentry release shows an uploaded ProGuard UUID and a forced test crash appears in the TV project, symbolicated and tagged `app.platform=tv`.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md — n/a (build/release config only)
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes — n/a (Fastlane/Gradle config)
- [x] All strings that need to be localized are in localization — n/a
- [x] Any jetpack compose components I added or changed are covered by compose previews — n/a
- [x] I have updated the Event Horizon schema to reflect any new or changed analytics — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)
