### PR TITLE
Allow skip intents to specify a custom number of seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 8.20
 -----
-*   New Features
+*   Updates 
     *   Allow the skip forward and skip back intents to specify a custom number of seconds
 
 8.19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 8.21
 -----
 
-
 8.20
 -----
-
+*   New Features
+    *   Allow the skip forward and skip back intents to specify a custom number of seconds
 
 8.19
 -----

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1160,7 +1160,7 @@ open class PlaybackManager @Inject constructor(
 
     fun skipForward(
         sourceView: SourceView = SourceView.UNKNOWN,
-        jumpAmountSeconds: Int = settings.skipForwardInSecs.value,
+        jumpAmountSeconds: Int? = null,
     ) {
         launch {
             skipForwardSuspend(sourceView, jumpAmountSeconds)
@@ -1169,13 +1169,13 @@ open class PlaybackManager @Inject constructor(
 
     suspend fun skipForwardSuspend(
         sourceView: SourceView = SourceView.UNKNOWN,
-        jumpAmountSeconds: Int = settings.skipForwardInSecs.value,
+        jumpAmountSeconds: Int? = null,
     ) {
         LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Skip forward tapped")
 
         cancelPendingChapterSeek()
         val episode = getCurrentEpisode() ?: return
-        val jumpAmountMs = jumpAmountSeconds * 1000
+        val jumpAmountMs = (jumpAmountSeconds ?: settings.skipForwardInSecs.value) * 1000
 
         val currentTimeMs = getCurrentTimeMs(episode = episode)
         if (currentTimeMs < 0 || player?.episodeUuid != episode.uuid) return // Make sure the player hasn't changed episodes before using the current time to seek
@@ -1199,19 +1199,19 @@ open class PlaybackManager @Inject constructor(
         }
     }
 
-    fun skipBackward(sourceView: SourceView = SourceView.UNKNOWN, jumpAmountSeconds: Int = settings.skipBackInSecs.value) {
+    fun skipBackward(sourceView: SourceView = SourceView.UNKNOWN, jumpAmountSeconds: Int? = null) {
         launch {
             skipBackwardSuspend(sourceView, jumpAmountSeconds)
         }
     }
 
-    suspend fun skipBackwardSuspend(sourceView: SourceView = SourceView.UNKNOWN, jumpAmountSeconds: Int = settings.skipBackInSecs.value) {
+    suspend fun skipBackwardSuspend(sourceView: SourceView = SourceView.UNKNOWN, jumpAmountSeconds: Int? = null) {
         LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Skip backward tapped")
 
         cancelPendingChapterSeek()
         val episode = getCurrentEpisode() ?: return
 
-        val jumpAmountMs = jumpAmountSeconds * 1000
+        val jumpAmountMs = (jumpAmountSeconds ?: settings.skipBackInSecs.value) * 1000
         val currentTimeMs = getCurrentTimeMs(episode = episode)
         if (currentTimeMs < 0) return
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayerBroadcastReceiver.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayerBroadcastReceiver.kt
@@ -4,7 +4,6 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
-import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import dagger.hilt.android.AndroidEntryPoint
@@ -34,8 +33,6 @@ class PlayerBroadcastReceiver : BroadcastReceiver() {
 
     @Inject lateinit var playbackManager: PlaybackManager
 
-    @Inject lateinit var settings: Settings
-
     private val sourceView = SourceView.PLAYER_BROADCAST_ACTION
 
     override fun onReceive(context: Context, intent: Intent) {
@@ -61,17 +58,11 @@ class PlayerBroadcastReceiver : BroadcastReceiver() {
     }
 
     private fun skipBackward(jumpAmountSeconds: Int?) {
-        playbackManager.skipBackward(
-            sourceView = sourceView,
-            jumpAmountSeconds = jumpAmountSeconds ?: settings.skipBackInSecs.value,
-        )
+        playbackManager.skipBackward(sourceView = sourceView, jumpAmountSeconds = jumpAmountSeconds)
     }
 
     private fun skipForward(jumpAmountSeconds: Int?) {
-        playbackManager.skipForward(
-            sourceView = sourceView,
-            jumpAmountSeconds = jumpAmountSeconds ?: settings.skipForwardInSecs.value,
-        )
+        playbackManager.skipForward(sourceView = sourceView, jumpAmountSeconds = jumpAmountSeconds)
     }
 
     private fun pause() {
@@ -95,10 +86,12 @@ class PlayerBroadcastReceiver : BroadcastReceiver() {
  * Reads the skip amount override, or null to fall back to the user's setting.
  */
 internal fun Intent.skipAmountSecondsOrNull(): Int? {
-    val seconds = getStringExtra(PlayerBroadcastReceiver.INTENT_EXTRA_SECONDS)?.toIntOrNull()
-        ?: getIntExtra(PlayerBroadcastReceiver.INTENT_EXTRA_SECONDS, 0)
-    // Capped because PlaybackManager converts the amount to milliseconds in Int arithmetic.
+    val seconds = runCatching {
+        getStringExtra(PlayerBroadcastReceiver.INTENT_EXTRA_SECONDS)?.toIntOrNull()
+            ?: getIntExtra(PlayerBroadcastReceiver.INTENT_EXTRA_SECONDS, 0)
+    }.getOrDefault(0)
     return seconds.takeIf { it > 0 }?.coerceAtMost(MAX_SKIP_AMOUNT_SECONDS)
 }
 
-private const val MAX_SKIP_AMOUNT_SECONDS = 86_400
+// Limit the skip amount to an hour
+private const val MAX_SKIP_AMOUNT_SECONDS = 3_600

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayerBroadcastReceiver.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayerBroadcastReceiver.kt
@@ -4,6 +4,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import dagger.hilt.android.AndroidEntryPoint
@@ -24,11 +25,17 @@ class PlayerBroadcastReceiver : BroadcastReceiver() {
         const val INTENT_ACTION_PAUSE = "au.com.shiftyjelly.pocketcasts.action.PAUSE"
         const val INTENT_ACTION_STOP = "au.com.shiftyjelly.pocketcasts.action.STOP"
         const val INTENT_ACTION_NEXT = "au.com.shiftyjelly.pocketcasts.action.NEXT"
+
+        // Optional extra on the skip actions to override the user's configured skip amount.
+        const val INTENT_EXTRA_SECONDS = "au.com.shiftyjelly.pocketcasts.extra.SECONDS"
     }
 
     @Inject lateinit var podcastManager: PodcastManager
 
     @Inject lateinit var playbackManager: PlaybackManager
+
+    @Inject lateinit var settings: Settings
+
     private val sourceView = SourceView.PLAYER_BROADCAST_ACTION
 
     override fun onReceive(context: Context, intent: Intent) {
@@ -40,8 +47,8 @@ class PlayerBroadcastReceiver : BroadcastReceiver() {
                 INTENT_ACTION_NOTIFICATION_PAUSE, INTENT_ACTION_WIDGET_PAUSE, INTENT_ACTION_PAUSE -> pause()
                 INTENT_ACTION_STOP -> stop()
                 INTENT_ACTION_NEXT -> playNext()
-                INTENT_ACTION_SKIP_FORWARD -> skipForward()
-                INTENT_ACTION_SKIP_BACKWARD -> skipBackward()
+                INTENT_ACTION_SKIP_FORWARD -> skipForward(intent.skipAmountSecondsOrNull())
+                INTENT_ACTION_SKIP_BACKWARD -> skipBackward(intent.skipAmountSecondsOrNull())
             }
             // To help us with debugging user support emails log where the user took the action.
             val logFrom = when (intent.action) {
@@ -53,12 +60,18 @@ class PlayerBroadcastReceiver : BroadcastReceiver() {
         }
     }
 
-    private fun skipBackward() {
-        playbackManager.skipBackward(sourceView = sourceView)
+    private fun skipBackward(jumpAmountSeconds: Int?) {
+        playbackManager.skipBackward(
+            sourceView = sourceView,
+            jumpAmountSeconds = jumpAmountSeconds ?: settings.skipBackInSecs.value,
+        )
     }
 
-    private fun skipForward() {
-        playbackManager.skipForward(sourceView = sourceView)
+    private fun skipForward(jumpAmountSeconds: Int?) {
+        playbackManager.skipForward(
+            sourceView = sourceView,
+            jumpAmountSeconds = jumpAmountSeconds ?: settings.skipForwardInSecs.value,
+        )
     }
 
     private fun pause() {
@@ -77,3 +90,15 @@ class PlayerBroadcastReceiver : BroadcastReceiver() {
         playbackManager.stopAsync(sourceView = sourceView)
     }
 }
+
+/**
+ * Reads the skip amount override, or null to fall back to the user's setting.
+ */
+internal fun Intent.skipAmountSecondsOrNull(): Int? {
+    val seconds = getStringExtra(PlayerBroadcastReceiver.INTENT_EXTRA_SECONDS)?.toIntOrNull()
+        ?: getIntExtra(PlayerBroadcastReceiver.INTENT_EXTRA_SECONDS, 0)
+    // Capped because PlaybackManager converts the amount to milliseconds in Int arithmetic.
+    return seconds.takeIf { it > 0 }?.coerceAtMost(MAX_SKIP_AMOUNT_SECONDS)
+}
+
+private const val MAX_SKIP_AMOUNT_SECONDS = 86_400

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayerBroadcastReceiverTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayerBroadcastReceiverTest.kt
@@ -45,8 +45,13 @@ class PlayerBroadcastReceiverTest {
     }
 
     @Test
-    fun `caps an amount that would overflow the millisecond conversion`() {
-        assertEquals(86_400, skipIntent().putExtra(INTENT_EXTRA_SECONDS, Int.MAX_VALUE).skipAmountSecondsOrNull())
+    fun `caps an amount above an hour`() {
+        assertEquals(3_600, skipIntent().putExtra(INTENT_EXTRA_SECONDS, Int.MAX_VALUE).skipAmountSecondsOrNull())
+    }
+
+    @Test
+    fun `keeps an amount at the cap`() {
+        assertEquals(3_600, skipIntent().putExtra(INTENT_EXTRA_SECONDS, 3_600).skipAmountSecondsOrNull())
     }
 
     private fun skipIntent() = Intent(INTENT_ACTION_SKIP_FORWARD)

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayerBroadcastReceiverTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayerBroadcastReceiverTest.kt
@@ -1,0 +1,53 @@
+package au.com.shiftyjelly.pocketcasts.repositories.playback
+
+import android.content.Intent
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlayerBroadcastReceiver.Companion.INTENT_ACTION_SKIP_FORWARD
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlayerBroadcastReceiver.Companion.INTENT_EXTRA_SECONDS
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@Config(manifest = Config.NONE)
+@RunWith(RobolectricTestRunner::class)
+class PlayerBroadcastReceiverTest {
+
+    @Test
+    fun `returns null when the extra is missing`() {
+        assertNull(skipIntent().skipAmountSecondsOrNull())
+    }
+
+    @Test
+    fun `reads an int extra`() {
+        assertEquals(45, skipIntent().putExtra(INTENT_EXTRA_SECONDS, 45).skipAmountSecondsOrNull())
+    }
+
+    @Test
+    fun `reads a string extra`() {
+        assertEquals(45, skipIntent().putExtra(INTENT_EXTRA_SECONDS, "45").skipAmountSecondsOrNull())
+    }
+
+    @Test
+    fun `returns null for a non numeric string extra`() {
+        assertNull(skipIntent().putExtra(INTENT_EXTRA_SECONDS, "abc").skipAmountSecondsOrNull())
+    }
+
+    @Test
+    fun `returns null for zero`() {
+        assertNull(skipIntent().putExtra(INTENT_EXTRA_SECONDS, 0).skipAmountSecondsOrNull())
+    }
+
+    @Test
+    fun `returns null for a negative amount`() {
+        assertNull(skipIntent().putExtra(INTENT_EXTRA_SECONDS, -30).skipAmountSecondsOrNull())
+    }
+
+    @Test
+    fun `caps an amount that would overflow the millisecond conversion`() {
+        assertEquals(86_400, skipIntent().putExtra(INTENT_EXTRA_SECONDS, Int.MAX_VALUE).skipAmountSecondsOrNull())
+    }
+
+    private fun skipIntent() = Intent(INTENT_ACTION_SKIP_FORWARD)
+}


### PR DESCRIPTION
## Description

Automation apps that trigger Pocket Casts' skip forward / skip back actions can now ask for a specific number of seconds, instead of always being stuck with whatever skip amount the user has configured in settings.

Previously the skip broadcast actions took no parameters, so a Tasker task (or any other automation) could only skip by the user's global skip amount. Someone who wants a 5 second nudge from a shortcut while keeping their 45 second skip button had no way to express that.

The skip broadcast actions now accept an optional `au.com.shiftyjelly.pocketcasts.extra.SECONDS` extra. It is read as either an int or a numeric string, since some automation tools can only send string extras. When the extra is absent, zero, negative, or not a number, the receiver falls back to the user's configured `skipForwardInSecs` / `skipBackInSecs`, so existing integrations are unaffected. The value is capped at 3,600 seconds (one hour), which is beyond anything a real automation would ask for. The cap also limits abuse: the receiver is exported with no permission, and `PlaybackManager` credits `addTimeSavedSkipping` with the full requested jump even when the seek overshoots the end of the episode, so an uncapped extra would let any installed app add arbitrary hours to the user's synced "time saved skipping" total.

## Testing Instructions

1. Install a debug build on a device and start playing an episode.
2. Note the current skip forward amount in Settings > General (e.g. 45 seconds).
3. From adb, send a skip with an explicit amount:
   `adb shell am broadcast -a au.com.shiftyjelly.pocketcasts.action.SKIP_FORWARD --ei au.com.shiftyjelly.pocketcasts.extra.SECONDS 10 -p au.com.shiftyjelly.pocketcasts.debug`
4. Confirm playback jumps forward by 10 seconds, not by the configured amount.
5. Repeat with a string extra to confirm it is also accepted:
   `adb shell am broadcast -a au.com.shiftyjelly.pocketcasts.action.SKIP_FORWARD --es au.com.shiftyjelly.pocketcasts.extra.SECONDS 10 -p au.com.shiftyjelly.pocketcasts.debug`
6. Send the same broadcast with **no** extra and confirm it still skips by the configured amount.
7. Repeat steps 3-6 with `au.com.shiftyjelly.pocketcasts.action.SKIP_BACKWARD`.
8. Confirm the skip buttons in the player, notification and widget are unchanged.
9. Send a broadcast with an out of range amount, e.g. `--ei au.com.shiftyjelly.pocketcasts.extra.SECONDS 999999`, and confirm the skip is capped at one hour rather than jumping wildly.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
