### PR TITLE
[TV] Side by side design review and final touches

### DIFF
--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvBannerRow.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvBannerRow.kt
@@ -54,7 +54,7 @@ fun TvBannerRow(
 
     TvTile(
         onClick = onClick,
-        shape = CardDefaults.shape(RoundedCornerShape(12.dp)),
+        shape = CardDefaults.shape(RoundedCornerShape(9.dp)),
         scale = CardDefaults.scale(focusedScale = 1.05f),
         colors = CardDefaults.colors(
             containerColor = Color.Black,
@@ -63,7 +63,7 @@ fun TvBannerRow(
         interactionSource = interactionSource,
         modifier = modifier
             .fillMaxWidth()
-            .height(132.dp),
+            .height(99.dp),
     ) {
         Box(modifier = Modifier.fillMaxSize().clipToBounds()) {
             BackgroundLift()
@@ -93,12 +93,12 @@ fun TvBannerRow(
             }
             Row(
                 verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(48.dp),
+                horizontalArrangement = Arrangement.spacedBy(36.dp),
                 modifier = Modifier
                     .align(Alignment.CenterStart)
                     .fillMaxHeight()
                     .fillMaxWidth(banner.contentWidthFraction)
-                    .padding(horizontal = 48.dp),
+                    .padding(horizontal = 36.dp),
             ) {
                 BannerActionPill(banner, isFocused)
                 BannerText(banner, modifier = Modifier.weight(1f, fill = false))
@@ -148,7 +148,7 @@ private fun BannerActionPill(banner: TvDiscoverBanner, isFocused: Boolean) {
         modifier = Modifier
             .clip(RoundedCornerShape(percent = 50))
             .background(if (isFocused) MaterialTheme.tvColors.backgroundActive else MaterialTheme.tvColors.backgroundActive20)
-            .padding(horizontal = 24.dp, vertical = 12.dp),
+            .padding(horizontal = 18.dp, vertical = 9.dp),
     ) {
         Text(
             text = banner.actionTitle(),
@@ -166,8 +166,8 @@ private fun TvDiscoverBanner.artwork(): Int = when (this) {
 
 private val TvDiscoverBanner.artworkHeight: Dp
     get() = when (this) {
-        TvDiscoverBanner.CreateAccount -> 150.dp
-        TvDiscoverBanner.DiscoverMore -> 170.dp
+        TvDiscoverBanner.CreateAccount -> 112.5.dp
+        TvDiscoverBanner.DiscoverMore -> 127.5.dp
     }
 
 private val TvDiscoverBanner.contentWidthFraction: Float
@@ -202,10 +202,10 @@ private fun TvDiscoverBanner.actionTitle(): String = when (this) {
 private fun TvBannerRowPreview() {
     TvTheme {
         Column(
-            verticalArrangement = Arrangement.spacedBy(24.dp),
+            verticalArrangement = Arrangement.spacedBy(18.dp),
             modifier = Modifier
                 .background(MaterialTheme.tvColors.backgroundSunken)
-                .padding(48.dp),
+                .padding(36.dp),
         ) {
             TvBannerRow(banner = TvDiscoverBanner.CreateAccount, onClick = {})
             TvBannerRow(banner = TvDiscoverBanner.DiscoverMore, onClick = {})

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvCategoryTile.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvCategoryTile.kt
@@ -48,7 +48,7 @@ import au.com.shiftyjelly.pocketcasts.theme.tvTypography
 import coil3.compose.AsyncImage
 
 private val CardShape = RoundedCornerShape(9.dp)
-private val CoverSize = 60.dp
+private val CoverSize = 78.dp
 private val CoverShape = RoundedCornerShape(6.dp)
 private const val COVER_VISIBLE_FRACTION = 0.55f
 private const val COVER_RESTING_SCALE = 0.85f
@@ -93,8 +93,8 @@ fun TvCategoryTile(
         ),
         interactionSource = interactionSource,
         modifier = modifier
-            .width(210.dp)
-            .height(96.dp),
+            .width(284.dp)
+            .height(129.dp),
     ) {
         Box(modifier = Modifier.fillMaxSize()) {
             Box(
@@ -132,12 +132,12 @@ fun TvCategoryTile(
                     model = category.icon,
                     contentDescription = null,
                     colorFilter = ColorFilter.tint(contentColor),
-                    modifier = Modifier.size(21.dp),
+                    modifier = Modifier.size(24.dp),
                 )
-                Spacer(modifier = Modifier.height(7.5.dp))
+                Spacer(modifier = Modifier.height(4.dp))
                 Text(
                     text = category.name,
-                    style = MaterialTheme.tvTypography.body,
+                    style = MaterialTheme.tvTypography.headline,
                     color = contentColor,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvCategoryTile.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvCategoryTile.kt
@@ -47,9 +47,9 @@ import au.com.shiftyjelly.pocketcasts.theme.tvColors
 import au.com.shiftyjelly.pocketcasts.theme.tvTypography
 import coil3.compose.AsyncImage
 
-private val CardShape = RoundedCornerShape(12.dp)
-private val CoverSize = 80.dp
-private val CoverShape = RoundedCornerShape(8.dp)
+private val CardShape = RoundedCornerShape(9.dp)
+private val CoverSize = 60.dp
+private val CoverShape = RoundedCornerShape(6.dp)
 private const val COVER_VISIBLE_FRACTION = 0.55f
 private const val COVER_RESTING_SCALE = 0.85f
 
@@ -89,12 +89,12 @@ fun TvCategoryTile(
             focusedContainerColor = MaterialTheme.tvColors.backgroundOverlay,
         ),
         glow = CardDefaults.glow(
-            focusedGlow = Glow(elevationColor = Color.Black.copy(alpha = 0.5f), elevation = 8.dp),
+            focusedGlow = Glow(elevationColor = Color.Black.copy(alpha = 0.5f), elevation = 6.dp),
         ),
         interactionSource = interactionSource,
         modifier = modifier
-            .width(280.dp)
-            .height(128.dp),
+            .width(210.dp)
+            .height(96.dp),
     ) {
         Box(modifier = Modifier.fillMaxSize()) {
             Box(
@@ -132,16 +132,16 @@ fun TvCategoryTile(
                     model = category.icon,
                     contentDescription = null,
                     colorFilter = ColorFilter.tint(contentColor),
-                    modifier = Modifier.size(28.dp),
+                    modifier = Modifier.size(21.dp),
                 )
-                Spacer(modifier = Modifier.height(10.dp))
+                Spacer(modifier = Modifier.height(7.5.dp))
                 Text(
                     text = category.name,
                     style = MaterialTheme.tvTypography.body,
                     color = contentColor,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.padding(horizontal = 12.dp),
+                    modifier = Modifier.padding(horizontal = 9.dp),
                 )
             }
         }
@@ -185,7 +185,7 @@ private fun TvCategoryTilePreview() {
         Column(
             modifier = Modifier
                 .background(MaterialTheme.tvColors.backgroundSunken)
-                .padding(48.dp),
+                .padding(36.dp),
         ) {
             TvCategoryTile(
                 category = DiscoverCategory(id = 1, name = "Comedy", icon = "", source = ""),

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvDropdownMenu.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvDropdownMenu.kt
@@ -51,7 +51,7 @@ fun TvDropdownMenu(
     width: Dp = DefaultMenuWidth,
     maxHeight: Dp? = null,
     alignment: Alignment = Alignment.TopEnd,
-    offset: DpOffset = DpOffset(x = 0.dp, y = 48.dp),
+    offset: DpOffset = DpOffset(x = 0.dp, y = 36.dp),
     content: @Composable ColumnScope.() -> Unit,
 ) {
     val intOffset = with(LocalDensity.current) {
@@ -87,7 +87,7 @@ internal fun TvDropdownMenuSurface(
             .clip(MenuShape)
             .background(MaterialTheme.tvColors.overlayContainer)
             .border(1.dp, MaterialTheme.tvColors.overlayBorder, MenuShape)
-            .padding(horizontal = 20.dp, vertical = 12.dp),
+            .padding(horizontal = 15.dp, vertical = 9.dp),
     ) {
         if (title != null) {
             TvDropdownMenuSectionTitle(text = title)
@@ -114,7 +114,7 @@ fun TvDropdownMenuSectionTitle(
         text = text,
         style = MaterialTheme.tvTypography.caption2,
         color = MaterialTheme.tvColors.textSecondary,
-        modifier = modifier.padding(start = 16.dp, top = 4.dp, bottom = 8.dp),
+        modifier = modifier.padding(start = 12.dp, top = 3.dp, bottom = 6.dp),
     )
 }
 
@@ -148,25 +148,25 @@ fun TvDropdownMenuItem(
             .fillMaxWidth()
             .then(focusModifier),
     ) {
-        Box(modifier = Modifier.size(14.dp)) {
+        Box(modifier = Modifier.size(10.5.dp)) {
             if (isSelected) {
                 Icon(
                     painter = painterResource(IR.drawable.ic_check),
                     contentDescription = null,
-                    modifier = Modifier.size(14.dp),
+                    modifier = Modifier.size(10.5.dp),
                 )
             }
         }
         Text(
             text = label,
-            modifier = Modifier.padding(start = 10.dp),
+            modifier = Modifier.padding(start = 7.5.dp),
         )
         Spacer(modifier = Modifier.weight(1f))
     }
 }
 
-private val DefaultMenuWidth = 256.dp
-private val MenuShape = RoundedCornerShape(20.dp)
+private val DefaultMenuWidth = 192.dp
+private val MenuShape = RoundedCornerShape(15.dp)
 
 @Preview
 @Composable

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEmptyState.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEmptyState.kt
@@ -54,16 +54,16 @@ fun TvEmptyState(
                 color = MaterialTheme.tvColors.textPrimary,
                 textAlign = TextAlign.Center,
             )
-            Spacer(modifier = Modifier.height(12.dp))
+            Spacer(modifier = Modifier.height(9.dp))
             Text(
                 text = subtitle,
                 style = MaterialTheme.tvTypography.caption1,
                 color = MaterialTheme.tvColors.textSecondary,
                 textAlign = TextAlign.Center,
-                modifier = Modifier.widthIn(max = 400.dp),
+                modifier = Modifier.widthIn(max = 300.dp),
             )
             if (actionLabel != null && onAction != null) {
-                Spacer(modifier = Modifier.height(32.dp))
+                Spacer(modifier = Modifier.height(24.dp))
                 Button(
                     onClick = onAction,
                     colors = TvButtonDefaults.filledButtonColors(),

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionsModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionsModal.kt
@@ -324,4 +324,4 @@ private object NoOpTvEpisodeActions : TvEpisodeActions {
     override fun trackActionsShown(source: EpisodeViewSourceType) = Unit
 }
 
-private val ContentPadding = PaddingValues(horizontal = 24.dp, vertical = 27.dp)
+private val ContentPadding = PaddingValues(horizontal = 18.dp, vertical = 20.dp)

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeInfoModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeInfoModal.kt
@@ -113,16 +113,16 @@ private fun EpisodeHeader(
     context: Context,
 ) {
     Row(
-        horizontalArrangement = Arrangement.spacedBy(24.dp),
+        horizontalArrangement = Arrangement.spacedBy(18.dp),
         modifier = Modifier.fillMaxWidth(),
     ) {
         TvArtworkImage(
             model = PodcastImage.getMediumArtworkUrl(episode.podcastUuid),
             modifier = Modifier
                 .size(ArtworkSize)
-                .clip(RoundedCornerShape(8.dp)),
+                .clip(RoundedCornerShape(6.dp)),
         )
-        Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        Column(verticalArrangement = Arrangement.spacedBy(4.5.dp)) {
             if (!podcastTitle.isNullOrBlank()) {
                 Text(
                     text = podcastTitle,
@@ -154,7 +154,7 @@ private fun EpisodeDescriptionPane(
     val scrollState = rememberScrollState()
     val scope = rememberCoroutineScope()
     val focusRequester = remember { FocusRequester() }
-    val scrollStep = with(LocalDensity.current) { 120.dp.toPx() }
+    val scrollStep = with(LocalDensity.current) { 90.dp.toPx() }
     LaunchedEffect(Unit) {
         focusRequester.requestFocus()
     }
@@ -207,9 +207,9 @@ private fun Date.formatSkeleton(skeleton: String): String {
     return SimpleDateFormat(DateFormat.getBestDateTimePattern(locale, skeleton), locale).format(this)
 }
 
-private val EpisodeInfoModalWidth = 760.dp
-private val ArtworkSize = 96.dp
-private val DescriptionHeight = 240.dp
+private val EpisodeInfoModalWidth = 570.dp
+private val ArtworkSize = 72.dp
+private val DescriptionHeight = 180.dp
 
 @Preview
 @Composable

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeListControls.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeListControls.kt
@@ -52,8 +52,8 @@ fun TvArchivedFilterButton(
                 painter = painterResource(IR.drawable.ic_chevron_small_up),
                 contentDescription = null,
                 modifier = Modifier
-                    .padding(start = 6.dp)
-                    .size(16.dp)
+                    .padding(start = 4.5.dp)
+                    .size(12.dp)
                     .rotate(180f),
             )
         }
@@ -108,7 +108,7 @@ fun <T> TvSortButton(
             Icon(
                 painter = painterResource(IR.drawable.ic_sort),
                 contentDescription = stringResource(LR.string.sort_by),
-                modifier = Modifier.size(20.dp),
+                modifier = Modifier.size(15.dp),
             )
         }
         if (isExpanded) {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeListItem.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeListItem.kt
@@ -76,7 +76,7 @@ fun TvEpisodeListItemContainer(
                 fadeOut(tween(MORE_BUTTON_ANIMATION_DURATION_MS)),
         ) {
             Row(verticalAlignment = Alignment.CenterVertically) {
-                Spacer(Modifier.width(16.dp))
+                Spacer(Modifier.width(12.dp))
                 TvMoreButton(onClick = onOpenActions)
             }
         }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeRow.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeRow.kt
@@ -78,7 +78,7 @@ fun TvEpisodeRow(
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(12.dp),
@@ -156,7 +156,7 @@ private fun EpisodeArtwork(
     TvArtworkImage(
         model = model,
         modifier = modifier
-            .size(82.dp)
+            .size(62.dp)
             .clip(RoundedCornerShape(4.dp)),
     )
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeRow.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeRow.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -83,7 +82,7 @@ fun TvEpisodeRow(
             horizontalArrangement = Arrangement.spacedBy(12.dp),
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(12.dp),
+                .padding(16.dp),
         ) {
             EpisodeArtwork(episode = episode)
             Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
@@ -125,6 +124,7 @@ fun TvEpisodeRow(
                         EpisodeProgressBar(
                             progress = (episode.playedUpTo / episode.duration).toFloat().coerceIn(0f, 1f),
                             color = captionColor,
+                            modifier = Modifier.width(48.dp),
                         )
                     } else if (episode.isFinished) {
                         Icon(
@@ -166,25 +166,24 @@ fun TvResumeCard(
         ),
         interactionSource = interactionSource,
         modifier = modifier
-            .width(653.dp)
-            .height(184.dp)
+            .width(621.dp)
             .alpha(if (episode.isArchived && !isFocused) 0.3f else 1f),
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(18.dp),
+            horizontalArrangement = Arrangement.spacedBy(24.dp),
             modifier = Modifier
-                .fillMaxSize()
-                .padding(18.dp),
+                .fillMaxWidth()
+                .padding(16.dp),
         ) {
-            EpisodeArtwork(episode = episode, size = 148.dp, cornerRadius = 6.dp)
+            EpisodeArtwork(episode = episode, size = 136.dp, cornerRadius = 6.dp)
             Column(
                 verticalArrangement = Arrangement.spacedBy(8.dp),
                 modifier = Modifier.weight(1f),
             ) {
                 Text(
                     text = episode.rememberPublishedDateText(dateFormatter),
-                    style = MaterialTheme.tvTypography.caption2,
+                    style = MaterialTheme.tvTypography.body,
                     color = captionColor,
                 )
                 Text(
@@ -194,29 +193,18 @@ fun TvResumeCard(
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,
                 )
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                ) {
-                    Text(
-                        text = episode.rememberPlaybackTimeText(),
-                        style = MaterialTheme.tvTypography.caption2,
+                if (episode.isInProgress && episode.duration > 0.0) {
+                    EpisodeProgressBar(
+                        progress = (episode.playedUpTo / episode.duration).toFloat().coerceIn(0f, 1f),
                         color = captionColor,
+                        modifier = Modifier.fillMaxWidth(),
                     )
-                    if (episode.isInProgress && episode.duration > 0.0) {
-                        EpisodeProgressBar(
-                            progress = (episode.playedUpTo / episode.duration).toFloat().coerceIn(0f, 1f),
-                            color = captionColor,
-                        )
-                    } else if (episode.isFinished) {
-                        Icon(
-                            painter = painterResource(IR.drawable.ic_check),
-                            contentDescription = null,
-                            tint = captionColor,
-                            modifier = Modifier.size(14.dp),
-                        )
-                    }
                 }
+                Text(
+                    text = episode.rememberPlaybackTimeText(),
+                    style = MaterialTheme.tvTypography.body,
+                    color = captionColor,
+                )
             }
         }
     }
@@ -255,8 +243,7 @@ private fun EpisodeProgressBar(
 ) {
     Box(
         modifier = modifier
-            .width(120.dp)
-            .height(4.dp)
+            .height(3.dp)
             .clip(CircleShape)
             .background(color.copy(alpha = 0.3f)),
     ) {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeRow.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeRow.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -29,6 +30,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.CardDefaults
 import androidx.tv.material3.Icon
@@ -139,9 +141,93 @@ fun TvEpisodeRow(
 }
 
 @Composable
+fun TvResumeCard(
+    episode: PodcastEpisode,
+    onClick: () -> Unit,
+    dateFormatter: RelativeDateFormatter,
+    modifier: Modifier = Modifier,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isFocused by interactionSource.collectIsFocusedAsState()
+    val titleColor = if (isFocused) MaterialTheme.tvColors.textPrimaryActive else MaterialTheme.tvColors.textPrimary
+    val captionColor = if (isFocused) {
+        MaterialTheme.tvColors.textSecondaryActive
+    } else {
+        MaterialTheme.tvColors.textSecondary
+    }
+
+    TvTile(
+        onClick = onClick,
+        scale = CardDefaults.scale(focusedScale = 1.02f),
+        shape = CardDefaults.shape(RoundedCornerShape(8.dp)),
+        colors = CardDefaults.colors(
+            containerColor = MaterialTheme.tvColors.backgroundBase,
+            focusedContainerColor = MaterialTheme.tvColors.backgroundActive,
+        ),
+        interactionSource = interactionSource,
+        modifier = modifier
+            .width(653.dp)
+            .height(184.dp)
+            .alpha(if (episode.isArchived && !isFocused) 0.3f else 1f),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(18.dp),
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(18.dp),
+        ) {
+            EpisodeArtwork(episode = episode, size = 148.dp, cornerRadius = 6.dp)
+            Column(
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.weight(1f),
+            ) {
+                Text(
+                    text = episode.rememberPublishedDateText(dateFormatter),
+                    style = MaterialTheme.tvTypography.caption2,
+                    color = captionColor,
+                )
+                Text(
+                    text = episode.title,
+                    style = MaterialTheme.tvTypography.title3,
+                    color = titleColor,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Text(
+                        text = episode.rememberPlaybackTimeText(),
+                        style = MaterialTheme.tvTypography.caption2,
+                        color = captionColor,
+                    )
+                    if (episode.isInProgress && episode.duration > 0.0) {
+                        EpisodeProgressBar(
+                            progress = (episode.playedUpTo / episode.duration).toFloat().coerceIn(0f, 1f),
+                            color = captionColor,
+                        )
+                    } else if (episode.isFinished) {
+                        Icon(
+                            painter = painterResource(IR.drawable.ic_check),
+                            contentDescription = null,
+                            tint = captionColor,
+                            modifier = Modifier.size(14.dp),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
 private fun EpisodeArtwork(
     episode: PodcastEpisode,
     modifier: Modifier = Modifier,
+    size: Dp = 62.dp,
+    cornerRadius: Dp = 4.dp,
 ) {
     val useEpisodeArtwork = LocalUseEpisodeArtwork.current
     val context = LocalContext.current
@@ -156,8 +242,8 @@ private fun EpisodeArtwork(
     TvArtworkImage(
         model = model,
         modifier = modifier
-            .size(62.dp)
-            .clip(RoundedCornerShape(4.dp)),
+            .size(size)
+            .clip(RoundedCornerShape(cornerRadius)),
     )
 }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvFeaturedTile.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvFeaturedTile.kt
@@ -67,8 +67,8 @@ fun TvFeaturedTile(
     ) {
         Box(
             modifier = Modifier
-                .width(642.dp)
-                .height(200.dp),
+                .width(481.5.dp)
+                .height(150.dp),
         ) {
             AsyncImage(
                 model = artworkUrl,
@@ -76,7 +76,7 @@ fun TvFeaturedTile(
                 contentScale = ContentScale.Crop,
                 modifier = Modifier
                     .fillMaxSize()
-                    .blur(40.dp),
+                    .blur(30.dp),
             )
 
             Box(
@@ -103,16 +103,16 @@ fun TvFeaturedTile(
                     contentDescription = title,
                     contentScale = ContentScale.Crop,
                     modifier = Modifier
-                        .padding(16.dp)
-                        .size(168.dp)
-                        .clip(RoundedCornerShape(4.dp)),
+                        .padding(12.dp)
+                        .size(126.dp)
+                        .clip(RoundedCornerShape(3.dp)),
                 )
 
                 Column(
                     modifier = Modifier
                         .fillMaxHeight()
                         .weight(1f)
-                        .padding(horizontal = 14.dp, vertical = 17.dp),
+                        .padding(horizontal = 10.5.dp, vertical = 13.dp),
                 ) {
                     if (isSponsored) {
                         Text(
@@ -130,7 +130,7 @@ fun TvFeaturedTile(
                         color = MaterialTheme.tvColors.textPrimary,
                     )
 
-                    Spacer(modifier = Modifier.height(7.dp))
+                    Spacer(modifier = Modifier.height(5.dp))
 
                     Text(
                         text = description,
@@ -148,7 +148,7 @@ fun TvFeaturedTile(
                         exit = fadeOut() + shrinkVertically(shrinkTowards = Alignment.Top),
                     ) {
                         Row(
-                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                            horizontalArrangement = Arrangement.spacedBy(9.dp),
                         ) {
                             OutlinedButton(
                                 onClick = onPlayLastEpisode,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvFeaturedTile.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvFeaturedTile.kt
@@ -58,7 +58,7 @@ fun TvFeaturedTile(
 
     TvTile(
         onClick = onPlayLastEpisode,
-        scale = CardDefaults.scale(focusedScale = 1.05f),
+        scale = CardDefaults.scale(focusedScale = 1.02f),
         colors = CardDefaults.colors(
             containerColor = Color.Transparent,
             focusedContainerColor = Color.Transparent,
@@ -113,6 +113,7 @@ fun TvFeaturedTile(
                         .fillMaxHeight()
                         .weight(1f)
                         .padding(horizontal = 10.5.dp, vertical = 13.dp),
+                    verticalArrangement = Arrangement.Center,
                 ) {
                     if (isSponsored) {
                         Text(
@@ -120,9 +121,8 @@ fun TvFeaturedTile(
                             style = MaterialTheme.tvTypography.caption2,
                             color = MaterialTheme.tvColors.textPrimary70,
                         )
+                        Spacer(modifier = Modifier.height(4.dp))
                     }
-
-                    Spacer(modifier = Modifier.weight(1f))
 
                     Text(
                         text = title,
@@ -140,14 +140,13 @@ fun TvFeaturedTile(
                         overflow = TextOverflow.Ellipsis,
                     )
 
-                    Spacer(modifier = Modifier.weight(1f))
-
                     AnimatedVisibility(
                         visible = buttonState.isFocused,
                         enter = fadeIn() + expandVertically(expandFrom = Alignment.Top),
                         exit = fadeOut() + shrinkVertically(shrinkTowards = Alignment.Top),
                     ) {
                         Row(
+                            modifier = Modifier.padding(top = 12.dp),
                             horizontalArrangement = Arrangement.spacedBy(12.dp),
                         ) {
                             OutlinedButton(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvFeaturedTile.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvFeaturedTile.kt
@@ -67,8 +67,8 @@ fun TvFeaturedTile(
     ) {
         Box(
             modifier = Modifier
-                .width(481.5.dp)
-                .height(150.dp),
+                .width(802.dp)
+                .height(250.dp),
         ) {
             AsyncImage(
                 model = artworkUrl,
@@ -103,8 +103,8 @@ fun TvFeaturedTile(
                     contentDescription = title,
                     contentScale = ContentScale.Crop,
                     modifier = Modifier
-                        .padding(12.dp)
-                        .size(126.dp)
+                        .padding(20.dp)
+                        .size(210.dp)
                         .clip(RoundedCornerShape(3.dp)),
                 )
 
@@ -126,7 +126,7 @@ fun TvFeaturedTile(
 
                     Text(
                         text = title,
-                        style = MaterialTheme.tvTypography.headline,
+                        style = MaterialTheme.tvTypography.title2,
                         color = MaterialTheme.tvColors.textPrimary,
                     )
 
@@ -148,7 +148,7 @@ fun TvFeaturedTile(
                         exit = fadeOut() + shrinkVertically(shrinkTowards = Alignment.Top),
                     ) {
                         Row(
-                            horizontalArrangement = Arrangement.spacedBy(9.dp),
+                            horizontalArrangement = Arrangement.spacedBy(12.dp),
                         ) {
                             OutlinedButton(
                                 onClick = onPlayLastEpisode,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvFolderCard.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvFolderCard.kt
@@ -87,7 +87,7 @@ fun TvFolderCard(
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
-                    .padding(horizontal = 16.dp, vertical = cardWidth * TITLE_VERTICAL_PADDING_RATIO)
+                    .padding(horizontal = 12.dp, vertical = cardWidth * TITLE_VERTICAL_PADDING_RATIO)
                     .fillMaxWidth(),
             )
         }
@@ -103,7 +103,7 @@ private const val TITLE_VERTICAL_PADDING_RATIO = 0.064f
 @Composable
 private fun TvFolderCardPreview() {
     TvTheme {
-        Box(modifier = Modifier.background(MaterialTheme.tvColors.backgroundSunken).padding(32.dp)) {
+        Box(modifier = Modifier.background(MaterialTheme.tvColors.backgroundSunken).padding(24.dp)) {
             TvFolderCard(
                 folder = Folder(
                     uuid = "folder",
@@ -117,7 +117,7 @@ private fun TvFolderCardPreview() {
                 ),
                 coverUrls = listOf("", ""),
                 onClick = {},
-                modifier = Modifier.size(160.dp),
+                modifier = Modifier.size(120.dp),
             )
         }
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvModal.kt
@@ -73,7 +73,7 @@ internal fun TvModalSurface(
     }
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
         content = content,
         modifier = modifier
             .width(width)
@@ -88,7 +88,7 @@ internal fun TvModalSurface(
 @Composable
 private fun TvModalWindowEffects(isBlurBehindEnabled: Boolean) {
     val window = (LocalView.current.parent as? DialogWindowProvider)?.window ?: return
-    val blurRadius = with(LocalDensity.current) { 60.dp.roundToPx() }
+    val blurRadius = with(LocalDensity.current) { 45.dp.roundToPx() }
     LaunchedEffect(window, isBlurBehindEnabled, blurRadius) {
         window.setDimAmount(0.55f)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
@@ -119,9 +119,9 @@ private fun rememberIsBlurBehindEnabled(): State<Boolean> {
     return isBlurBehindEnabled
 }
 
-private val DefaultModalWidth = 400.dp
-private val DefaultContentPadding = PaddingValues(horizontal = 53.dp, vertical = 40.dp)
-private val ModalShape = RoundedCornerShape(28.dp)
+private val DefaultModalWidth = 300.dp
+private val DefaultContentPadding = PaddingValues(horizontal = 40.dp, vertical = 30.dp)
+private val ModalShape = RoundedCornerShape(21.dp)
 private val HighlightBrush = Brush.verticalGradient(
     colors = listOf(
         Color.White.copy(alpha = 0.08f),

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvMoreButton.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvMoreButton.kt
@@ -20,8 +20,8 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 fun TvMoreButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    buttonSize: Dp = 48.dp,
-    iconSize: Dp = 20.dp,
+    buttonSize: Dp = 36.dp,
+    iconSize: Dp = 15.dp,
     colors: ButtonColors = TvButtonDefaults.iconButtonColors(),
 ) {
     IconButton(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPlaylistCard.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPlaylistCard.kt
@@ -106,11 +106,11 @@ fun TvPlaylistCard(
             Column(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(horizontal = 24.dp, vertical = 16.dp),
+                    .padding(horizontal = 18.dp, vertical = 12.dp),
             ) {
                 Text(
                     text = title,
-                    style = MaterialTheme.tvTypography.callout,
+                    style = MaterialTheme.tvTypography.headline,
                     color = titleColor,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastGridScaffold.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastGridScaffold.kt
@@ -34,7 +34,7 @@ internal fun TvPodcastGridScaffold(
     itemKeys: List<Any>,
     modifier: Modifier = Modifier,
     title: String? = null,
-    horizontalContentPadding: Dp = 32.dp,
+    horizontalContentPadding: Dp = 42.dp,
     autoFocusFirstItem: Boolean = false,
     restoreFocusTrigger: Int = 0,
     itemContent: @Composable (index: Int, itemModifier: Modifier) -> Unit,
@@ -43,9 +43,9 @@ internal fun TvPodcastGridScaffold(
         if (title != null) {
             Text(
                 text = title,
-                style = MaterialTheme.tvTypography.title3,
+                style = MaterialTheme.tvTypography.title2,
                 color = MaterialTheme.tvColors.textPrimary,
-                modifier = Modifier.padding(start = horizontalContentPadding, top = 8.dp, bottom = 10.dp),
+                modifier = Modifier.padding(start = horizontalContentPadding, top = 40.dp, bottom = 0.dp),
             )
         }
         val gridState = rememberLazyGridState()
@@ -74,9 +74,9 @@ internal fun TvPodcastGridScaffold(
         LazyVerticalGrid(
             state = gridState,
             columns = GridCells.Fixed(GRID_COLUMNS),
-            horizontalArrangement = Arrangement.spacedBy(16.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp),
-            contentPadding = PaddingValues(start = horizontalContentPadding, top = 16.dp, end = horizontalContentPadding, bottom = 32.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            contentPadding = PaddingValues(start = horizontalContentPadding, top = 20.dp, end = horizontalContentPadding, bottom = 32.dp),
             modifier = Modifier
                 .focusRequester(gridFocusRequester)
                 .focusGroup()

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastInfoModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastInfoModal.kt
@@ -58,7 +58,7 @@ fun TvPodcastInfoModal(
         modifier = modifier,
     ) {
         Row(
-            horizontalArrangement = Arrangement.spacedBy(38.dp),
+            horizontalArrangement = Arrangement.spacedBy(28.5.dp),
             modifier = Modifier
                 .fillMaxWidth()
                 .height(InfoModalHeight),
@@ -83,16 +83,16 @@ private fun PodcastInfoPane(
     val context = LocalContext.current
     val dateFormatter = remember(context) { RelativeDateFormatter(context) }
     Column(
-        verticalArrangement = Arrangement.spacedBy(24.dp),
+        verticalArrangement = Arrangement.spacedBy(18.dp),
         modifier = modifier,
     ) {
         TvArtworkImage(
             model = PodcastImage.getMediumArtworkUrl(podcast.uuid),
             modifier = Modifier
                 .size(InfoArtworkSize)
-                .clip(RoundedCornerShape(8.dp)),
+                .clip(RoundedCornerShape(6.dp)),
         )
-        Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
             InfoRow(
                 label = stringResource(LR.string.tv_podcast_info_network),
                 value = podcast.author.takeIf { it.isNotBlank() },
@@ -121,7 +121,7 @@ private fun InfoRow(
     if (value == null) {
         return
     }
-    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+    Column(verticalArrangement = Arrangement.spacedBy(1.5.dp)) {
         Text(
             text = label,
             style = MaterialTheme.tvTypography.caption2,
@@ -146,12 +146,12 @@ private fun PodcastDescriptionPane(
     val scrollState = rememberScrollState()
     val scope = rememberCoroutineScope()
     val focusRequester = remember { FocusRequester() }
-    val scrollStep = with(LocalDensity.current) { 120.dp.toPx() }
+    val scrollStep = with(LocalDensity.current) { 90.dp.toPx() }
     LaunchedEffect(Unit) {
         focusRequester.requestFocus()
     }
     Column(
-        verticalArrangement = Arrangement.spacedBy(12.dp),
+        verticalArrangement = Arrangement.spacedBy(9.dp),
         modifier = modifier
             .focusRequester(focusRequester)
             .onKeyEvent { event ->
@@ -218,10 +218,10 @@ private fun Podcast.displayableNextEpisode(context: Context, dateFormatter: Rela
     }
 }
 
-private val InfoModalWidth = 688.dp
-private val InfoModalHeight = 336.dp
-private val InfoPaneWidth = 176.dp
-private val InfoArtworkSize = 96.dp
+private val InfoModalWidth = 516.dp
+private val InfoModalHeight = 252.dp
+private val InfoPaneWidth = 132.dp
+private val InfoArtworkSize = 72.dp
 
 @Preview
 @Composable
@@ -229,7 +229,7 @@ private fun TvPodcastInfoModalPreview() {
     TvTheme {
         TvModalSurface(width = InfoModalWidth) {
             Row(
-                horizontalArrangement = Arrangement.spacedBy(38.dp),
+                horizontalArrangement = Arrangement.spacedBy(28.5.dp),
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(InfoModalHeight),

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastTile.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastTile.kt
@@ -42,14 +42,14 @@ fun TvPodcastTile(
                     contentDescription = podcastTitle,
                     contentScale = ContentScale.Crop,
                     modifier = imageModifier
-                        .padding(horizontal = 18.dp, vertical = 9.dp)
+                        .padding(horizontal = 13.5.dp, vertical = 7.dp)
                         .aspectRatio(1f),
                 )
                 Text(
                     text = stringResource(LR.string.sponsored),
                     style = MaterialTheme.tvTypography.caption2,
                     color = MaterialTheme.tvColors.textSecondary,
-                    modifier = Modifier.padding(bottom = 9.dp),
+                    modifier = Modifier.padding(bottom = 7.dp),
                 )
             }
         } else {
@@ -64,7 +64,7 @@ fun TvPodcastTile(
 }
 
 object TvPodcastTileDefaults {
-    val RowImageWidth = 123.dp
+    val RowImageWidth = 92.dp
 }
 
 @Preview(device = Devices.TV_1080p)

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastTile.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastTile.kt
@@ -64,7 +64,7 @@ fun TvPodcastTile(
 }
 
 object TvPodcastTileDefaults {
-    val RowImageWidth = 92.dp
+    val RowImageWidth = 136.dp
 }
 
 @Preview(device = Devices.TV_1080p)

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvRow.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvRow.kt
@@ -67,8 +67,8 @@ fun <T> TvRow(
     title: String,
     items: List<T>,
     modifier: Modifier = Modifier,
-    contentPadding: PaddingValues = PaddingValues(horizontal = 32.dp),
-    itemSpacing: Dp = 16.dp,
+    contentPadding: PaddingValues = PaddingValues(horizontal = 42.dp),
+    itemSpacing: Dp = 12.dp,
     key: ((T) -> Any)? = null,
     focusRequester: FocusRequester? = null,
     content: @Composable (T) -> Unit,
@@ -89,7 +89,7 @@ fun <T> TvRow(
             fontSize = titleSize.sp,
             modifier = Modifier
                 .padding(contentPadding)
-                .padding(bottom = 17.dp),
+                .padding(bottom = 13.dp),
         )
 
         var lastFocusedIndex by rememberSaveable(items) { mutableIntStateOf(0) }
@@ -139,8 +139,8 @@ private fun TvRowPreview() {
                 TvTile(onClick = {}) {
                     Box(
                         modifier = Modifier
-                            .size(160.dp, 100.dp)
-                            .padding(12.dp),
+                            .size(120.dp, 75.dp)
+                            .padding(9.dp),
                         contentAlignment = Alignment.BottomStart,
                     ) {
                         Text(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvRow.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvRow.kt
@@ -98,6 +98,7 @@ fun <T> TvRow(
         LazyRow(
             contentPadding = contentPadding,
             horizontalArrangement = Arrangement.spacedBy(itemSpacing),
+            verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier
                 .then(if (focusRequester != null) Modifier.focusRequester(focusRequester) else Modifier)
                 .focusGroup()

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvRow.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvRow.kt
@@ -40,8 +40,8 @@ import au.com.shiftyjelly.pocketcasts.theme.GoogleSansFontFamily
 import au.com.shiftyjelly.pocketcasts.theme.TvTheme
 import au.com.shiftyjelly.pocketcasts.theme.tvColors
 
-private const val TITLE_UNFOCUSED_SIZE = 17f
-private const val TITLE_FOCUSED_SIZE = 21f
+private const val TITLE_UNFOCUSED_SIZE = 19f
+private const val TITLE_FOCUSED_SIZE = 23f
 
 @Composable
 fun TvSectionTitle(
@@ -89,7 +89,7 @@ fun <T> TvRow(
             fontSize = titleSize.sp,
             modifier = Modifier
                 .padding(contentPadding)
-                .padding(bottom = 13.dp),
+                .padding(bottom = 16.dp),
         )
 
         var lastFocusedIndex by rememberSaveable(items) { mutableIntStateOf(0) }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvSinglePodcastTile.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvSinglePodcastTile.kt
@@ -52,7 +52,7 @@ fun TvSinglePodcastTile(
     TvTile(
         onClick = onClick,
         scale = CardDefaults.scale(focusedScale = 1.05f),
-        shape = CardDefaults.shape(shape = RoundedCornerShape(12.dp)),
+        shape = CardDefaults.shape(shape = RoundedCornerShape(9.dp)),
         colors = CardDefaults.colors(
             containerColor = MaterialTheme.tvColors.backgroundSunken,
             focusedContainerColor = MaterialTheme.tvColors.backgroundActive,
@@ -61,9 +61,9 @@ fun TvSinglePodcastTile(
     ) {
         Row(
             modifier = Modifier
-                .width(642.dp)
-                .height(200.dp)
-                .padding(24.dp),
+                .width(481.5.dp)
+                .height(150.dp)
+                .padding(18.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             AsyncImage(
@@ -71,17 +71,17 @@ fun TvSinglePodcastTile(
                 contentDescription = title,
                 contentScale = ContentScale.Crop,
                 modifier = Modifier
-                    .size(152.dp)
-                    .clip(RoundedCornerShape(4.dp)),
+                    .size(114.dp)
+                    .clip(RoundedCornerShape(3.dp)),
             )
 
             Column(
                 modifier = Modifier
                     .weight(1f)
-                    .padding(start = 24.dp),
+                    .padding(start = 18.dp),
             ) {
                 if (isSponsored || author.isNotBlank()) {
-                    Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                    Row(horizontalArrangement = Arrangement.spacedBy(3.dp)) {
                         if (isSponsored) {
                             Text(
                                 text = stringResource(LR.string.sponsored),
@@ -107,7 +107,7 @@ fun TvSinglePodcastTile(
                         }
                     }
 
-                    Spacer(modifier = Modifier.height(12.dp))
+                    Spacer(modifier = Modifier.height(9.dp))
                 }
 
                 Text(
@@ -119,7 +119,7 @@ fun TvSinglePodcastTile(
                 )
 
                 if (description.isNotBlank()) {
-                    Spacer(modifier = Modifier.height(8.dp))
+                    Spacer(modifier = Modifier.height(6.dp))
                     Text(
                         text = description,
                         style = MaterialTheme.tvTypography.body,
@@ -137,7 +137,7 @@ fun TvSinglePodcastTile(
 @Composable
 private fun TvSinglePodcastTilePreview() {
     TvTheme {
-        Box(modifier = Modifier.background(MaterialTheme.tvColors.backgroundSunken).padding(24.dp)) {
+        Box(modifier = Modifier.background(MaterialTheme.tvColors.backgroundSunken).padding(18.dp)) {
             TvSinglePodcastTile(
                 artworkUrl = "",
                 title = "The Writer's Voice",
@@ -154,7 +154,7 @@ private fun TvSinglePodcastTilePreview() {
 @Composable
 private fun TvSinglePodcastTileRecommendedPreview() {
     TvTheme {
-        Box(modifier = Modifier.background(MaterialTheme.tvColors.backgroundSunken).padding(24.dp)) {
+        Box(modifier = Modifier.background(MaterialTheme.tvColors.backgroundSunken).padding(18.dp)) {
             TvSinglePodcastTile(
                 artworkUrl = "",
                 title = "The Writer's Voice",

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvSinglePodcastTile.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvSinglePodcastTile.kt
@@ -51,7 +51,7 @@ fun TvSinglePodcastTile(
 
     TvTile(
         onClick = onClick,
-        scale = CardDefaults.scale(focusedScale = 1.05f),
+        scale = CardDefaults.scale(focusedScale = 1.02f),
         shape = CardDefaults.shape(shape = RoundedCornerShape(9.dp)),
         colors = CardDefaults.colors(
             containerColor = MaterialTheme.tvColors.backgroundSunken,
@@ -61,8 +61,8 @@ fun TvSinglePodcastTile(
     ) {
         Row(
             modifier = Modifier
-                .width(481.5.dp)
-                .height(150.dp)
+                .width(876.dp)
+                .height(184.dp)
                 .padding(18.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvTile.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvTile.kt
@@ -67,9 +67,9 @@ private fun TvTilePreview() {
         TvTile(onClick = {}) {
             Box(
                 modifier = Modifier
-                    .size(160.dp, 100.dp)
+                    .size(120.dp, 75.dp)
                     .background(MaterialTheme.tvColors.backgroundBase)
-                    .padding(12.dp),
+                    .padding(9.dp),
                 contentAlignment = Alignment.BottomStart,
             ) {
                 Text(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvToast.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvToast.kt
@@ -7,7 +7,6 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -98,21 +97,20 @@ private fun TvToastContent(
     Text(
         text = message,
         color = MaterialTheme.tvColors.textPrimary,
-        style = MaterialTheme.tvTypography.body.copy(textAlign = TextAlign.Center),
+        style = MaterialTheme.tvTypography.caption1.copy(textAlign = TextAlign.Center),
         modifier = modifier
             .semantics { liveRegion = LiveRegionMode.Polite }
             .widthIn(max = ToastMaxWidth)
             .clip(ToastShape)
-            .background(MaterialTheme.tvColors.overlayContainer)
-            .border(1.dp, MaterialTheme.tvColors.overlayBorder, ToastShape)
-            .padding(horizontal = 22.5.dp, vertical = 15.dp),
+            .background(MaterialTheme.tvColors.backgroundOverlay)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
     )
 }
 
 private val ToastDurationMillis = 3000L
 private val ToastAnimationMillis = 300
 private val ToastMaxWidth = 450.dp
-private val ToastShape = RoundedCornerShape(12.dp)
+private val ToastShape = RoundedCornerShape(5.dp)
 
 @Preview(device = Devices.TV_1080p)
 @Composable

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvToast.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvToast.kt
@@ -105,14 +105,14 @@ private fun TvToastContent(
             .clip(ToastShape)
             .background(MaterialTheme.tvColors.overlayContainer)
             .border(1.dp, MaterialTheme.tvColors.overlayBorder, ToastShape)
-            .padding(horizontal = 30.dp, vertical = 20.dp),
+            .padding(horizontal = 22.5.dp, vertical = 15.dp),
     )
 }
 
 private val ToastDurationMillis = 3000L
 private val ToastAnimationMillis = 300
-private val ToastMaxWidth = 600.dp
-private val ToastShape = RoundedCornerShape(16.dp)
+private val ToastMaxWidth = 450.dp
+private val ToastShape = RoundedCornerShape(12.dp)
 
 @Preview(device = Devices.TV_1080p)
 @Composable

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvVideoTile.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvVideoTile.kt
@@ -61,7 +61,7 @@ fun TvVideoTile(
     ) {
         Box(
             modifier = Modifier
-                .width(323.dp)
+                .width(242.dp)
                 .aspectRatio(16f / 9f),
         ) {
             AsyncImage(
@@ -102,11 +102,11 @@ fun TvVideoTile(
                             colors = listOf(Color.Transparent, Color.Black.copy(alpha = 0.9f)),
                         ),
                     )
-                    .padding(14.dp),
+                    .padding(10.5.dp),
                 contentAlignment = Alignment.BottomStart,
             ) {
                 Row(
-                    horizontalArrangement = Arrangement.spacedBy(10.dp),
+                    horizontalArrangement = Arrangement.spacedBy(7.5.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     AsyncImage(
@@ -114,8 +114,8 @@ fun TvVideoTile(
                         contentDescription = null,
                         contentScale = ContentScale.Crop,
                         modifier = Modifier
-                            .size(36.dp)
-                            .clip(RoundedCornerShape(4.dp)),
+                            .size(27.dp)
+                            .clip(RoundedCornerShape(3.dp)),
                     )
                     Column {
                         Text(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvVideoTile.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvVideoTile.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.tv.material3.CardDefaults
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.theme.TvTheme
@@ -57,6 +58,7 @@ fun TvVideoTile(
     TvTile(
         onClick = onPlayEpisode,
         onLongClick = onGoToPodcast,
+        scale = CardDefaults.scale(focusedScale = 1.05f),
         modifier = modifier.onFocusChanged { isFocused = it.hasFocus },
     ) {
         Box(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvVideoTile.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvVideoTile.kt
@@ -61,7 +61,7 @@ fun TvVideoTile(
     ) {
         Box(
             modifier = Modifier
-                .width(242.dp)
+                .width(358.dp)
                 .aspectRatio(16f / 9f),
         ) {
             AsyncImage(
@@ -102,11 +102,11 @@ fun TvVideoTile(
                             colors = listOf(Color.Transparent, Color.Black.copy(alpha = 0.9f)),
                         ),
                     )
-                    .padding(10.5.dp),
+                    .padding(16.dp),
                 contentAlignment = Alignment.BottomStart,
             ) {
                 Row(
-                    horizontalArrangement = Arrangement.spacedBy(7.5.dp),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     AsyncImage(
@@ -114,7 +114,7 @@ fun TvVideoTile(
                         contentDescription = null,
                         contentScale = ContentScale.Crop,
                         modifier = Modifier
-                            .size(27.dp)
+                            .size(36.dp)
                             .clip(RoundedCornerShape(3.dp)),
                     )
                     Column {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/discover/TvDiscoverModels.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/discover/TvDiscoverModels.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.discover
 
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImage
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
 
@@ -49,12 +50,18 @@ sealed interface TvDiscoverRow {
         val episodes: List<TvDiscoverEpisode>,
         val listId: String? = null,
         val listDatetime: String? = null,
+        val progressCardStyle: TvProgressCardStyle? = null,
     ) : TvDiscoverRow
 
     data class Failed(
         override val id: String,
         override val title: String,
     ) : TvDiscoverRow
+}
+
+enum class TvProgressCardStyle {
+    Resume,
+    Queue,
 }
 
 enum class TvDiscoverBanner(val id: String) {
@@ -88,6 +95,7 @@ data class TvDiscoverEpisode(
     val podcastUuid: String,
     val podcastTitle: String,
     val videoPreviewUrl: String? = null,
+    val episode: PodcastEpisode? = null,
 ) {
     val thumbnailUrl: String = PodcastImage.getArtworkUrl(size = 960, uuid = podcastUuid, isWearOS = false)
     val podcastArtworkUrl: String = PodcastImage.getArtworkUrl(size = 200, uuid = podcastUuid, isWearOS = false)

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/discover/TvDiscoverRows.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/discover/TvDiscoverRows.kt
@@ -39,7 +39,7 @@ fun LazyListScope.tvDiscoverRow(
     onPlayLatestEpisode: (TvDiscoverRow, TvDiscoverPodcast) -> Unit,
     modifier: Modifier = Modifier,
     focusRequester: FocusRequester? = null,
-    contentPadding: PaddingValues = PaddingValues(horizontal = 32.dp),
+    contentPadding: PaddingValues = PaddingValues(horizontal = 42.dp),
     onTapBanner: (TvDiscoverBanner) -> Unit = {},
     onListImpression: (TvDiscoverRow) -> Unit = {},
     onRetryRow: (TvDiscoverRow) -> Unit = {},
@@ -52,7 +52,7 @@ fun LazyListScope.tvDiscoverRow(
             TvRow(
                 title = row.title,
                 items = row.podcasts,
-                itemSpacing = 32.dp,
+                itemSpacing = 24.dp,
                 contentPadding = contentPadding,
                 key = TvDiscoverPodcast::uuid,
                 focusRequester = focusRequester,
@@ -74,7 +74,7 @@ fun LazyListScope.tvDiscoverRow(
             TvRow(
                 title = row.title,
                 items = row.podcasts,
-                itemSpacing = 32.dp,
+                itemSpacing = 24.dp,
                 contentPadding = contentPadding,
                 key = TvDiscoverPodcast::uuid,
                 focusRequester = focusRequester,
@@ -96,7 +96,7 @@ fun LazyListScope.tvDiscoverRow(
             TvRow(
                 title = row.title,
                 items = row.episodes,
-                itemSpacing = 32.dp,
+                itemSpacing = 24.dp,
                 contentPadding = contentPadding,
                 key = TvDiscoverEpisode::episodeUuid,
                 focusRequester = focusRequester,
@@ -180,7 +180,7 @@ private fun TvDiscoverFailedRow(
     onRetry: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Column(verticalArrangement = Arrangement.spacedBy(12.dp), modifier = modifier) {
+    Column(verticalArrangement = Arrangement.spacedBy(9.dp), modifier = modifier) {
         if (title.isNotBlank()) {
             Text(
                 text = title,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/discover/TvDiscoverRows.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/discover/TvDiscoverRows.kt
@@ -8,9 +8,11 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.Button
@@ -18,12 +20,15 @@ import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.component.TvBannerRow
 import au.com.shiftyjelly.pocketcasts.component.TvCategoryTile
+import au.com.shiftyjelly.pocketcasts.component.TvEpisodeRow
 import au.com.shiftyjelly.pocketcasts.component.TvFeaturedTile
 import au.com.shiftyjelly.pocketcasts.component.TvPodcastTile
 import au.com.shiftyjelly.pocketcasts.component.TvPodcastTileDefaults
+import au.com.shiftyjelly.pocketcasts.component.TvResumeCard
 import au.com.shiftyjelly.pocketcasts.component.TvRow
 import au.com.shiftyjelly.pocketcasts.component.TvSinglePodcastTile
 import au.com.shiftyjelly.pocketcasts.component.TvVideoTile
+import au.com.shiftyjelly.pocketcasts.localization.helper.RelativeDateFormatter
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
 import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
 import au.com.shiftyjelly.pocketcasts.theme.tvColors
@@ -102,16 +107,36 @@ fun LazyListScope.tvDiscoverRow(
                 focusRequester = focusRequester,
                 modifier = modifier,
             ) { episode ->
-                TvVideoTile(
-                    thumbnailUrl = episode.thumbnailUrl,
-                    podcastArtworkUrl = episode.podcastArtworkUrl,
-                    podcastTitle = episode.podcastTitle,
-                    episodeTitle = episode.episodeTitle,
-                    onPlayEpisode = { onEpisodePlay(row, episode) },
-                    onGoToPodcast = { onEpisodePodcastClick(row, episode) },
-                    videoPreviewUrl = episode.videoPreviewUrl,
-                    isPodcastPlaying = isPodcastPlaying,
-                )
+                val podcastEpisode = episode.episode
+                if (row.progressCardStyle != null && podcastEpisode != null) {
+                    val context = LocalContext.current
+                    val dateFormatter = remember(context) { RelativeDateFormatter(context) }
+                    when (row.progressCardStyle) {
+                        TvProgressCardStyle.Resume -> TvResumeCard(
+                            episode = podcastEpisode,
+                            onClick = { onEpisodePlay(row, episode) },
+                            dateFormatter = dateFormatter,
+                        )
+
+                        TvProgressCardStyle.Queue -> TvEpisodeRow(
+                            episode = podcastEpisode,
+                            onClick = { onEpisodePlay(row, episode) },
+                            dateFormatter = dateFormatter,
+                            modifier = Modifier.width(431.dp),
+                        )
+                    }
+                } else {
+                    TvVideoTile(
+                        thumbnailUrl = episode.thumbnailUrl,
+                        podcastArtworkUrl = episode.podcastArtworkUrl,
+                        podcastTitle = episode.podcastTitle,
+                        episodeTitle = episode.episodeTitle,
+                        onPlayEpisode = { onEpisodePlay(row, episode) },
+                        onGoToPodcast = { onEpisodePodcastClick(row, episode) },
+                        videoPreviewUrl = episode.videoPreviewUrl,
+                        isPodcastPlaying = isPodcastPlaying,
+                    )
+                }
             }
         }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/discover/TvDiscoverRows.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/discover/TvDiscoverRows.kt
@@ -52,7 +52,7 @@ fun LazyListScope.tvDiscoverRow(
             TvRow(
                 title = row.title,
                 items = row.podcasts,
-                itemSpacing = 24.dp,
+                itemSpacing = 12.dp,
                 contentPadding = contentPadding,
                 key = TvDiscoverPodcast::uuid,
                 focusRequester = focusRequester,
@@ -74,7 +74,7 @@ fun LazyListScope.tvDiscoverRow(
             TvRow(
                 title = row.title,
                 items = row.podcasts,
-                itemSpacing = 24.dp,
+                itemSpacing = 12.dp,
                 contentPadding = contentPadding,
                 key = TvDiscoverPodcast::uuid,
                 focusRequester = focusRequester,
@@ -96,7 +96,7 @@ fun LazyListScope.tvDiscoverRow(
             TvRow(
                 title = row.title,
                 items = row.episodes,
-                itemSpacing = 24.dp,
+                itemSpacing = 12.dp,
                 contentPadding = contentPadding,
                 key = TvDiscoverEpisode::episodeUuid,
                 focusRequester = focusRequester,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/history/TvListeningHistoryScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/history/TvListeningHistoryScreen.kt
@@ -115,18 +115,18 @@ private fun HistoryList(
         modifier = modifier
             .fillMaxHeight()
             .fillMaxWidth(ROW_WIDTH_FRACTION)
-            .padding(start = 32.dp, top = 8.dp),
+            .padding(start = 42.dp, top = 6.dp),
     ) {
         Text(
             text = stringResource(LR.string.profile_navigation_listening_history),
             style = MaterialTheme.tvTypography.title3,
             color = MaterialTheme.tvColors.textPrimary,
         )
-        Spacer(Modifier.height(26.dp))
+        Spacer(Modifier.height(19.5.dp))
         LazyColumn(
             state = listState,
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-            contentPadding = PaddingValues(bottom = 32.dp),
+            verticalArrangement = Arrangement.spacedBy(9.dp),
+            contentPadding = PaddingValues(bottom = 24.dp),
             modifier = Modifier.weight(1f),
         ) {
             itemsIndexed(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeScreen.kt
@@ -249,7 +249,7 @@ private fun TvHomeRows(
 
     LazyColumn(
         modifier = modifier.fillMaxSize(),
-        verticalArrangement = Arrangement.spacedBy(18.dp),
+        verticalArrangement = Arrangement.spacedBy(40.dp),
     ) {
         item { Spacer(modifier = Modifier.height(6.dp)) }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeScreen.kt
@@ -210,7 +210,7 @@ private fun TvHomeError(
                 color = MaterialTheme.tvColors.textPrimary,
                 style = MaterialTheme.tvTypography.caption1,
             )
-            Spacer(modifier = Modifier.height(24.dp))
+            Spacer(modifier = Modifier.height(18.dp))
             OutlinedButton(onClick = onRetry) {
                 Text(stringResource(LR.string.retry))
             }
@@ -249,9 +249,9 @@ private fun TvHomeRows(
 
     LazyColumn(
         modifier = modifier.fillMaxSize(),
-        verticalArrangement = Arrangement.spacedBy(24.dp),
+        verticalArrangement = Arrangement.spacedBy(18.dp),
     ) {
-        item { Spacer(modifier = Modifier.height(8.dp)) }
+        item { Spacer(modifier = Modifier.height(6.dp)) }
 
         rows.forEachIndexed { rowIndex, row ->
             val rowModifier = Modifier.onFocusChanged { focusState ->
@@ -277,7 +277,7 @@ private fun TvHomeRows(
             )
         }
 
-        item { Spacer(modifier = Modifier.height(8.dp)) }
+        item { Spacer(modifier = Modifier.height(6.dp)) }
     }
 }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModel.kt
@@ -13,6 +13,7 @@ import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverPodcast
 import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverPodcastAttribution
 import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverRow
 import au.com.shiftyjelly.pocketcasts.discover.TvOpenedCategory
+import au.com.shiftyjelly.pocketcasts.discover.TvProgressCardStyle
 import au.com.shiftyjelly.pocketcasts.models.db.dao.PodcastDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.UpNextDao
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
@@ -189,6 +190,7 @@ class TvHomeViewModel @Inject constructor(
                             id = KEEP_LISTENING_ROW_ID,
                             title = context.getString(LR.string.tv_home_keep_listening),
                             episodes = listOf(current.toTvDiscoverEpisode(podcastTitles)),
+                            progressCardStyle = TvProgressCardStyle.Resume,
                         ),
                     )
                 }
@@ -201,6 +203,7 @@ class TvHomeViewModel @Inject constructor(
                             id = UP_NEXT_ROW_ID,
                             title = context.getString(LR.string.up_next),
                             episodes = queue.map { it.toTvDiscoverEpisode(podcastTitles) },
+                            progressCardStyle = TvProgressCardStyle.Queue,
                         ),
                     )
                 }
@@ -322,6 +325,7 @@ class TvHomeViewModel @Inject constructor(
         episodeTitle = title,
         podcastUuid = podcastUuid,
         podcastTitle = podcastTitles[podcastUuid].orEmpty(),
+        episode = this,
     )
 
     private fun PodcastEpisode.toTvDiscoverEpisode(podcast: TvDiscoverPodcast) = TvDiscoverEpisode(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvProfileModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvProfileModal.kt
@@ -109,7 +109,7 @@ private fun ColumnScope.TvProfileModalContent(
                     text = profile.email,
                     color = MaterialTheme.tvColors.textPrimary,
                     style = MaterialTheme.tvTypography.callout.copy(textAlign = TextAlign.Center),
-                    modifier = Modifier.padding(bottom = 16.dp),
+                    modifier = Modifier.padding(bottom = 12.dp),
                 )
             }
             TvModalButton(
@@ -157,7 +157,7 @@ private fun ColumnScope.TvProfileModalContent(
         ),
         color = MaterialTheme.tvColors.textSecondary,
         style = MaterialTheme.tvTypography.caption1,
-        modifier = Modifier.padding(top = 8.dp),
+        modifier = Modifier.padding(top = 6.dp),
     )
 }
 
@@ -189,12 +189,12 @@ private fun TvProfileModalAvatarPlaceholder(modifier: Modifier = Modifier) {
             painter = painterResource(IR.drawable.ic_profile),
             contentDescription = null,
             tint = MaterialTheme.tvColors.textPrimary,
-            modifier = Modifier.size(36.dp),
+            modifier = Modifier.size(27.dp),
         )
     }
 }
 
-private val AvatarSize = 80.dp
+private val AvatarSize = 60.dp
 
 @Preview
 @Composable

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvTabBar.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvTabBar.kt
@@ -105,8 +105,8 @@ fun TvTabBar(
                     onFocus = { onTabSelect(index) },
                     onClick = { onTabClick(index) },
                     modifier = Modifier
-                        .height(44.dp)
-                        .padding(horizontal = 21.dp)
+                        .height(33.dp)
+                        .padding(horizontal = 19.dp)
                         .then(if (index == selectedTabIndex) Modifier.focusRequester(focusRequester) else Modifier),
                     colors = TabDefaults.pillIndicatorTabColors(
                         contentColor = MaterialTheme.tvColors.textPrimary,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvTabPlaceholder.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvTabPlaceholder.kt
@@ -32,15 +32,15 @@ fun TvTabPlaceholder(
 ) {
     LazyColumn(
         modifier = modifier.fillMaxSize(),
-        verticalArrangement = Arrangement.spacedBy(24.dp),
+        verticalArrangement = Arrangement.spacedBy(18.dp),
     ) {
-        item { Spacer(modifier = Modifier.height(8.dp)) }
+        item { Spacer(modifier = Modifier.height(6.dp)) }
 
         item {
             TvRow(
                 title = stringResource(LR.string.tv_row_featured),
                 items = (1..3).toList(),
-                itemSpacing = 32.dp,
+                itemSpacing = 24.dp,
             ) { index ->
                 TvFeaturedTile(
                     artworkUrl = "https://picsum.photos/seed/featured$index/500/500",
@@ -58,7 +58,7 @@ fun TvTabPlaceholder(
             TvRow(
                 title = stringResource(LR.string.tv_row_trending_videos),
                 items = (1..6).toList(),
-                itemSpacing = 32.dp,
+                itemSpacing = 24.dp,
             ) { index ->
                 TvVideoTile(
                     thumbnailUrl = "https://picsum.photos/seed/video$index/716/403",
@@ -99,7 +99,7 @@ fun TvTabPlaceholder(
             }
         }
 
-        item { Spacer(modifier = Modifier.height(8.dp)) }
+        item { Spacer(modifier = Modifier.height(6.dp)) }
     }
 }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvTopBar.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvTopBar.kt
@@ -52,7 +52,7 @@ fun TvTopBar(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 32.dp, vertical = 16.dp),
+            .padding(start = 42.dp, end = 42.dp, top = 24.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         TvProfileButton(
@@ -74,7 +74,7 @@ fun TvTopBar(
         Image(
             painter = painterResource(IR.drawable.ic_pocket_casts_logo),
             contentDescription = stringResource(LR.string.app_name),
-            modifier = Modifier.size(40.dp),
+            modifier = Modifier.size(30.dp),
         )
     }
 }
@@ -92,7 +92,7 @@ private fun TvProfileButton(
         border = IconButtonDefaults.border(
             focusedBorder = Border(BorderStroke(2.dp, Color.White), inset = 2.dp, shape = CircleShape),
         ),
-        modifier = modifier.size(40.dp),
+        modifier = modifier.size(30.dp),
     ) {
         val email = (profile as? TvProfileState.SignedIn)?.email
         if (email != null) {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
@@ -438,7 +438,7 @@ private fun EpisodeTitles(
         }
         Text(
             text = episode.title,
-            style = MaterialTheme.tvTypography.headline,
+            style = MaterialTheme.tvTypography.title2,
             color = MaterialTheme.tvColors.textPrimary,
             textAlign = TextAlign.Start,
             maxLines = 1,
@@ -514,7 +514,7 @@ private fun InfoButton(
     }
 }
 
-private val ArtworkSize = 180.dp
+private val ArtworkSize = 210.dp
 private val ArtworkTopLift = 18.dp
 private val BlurredArtworkScale = 1.25f
 private val BlurredArtworkOffset = -ArtworkSize * 0.2f

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
@@ -295,7 +295,7 @@ private fun TvNowPlayingContent(
                 .graphicsLayer { alpha = chromeAlpha }
                 .background(ChromeScrimBrush)
                 .padding(horizontal = ChromeHorizontalInset)
-                .padding(top = ChromeScrimTopInset, bottom = 24.dp),
+                .padding(top = ChromeScrimTopInset, bottom = 18.dp),
         ) {
             Row(
                 verticalAlignment = Alignment.CenterVertically,
@@ -306,7 +306,7 @@ private fun TvNowPlayingContent(
                     podcastTitle = state.podcastTitle,
                     modifier = Modifier.weight(1f),
                 )
-                Spacer(modifier = Modifier.width(24.dp))
+                Spacer(modifier = Modifier.width(18.dp))
                 ControlBar(
                     playbackSpeed = state.playbackSpeed,
                     trimMode = state.trimMode,
@@ -330,7 +330,7 @@ private fun TvNowPlayingContent(
                     },
                 )
             }
-            Spacer(modifier = Modifier.height(12.dp))
+            Spacer(modifier = Modifier.height(9.dp))
             state.errorMessage?.let { errorMessage ->
                 Text(
                     text = errorMessage,
@@ -339,7 +339,7 @@ private fun TvNowPlayingContent(
                     textAlign = TextAlign.Start,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(bottom = 16.dp),
+                        .padding(bottom = 12.dp),
                 )
             }
             TvSeekBar(
@@ -411,7 +411,7 @@ private fun EpisodeArtwork(
             model = episode.artworkModel(),
             modifier = Modifier
                 .size(ArtworkSize)
-                .clip(RoundedCornerShape(8.dp)),
+                .clip(RoundedCornerShape(6.dp)),
         )
     }
 }
@@ -514,17 +514,17 @@ private fun InfoButton(
     }
 }
 
-private val ArtworkSize = 240.dp
-private val ArtworkTopLift = 24.dp
+private val ArtworkSize = 180.dp
+private val ArtworkTopLift = 18.dp
 private val BlurredArtworkScale = 1.25f
 private val BlurredArtworkOffset = -ArtworkSize * 0.2f
-private val BlurredArtworkRadius = 66.dp
+private val BlurredArtworkRadius = 49.5.dp
 
 private val CHROME_HIDE_DELAY = 5.seconds
 private const val VIDEO_OVERLAY_FADE_MILLIS = 200
 
-private val ChromeHorizontalInset = 56.dp
-private val ChromeScrimTopInset = 48.dp
+private val ChromeHorizontalInset = 42.dp
+private val ChromeScrimTopInset = 36.dp
 private val ChromeScrimBrush = Brush.verticalGradient(
     0f to Color.Transparent,
     1f to Color.Black.copy(alpha = 0.8f),

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingWaveform.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingWaveform.kt
@@ -214,8 +214,8 @@ internal class WaveformLevelSmoother(
 private const val WIDTH_FRACTION = 0.75f
 private const val AUDIO_DETECT_THRESHOLD = 0.01f
 private const val MIN_REACTIVE_LEVEL = 0.05f
-private val BarWidth = 3.33.dp
-private val BarSpacing = 4.67.dp
-private val MaxBarHeight = 66.67.dp
-private val MinBarHeight = 1.33.dp
-private val BarCornerRadius = 1.33.dp
+private val BarWidth = 2.5.dp
+private val BarSpacing = 3.5.dp
+private val MaxBarHeight = 50.dp
+private val MinBarHeight = 1.dp
+private val BarCornerRadius = 1.dp

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvPlayerEffectsControls.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvPlayerEffectsControls.kt
@@ -24,8 +24,8 @@ import kotlin.math.abs
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
-internal val TvControlBarButtonSize = 39.dp
-internal val TvControlBarIconSize = 18.dp
+internal val TvControlBarButtonSize = 48.dp
+internal val TvControlBarIconSize = 24.dp
 internal val TvControlBarButtonSpacing = 8.dp
 
 internal val tvPlaybackSpeedOptions: List<Double> = (5..30).map { it / 10.0 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvPlayerEffectsControls.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvPlayerEffectsControls.kt
@@ -24,9 +24,9 @@ import kotlin.math.abs
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
-internal val TvControlBarButtonSize = 52.dp
-internal val TvControlBarIconSize = 24.dp
-internal val TvControlBarButtonSpacing = 11.dp
+internal val TvControlBarButtonSize = 39.dp
+internal val TvControlBarIconSize = 18.dp
+internal val TvControlBarButtonSpacing = 8.dp
 
 internal val tvPlaybackSpeedOptions: List<Double> = (5..30).map { it / 10.0 }
 
@@ -63,7 +63,7 @@ internal fun TvPlaybackSpeedButton(
             TvDropdownMenu(
                 title = stringResource(LR.string.playback_speed),
                 onDismissRequest = { onMenuVisibleChange(false) },
-                maxHeight = 320.dp,
+                maxHeight = 240.dp,
                 alignment = Alignment.BottomCenter,
                 offset = DpOffset(x = 0.dp, y = (-64).dp),
             ) {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvSeekBar.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvSeekBar.kt
@@ -64,14 +64,14 @@ fun TvSeekBar(
     val hasDuration = durationMs > 0
     val progress = if (hasDuration) (positionMs.toFloat() / durationMs).coerceIn(0f, 1f) else 0f
     val trackHeight by animateDpAsState(if (isFocused) 8.dp else 4.dp, label = "TvSeekBarTrackHeight")
-    val thumbSize = 9.dp
+    val thumbSize = 12.dp
 
     Column(modifier = modifier) {
         BoxWithConstraints(
             contentAlignment = Alignment.CenterStart,
             modifier = Modifier
                 .fillMaxWidth()
-                .height(9.dp)
+                .height(12.dp)
                 .onFocusChanged { isFocused = it.isFocused }
                 .semantics {
                     progressBarRangeInfo = ProgressBarRangeInfo(progress, 0f..1f)

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvSeekBar.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvSeekBar.kt
@@ -63,7 +63,7 @@ fun TvSeekBar(
     var isFocused by remember { mutableStateOf(false) }
     val hasDuration = durationMs > 0
     val progress = if (hasDuration) (positionMs.toFloat() / durationMs).coerceIn(0f, 1f) else 0f
-    val trackHeight by animateDpAsState(if (isFocused) 6.dp else 3.dp, label = "TvSeekBarTrackHeight")
+    val trackHeight by animateDpAsState(if (isFocused) 8.dp else 4.dp, label = "TvSeekBarTrackHeight")
     val thumbSize = 9.dp
 
     Column(modifier = modifier) {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvSeekBar.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvSeekBar.kt
@@ -47,8 +47,8 @@ import au.com.shiftyjelly.pocketcasts.theme.tvColors
 import au.com.shiftyjelly.pocketcasts.theme.tvTypography
 import kotlin.math.roundToInt
 
-private val LabelGap = 8.dp
-private val LabelFadeRange = 16.dp
+private val LabelGap = 6.dp
+private val LabelFadeRange = 12.dp
 
 @Composable
 fun TvSeekBar(
@@ -63,15 +63,15 @@ fun TvSeekBar(
     var isFocused by remember { mutableStateOf(false) }
     val hasDuration = durationMs > 0
     val progress = if (hasDuration) (positionMs.toFloat() / durationMs).coerceIn(0f, 1f) else 0f
-    val trackHeight by animateDpAsState(if (isFocused) 8.dp else 4.dp, label = "TvSeekBarTrackHeight")
-    val thumbSize = 12.dp
+    val trackHeight by animateDpAsState(if (isFocused) 6.dp else 3.dp, label = "TvSeekBarTrackHeight")
+    val thumbSize = 9.dp
 
     Column(modifier = modifier) {
         BoxWithConstraints(
             contentAlignment = Alignment.CenterStart,
             modifier = Modifier
                 .fillMaxWidth()
-                .height(12.dp)
+                .height(9.dp)
                 .onFocusChanged { isFocused = it.isFocused }
                 .semantics {
                     progressBarRangeInfo = ProgressBarRangeInfo(progress, 0f..1f)
@@ -133,7 +133,7 @@ fun TvSeekBar(
         BoxWithConstraints(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(top = 8.dp),
+                .padding(top = 6.dp),
         ) {
             val maxWidthPx = constraints.maxWidth.toFloat()
             var positionLabelWidth by remember { mutableIntStateOf(0) }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingBackground.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingBackground.kt
@@ -1,0 +1,18 @@
+package au.com.shiftyjelly.pocketcasts.onboarding
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+
+fun Modifier.tvOnboardingBackground(base: Color, sunken: Color): Modifier = drawBehind {
+    drawRect(sunken)
+    drawRect(
+        Brush.linearGradient(
+            colors = listOf(base, sunken),
+            start = Offset.Zero,
+            end = Offset(size.width, size.height),
+        ),
+    )
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingNavHost.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingNavHost.kt
@@ -102,7 +102,7 @@ fun TvOnboardingNavHost(
                 state = toastHostState,
                 modifier = Modifier
                     .align(Alignment.TopEnd)
-                    .padding(top = 80.dp, end = 48.dp),
+                    .padding(top = 60.dp, end = 36.dp),
             )
         }
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingNavHost.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingNavHost.kt
@@ -102,7 +102,7 @@ fun TvOnboardingNavHost(
                 state = toastHostState,
                 modifier = Modifier
                     .align(Alignment.TopEnd)
-                    .padding(top = 60.dp, end = 36.dp),
+                    .padding(top = 44.dp, end = 42.dp),
             )
         }
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/createaccount/TvCreateAccountModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/createaccount/TvCreateAccountModal.kt
@@ -47,7 +47,7 @@ fun TvCreateAccountModal(
         modifier = modifier,
     ) {
         Column(
-            verticalArrangement = Arrangement.spacedBy(32.dp),
+            verticalArrangement = Arrangement.spacedBy(24.dp),
             modifier = Modifier.fillMaxWidth(),
         ) {
             Header()
@@ -63,7 +63,7 @@ fun TvCreateAccountModal(
 @Composable
 private fun Header(modifier: Modifier = Modifier) {
     Column(
-        verticalArrangement = Arrangement.spacedBy(12.dp),
+        verticalArrangement = Arrangement.spacedBy(9.dp),
         modifier = modifier.fillMaxWidth(),
     ) {
         Text(
@@ -136,5 +136,5 @@ private fun ErrorContent(
     )
 }
 
-private val ModalWidth = 760.dp
-private val ContentHeight = 220.dp
+private val ModalWidth = 570.dp
+private val ContentHeight = 165.dp

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/createaccount/TvCreateAccountScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/createaccount/TvCreateAccountScreen.kt
@@ -1,7 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.onboarding.createaccount
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -34,6 +33,7 @@ import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.onboarding.signin.TvSignInQrContent
 import au.com.shiftyjelly.pocketcasts.onboarding.signin.TvSignInUiState
 import au.com.shiftyjelly.pocketcasts.onboarding.signin.verificationDisplayUrl
+import au.com.shiftyjelly.pocketcasts.onboarding.tvOnboardingBackground
 import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
 import au.com.shiftyjelly.pocketcasts.theme.TvTheme
 import au.com.shiftyjelly.pocketcasts.theme.tvColors
@@ -80,7 +80,7 @@ private fun TvCreateAccountLoading(modifier: Modifier = Modifier) {
         contentAlignment = Alignment.Center,
         modifier = modifier
             .fillMaxSize()
-            .background(MaterialTheme.tvColors.backgroundSunken)
+            .tvOnboardingBackground(MaterialTheme.tvColors.backgroundBase, MaterialTheme.tvColors.backgroundSunken)
             .focusRequester(focusRequester)
             .focusable(),
     ) {
@@ -94,7 +94,7 @@ private fun TvCreateAccountLoading(modifier: Modifier = Modifier) {
             Text(
                 text = stringResource(LR.string.tv_create_account_title),
                 color = MaterialTheme.tvColors.textPrimary,
-                style = MaterialTheme.tvTypography.title2.copy(textAlign = TextAlign.Center),
+                style = MaterialTheme.tvTypography.title3.copy(textAlign = TextAlign.Center),
             )
         }
     }
@@ -115,7 +115,7 @@ private fun TvCreateAccountError(
         contentAlignment = Alignment.Center,
         modifier = modifier
             .fillMaxSize()
-            .background(MaterialTheme.tvColors.backgroundSunken),
+            .tvOnboardingBackground(MaterialTheme.tvColors.backgroundBase, MaterialTheme.tvColors.backgroundSunken),
     ) {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
             Image(
@@ -159,7 +159,7 @@ private fun TvCreateAccountContent(
         contentAlignment = Alignment.Center,
         modifier = modifier
             .fillMaxSize()
-            .background(MaterialTheme.tvColors.backgroundSunken)
+            .tvOnboardingBackground(MaterialTheme.tvColors.backgroundBase, MaterialTheme.tvColors.backgroundSunken)
             .focusRequester(focusRequester)
             .focusable(),
     ) {
@@ -170,7 +170,7 @@ private fun TvCreateAccountContent(
             Text(
                 text = stringResource(LR.string.tv_create_account_title),
                 color = MaterialTheme.tvColors.textPrimary,
-                style = MaterialTheme.tvTypography.title2.copy(textAlign = TextAlign.Center),
+                style = MaterialTheme.tvTypography.title3.copy(textAlign = TextAlign.Center),
             )
             TvSignInQrContent(
                 userCode = userCode,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/createaccount/TvCreateAccountScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/createaccount/TvCreateAccountScreen.kt
@@ -165,7 +165,7 @@ private fun TvCreateAccountContent(
     ) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(48.dp),
+            verticalArrangement = Arrangement.spacedBy(40.dp),
         ) {
             Text(
                 text = stringResource(LR.string.tv_create_account_title),

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signedout/TvSignedOutScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signedout/TvSignedOutScreen.kt
@@ -67,13 +67,13 @@ private fun TvSignedOutContent(
     ) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(16.dp),
-            modifier = Modifier.padding(horizontal = 48.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            modifier = Modifier.padding(horizontal = 36.dp),
         ) {
             Image(
                 painter = painterResource(IR.drawable.ic_pocket_casts_logo),
                 contentDescription = null,
-                modifier = Modifier.size(36.dp),
+                modifier = Modifier.size(27.dp),
             )
             Text(
                 text = stringResource(LR.string.tv_account_signed_out_alert_title),
@@ -85,7 +85,7 @@ private fun TvSignedOutContent(
                 color = MaterialTheme.tvColors.textSecondary,
                 style = MaterialTheme.tvTypography.body.copy(textAlign = TextAlign.Center),
             )
-            Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(12.dp))
             Button(
                 onClick = onLogIn,
                 colors = TvButtonDefaults.filledButtonColors(),

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvEmailSignInForm.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvEmailSignInForm.kt
@@ -256,4 +256,4 @@ private val FormWidth = 315.dp
 private const val IME_SETTLE_MILLIS = 250L
 
 /** Estimated height of the TV soft keyboard, which reports no window insets, used to lift a focused field clear of it. */
-internal val TvSignInKeyboardInset = 240.dp
+internal val TvSignInKeyboardInset = 320.dp

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvEmailSignInForm.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvEmailSignInForm.kt
@@ -77,7 +77,7 @@ internal fun TvEmailSignInForm(
 
     Column(
         modifier = modifier.width(FormWidth),
-        verticalArrangement = Arrangement.spacedBy(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         TvSignInTextField(
             value = state.email,
@@ -123,7 +123,7 @@ internal fun TvEmailSignInForm(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .heightIn(min = 24.dp),
+                .heightIn(min = 18.dp),
             contentAlignment = Alignment.CenterStart,
         ) {
             state.serverError?.let { serverError ->
@@ -147,7 +147,7 @@ internal fun TvEmailSignInForm(
                     LoadingView(
                         color = LocalContentColor.current,
                         modifier = Modifier
-                            .size(24.dp)
+                            .size(18.dp)
                             .semantics { contentDescription = signingInDescription },
                     )
                 } else {
@@ -182,7 +182,7 @@ private fun TvSignInTextField(
     val contentColor = if (isFocused) MaterialTheme.tvColors.backgroundSunken else MaterialTheme.tvColors.textPrimary
     val placeholderColor = if (isFocused) contentColor.copy(alpha = 0.5f) else MaterialTheme.tvColors.textSecondary
 
-    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.5.dp)) {
         BasicTextField(
             value = value,
             onValueChange = onValueChange,
@@ -219,8 +219,8 @@ private fun TvSignInTextField(
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .background(fieldColor, RoundedCornerShape(12.dp))
-                        .padding(horizontal = 20.dp, vertical = 18.dp),
+                        .background(fieldColor, RoundedCornerShape(9.dp))
+                        .padding(horizontal = 15.dp, vertical = 13.5.dp),
                     contentAlignment = Alignment.CenterStart,
                 ) {
                     if (value.isEmpty()) {
@@ -252,8 +252,8 @@ private fun TvSignInTextField(
     }
 }
 
-private val FormWidth = 420.dp
+private val FormWidth = 315.dp
 private const val IME_SETTLE_MILLIS = 250L
 
 /** Estimated height of the TV soft keyboard, which reports no window insets, used to lift a focused field clear of it. */
-internal val TvSignInKeyboardInset = 320.dp
+internal val TvSignInKeyboardInset = 240.dp

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInQrContent.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInQrContent.kt
@@ -33,11 +33,11 @@ fun TvSignInQrContent(
     modifier: Modifier = Modifier,
 ) {
     Column(
-        verticalArrangement = Arrangement.spacedBy(28.dp),
+        verticalArrangement = Arrangement.spacedBy(40.dp),
         modifier = modifier,
     ) {
         Row(
-            horizontalArrangement = Arrangement.spacedBy(40.dp),
+            horizontalArrangement = Arrangement.spacedBy(32.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             QrCode(content = verificationUriComplete)
@@ -55,9 +55,9 @@ private fun QrCode(content: String, modifier: Modifier = Modifier) {
     val qrPainter = rememberQrPainter(content = content, size = QrSize)
     Box(
         modifier = modifier
-            .clip(RoundedCornerShape(8.dp))
+            .clip(RoundedCornerShape(6.dp))
             .background(Color.White)
-            .padding(10.dp),
+            .padding(7.dp),
     ) {
         Image(
             painter = qrPainter,
@@ -110,14 +110,14 @@ private fun StepRow(number: Int, text: String, modifier: Modifier = Modifier) {
 @Composable
 private fun CodeRow(userCode: List<String>, modifier: Modifier = Modifier) {
     Row(
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
         modifier = modifier,
     ) {
         userCode.forEach { character ->
             Box(
                 contentAlignment = Alignment.Center,
                 modifier = Modifier
-                    .size(44.dp)
+                    .size(40.dp)
                     .background(MaterialTheme.tvColors.backgroundActive20, CircleShape),
             ) {
                 Text(
@@ -139,4 +139,4 @@ fun verificationDisplayUrl(verificationUri: String): String {
         .trimEnd('/')
 }
 
-private val QrSize = 132.dp
+private val QrSize = 121.dp

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInScreen.kt
@@ -45,6 +45,7 @@ import androidx.tv.material3.TabRowDefaults
 import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.compose.loading.LoadingView
+import au.com.shiftyjelly.pocketcasts.onboarding.tvOnboardingBackground
 import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
 import au.com.shiftyjelly.pocketcasts.theme.TvTheme
 import au.com.shiftyjelly.pocketcasts.theme.tvColors
@@ -100,7 +101,7 @@ private fun TvSignInContent(
         contentAlignment = Alignment.TopCenter,
         modifier = modifier
             .fillMaxSize()
-            .background(MaterialTheme.tvColors.backgroundSunken),
+            .tvOnboardingBackground(MaterialTheme.tvColors.backgroundBase, MaterialTheme.tvColors.backgroundSunken),
     ) {
         Column(
             modifier = Modifier
@@ -117,7 +118,7 @@ private fun TvSignInContent(
             Text(
                 text = stringResource(LR.string.tv_sign_in_title),
                 color = MaterialTheme.tvColors.textPrimary,
-                style = MaterialTheme.tvTypography.title2.copy(textAlign = TextAlign.Center),
+                style = MaterialTheme.tvTypography.title3.copy(textAlign = TextAlign.Center),
             )
             Spacer(modifier = Modifier.height(40.dp))
             TvSignInModeTabs(selected = mode, onSelect = onSelectMode)

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInScreen.kt
@@ -107,19 +107,21 @@ private fun TvSignInContent(
                 .verticalScroll(rememberScrollState())
                 .padding(vertical = 48.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(20.dp),
         ) {
             Image(
                 painter = painterResource(IR.drawable.ic_pocket_casts_logo),
                 contentDescription = null,
                 modifier = Modifier.size(36.dp),
             )
+            Spacer(modifier = Modifier.height(8.dp))
             Text(
                 text = stringResource(LR.string.tv_sign_in_title),
                 color = MaterialTheme.tvColors.textPrimary,
                 style = MaterialTheme.tvTypography.title2.copy(textAlign = TextAlign.Center),
             )
+            Spacer(modifier = Modifier.height(40.dp))
             TvSignInModeTabs(selected = mode, onSelect = onSelectMode)
+            Spacer(modifier = Modifier.height(40.dp))
             when (mode) {
                 TvSignInMode.QrCode -> TvQrSignIn(state = qrState, onRetry = onRetryQr)
 
@@ -174,8 +176,8 @@ private fun TvSignInModeTabs(
                     onFocus = { onSelect(tabMode) },
                     onClick = { onSelect(tabMode) },
                     modifier = Modifier
-                        .height(44.dp)
-                        .padding(horizontal = 24.dp)
+                        .height(33.dp)
+                        .padding(horizontal = 19.dp)
                         .then(
                             if (index == selectedIndex) Modifier.focusRequester(selectedTabFocusRequester) else Modifier,
                         ),
@@ -215,7 +217,7 @@ private fun TvQrSignIn(
 ) {
     Box(
         contentAlignment = Alignment.Center,
-        modifier = modifier.heightIn(min = 280.dp),
+        modifier = modifier.heightIn(min = 216.dp),
     ) {
         when (state) {
             is TvSignInUiState.Ready -> TvSignInQrContent(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSyncingScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSyncingScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.animation.core.LinearOutSlowInEasing
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -42,6 +41,7 @@ import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.component.TvArtworkImage
 import au.com.shiftyjelly.pocketcasts.compose.CallOnce
+import au.com.shiftyjelly.pocketcasts.onboarding.tvOnboardingBackground
 import au.com.shiftyjelly.pocketcasts.onboarding.welcome.artworkResIds
 import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImage
 import au.com.shiftyjelly.pocketcasts.theme.TvTheme
@@ -53,7 +53,7 @@ import kotlinx.coroutines.launch
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
-private const val COVER_SIZE_DP = 240
+private const val COVER_SIZE_DP = 140
 private const val COVER_CORNER_RADIUS_DP = 14
 private const val MAX_SIMULTANEOUS = 2
 private const val MAX_COVER_POOL = 40
@@ -97,7 +97,7 @@ private fun TvSyncingScreenContent(
     Box(
         modifier = modifier
             .fillMaxSize()
-            .background(MaterialTheme.tvColors.backgroundSunken),
+            .tvOnboardingBackground(MaterialTheme.tvColors.backgroundBase, MaterialTheme.tvColors.backgroundSunken),
     ) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
@@ -113,13 +113,13 @@ private fun TvSyncingScreenContent(
             Text(
                 text = stringResource(LR.string.tv_onboarding_welcome_back),
                 color = MaterialTheme.tvColors.textPrimary,
-                style = MaterialTheme.tvTypography.title2.copy(textAlign = TextAlign.Center),
+                style = MaterialTheme.tvTypography.title1.copy(textAlign = TextAlign.Center),
             )
             Spacer(modifier = Modifier.height(6.dp))
             Text(
                 text = stringResource(LR.string.tv_onboarding_syncing_subtitle),
                 color = MaterialTheme.tvColors.textSecondary,
-                style = MaterialTheme.tvTypography.body.copy(textAlign = TextAlign.Center),
+                style = MaterialTheme.tvTypography.headline.copy(textAlign = TextAlign.Center),
             )
             Spacer(modifier = Modifier.height(30.dp))
             TvSyncingCoverStack(podcastUuids = podcastUuids)

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSyncingScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSyncingScreen.kt
@@ -107,21 +107,21 @@ private fun TvSyncingScreenContent(
             Image(
                 painter = painterResource(IR.drawable.ic_pocket_casts_logo),
                 contentDescription = null,
-                modifier = Modifier.size(36.dp),
+                modifier = Modifier.size(27.dp),
             )
-            Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(12.dp))
             Text(
                 text = stringResource(LR.string.tv_onboarding_welcome_back),
                 color = MaterialTheme.tvColors.textPrimary,
                 style = MaterialTheme.tvTypography.title2.copy(textAlign = TextAlign.Center),
             )
-            Spacer(modifier = Modifier.height(8.dp))
+            Spacer(modifier = Modifier.height(6.dp))
             Text(
                 text = stringResource(LR.string.tv_onboarding_syncing_subtitle),
                 color = MaterialTheme.tvColors.textSecondary,
                 style = MaterialTheme.tvTypography.body.copy(textAlign = TextAlign.Center),
             )
-            Spacer(modifier = Modifier.height(40.dp))
+            Spacer(modifier = Modifier.height(30.dp))
             TvSyncingCoverStack(podcastUuids = podcastUuids)
         }
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/welcome/TvAnimatedPodcastGrid.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/welcome/TvAnimatedPodcastGrid.kt
@@ -27,8 +27,8 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 
-private const val TILE_SIZE_DP = 145
-private const val TILE_SPACING_DP = 9
+private const val TILE_SIZE_DP = 136
+private const val TILE_SPACING_DP = 12
 private const val TILE_CORNER_RADIUS_DP = 6
 private const val ANIMATION_OFFSET_DP = 107
 private const val GRID_VERTICAL_OFFSET_DP = -73

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/welcome/TvWelcomeScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/welcome/TvWelcomeScreen.kt
@@ -110,23 +110,23 @@ private fun TvWelcomeContent(
             Image(
                 painter = painterResource(IR.drawable.ic_pocket_casts_logo),
                 contentDescription = null,
-                modifier = Modifier.size(36.dp),
+                modifier = Modifier.size(40.dp),
             )
-            Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(20.dp))
             Text(
                 text = stringResource(LR.string.tv_onboarding_welcome_tv),
                 color = MaterialTheme.tvColors.textPrimary,
                 style = MaterialTheme.tvTypography.title2.copy(textAlign = TextAlign.Center),
             )
-            Spacer(modifier = Modifier.height(8.dp))
+            Spacer(modifier = Modifier.height(16.dp))
             Text(
                 text = stringResource(LR.string.tv_onboarding_subtitle),
                 color = MaterialTheme.tvColors.textSecondary,
                 style = MaterialTheme.tvTypography.body.copy(textAlign = TextAlign.Center),
             )
-            Spacer(modifier = Modifier.height(32.dp))
+            Spacer(modifier = Modifier.height(20.dp))
 
-            Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                 Button(
                     onClick = onSignIn,
                     colors = TvButtonDefaults.filledButtonColors(),

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/welcome/TvWelcomeScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/welcome/TvWelcomeScreen.kt
@@ -116,13 +116,13 @@ private fun TvWelcomeContent(
             Text(
                 text = stringResource(LR.string.tv_onboarding_welcome_tv),
                 color = MaterialTheme.tvColors.textPrimary,
-                style = MaterialTheme.tvTypography.title2.copy(textAlign = TextAlign.Center),
+                style = MaterialTheme.tvTypography.title1.copy(textAlign = TextAlign.Center),
             )
             Spacer(modifier = Modifier.height(16.dp))
             Text(
                 text = stringResource(LR.string.tv_onboarding_subtitle),
                 color = MaterialTheme.tvColors.textSecondary,
-                style = MaterialTheme.tvTypography.body.copy(textAlign = TextAlign.Center),
+                style = MaterialTheme.tvTypography.headline.copy(textAlign = TextAlign.Center),
             )
             Spacer(modifier = Modifier.height(20.dp))
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvDownloadAppModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvDownloadAppModal.kt
@@ -36,7 +36,7 @@ fun TvDownloadAppModal(
 ) {
     TvModal(
         onDismissRequest = onDismissRequest,
-        width = 600.dp,
+        width = 450.dp,
         modifier = modifier,
     ) {
         TvDownloadAppModalContent(onDone = onDismissRequest)
@@ -66,9 +66,9 @@ private fun ColumnScope.TvDownloadAppModalContent(
         painter = rememberQrPainter(content = DOWNLOAD_URL, size = QrCodeSize),
         contentDescription = null,
         modifier = Modifier
-            .padding(vertical = 16.dp)
-            .background(Color.White, RoundedCornerShape(8.dp))
-            .padding(10.dp)
+            .padding(vertical = 12.dp)
+            .background(Color.White, RoundedCornerShape(6.dp))
+            .padding(7.5.dp)
             .size(QrCodeSize),
     )
     Text(
@@ -80,7 +80,7 @@ private fun ColumnScope.TvDownloadAppModalContent(
         onClick = onDone,
         colors = TvButtonDefaults.filledButtonColors(),
         modifier = Modifier
-            .padding(top = 16.dp)
+            .padding(top = 12.dp)
             .focusRequester(focusRequester),
     ) {
         Text(stringResource(LR.string.done), style = MaterialTheme.tvTypography.caption1)
@@ -89,13 +89,13 @@ private fun ColumnScope.TvDownloadAppModalContent(
 
 private const val DOWNLOAD_URL = "https://pocketcasts.com/downloads"
 private val DOWNLOAD_URL_LABEL = DOWNLOAD_URL.removePrefix("https://")
-private val QrCodeSize = 144.dp
+private val QrCodeSize = 108.dp
 
 @Preview
 @Composable
 private fun TvDownloadAppModalPreview() {
     TvTheme {
-        TvModalSurface(width = 600.dp) {
+        TvModalSurface(width = 450.dp) {
             TvDownloadAppModalContent(onDone = {})
         }
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsScreen.kt
@@ -205,12 +205,12 @@ private fun TvPlaylistsGrid(
     modifier: Modifier = Modifier,
     restoreFocusTrigger: Int = 0,
 ) {
-    Column(modifier = modifier.padding(horizontal = 32.dp)) {
+    Column(modifier = modifier.padding(horizontal = 42.dp)) {
         Text(
             text = stringResource(LR.string.playlists),
-            style = MaterialTheme.tvTypography.title3,
+            style = MaterialTheme.tvTypography.title2,
             color = MaterialTheme.tvColors.textPrimary,
-            modifier = Modifier.padding(top = 8.dp, bottom = 26.dp),
+            modifier = Modifier.padding(top = 40.dp, bottom = 0.dp),
         )
         var lastFocusedIndex by rememberSaveable(playlists) { mutableIntStateOf(0) }
         val focusRequesters = remember(playlists) { List(playlists.size) { FocusRequester() } }
@@ -229,9 +229,9 @@ private fun TvPlaylistsGrid(
 
         LazyVerticalGrid(
             columns = GridCells.Fixed(3),
-            horizontalArrangement = Arrangement.spacedBy(16.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp),
-            contentPadding = PaddingValues(top = 16.dp, bottom = 32.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            contentPadding = PaddingValues(top = 20.dp, bottom = 32.dp),
             modifier = Modifier
                 .focusRequester(gridFocusRequester)
                 .focusGroup()

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
@@ -499,7 +499,7 @@ private fun episodeSummaryText(episodes: List<PodcastEpisode>): String {
     }
 }
 
-private val InfoPaneWidth = 150.dp
+private val InfoPaneWidth = TvDetailsArtworkSize
 
 @Preview(device = Devices.TV_1080p)
 @Composable

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
@@ -179,10 +179,10 @@ private fun TvPlaylistDetailsContent(
             is TvPlaylistDetailsUiState.Loaded -> {
                 val playAllFocusRequester = remember { FocusRequester() }
                 Row(
-                    horizontalArrangement = Arrangement.spacedBy(80.dp),
+                    horizontalArrangement = Arrangement.spacedBy(60.dp),
                     modifier = Modifier
                         .fillMaxSize()
-                        .padding(start = 32.dp, top = 16.dp, end = 32.dp),
+                        .padding(start = 42.dp, top = 12.dp, end = 42.dp),
                 ) {
                     PlaylistInfo(
                         playlist = uiState.playlist,
@@ -238,11 +238,11 @@ private fun SortableEpisodeList(
     val leftFocusRequester = playAllFocusRequester.takeIf { uiState.episodes.isNotEmpty() }
     Column(modifier = modifier) {
         Row(
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            horizontalArrangement = Arrangement.spacedBy(9.dp),
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier
                 .align(Alignment.End)
-                .padding(bottom = 12.dp),
+                .padding(bottom = 9.dp),
         ) {
             if (isManual) {
                 TvArchivedFilterButton(
@@ -292,7 +292,7 @@ private fun AllEpisodesArchived(
             style = MaterialTheme.tvTypography.caption1,
             color = MaterialTheme.tvColors.textSecondary,
             textAlign = TextAlign.Center,
-            modifier = Modifier.widthIn(max = 400.dp),
+            modifier = Modifier.widthIn(max = 300.dp),
         )
     }
 }
@@ -313,7 +313,7 @@ private fun EpisodeList(
     var detailsEpisode by remember { mutableStateOf<PodcastEpisode?>(null) }
     LazyColumn(
         state = listState,
-        verticalArrangement = Arrangement.spacedBy(12.dp),
+        verticalArrangement = Arrangement.spacedBy(9.dp),
         modifier = modifier,
     ) {
         itemsIndexed(
@@ -365,7 +365,7 @@ private fun NoEpisodes(
     ) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(12.dp),
+            verticalArrangement = Arrangement.spacedBy(9.dp),
         ) {
             Text(
                 text = stringResource(LR.string.tv_playlist_empty_title),
@@ -381,7 +381,7 @@ private fun NoEpisodes(
                 style = MaterialTheme.tvTypography.caption1,
                 color = MaterialTheme.tvColors.textSecondary,
                 textAlign = TextAlign.Center,
-                modifier = Modifier.widthIn(max = 400.dp),
+                modifier = Modifier.widthIn(max = 300.dp),
             )
         }
     }
@@ -396,15 +396,15 @@ private fun PlaylistInfo(
     modifier: Modifier = Modifier,
 ) {
     Column(
-        verticalArrangement = Arrangement.spacedBy(28.dp),
+        verticalArrangement = Arrangement.spacedBy(21.dp),
         modifier = modifier,
     ) {
         PlaylistArtwork(
             podcastUuids = playlist.metadata.artworkUuids,
             artworkSize = TvDetailsArtworkSize,
-            cornerSize = 8.dp,
+            cornerSize = 6.dp,
         )
-        Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        Column(verticalArrangement = Arrangement.spacedBy(4.5.dp)) {
             Text(
                 text = when (playlist.type) {
                     Playlist.Type.Manual -> stringResource(LR.string.playlist)
@@ -499,7 +499,7 @@ private fun episodeSummaryText(episodes: List<PodcastEpisode>): String {
     }
 }
 
-private val InfoPaneWidth = 200.dp
+private val InfoPaneWidth = 150.dp
 
 @Preview(device = Devices.TV_1080p)
 @Composable

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
@@ -145,10 +145,10 @@ private fun TvPodcastDetailsContent(
                 var isShowingInfoModal by remember { mutableStateOf(false) }
                 var isShowingAccountModal by rememberSaveable { mutableStateOf(false) }
                 Row(
-                    horizontalArrangement = Arrangement.spacedBy(80.dp),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
                     modifier = Modifier
                         .fillMaxSize()
-                        .padding(start = 32.dp, top = 16.dp, end = 32.dp),
+                        .padding(start = 42.dp, top = 16.dp, end = 42.dp),
                 ) {
                     PodcastInfo(
                         podcast = uiState.podcast,
@@ -225,7 +225,7 @@ private fun PodcastInfo(
     modifier: Modifier = Modifier,
 ) {
     Column(
-        verticalArrangement = Arrangement.spacedBy(24.dp),
+        verticalArrangement = Arrangement.spacedBy(20.dp),
         modifier = modifier,
     ) {
         TvArtworkImage(
@@ -234,7 +234,7 @@ private fun PodcastInfo(
                 .size(TvDetailsArtworkSize)
                 .clip(RoundedCornerShape(8.dp)),
         )
-        Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
             if (podcast.author.isNotBlank()) {
                 Text(
                     text = podcast.author,
@@ -244,7 +244,7 @@ private fun PodcastInfo(
             }
             Text(
                 text = podcast.title,
-                style = MaterialTheme.tvTypography.title3,
+                style = MaterialTheme.tvTypography.title2,
                 color = MaterialTheme.tvColors.textPrimary,
             )
             if (podcast.podcastDescription.isNotBlank()) {
@@ -330,7 +330,7 @@ private fun EpisodeList(
         } else {
             LazyColumn(
                 state = listState,
-                verticalArrangement = Arrangement.spacedBy(12.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
                 modifier = Modifier.weight(1f),
             ) {
                 itemsIndexed(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchEpisodeRow.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchEpisodeRow.kt
@@ -58,7 +58,7 @@ internal fun TvSearchEpisodeCard(
         onClick = onClick,
         onLongClick = onLongClick,
         scale = CardDefaults.scale(focusedScale = 1.02f),
-        shape = CardDefaults.shape(shape = RoundedCornerShape(12.dp)),
+        shape = CardDefaults.shape(shape = RoundedCornerShape(9.dp)),
         colors = CardDefaults.colors(
             containerColor = MaterialTheme.tvColors.backgroundSunken,
             focusedContainerColor = MaterialTheme.tvColors.backgroundActive,
@@ -68,19 +68,19 @@ internal fun TvSearchEpisodeCard(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(24.dp),
+                .padding(18.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             TvArtworkImage(
                 model = PodcastImage.getMediumArtworkUrl(episode.podcastUuid),
                 modifier = Modifier
-                    .size(96.dp)
-                    .clip(RoundedCornerShape(6.dp)),
+                    .size(72.dp)
+                    .clip(RoundedCornerShape(4.5.dp)),
             )
             Column(
                 modifier = Modifier
                     .weight(1f)
-                    .padding(start = 24.dp),
+                    .padding(start = 18.dp),
             ) {
                 if (episode.podcastTitle.isNotBlank()) {
                     Text(
@@ -90,7 +90,7 @@ internal fun TvSearchEpisodeCard(
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                     )
-                    Spacer(modifier = Modifier.height(4.dp))
+                    Spacer(modifier = Modifier.height(3.dp))
                 }
                 Text(
                     text = episode.title,
@@ -100,7 +100,7 @@ internal fun TvSearchEpisodeCard(
                     overflow = TextOverflow.Ellipsis,
                 )
                 if (duration.isNotBlank()) {
-                    Spacer(modifier = Modifier.height(4.dp))
+                    Spacer(modifier = Modifier.height(3.dp))
                     Text(
                         text = duration,
                         style = MaterialTheme.tvTypography.caption1,
@@ -117,7 +117,7 @@ internal fun TvSearchEpisodeCard(
 @Composable
 private fun TvSearchEpisodeCardPreview() {
     TvTheme {
-        Box(modifier = Modifier.background(MaterialTheme.tvColors.backgroundSunken).padding(48.dp)) {
+        Box(modifier = Modifier.background(MaterialTheme.tvColors.backgroundSunken).padding(36.dp)) {
             TvSearchEpisodeCard(
                 episode = ImprovedSearchResultItem.EpisodeItem(
                     uuid = "episode-1",

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchField.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchField.kt
@@ -173,9 +173,9 @@ private fun TvSearchFieldContent(
             painter = painterResource(IR.drawable.ic_search),
             contentDescription = null,
             tint = contentColor,
-            modifier = Modifier.size(32.dp),
+            modifier = Modifier.size(24.dp),
         )
-        Spacer(modifier = Modifier.width(16.dp))
+        Spacer(modifier = Modifier.width(12.dp))
         Box(contentAlignment = Alignment.CenterStart) {
             if (query.isEmpty()) {
                 Text(
@@ -204,7 +204,7 @@ private fun TvSearchFieldPreview() {
         Box(
             modifier = Modifier
                 .background(MaterialTheme.tvColors.backgroundSunken)
-                .padding(48.dp),
+                .padding(36.dp),
         ) {
             TvSearchField(query = "", onQueryChange = {})
         }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchFilters.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchFilters.kt
@@ -46,14 +46,14 @@ internal fun TvSearchFilters(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         FilterDivider(modifier = Modifier.weight(1f))
-        Spacer(modifier = Modifier.width(20.dp))
+        Spacer(modifier = Modifier.width(15.dp))
         TvSearchFilterPills(
             filters = filters,
             selected = selected,
             onFilterSelect = onFilterSelect,
             upFocusRequester = upFocusRequester,
         )
-        Spacer(modifier = Modifier.width(20.dp))
+        Spacer(modifier = Modifier.width(15.dp))
         FilterDivider(modifier = Modifier.weight(1f))
     }
 }
@@ -70,7 +70,7 @@ private fun TvSearchFilterPills(
     Box(
         modifier = Modifier
             .background(MaterialTheme.tvColors.backgroundSunken, RoundedCornerShape(percent = 50))
-            .padding(3.dp),
+            .padding(2.dp),
     ) {
         TabRow(
             selectedTabIndex = selectedIndex,
@@ -95,8 +95,8 @@ private fun TvSearchFilterPills(
                     onFocus = { onFilterSelect(filter) },
                     onClick = { onFilterSelect(filter) },
                     modifier = Modifier
-                        .height(44.dp)
-                        .padding(horizontal = 21.dp)
+                        .height(33.dp)
+                        .padding(horizontal = 16.dp)
                         .focusProperties { upFocusRequester?.let { up = it } }
                         .then(if (index == selectedIndex) Modifier.focusRequester(focusRequester) else Modifier),
                     colors = TabDefaults.pillIndicatorTabColors(
@@ -141,7 +141,7 @@ private fun TvSearchFiltersPreview() {
             onFilterSelect = {},
             modifier = Modifier
                 .background(MaterialTheme.tvColors.backgroundSunken)
-                .padding(48.dp),
+                .padding(36.dp),
         )
     }
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
@@ -88,11 +88,11 @@ import kotlin.time.Duration.Companion.seconds
 import androidx.compose.foundation.lazy.grid.itemsIndexed as gridItemsIndexed
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
-private val ContentHorizontalPadding = 48.dp
+private val ContentHorizontalPadding = 42.dp
 private val ContentPadding = PaddingValues(horizontal = ContentHorizontalPadding)
 private const val SEARCH_ROW_LIMIT = 10
 private const val FOLDER_COVER_COUNT = 4
-private val SearchEpisodeCardWidth = 360.dp
+private val SearchEpisodeCardWidth = 270.dp
 private const val EPISODE_GRID_COLUMNS = 2
 
 private data class SearchOpenedFolder(val uuid: String, val name: String)
@@ -303,7 +303,7 @@ private fun TvSearchContent(
     val showSuggestions = (isEditing || suggestionsFocused) && suggestions.isNotEmpty()
     Column(modifier = modifier.fillMaxSize()) {
         Column(modifier = Modifier.padding(ContentPadding)) {
-            Spacer(modifier = Modifier.height(40.dp))
+            Spacer(modifier = Modifier.height(30.dp))
             TvSearchField(
                 query = query,
                 onQueryChange = onQueryChange,
@@ -317,7 +317,7 @@ private fun TvSearchContent(
                     .fillMaxWidth()
                     .focusRequester(searchFieldFocusRequester),
             )
-            Spacer(modifier = Modifier.height(24.dp))
+            Spacer(modifier = Modifier.height(18.dp))
         }
 
         if (showSuggestions) {
@@ -326,7 +326,7 @@ private fun TvSearchContent(
                 onSuggestionSelect = onSuggestionSelect,
                 modifier = Modifier.onFocusChanged { suggestionsFocused = it.hasFocus },
             )
-            Spacer(modifier = Modifier.height(24.dp))
+            Spacer(modifier = Modifier.height(18.dp))
         }
 
         val filters = remember(hasFolderResults) { TvSearchFilter.entries.filter { it != TvSearchFilter.Folders || hasFolderResults } }
@@ -340,7 +340,7 @@ private fun TvSearchContent(
                 modifier = Modifier.padding(ContentPadding),
                 upFocusRequester = searchFieldFocusRequester,
             )
-            Spacer(modifier = Modifier.height(24.dp))
+            Spacer(modifier = Modifier.height(18.dp))
         }
 
         Box(
@@ -423,11 +423,11 @@ private fun TvSearchIdle(
                         text = term,
                         style = MaterialTheme.tvTypography.body,
                         color = MaterialTheme.tvColors.textPrimary,
-                        modifier = Modifier.padding(horizontal = 20.dp, vertical = 12.dp),
+                        modifier = Modifier.padding(horizontal = 15.dp, vertical = 9.dp),
                     )
                 }
             }
-            Spacer(modifier = Modifier.height(24.dp))
+            Spacer(modifier = Modifier.height(18.dp))
         }
         TvSearchDiscover(
             categories = categories,
@@ -487,7 +487,7 @@ private fun TvSearchDiscover(
                 )
             }
             item {
-                Spacer(modifier = Modifier.height(24.dp))
+                Spacer(modifier = Modifier.height(18.dp))
                 TvRow(
                     title = stringResource(LR.string.tv_search_browse_categories),
                     items = categories,
@@ -511,7 +511,7 @@ private fun TvSearchDiscover(
 
         discoverRows.forEachIndexed { index, row ->
             val rowIndex = categoryOffset + index
-            item { Spacer(modifier = Modifier.height(24.dp)) }
+            item { Spacer(modifier = Modifier.height(18.dp)) }
             tvDiscoverRow(
                 row = row,
                 onPodcastClick = onDiscoverPodcastClick,
@@ -528,7 +528,7 @@ private fun TvSearchDiscover(
             )
         }
 
-        item { Spacer(modifier = Modifier.height(40.dp)) }
+        item { Spacer(modifier = Modifier.height(30.dp)) }
     }
 }
 
@@ -659,7 +659,7 @@ private fun TvSearchTopResults(
     val podcastsFirst = !featuredFirst && !episodesFirst && !foldersFirst
 
     LazyColumn(modifier = Modifier.fillMaxSize()) {
-        item { Spacer(modifier = Modifier.height(8.dp)) }
+        item { Spacer(modifier = Modifier.height(6.dp)) }
         if (featured.isNotEmpty()) {
             item {
                 TvSearchEpisodeCarousel(
@@ -672,7 +672,7 @@ private fun TvSearchTopResults(
             }
         }
         if (otherEpisodes.isNotEmpty()) {
-            item { Spacer(modifier = Modifier.height(24.dp)) }
+            item { Spacer(modifier = Modifier.height(18.dp)) }
             item {
                 TvSearchEpisodeCarousel(
                     title = stringResource(LR.string.episodes),
@@ -684,7 +684,7 @@ private fun TvSearchTopResults(
             }
         }
         if (topFolders.isNotEmpty()) {
-            item { Spacer(modifier = Modifier.height(24.dp)) }
+            item { Spacer(modifier = Modifier.height(18.dp)) }
             tvSearchFoldersRow(
                 folders = topFolders,
                 onOpenFolder = onOpenFolder,
@@ -692,14 +692,14 @@ private fun TvSearchTopResults(
             )
         }
         if (topPodcasts.isNotEmpty()) {
-            item { Spacer(modifier = Modifier.height(24.dp)) }
+            item { Spacer(modifier = Modifier.height(18.dp)) }
             tvSearchPodcastsRow(
                 podcasts = topPodcasts,
                 onPodcastResultClick = onPodcastResultClick,
                 focusRequester = restoreFocusRequester.takeIf { podcastsFirst },
             )
         }
-        item { Spacer(modifier = Modifier.height(40.dp)) }
+        item { Spacer(modifier = Modifier.height(30.dp)) }
     }
 }
 
@@ -774,9 +774,9 @@ private fun TvSearchEpisodeGrid(
     LazyVerticalGrid(
         state = gridState,
         columns = GridCells.Fixed(EPISODE_GRID_COLUMNS),
-        horizontalArrangement = Arrangement.spacedBy(24.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp),
-        contentPadding = PaddingValues(start = 48.dp, end = 48.dp, bottom = 40.dp),
+        horizontalArrangement = Arrangement.spacedBy(18.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+        contentPadding = PaddingValues(start = 42.dp, end = 42.dp, bottom = 30.dp),
         modifier = Modifier
             .fillMaxSize()
             .focusRequester(gridFocusRequester)
@@ -857,7 +857,7 @@ private fun TvSearchSuggestions(
     LazyRow(
         modifier = modifier.fillMaxWidth(),
         contentPadding = ContentPadding,
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        horizontalArrangement = Arrangement.spacedBy(9.dp),
     ) {
         items(suggestions) { term ->
             TvTile(onClick = { onSuggestionSelect(term) }) {
@@ -866,7 +866,7 @@ private fun TvSearchSuggestions(
                     style = MaterialTheme.tvTypography.body,
                     color = MaterialTheme.tvColors.textPrimary,
                     maxLines = 1,
-                    modifier = Modifier.padding(horizontal = 20.dp, vertical = 12.dp),
+                    modifier = Modifier.padding(horizontal = 15.dp, vertical = 9.dp),
                 )
             }
         }
@@ -882,9 +882,9 @@ private fun TvSearchLoading() {
     ) {
         LoadingView(
             color = MaterialTheme.tvColors.textPrimary,
-            modifier = Modifier.size(48.dp),
+            modifier = Modifier.size(36.dp),
         )
-        Spacer(modifier = Modifier.height(16.dp))
+        Spacer(modifier = Modifier.height(12.dp))
         Text(
             text = stringResource(LR.string.tv_search_searching),
             style = MaterialTheme.tvTypography.body,
@@ -1021,7 +1021,7 @@ private fun TvSearchResultsPreview() {
 @Composable
 private fun TvSearchSuggestionsPreview() {
     TvTheme {
-        Box(modifier = Modifier.background(MaterialTheme.tvColors.backgroundSunken).padding(48.dp)) {
+        Box(modifier = Modifier.background(MaterialTheme.tvColors.backgroundSunken).padding(36.dp)) {
             TvSearchSuggestions(
                 suggestions = listOf("business daily", "business wars", "business insider"),
                 onSuggestionSelect = {},

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/settings/TvSettingsModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/settings/TvSettingsModal.kt
@@ -181,7 +181,7 @@ private fun TvSettingsToggleRow(
                 Icon(
                     painter = painterResource(IR.drawable.ic_check),
                     contentDescription = null,
-                    modifier = Modifier.size(20.dp),
+                    modifier = Modifier.size(15.dp),
                 )
             }
         }
@@ -262,7 +262,7 @@ private val Subscription.isManagedOnAnotherPlatform: Boolean
 @Composable
 private fun TvSettingsInfoRow(label: String, value: String) {
     Row(
-        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
         modifier = Modifier.fillMaxWidth(),
     ) {
         Text(
@@ -355,9 +355,9 @@ private fun TvQrCode(content: String, modifier: Modifier = Modifier) {
     val qrPainter = rememberQrPainter(content = content, size = QrSize)
     Box(
         modifier = modifier
-            .clip(RoundedCornerShape(8.dp))
+            .clip(RoundedCornerShape(6.dp))
             .background(Color.White)
-            .padding(10.dp),
+            .padding(7.5.dp),
     ) {
         Image(
             painter = qrPainter,
@@ -367,7 +367,7 @@ private fun TvQrCode(content: String, modifier: Modifier = Modifier) {
     }
 }
 
-private val QrSize = 160.dp
+private val QrSize = 120.dp
 
 @Preview
 @Composable

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/starred/TvStarredScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/starred/TvStarredScreen.kt
@@ -137,18 +137,18 @@ private fun StarredList(
         modifier = modifier
             .fillMaxHeight()
             .fillMaxWidth(ROW_WIDTH_FRACTION)
-            .padding(start = 32.dp, top = 8.dp),
+            .padding(start = 42.dp, top = 6.dp),
     ) {
         Text(
             text = stringResource(LR.string.tv_profile_starred_episodes),
             style = MaterialTheme.tvTypography.title3,
             color = MaterialTheme.tvColors.textPrimary,
         )
-        Spacer(Modifier.height(26.dp))
+        Spacer(Modifier.height(19.5.dp))
         LazyColumn(
             state = listState,
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-            contentPadding = PaddingValues(bottom = 32.dp),
+            verticalArrangement = Arrangement.spacedBy(9.dp),
+            contentPadding = PaddingValues(bottom = 24.dp),
             modifier = Modifier.weight(1f),
         ) {
             itemsIndexed(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvColorScheme.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvColorScheme.kt
@@ -18,7 +18,7 @@ data class TvColorScheme(
     val backgroundSurface: Color = Color(0xFF1F2123),
     val backgroundBase: Color = Color(0xFF292B2E),
     val backgroundOverlay: Color = Color(0xFF323538),
-    val backgroundActive: Color = Color(0xFFFBFBFC),
+    val backgroundActive: Color = Color(0xFFD4D6DB),
     val backgroundActive50: Color = Color(0x80FBFBFC),
     val backgroundActive20: Color = Color(0x33FBFBFC),
     val overlayContainer: Color = backgroundSunken.copy(alpha = 0.94f),

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvDimensions.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvDimensions.kt
@@ -2,10 +2,10 @@ package au.com.shiftyjelly.pocketcasts.theme
 
 import androidx.compose.ui.unit.dp
 
-val TvDetailsArtworkSize = 180.dp
+val TvDetailsArtworkSize = 209.dp
 
 // The top bar is a fixed-height row, so top-level tab content reserves this much space to sit below it.
-val TvTopBarHeight = 82.dp
+val TvTopBarHeight = 63.dp
 
 // Breathing room detail screens keep at the top now that they fill the height under a hidden top bar.
-val TvDetailTopInset = 32.dp
+val TvDetailTopInset = 24.dp

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvTypography.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvTypography.kt
@@ -7,79 +7,79 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 
 /**
- * The Figma type ramp for TV. Sizes are the Figma px values divided by 1.5 (the 1920x1080 → dp
- * convention), hence the fractional `sp`.
+ * The Figma type ramp for TV. Sizes are the Figma px values divided by 2.0 (the 1920x1080 → 960x540
+ * dp convention; Android TV renders at 320dpi = density 2.0), hence the fractional `sp`.
  */
 @Immutable
 data class TvTypography(
     val title1: TextStyle = TextStyle(
         fontFamily = GoogleSansFontFamily,
-        fontSize = 50.67.sp,
-        lineHeight = 64.sp,
+        fontSize = 38.sp,
+        lineHeight = 48.sp,
         fontWeight = FontWeight(510),
         letterSpacing = 0.sp,
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     ),
     val title2: TextStyle = TextStyle(
         fontFamily = GoogleSansFontFamily,
-        fontSize = 38.sp,
-        lineHeight = 44.sp,
+        fontSize = 28.5.sp,
+        lineHeight = 33.sp,
         fontWeight = FontWeight(510),
         letterSpacing = 0.sp,
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     ),
     val title3: TextStyle = TextStyle(
         fontFamily = GoogleSansFontFamily,
-        fontSize = 32.sp,
-        lineHeight = 37.33.sp,
+        fontSize = 24.sp,
+        lineHeight = 28.sp,
         fontWeight = FontWeight(510),
         letterSpacing = 0.sp,
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     ),
     val headline: TextStyle = TextStyle(
         fontFamily = GoogleSansFontFamily,
-        fontSize = 25.33.sp,
-        lineHeight = 30.67.sp,
+        fontSize = 19.sp,
+        lineHeight = 23.sp,
         fontWeight = FontWeight(510),
         letterSpacing = 0.sp,
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     ),
     val subtitle1: TextStyle = TextStyle(
         fontFamily = GoogleSansFontFamily,
-        fontSize = 25.33.sp,
-        lineHeight = 30.67.sp,
+        fontSize = 19.sp,
+        lineHeight = 23.sp,
         fontWeight = FontWeight(400),
         letterSpacing = 0.sp,
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     ),
     val callout: TextStyle = TextStyle(
         fontFamily = GoogleSansFontFamily,
-        fontSize = 19.33.sp,
-        lineHeight = 24.sp,
+        fontSize = 14.5.sp,
+        lineHeight = 18.sp,
         fontWeight = FontWeight(510),
         letterSpacing = 0.sp,
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     ),
     val body: TextStyle = TextStyle(
         fontFamily = GoogleSansFontFamily,
-        fontSize = 19.33.sp,
-        lineHeight = 24.sp,
+        fontSize = 14.5.sp,
+        lineHeight = 18.sp,
         fontWeight = FontWeight(400),
         letterSpacing = 0.sp,
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     ),
     val caption1: TextStyle = TextStyle(
         fontFamily = GoogleSansFontFamily,
-        fontSize = 16.67.sp,
-        lineHeight = 21.33.sp,
+        fontSize = 12.5.sp,
+        lineHeight = 16.sp,
         fontWeight = FontWeight(510),
         letterSpacing = 0.sp,
         platformStyle = PlatformTextStyle(includeFontPadding = false),
     ),
     val caption2: TextStyle = TextStyle(
         fontFamily = GoogleSansFontFamily,
-        fontSize = 15.33.sp,
-        lineHeight = 20.sp,
+        fontSize = 11.5.sp,
+        lineHeight = 15.sp,
         fontWeight = FontWeight(510),
         letterSpacing = 0.sp,
         platformStyle = PlatformTextStyle(includeFontPadding = false),

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/upnext/TvUpNextScreen.kt
@@ -143,13 +143,13 @@ private fun UpNextList(
         modifier = modifier
             .fillMaxHeight()
             .fillMaxWidth(ROW_WIDTH_FRACTION)
-            .padding(start = 32.dp, top = 8.dp),
+            .padding(start = 42.dp, top = 40.dp),
     ) {
         UpNextHeader(episodes = episodes)
-        Spacer(Modifier.height(26.dp))
+        Spacer(Modifier.height(16.dp))
         LazyColumn(
             state = listState,
-            verticalArrangement = Arrangement.spacedBy(12.dp),
+            verticalArrangement = Arrangement.spacedBy(6.dp),
             contentPadding = PaddingValues(bottom = 32.dp),
             modifier = Modifier.weight(1f),
         ) {
@@ -203,7 +203,7 @@ private fun UpNextHeader(
     ) {
         Text(
             text = stringResource(LR.string.up_next),
-            style = MaterialTheme.tvTypography.title3,
+            style = MaterialTheme.tvTypography.title2,
             color = MaterialTheme.tvColors.textPrimary,
         )
         Text(
@@ -239,7 +239,7 @@ private fun UpNextEmpty(
     )
 }
 
-private const val ROW_WIDTH_FRACTION = 0.75f
+private const val ROW_WIDTH_FRACTION = 0.65f
 
 @Preview(device = Devices.TV_1080p)
 @Composable


### PR DESCRIPTION
## What this does

The Android TV UI was scaled from Figma with the wrong divisor. The Figma artboard is 1920×1080, but the TV renders at 320 dpi (density 2.0), so the real canvas is 960×540 dp and `dp = figma_px / 2.0`. The code used `÷1.5`, which made everything about 33% too big.

This PR rescales the whole TV module to `÷2.0` and tunes each screen to match the Figma designs.

## Changes

- Rescaled the type ramp and every `dp`/`sp` value to `÷2.0`.
- Matched the shared components to Figma: top bar, episode rows, cards, tiles, and modals.
- Tuned each screen to Figma: onboarding, Home/Discover, Search, Your Podcasts, Playlists and playlist details, Up Next, Podcast view, Now Playing, and Profile.
- Added a gradient background to the onboarding screens.
- Added the Home "Keep Listening" resume card and the "Up Next" progress rows.
- Fixed the episode-action toast to match Figma (fill colour, text style, corner radius, removed the border, top-right position).

## How I checked

I compared each screen against its Figma frame on a real Google TV Streamer. The device runs at 1920×1080 @ density 2.0, so device pixels line up 1:1 with Figma pixels. The side-by-sides are below.

## Screenshots

| Screen | Figma vs Device |
| --- | --- |
| Home / Discover | <img width="9466" height="960" alt="home_coverrow_cmp" src="https://github.com/user-attachments/assets/0d27ab0e-4cb7-4eb2-9086-7a4a86b348d8" /> |
| Search |  <img width="3224" height="960" alt="search_cmp" src="https://github.com/user-attachments/assets/33607ed3-ebb4-44f9-9ece-07cd6e620987" /> |
| Your Podcasts | <img width="3224" height="960" alt="your_podcasts_cmp" src="https://github.com/user-attachments/assets/9a1a48f7-f7c3-4b1b-84c7-bdf414c7d383" /> |
| Playlists | <img width="3224" height="960" alt="playlists_cmp" src="https://github.com/user-attachments/assets/b57bcba6-a4bf-4b9d-8223-09c522771c7a" /> |
| Playlist details | <img width="3224" height="960" alt="playlist_detail_cmp" src="https://github.com/user-attachments/assets/0e8197a2-b6f9-4cdf-875a-20e097a24344" /> |
| Podcast view | <img width="3224" height="960" alt="podcast_view_cmp" src="https://github.com/user-attachments/assets/292209a2-bc43-44c8-b43f-af6ff5d088d5" /> |
| Now Playing | <img width="3224" height="960" alt="now_playing_base_cmp" src="https://github.com/user-attachments/assets/b0c4c828-970d-45d6-8957-bac56f74fe72" /> |
| Profile | <img width="1454" height="960" alt="profile_cmp" src="https://github.com/user-attachments/assets/1f03f9fa-161c-4a36-bdf1-1c96228f159c" /> |
| Toast | <img width="3624" height="960" alt="toast_cmp" src="https://github.com/user-attachments/assets/62ea2ce5-3395-41b0-86e8-15ef0cace369" /> |

## Testing instructions

1. Install the TV app: `./gradlew :tv:installDebugProd`.
2. Sign in and walk through Home, Search, Your Podcasts, Playlists, Podcast view, Up Next, Now Playing, and Profile.
3. Check that elements look right-sized, margins are consistent, and nothing clips or overlaps.

## Checklist

- [ ] I have considered whether this change needs a CHANGELOG.md entry.
- [ ] I have tested the UI on a TV device or emulator.
- [ ] I have considered accessibility (focus order, TalkBack).
