### PR TITLE
Fix Huawei/HiSilicon Android ≤9 native playback crash via a fingerprint device-capability policy (cherry-pick to 8.20)

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/ChapterSeekResult.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/ChapterSeekResult.kt
@@ -14,5 +14,6 @@ sealed interface ChapterSeekResult {
         const val REASON_AUDIO_UNAVAILABLE = "audio_unavailable"
         const val REASON_NO_MATCH = "no_match"
         const val REASON_METERED_NETWORK = "metered_network"
+        const val REASON_UNSUPPORTED_DEVICE = "unsupported_device"
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
@@ -20,6 +20,8 @@ import au.com.shiftyjelly.pocketcasts.utils.Network
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
+import au.com.shiftyjelly.pocketcasts.utils.fingerprint.FingerprintDecodePolicy
+import au.com.shiftyjelly.pocketcasts.utils.fingerprint.FingerprintPolicy
 import com.automattic.eventhorizon.EventHorizon
 import com.automattic.eventhorizon.SyncedTranscriptsPreparationCompletedEvent
 import com.automattic.eventhorizon.SyncedTranscriptsPreparationFailedEvent
@@ -73,6 +75,7 @@ class FingerprintTimingManager @Inject constructor(
     private val settings: Settings,
     private val dataSourceFactory: Lazy<ExoPlayerDataSourceFactory>,
     private val pcmTap: FingerprintPcmTap,
+    private val decodePolicy: FingerprintDecodePolicy,
 ) {
 
     /** Who asked for preparation; decides whether streaming over a metered network is acceptable. */
@@ -328,6 +331,11 @@ class FingerprintTimingManager @Inject constructor(
      * accumulator, and never touches the continuous mapping or the public state.
      */
     suspend fun resolvePlaybackTime(episode: BaseEpisode, referenceTime: Duration): ChapterSeekResult {
+        if (decodePolicy.current() != FingerprintPolicy.PLATFORM) {
+            return densePlaybackTime(episode.uuid, referenceTime)
+                ?.let { ChapterSeekResult.Resolved(it, usedPrior = true) }
+                ?: ChapterSeekResult.Unresolved(ChapterSeekResult.REASON_UNSUPPORTED_DEVICE)
+        }
         val audioSource = episode.downloadedFilePath
             ?: episode.downloadUrl
             ?: return ChapterSeekResult.Unresolved(ChapterSeekResult.REASON_NO_AUDIO_SOURCE)
@@ -716,6 +724,7 @@ class FingerprintTimingManager @Inject constructor(
      */
     private suspend fun shouldRunEagerPass(episodeUuid: String, isDownloaded: Boolean): Boolean {
         if (Util.getAppPlatform(context) != AppPlatform.Phone) return false
+        if (decodePolicy.current() != FingerprintPolicy.PLATFORM) return false
         return computeEager(
             hasGeneratedChapters = chapterManager.get().hasGeneratedChapters(episodeUuid),
             isDownloaded = isDownloaded,
@@ -741,6 +750,12 @@ class FingerprintTimingManager @Inject constructor(
         if (Util.getAppPlatform(context) != AppPlatform.Phone) {
             markUnavailable(reason = "unsupported_platform", isStreaming = !isDownloaded, episodeUuid = episodeUuid)
             Timber.d("FingerprintTimingManager: unsupported platform")
+            return
+        }
+
+        if (decodePolicy.current() == FingerprintPolicy.DISABLED) {
+            markUnavailable(reason = "unsupported_device", isStreaming = !isDownloaded, episodeUuid = episodeUuid)
+            Timber.d("FingerprintTimingManager: unsupported device")
             return
         }
 
@@ -982,6 +997,7 @@ class FingerprintTimingManager @Inject constructor(
      */
     private fun maybeStartCatchUpResolve(gen: Long, startSec: Double) {
         if (currentEager) return
+        if (decodePolicy.current() != FingerprintPolicy.PLATFORM) return
         if (isWithinMatchedContent(startSec, snapshotPlaybackToReference)) return
         catchUpJob?.cancel()
         catchUpJob = scope.launch(Dispatchers.IO) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/GeneratedChapterSeeker.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/GeneratedChapterSeeker.kt
@@ -5,6 +5,8 @@ import au.com.shiftyjelly.pocketcasts.models.to.Chapter
 import au.com.shiftyjelly.pocketcasts.utils.AppPlatform
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
+import au.com.shiftyjelly.pocketcasts.utils.fingerprint.FingerprintDecodePolicy
+import au.com.shiftyjelly.pocketcasts.utils.fingerprint.FingerprintPolicy
 import dagger.Lazy
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -35,6 +37,7 @@ import timber.log.Timber
 class GeneratedChapterSeeker @Inject constructor(
     private val fingerprintTimingManager: Lazy<FingerprintTimingManager>,
     private val appPlatform: AppPlatform,
+    private val decodePolicy: FingerprintDecodePolicy,
 ) {
     data class ResolvingChapter(val episodeUuid: String, val chapterIndex: Int)
 
@@ -89,6 +92,8 @@ class GeneratedChapterSeeker @Inject constructor(
         val manager = fingerprintTimingManager.get()
         manager.densePlaybackTime(episode.uuid, referenceTime)?.let { return it.coerceAtLeast(chapter.startTime) }
 
+        if (decodePolicy.current() != FingerprintPolicy.PLATFORM) return null
+
         // A remembered failure repeats deterministically, so fall back without re-resolving.
         if (mutex.withLock { referenceUnavailable || chapter.index in failedChapters }) return null
 
@@ -139,6 +144,7 @@ class GeneratedChapterSeeker @Inject constructor(
 
     private fun isEnabled(chapter: Chapter): Boolean = chapter.isGenerated &&
         appPlatform == AppPlatform.Phone &&
+        decodePolicy.current() != FingerprintPolicy.DISABLED &&
         FeatureFlag.isEnabled(Feature.SYNCED_TRANSCRIPTS) &&
         FeatureFlag.isEnabled(Feature.GENERATED_CHAPTERS)
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayerFactoryImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayerFactoryImpl.kt
@@ -5,6 +5,7 @@ import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.FingerprintPcmTap
 import au.com.shiftyjelly.pocketcasts.repositories.stats.PlaybackStatsCollector
 import au.com.shiftyjelly.pocketcasts.repositories.user.StatsManager
+import au.com.shiftyjelly.pocketcasts.utils.fingerprint.FingerprintDecodePolicy
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 
@@ -14,6 +15,7 @@ class PlayerFactoryImpl @Inject constructor(
     private val playbackStatsCollector: PlaybackStatsCollector,
     private val dataSourceFactory: ExoPlayerDataSourceFactory,
     private val fingerprintPcmTap: FingerprintPcmTap,
+    private val fingerprintDecodePolicy: FingerprintDecodePolicy,
     @ApplicationContext private val context: Context,
 ) : PlayerFactory {
 
@@ -32,6 +34,7 @@ class PlayerFactoryImpl @Inject constructor(
             context = context,
             dataSourceFactory = dataSourceFactory,
             fingerprintPcmTap = fingerprintPcmTap,
+            fingerprintDecodePolicy = fingerprintDecodePolicy,
             onPlayerEvent = onPlayerEvent,
         )
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -29,6 +29,8 @@ import au.com.shiftyjelly.pocketcasts.utils.AppPlatform
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
+import au.com.shiftyjelly.pocketcasts.utils.fingerprint.FingerprintDecodePolicy
+import au.com.shiftyjelly.pocketcasts.utils.fingerprint.FingerprintPolicy
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.Dispatchers
@@ -42,6 +44,7 @@ class SimplePlayer(
     private val context: Context,
     private val dataSourceFactory: ExoPlayerDataSourceFactory,
     private val fingerprintPcmTap: FingerprintPcmTap? = null,
+    private val fingerprintDecodePolicy: FingerprintDecodePolicy,
     override val onPlayerEvent: (au.com.shiftyjelly.pocketcasts.repositories.playback.Player, PlayerEvent) -> Unit,
 ) : LocalPlayer(onPlayerEvent) {
     private val reducedBufferManufacturers = listOf("mercedes-benz")
@@ -370,7 +373,9 @@ class SimplePlayer(
             boostVolume = playbackEffects?.isVolumeBoosted ?: false,
             fingerprintPcmTap = fingerprintPcmTap,
             fingerprintTapEnabled = {
-                FeatureFlag.isEnabled(Feature.SYNCED_TRANSCRIPTS) && Util.getAppPlatform(context) == AppPlatform.Phone
+                FeatureFlag.isEnabled(Feature.SYNCED_TRANSCRIPTS) &&
+                    Util.getAppPlatform(context) == AppPlatform.Phone &&
+                    fingerprintDecodePolicy.current() != FingerprintPolicy.DISABLED
             },
             audioLevelMeterEnabled = { isTv },
         )

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/DriftFilterTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/DriftFilterTest.kt
@@ -1,15 +1,21 @@
 package au.com.shiftyjelly.pocketcasts.repositories.fingerprint
 
 import android.content.Context
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.FingerprintTimingManager.TimeMappingEntry
 import au.com.shiftyjelly.pocketcasts.repositories.playback.ExoPlayerDataSourceFactory
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.ChapterManager
+import au.com.shiftyjelly.pocketcasts.utils.fingerprint.FingerprintDecodePolicy
+import au.com.shiftyjelly.pocketcasts.utils.fingerprint.FingerprintPolicy
 import com.automattic.eventhorizon.EventHorizon
 import dagger.Lazy
+import java.util.Date
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -25,9 +31,16 @@ class DriftFilterTest {
 
     @Before
     fun setUp() {
+        manager = buildManager()
+        manager.debugTrackingEnabled = true
+    }
+
+    private fun buildManager(policy: FingerprintPolicy = FingerprintPolicy.PLATFORM): FingerprintTimingManager {
         val playbackManager = mock(PlaybackManager::class.java)
         whenever(playbackManager.playbackStateFlow).thenReturn(MutableStateFlow(PlaybackState()))
-        manager = FingerprintTimingManager(
+        val decodePolicy = mock(FingerprintDecodePolicy::class.java)
+        whenever(decodePolicy.current()).thenReturn(policy)
+        return FingerprintTimingManager(
             playbackManager = playbackManager,
             referenceRetriever = mock(FingerprintReferenceRetriever::class.java),
             eventHorizon = mock(EventHorizon::class.java),
@@ -36,8 +49,8 @@ class DriftFilterTest {
             settings = mock(Settings::class.java),
             dataSourceFactory = Lazy { mock(ExoPlayerDataSourceFactory::class.java) },
             pcmTap = FingerprintPcmTap(),
+            decodePolicy = decodePolicy,
         )
-        manager.debugTrackingEnabled = true
     }
 
     @Test
@@ -188,5 +201,18 @@ class DriftFilterTest {
 
         val rejections = manager.debugRejectionsSnapshot
         assertTrue("Rejections should not exceed cap", rejections.size <= cap)
+    }
+
+    @Test
+    fun `resolvePlaybackTime is unavailable under a restricted policy`() = runTest {
+        val restricted = buildManager(FingerprintPolicy.TAP_ONLY)
+        val episode = PodcastEpisode(uuid = "episode-uuid", publishedDate = Date())
+
+        val result = restricted.resolvePlaybackTime(episode, 100.seconds)
+
+        assertEquals(
+            ChapterSeekResult.Unresolved(ChapterSeekResult.REASON_UNSUPPORTED_DEVICE),
+            result,
+        )
     }
 }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/GeneratedChapterSeekerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/GeneratedChapterSeekerTest.kt
@@ -7,6 +7,7 @@ import au.com.shiftyjelly.pocketcasts.sharedtest.InMemoryFeatureFlagRule
 import au.com.shiftyjelly.pocketcasts.utils.AppPlatform
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
+import au.com.shiftyjelly.pocketcasts.utils.fingerprint.FingerprintPolicy
 import dagger.Lazy
 import java.util.Date
 import kotlin.time.Duration.Companion.seconds
@@ -60,10 +61,35 @@ class GeneratedChapterSeekerTest {
         timingManager = mock()
     }
 
-    private fun seeker(appPlatform: AppPlatform = AppPlatform.Phone) = GeneratedChapterSeeker(
+    private fun seeker(
+        appPlatform: AppPlatform = AppPlatform.Phone,
+        policy: FingerprintPolicy = FingerprintPolicy.PLATFORM,
+    ) = GeneratedChapterSeeker(
         fingerprintTimingManager = Lazy { timingManager },
         appPlatform = appPlatform,
+        decodePolicy = mock { on { current() } doReturn policy },
     )
+
+    @Test
+    fun `tap only policy resolves from the dense map without an on-demand decode`() = runTest {
+        timingManager = mock { on { densePlaybackTime(eq("episode-uuid"), eq(100.seconds)) } doReturn 131.5.seconds }
+        assertEquals(131.5.seconds, seeker(policy = FingerprintPolicy.TAP_ONLY).resolveSeekTime(episode, generatedChapter))
+        verifyBlocking(timingManager, never()) { resolvePlaybackTime(any(), any()) }
+    }
+
+    @Test
+    fun `tap only policy returns null when the dense map misses without resolving`() = runTest {
+        timingManager = mock { on { densePlaybackTime(any(), any()) } doReturn null }
+        assertNull(seeker(policy = FingerprintPolicy.TAP_ONLY).resolveSeekTime(episode, generatedChapter))
+        verifyBlocking(timingManager, never()) { resolvePlaybackTime(any(), any()) }
+    }
+
+    @Test
+    fun `disabled policy returns null without touching the timing manager`() = runTest {
+        assertNull(seeker(policy = FingerprintPolicy.DISABLED).resolveSeekTime(episode, generatedChapter))
+        verify(timingManager, never()).densePlaybackTime(any(), any())
+        verifyBlocking(timingManager, never()) { resolvePlaybackTime(any(), any()) }
+    }
 
     @Test
     fun `returns null for non-generated chapters`() = runTest {

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/config/FirebaseConfig.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/config/FirebaseConfig.kt
@@ -14,6 +14,7 @@ object FirebaseConfig {
     const val EXOPLAYER_CACHE_ENTIRE_PLAYING_EPISODE_SIZE_IN_MB = "exoplayer_cache_entire_playing_episode_size_in_mb"
     const val EXOPLAYER_CACHE_ENTIRE_PLAYING_EPISODE_SETTING_DEFAULT = "exoplayer_cache_entire_playing_episode_setting_default"
     const val PLAYBACK_EPISODE_POSITION_CHANGED_ON_SYNC_THRESHOLD_SECS = "playback_episode_position_changed_on_sync_threshold_secs"
+    const val FINGERPRINT_POLICY_OVERRIDE = "fingerprint_policy_override"
 
     val defaults = mapOf(
         PERIODIC_SAVE_TIME_MS to 60000L,
@@ -26,6 +27,7 @@ object FirebaseConfig {
         EXOPLAYER_CACHE_ENTIRE_PLAYING_EPISODE_SIZE_IN_MB to 500L,
         EXOPLAYER_CACHE_ENTIRE_PLAYING_EPISODE_SETTING_DEFAULT to true,
         PLAYBACK_EPISODE_POSITION_CHANGED_ON_SYNC_THRESHOLD_SECS to 5L,
+        FINGERPRINT_POLICY_OVERRIDE to "",
     ) + Feature.entries
         .filter { it.hasFirebaseRemoteFlag }
         .associate { it.key to it.defaultValue }

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/fingerprint/FingerprintDecodePolicy.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/fingerprint/FingerprintDecodePolicy.kt
@@ -1,0 +1,56 @@
+package au.com.shiftyjelly.pocketcasts.utils.fingerprint
+
+import android.os.Build
+import androidx.annotation.VisibleForTesting
+import au.com.shiftyjelly.pocketcasts.utils.config.FirebaseConfig
+import com.google.firebase.remoteconfig.FirebaseRemoteConfig
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class FingerprintDecodePolicy @Inject constructor(
+    private val remoteConfig: FirebaseRemoteConfig,
+) {
+    fun current(): FingerprintPolicy = resolve(
+        sdkInt = Build.VERSION.SDK_INT,
+        manufacturer = Build.MANUFACTURER,
+        brand = Build.BRAND,
+        hardware = Build.HARDWARE,
+        board = Build.BOARD,
+        override = { remoteConfig.getString(FirebaseConfig.FINGERPRINT_POLICY_OVERRIDE) },
+    )
+
+    companion object {
+        private val hiSiliconSocPattern = Regex("hi\\d")
+
+        @VisibleForTesting
+        fun resolve(
+            sdkInt: Int,
+            manufacturer: String,
+            brand: String,
+            hardware: String,
+            board: String,
+            override: () -> String,
+        ): FingerprintPolicy {
+            if (!isAffected(sdkInt, manufacturer, brand, hardware, board)) return FingerprintPolicy.PLATFORM
+            return parseOverride(override()) ?: FingerprintPolicy.TAP_ONLY
+        }
+
+        private fun isAffected(
+            sdkInt: Int,
+            manufacturer: String,
+            brand: String,
+            hardware: String,
+            board: String,
+        ): Boolean {
+            if (sdkInt > Build.VERSION_CODES.P) return false
+            val vendor = "$manufacturer $brand".lowercase()
+            val soc = "$hardware $board".lowercase()
+            val isHuawei = "huawei" in vendor || "honor" in vendor
+            val isHiSilicon = "kirin" in soc || hiSiliconSocPattern.containsMatchIn(soc)
+            return isHuawei && isHiSilicon
+        }
+
+        private fun parseOverride(value: String): FingerprintPolicy? = FingerprintPolicy.entries.firstOrNull { it.name.equals(value.trim(), ignoreCase = true) }
+    }
+}

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/fingerprint/FingerprintPolicy.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/fingerprint/FingerprintPolicy.kt
@@ -1,0 +1,7 @@
+package au.com.shiftyjelly.pocketcasts.utils.fingerprint
+
+enum class FingerprintPolicy {
+    PLATFORM,
+    TAP_ONLY,
+    DISABLED,
+}

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/fingerprint/FingerprintDecodePolicyTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/fingerprint/FingerprintDecodePolicyTest.kt
@@ -1,0 +1,114 @@
+package au.com.shiftyjelly.pocketcasts.utils.fingerprint
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class FingerprintDecodePolicyTest {
+    @Test
+    fun `platform for non-huawei device`() {
+        assertEquals(FingerprintPolicy.PLATFORM, resolvePixel(sdkInt = 28, override = ""))
+    }
+
+    @Test
+    fun `platform for huawei on modern android`() {
+        assertEquals(FingerprintPolicy.PLATFORM, resolveHuaweiKirin(sdkInt = 29, override = ""))
+    }
+
+    @Test
+    fun `platform for huawei without a hisilicon soc`() {
+        val policy = resolve(
+            sdkInt = 28,
+            manufacturer = "HUAWEI",
+            brand = "HUAWEI",
+            hardware = "mt6762",
+            board = "mt6762",
+            override = "",
+        )
+        assertEquals(FingerprintPolicy.PLATFORM, policy)
+    }
+
+    @Test
+    fun `tap only for huawei hisilicon on legacy android`() {
+        assertEquals(FingerprintPolicy.TAP_ONLY, resolveHuaweiKirin(sdkInt = 28, override = ""))
+    }
+
+    @Test
+    fun `tap only for honor hisilicon`() {
+        val policy = resolve(
+            sdkInt = 27,
+            manufacturer = "HONOR",
+            brand = "HONOR",
+            hardware = "hi3660",
+            board = "hi3660",
+            override = "",
+        )
+        assertEquals(FingerprintPolicy.TAP_ONLY, policy)
+    }
+
+    @Test
+    fun `tap only for kirin 6xx hisilicon soc codename`() {
+        val policy = resolve(
+            sdkInt = 26,
+            manufacturer = "HUAWEI",
+            brand = "HONOR",
+            hardware = "hi6250",
+            board = "hi6250",
+            override = "",
+        )
+        assertEquals(FingerprintPolicy.TAP_ONLY, policy)
+    }
+
+    @Test
+    fun `garbage override falls back to tap only on affected devices`() {
+        assertEquals(FingerprintPolicy.TAP_ONLY, resolveHuaweiKirin(sdkInt = 28, override = "banana"))
+    }
+
+    @Test
+    fun `override disables the subsystem on affected devices`() {
+        assertEquals(FingerprintPolicy.DISABLED, resolveHuaweiKirin(sdkInt = 28, override = "disabled"))
+    }
+
+    @Test
+    fun `override can restore the platform path on affected devices`() {
+        assertEquals(FingerprintPolicy.PLATFORM, resolveHuaweiKirin(sdkInt = 28, override = "PLATFORM"))
+    }
+
+    @Test
+    fun `override is ignored on non-affected devices`() {
+        assertEquals(FingerprintPolicy.PLATFORM, resolvePixel(sdkInt = 28, override = "DISABLED"))
+    }
+
+    private fun resolveHuaweiKirin(sdkInt: Int, override: String) = resolve(
+        sdkInt = sdkInt,
+        manufacturer = "HUAWEI",
+        brand = "HUAWEI",
+        hardware = "kirin970",
+        board = "kirin970",
+        override = override,
+    )
+
+    private fun resolvePixel(sdkInt: Int, override: String) = resolve(
+        sdkInt = sdkInt,
+        manufacturer = "Google",
+        brand = "google",
+        hardware = "walleye",
+        board = "walleye",
+        override = override,
+    )
+
+    private fun resolve(
+        sdkInt: Int,
+        manufacturer: String,
+        brand: String,
+        hardware: String,
+        board: String,
+        override: String,
+    ) = FingerprintDecodePolicy.resolve(
+        sdkInt = sdkInt,
+        manufacturer = manufacturer,
+        brand = brand,
+        hardware = hardware,
+        board = board,
+        override = { override },
+    )
+}


### PR DESCRIPTION
## Description

Cherry-pick of #5814 into `release/8.20`.

> **This change was already reviewed and merged on `main`.** This PR exists to land it in the upcoming release. CI and a quick review should still run to confirm the cherry-pick applies cleanly and introduces no issues on the release branch, since `release/8.20` may have diverged from `main`.

- Original PR: https://github.com/Automattic/pocket-casts-android/pull/5814
- Cherry-picked commit: `00abd928`

## Testing Instructions

See the original PR (https://github.com/Automattic/pocket-casts-android/pull/5814) for full testing steps. In addition, verify the change behaves as described on top of `release/8.20`.