### PR TITLE
[TV] Reveal browse category covers only once their artwork has loaded

### DIFF
--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvCategoryTile.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvCategoryTile.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.component
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsFocusedAsState
@@ -19,6 +20,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -30,6 +32,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.style.TextOverflow
@@ -46,6 +50,10 @@ import au.com.shiftyjelly.pocketcasts.theme.TvTheme
 import au.com.shiftyjelly.pocketcasts.theme.tvColors
 import au.com.shiftyjelly.pocketcasts.theme.tvTypography
 import coil3.compose.AsyncImage
+import coil3.compose.AsyncImagePainter
+import coil3.compose.rememberAsyncImagePainter
+import coil3.request.ImageRequest
+import coil3.request.crossfade
 
 private val CardShape = RoundedCornerShape(12.dp)
 private val CoverSize = 80.dp
@@ -109,7 +117,7 @@ fun TvCategoryTile(
                     url = url,
                     alignment = Alignment.CenterStart,
                     edgeSign = -1f * directionSign,
-                    focusProgress = { focusProgress.value },
+                    focused = isFocused,
                     coverSizePx = coverSizePx,
                 )
             }
@@ -118,7 +126,7 @@ fun TvCategoryTile(
                     url = url,
                     alignment = Alignment.CenterEnd,
                     edgeSign = 1f * directionSign,
-                    focusProgress = { focusProgress.value },
+                    focused = isFocused,
                     coverSizePx = coverSizePx,
                 )
             }
@@ -153,15 +161,29 @@ private fun BoxScope.CategoryCover(
     url: String,
     alignment: Alignment,
     edgeSign: Float,
-    focusProgress: () -> Float,
+    focused: Boolean,
     coverSizePx: Float,
 ) {
+    val painter = rememberAsyncImagePainter(
+        model = ImageRequest.Builder(LocalContext.current)
+            .data(url)
+            .crossfade(true)
+            .build(),
+    )
+    val state by painter.state.collectAsState()
+    val imageReady = state is AsyncImagePainter.State.Success
+
+    val reveal = animateFloatAsState(
+        targetValue = if (focused && imageReady) 1f else 0f,
+        animationSpec = spring(dampingRatio = 0.6f, stiffness = Spring.StiffnessMediumLow),
+        label = "TvCategoryCoverReveal",
+    )
     Box(
         modifier = Modifier
             .align(alignment)
             .size(CoverSize)
             .graphicsLayer {
-                val progress = focusProgress().coerceIn(0f, 1f)
+                val progress = reveal.value.coerceIn(0f, 1f)
                 alpha = progress
                 val scale = COVER_RESTING_SCALE + (1f - COVER_RESTING_SCALE) * progress
                 scaleX = scale
@@ -169,8 +191,10 @@ private fun BoxScope.CategoryCover(
                 translationX = edgeSign * coverSizePx * (1f - COVER_VISIBLE_FRACTION * progress)
             },
     ) {
-        TvArtworkImage(
-            model = url,
+        Image(
+            painter = painter,
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
             modifier = Modifier
                 .fillMaxSize()
                 .clip(CoverShape),

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvCategoryTile.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvCategoryTile.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
@@ -90,6 +91,16 @@ fun TvCategoryTile(
     val coverSizePx = with(LocalDensity.current) { CoverSize.toPx() }
     val directionSign = if (LocalLayoutDirection.current == LayoutDirection.Rtl) -1f else 1f
 
+    val firstCover = coverUrls.firstOrNull()?.let { rememberCoverState(it) }
+    val secondCover = coverUrls.getOrNull(1)?.let { rememberCoverState(it) }
+    val covers = listOfNotNull(firstCover, secondCover)
+    val coversReady = covers.isNotEmpty() && covers.all { it.isReady }
+    val coverReveal = animateFloatAsState(
+        targetValue = if (isFocused && coversReady) 1f else 0f,
+        animationSpec = spring(dampingRatio = 0.6f, stiffness = Spring.StiffnessMediumLow),
+        label = "TvCategoryCoverReveal",
+    )
+
     TvTile(
         onClick = onClick,
         shape = CardDefaults.shape(shape = CardShape),
@@ -113,21 +124,21 @@ fun TvCategoryTile(
                     .background(TvCategoryStyle.gradient(colorIndex)),
             )
 
-            coverUrls.firstOrNull()?.let { url ->
+            firstCover?.let { cover ->
                 CategoryCover(
-                    url = url,
+                    painter = cover.painter,
                     alignment = Alignment.CenterStart,
                     edgeSign = -1f * directionSign,
-                    focused = isFocused,
+                    reveal = { coverReveal.value },
                     coverSizePx = coverSizePx,
                 )
             }
-            coverUrls.getOrNull(1)?.let { url ->
+            secondCover?.let { cover ->
                 CategoryCover(
-                    url = url,
+                    painter = cover.painter,
                     alignment = Alignment.CenterEnd,
                     edgeSign = 1f * directionSign,
-                    focused = isFocused,
+                    reveal = { coverReveal.value },
                     coverSizePx = coverSizePx,
                 )
             }
@@ -157,14 +168,13 @@ fun TvCategoryTile(
     }
 }
 
+private data class CoverState(
+    val painter: AsyncImagePainter,
+    val isReady: Boolean,
+)
+
 @Composable
-private fun BoxScope.CategoryCover(
-    url: String,
-    alignment: Alignment,
-    edgeSign: Float,
-    focused: Boolean,
-    coverSizePx: Float,
-) {
+private fun rememberCoverState(url: String): CoverState {
     val painter = rememberAsyncImagePainter(
         model = ImageRequest.Builder(LocalContext.current)
             .data(url)
@@ -174,19 +184,23 @@ private fun BoxScope.CategoryCover(
         contentScale = ContentScale.Crop,
     )
     val state by painter.state.collectAsState()
-    val imageReady = state is AsyncImagePainter.State.Success
+    return CoverState(painter, isReady = state is AsyncImagePainter.State.Success)
+}
 
-    val reveal = animateFloatAsState(
-        targetValue = if (focused && imageReady) 1f else 0f,
-        animationSpec = spring(dampingRatio = 0.6f, stiffness = Spring.StiffnessMediumLow),
-        label = "TvCategoryCoverReveal",
-    )
+@Composable
+private fun BoxScope.CategoryCover(
+    painter: Painter,
+    alignment: Alignment,
+    edgeSign: Float,
+    reveal: () -> Float,
+    coverSizePx: Float,
+) {
     Box(
         modifier = Modifier
             .align(alignment)
             .size(CoverSize)
             .graphicsLayer {
-                val progress = reveal.value.coerceIn(0f, 1f)
+                val progress = reveal().coerceIn(0f, 1f)
                 alpha = progress
                 val scale = COVER_RESTING_SCALE + (1f - COVER_RESTING_SCALE) * progress
                 scaleX = scale

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvCategoryTile.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvCategoryTile.kt
@@ -54,6 +54,7 @@ import coil3.compose.AsyncImagePainter
 import coil3.compose.rememberAsyncImagePainter
 import coil3.request.ImageRequest
 import coil3.request.crossfade
+import coil3.size.Size
 
 private val CardShape = RoundedCornerShape(12.dp)
 private val CoverSize = 80.dp
@@ -168,7 +169,9 @@ private fun BoxScope.CategoryCover(
         model = ImageRequest.Builder(LocalContext.current)
             .data(url)
             .crossfade(true)
+            .size(Size.ORIGINAL)
             .build(),
+        contentScale = ContentScale.Crop,
     )
     val state by painter.state.collectAsState()
     val imageReady = state is AsyncImagePainter.State.Success


### PR DESCRIPTION
## Description

On Android TV, the Discover **Browse categories** cards reveal two peeking podcast covers (fade + scale + horizontal slide) when a card gains focus. Because a card's cover URLs are only fetched on first focus, the reveal spring — which was driven purely by focus progress — had already run to completion by the time the artwork arrived. The result was jarring: `TvArtworkImage`'s black placeholder ("shadow") slid in first, then Coil swapped the decoded bitmap in with no transition, so the image "popped" in abruptly.

This change gates each cover's reveal on its artwork actually being decoded. `CategoryCover` now loads via `rememberAsyncImagePainter` and observes `painter.state` (the same idiom used by `ProfileImage`/`CoilImage`); the reveal spring targets `1f` only when the card is focused **and** the image is `Success`. The cover stays fully transparent and off-edge until its bitmap is ready, then springs in already showing the real artwork — no placeholder shadow, no pop. The request also enables `crossfade(true)` as a belt-and-suspenders smoothing of the swap. The focus gradient behind the covers still fades on focus as before.

Loading is safely decoupled from the reveal: Coil starts the request in the painter's `onRemembered` and decodes at `SizeResolver.ORIGINAL`, so an alpha-0 / off-edge / not-yet-drawn cover still loads — there is no "reveal waits for image, image waits for reveal" deadlock.

Only `tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvCategoryTile.kt` changes.

## Testing Instructions

1. Launch the TV app and choose **Browse without an account** (or sign in).
2. On Home, scroll down to the **Browse categories** row.
3. Move focus onto a category card (e.g. Arts) for the first time.
4. Observe: the two peeking covers now fade/scale/slide in **already showing real artwork** — the black placeholder no longer slides in ahead of the image, and the image no longer pops in abruptly.
5. Move focus across other cards (Business, Comedy, …) and confirm the same clean reveal. The same row also appears on the Search screen.

## Screenshots or Screencast

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/dcdebc50-3690-4859-9c57-a955fa75c89f" /> | <video src="https://github.com/user-attachments/assets/8ba543ba-0543-4835-b23c-7aa641575c2b" /> |


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

#### I have tested any UI changes...
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
