### PR TITLE
Allow skip intents to specify a custom number of seconds (cherry-pick to 8.20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 8.21
 -----
 
-
 8.20
 -----
-
+*   Updates 
+    *   Allow the skip forward and skip back intents to specify a custom number of seconds
 
 8.19
 -----

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1160,7 +1160,7 @@ open class PlaybackManager @Inject constructor(
 
     fun skipForward(
         sourceView: SourceView = SourceView.UNKNOWN,
-        jumpAmountSeconds: Int = settings.skipForwardInSecs.value,
+        jumpAmountSeconds: Int? = null,
     ) {
         launch {
             skipForwardSuspend(sourceView, jumpAmountSeconds)
@@ -1169,13 +1169,13 @@ open class PlaybackManager @Inject constructor(
 
     suspend fun skipForwardSuspend(
         sourceView: SourceView = SourceView.UNKNOWN,
-        jumpAmountSeconds: Int = settings.skipForwardInSecs.value,
+        jumpAmountSeconds: Int? = null,
     ) {
         LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Skip forward tapped")
 
         cancelPendingChapterSeek()
         val episode = getCurrentEpisode() ?: return
-        val jumpAmountMs = jumpAmountSeconds * 1000
+        val jumpAmountMs = (jumpAmountSeconds ?: settings.skipForwardInSecs.value) * 1000
 
         val currentTimeMs = getCurrentTimeMs(episode = episode)
         if (currentTimeMs < 0 || player?.episodeUuid != episode.uuid) return // Make sure the player hasn't changed episodes before using the current time to seek
@@ -1199,19 +1199,19 @@ open class PlaybackManager @Inject constructor(
         }
     }
 
-    fun skipBackward(sourceView: SourceView = SourceView.UNKNOWN, jumpAmountSeconds: Int = settings.skipBackInSecs.value) {
+    fun skipBackward(sourceView: SourceView = SourceView.UNKNOWN, jumpAmountSeconds: Int? = null) {
         launch {
             skipBackwardSuspend(sourceView, jumpAmountSeconds)
         }
     }
 
-    suspend fun skipBackwardSuspend(sourceView: SourceView = SourceView.UNKNOWN, jumpAmountSeconds: Int = settings.skipBackInSecs.value) {
+    suspend fun skipBackwardSuspend(sourceView: SourceView = SourceView.UNKNOWN, jumpAmountSeconds: Int? = null) {
         LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Skip backward tapped")
 
         cancelPendingChapterSeek()
         val episode = getCurrentEpisode() ?: return
 
-        val jumpAmountMs = jumpAmountSeconds * 1000
+        val jumpAmountMs = (jumpAmountSeconds ?: settings.skipBackInSecs.value) * 1000
         val currentTimeMs = getCurrentTimeMs(episode = episode)
         if (currentTimeMs < 0) return
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayerBroadcastReceiver.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayerBroadcastReceiver.kt
@@ -24,11 +24,15 @@ class PlayerBroadcastReceiver : BroadcastReceiver() {
         const val INTENT_ACTION_PAUSE = "au.com.shiftyjelly.pocketcasts.action.PAUSE"
         const val INTENT_ACTION_STOP = "au.com.shiftyjelly.pocketcasts.action.STOP"
         const val INTENT_ACTION_NEXT = "au.com.shiftyjelly.pocketcasts.action.NEXT"
+
+        // Optional extra on the skip actions to override the user's configured skip amount.
+        const val INTENT_EXTRA_SECONDS = "au.com.shiftyjelly.pocketcasts.extra.SECONDS"
     }
 
     @Inject lateinit var podcastManager: PodcastManager
 
     @Inject lateinit var playbackManager: PlaybackManager
+
     private val sourceView = SourceView.PLAYER_BROADCAST_ACTION
 
     override fun onReceive(context: Context, intent: Intent) {
@@ -40,8 +44,8 @@ class PlayerBroadcastReceiver : BroadcastReceiver() {
                 INTENT_ACTION_NOTIFICATION_PAUSE, INTENT_ACTION_WIDGET_PAUSE, INTENT_ACTION_PAUSE -> pause()
                 INTENT_ACTION_STOP -> stop()
                 INTENT_ACTION_NEXT -> playNext()
-                INTENT_ACTION_SKIP_FORWARD -> skipForward()
-                INTENT_ACTION_SKIP_BACKWARD -> skipBackward()
+                INTENT_ACTION_SKIP_FORWARD -> skipForward(intent.skipAmountSecondsOrNull())
+                INTENT_ACTION_SKIP_BACKWARD -> skipBackward(intent.skipAmountSecondsOrNull())
             }
             // To help us with debugging user support emails log where the user took the action.
             val logFrom = when (intent.action) {
@@ -53,12 +57,12 @@ class PlayerBroadcastReceiver : BroadcastReceiver() {
         }
     }
 
-    private fun skipBackward() {
-        playbackManager.skipBackward(sourceView = sourceView)
+    private fun skipBackward(jumpAmountSeconds: Int?) {
+        playbackManager.skipBackward(sourceView = sourceView, jumpAmountSeconds = jumpAmountSeconds)
     }
 
-    private fun skipForward() {
-        playbackManager.skipForward(sourceView = sourceView)
+    private fun skipForward(jumpAmountSeconds: Int?) {
+        playbackManager.skipForward(sourceView = sourceView, jumpAmountSeconds = jumpAmountSeconds)
     }
 
     private fun pause() {
@@ -77,3 +81,17 @@ class PlayerBroadcastReceiver : BroadcastReceiver() {
         playbackManager.stopAsync(sourceView = sourceView)
     }
 }
+
+/**
+ * Reads the skip amount override, or null to fall back to the user's setting.
+ */
+internal fun Intent.skipAmountSecondsOrNull(): Int? {
+    val seconds = runCatching {
+        getStringExtra(PlayerBroadcastReceiver.INTENT_EXTRA_SECONDS)?.toIntOrNull()
+            ?: getIntExtra(PlayerBroadcastReceiver.INTENT_EXTRA_SECONDS, 0)
+    }.getOrDefault(0)
+    return seconds.takeIf { it > 0 }?.coerceAtMost(MAX_SKIP_AMOUNT_SECONDS)
+}
+
+// Limit the skip amount to an hour
+private const val MAX_SKIP_AMOUNT_SECONDS = 3_600

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayerBroadcastReceiverTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayerBroadcastReceiverTest.kt
@@ -1,0 +1,58 @@
+package au.com.shiftyjelly.pocketcasts.repositories.playback
+
+import android.content.Intent
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlayerBroadcastReceiver.Companion.INTENT_ACTION_SKIP_FORWARD
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlayerBroadcastReceiver.Companion.INTENT_EXTRA_SECONDS
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@Config(manifest = Config.NONE)
+@RunWith(RobolectricTestRunner::class)
+class PlayerBroadcastReceiverTest {
+
+    @Test
+    fun `returns null when the extra is missing`() {
+        assertNull(skipIntent().skipAmountSecondsOrNull())
+    }
+
+    @Test
+    fun `reads an int extra`() {
+        assertEquals(45, skipIntent().putExtra(INTENT_EXTRA_SECONDS, 45).skipAmountSecondsOrNull())
+    }
+
+    @Test
+    fun `reads a string extra`() {
+        assertEquals(45, skipIntent().putExtra(INTENT_EXTRA_SECONDS, "45").skipAmountSecondsOrNull())
+    }
+
+    @Test
+    fun `returns null for a non numeric string extra`() {
+        assertNull(skipIntent().putExtra(INTENT_EXTRA_SECONDS, "abc").skipAmountSecondsOrNull())
+    }
+
+    @Test
+    fun `returns null for zero`() {
+        assertNull(skipIntent().putExtra(INTENT_EXTRA_SECONDS, 0).skipAmountSecondsOrNull())
+    }
+
+    @Test
+    fun `returns null for a negative amount`() {
+        assertNull(skipIntent().putExtra(INTENT_EXTRA_SECONDS, -30).skipAmountSecondsOrNull())
+    }
+
+    @Test
+    fun `caps an amount above an hour`() {
+        assertEquals(3_600, skipIntent().putExtra(INTENT_EXTRA_SECONDS, Int.MAX_VALUE).skipAmountSecondsOrNull())
+    }
+
+    @Test
+    fun `keeps an amount at the cap`() {
+        assertEquals(3_600, skipIntent().putExtra(INTENT_EXTRA_SECONDS, 3_600).skipAmountSecondsOrNull())
+    }
+
+    private fun skipIntent() = Intent(INTENT_ACTION_SKIP_FORWARD)
+}


### PR DESCRIPTION
## Description

Cherry-pick of #5818 into `release/8.20`.

> **This change was already reviewed and merged on `main`.** This PR exists to land it in the upcoming release. CI and a quick review should still run to confirm the cherry-pick applies cleanly and introduces no issues on the release branch, since `release/8.20` may have diverged from `main`.

- Original PR: https://github.com/Automattic/pocket-casts-android/pull/5818
- Cherry-picked commit: `1680831`

## Testing Instructions

See the original PR (https://github.com/Automattic/pocket-casts-android/pull/5818) for full testing steps. In addition, verify the change behaves as described on top of `release/8.20`.
