### PR TITLE
Use the configured skip back interval for the Cast notification rewind button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 8.21
 -----
+*   Bug Fixes
+    *   Fix the Cast notification rewind button showing 30 seconds regardless of the configured skip back interval
+        ([#5820](https://github.com/Automattic/pocket-casts-android/pull/5820))
 
 
 8.20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 8.21
 -----
 *   Bug Fixes
-    *   Fix the Cast notification rewind button showing 30 seconds regardless of the configured skip back interval
+    *   Fix the skip forward and back intervals in the Cast notification
         ([#5820](https://github.com/Automattic/pocket-casts-android/pull/5820))
 
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -676,6 +676,9 @@
         <meta-data
             android:name="com.google.android.gms.cast.framework.OPTIONS_PROVIDER_CLASS_NAME"
             android:value="au.com.shiftyjelly.pocketcasts.CastOptionsProvider" />
+        <receiver
+            android:name="au.com.shiftyjelly.pocketcasts.PocketCastsMediaIntentReceiver"
+            android:exported="false" />
 
         <!-- Android Auto theme -->
         <meta-data

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/CastOptionsProvider.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/CastOptionsProvider.kt
@@ -27,6 +27,7 @@ class CastOptionsProvider : OptionsProvider {
             .build()
         val mediaOptions = CastMediaOptions.Builder()
             .setNotificationOptions(notificationOptions)
+            .setMediaIntentReceiverClassName(PocketCastsMediaIntentReceiver::class.java.name)
             .setExpandedControllerActivityClassName(MainActivity::class.java.name)
             .build()
         return CastOptions.Builder()

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/CastOptionsProvider.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/CastOptionsProvider.kt
@@ -22,7 +22,7 @@ class CastOptionsProvider : OptionsProvider {
         val compatButtonActionsIndices = intArrayOf(0, 1, 2)
         val notificationOptions = NotificationOptions.Builder()
             .setActions(buttonActions, compatButtonActionsIndices)
-            .setSkipStepMs(application.settings.skipForwardInSecs.value * 1000L)
+            .setSkipStepMs(application.settings.skipBackInSecs.value * 1000L)
             .setTargetActivityClassName(MainActivity::class.java.name)
             .build()
         val mediaOptions = CastMediaOptions.Builder()

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsMediaIntentReceiver.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsMediaIntentReceiver.kt
@@ -1,0 +1,38 @@
+package au.com.shiftyjelly.pocketcasts
+
+import android.content.Context
+import android.content.Intent
+import com.google.android.gms.cast.MediaSeekOptions
+import com.google.android.gms.cast.framework.CastSession
+import com.google.android.gms.cast.framework.Session
+import com.google.android.gms.cast.framework.media.MediaIntentReceiver
+
+class PocketCastsMediaIntentReceiver : MediaIntentReceiver() {
+    private lateinit var application: PocketCastsApplication
+
+    override fun onReceive(context: Context, intent: Intent) {
+        application = context.applicationContext as PocketCastsApplication
+        super.onReceive(context, intent)
+    }
+
+    override fun onReceiveActionRewind(session: Session, skipStepMs: Long) {
+        seek(session, -application.settings.skipBackInSecs.value * 1000L)
+    }
+
+    override fun onReceiveActionForward(session: Session, skipStepMs: Long) {
+        seek(session, application.settings.skipForwardInSecs.value * 1000L)
+    }
+
+    private fun seek(session: Session, deltaMs: Long) {
+        if (deltaMs == 0L) return
+        val castSession = session as? CastSession ?: return
+        if (!castSession.isConnected) return
+        val client = castSession.remoteMediaClient ?: return
+        if (client.isLiveStream || client.isPlayingAd) return
+        val seekOptions = MediaSeekOptions.Builder()
+            .setPosition(client.approximateStreamPosition + deltaMs)
+            .setResumeState(MediaSeekOptions.RESUME_STATE_UNCHANGED)
+            .build()
+        client.seek(seekOptions)
+    }
+}

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsMediaIntentReceiver.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsMediaIntentReceiver.kt
@@ -16,23 +16,42 @@ class PocketCastsMediaIntentReceiver : MediaIntentReceiver() {
     }
 
     override fun onReceiveActionRewind(session: Session, skipStepMs: Long) {
-        seek(session, -application.settings.skipBackInSecs.value * 1000L)
+        seek(session, rewindDeltaMs(application.settings.skipBackInSecs.value))
     }
 
     override fun onReceiveActionForward(session: Session, skipStepMs: Long) {
-        seek(session, application.settings.skipForwardInSecs.value * 1000L)
+        seek(session, forwardDeltaMs(application.settings.skipForwardInSecs.value))
     }
 
     private fun seek(session: Session, deltaMs: Long) {
-        if (deltaMs == 0L) return
         val castSession = session as? CastSession ?: return
         if (!castSession.isConnected) return
         val client = castSession.remoteMediaClient ?: return
-        if (client.isLiveStream || client.isPlayingAd) return
-        val seekOptions = MediaSeekOptions.Builder()
-            .setPosition(client.approximateStreamPosition + deltaMs)
-            .setResumeState(MediaSeekOptions.RESUME_STATE_UNCHANGED)
-            .build()
-        client.seek(seekOptions)
+        val targetPositionMs = seekTargetPositionMs(
+            approximatePositionMs = client.approximateStreamPosition,
+            deltaMs = deltaMs,
+            isLiveStream = client.isLiveStream,
+            isPlayingAd = client.isPlayingAd,
+        ) ?: return
+        client.seek(
+            MediaSeekOptions.Builder()
+                .setPosition(targetPositionMs)
+                .setResumeState(MediaSeekOptions.RESUME_STATE_UNCHANGED)
+                .build(),
+        )
     }
+}
+
+internal fun rewindDeltaMs(skipBackInSecs: Int): Long = -skipBackInSecs.toLong() * 1000L
+
+internal fun forwardDeltaMs(skipForwardInSecs: Int): Long = skipForwardInSecs.toLong() * 1000L
+
+internal fun seekTargetPositionMs(
+    approximatePositionMs: Long,
+    deltaMs: Long,
+    isLiveStream: Boolean,
+    isPlayingAd: Boolean,
+): Long? {
+    if (deltaMs == 0L || isLiveStream || isPlayingAd) return null
+    return approximatePositionMs + deltaMs
 }

--- a/app/src/test/java/au/com/shiftyjelly/pocketcasts/PocketCastsMediaIntentReceiverTest.kt
+++ b/app/src/test/java/au/com/shiftyjelly/pocketcasts/PocketCastsMediaIntentReceiverTest.kt
@@ -1,0 +1,50 @@
+package au.com.shiftyjelly.pocketcasts
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class PocketCastsMediaIntentReceiverTest {
+    @Test
+    fun `rewind delta is negative and in milliseconds`() {
+        assertEquals(-10_000L, rewindDeltaMs(10))
+        assertEquals(-45_000L, rewindDeltaMs(45))
+    }
+
+    @Test
+    fun `forward delta is positive and in milliseconds`() {
+        assertEquals(30_000L, forwardDeltaMs(30))
+        assertEquals(60_000L, forwardDeltaMs(60))
+    }
+
+    @Test
+    fun `zero skip interval produces a zero delta`() {
+        assertEquals(0L, rewindDeltaMs(0))
+        assertEquals(0L, forwardDeltaMs(0))
+    }
+
+    @Test
+    fun `seek target moves back by the rewind delta`() {
+        assertEquals(50_000L, seekTargetPositionMs(approximatePositionMs = 60_000L, deltaMs = -10_000L, isLiveStream = false, isPlayingAd = false))
+    }
+
+    @Test
+    fun `seek target moves forward by the forward delta`() {
+        assertEquals(90_000L, seekTargetPositionMs(approximatePositionMs = 60_000L, deltaMs = 30_000L, isLiveStream = false, isPlayingAd = false))
+    }
+
+    @Test
+    fun `seek target is null when delta is zero`() {
+        assertNull(seekTargetPositionMs(approximatePositionMs = 60_000L, deltaMs = 0L, isLiveStream = false, isPlayingAd = false))
+    }
+
+    @Test
+    fun `seek target is null for a live stream`() {
+        assertNull(seekTargetPositionMs(approximatePositionMs = 60_000L, deltaMs = -10_000L, isLiveStream = true, isPlayingAd = false))
+    }
+
+    @Test
+    fun `seek target is null when an ad is playing`() {
+        assertNull(seekTargetPositionMs(approximatePositionMs = 60_000L, deltaMs = -10_000L, isLiveStream = false, isPlayingAd = true))
+    }
+}


### PR DESCRIPTION
## Description

When casting, the media notification's rewind button always showed 30 seconds, no matter what the user set for skip back. The Cast skip step was configured from the skip forward value, and the Cast SDK's rewind and forward actions both seek by that same step.

This change:
- Uses the configured skip back interval for the Cast skip step, so the rewind button reflects the user's setting.
- Adds a custom media intent receiver so rewind and forward seek by their own configured intervals instead of a shared one.

One Cast SDK limitation remains: the rewind and forward button icons can't show two different numbers, since the SDK supports a single skip step for both. The seek behaviour is now correct for both directions.

Fixes PCDROID-633 https://linear.app/a8c/issue/PCDROID-633/notification-player-skip-back-shows-wrong-interval-android-814-rc-3

## Testing Instructions

1. Set skip back to something other than 30 seconds (for example 10 seconds).
2. Cast an episode.
3. Confirm the rewind button shows the configured value and rewinds by that amount.
4. Confirm the forward button still skips forward by the configured forward value.

## Screenshots or Screencast

N/A (notification behaviour, verified via `dumpsys notification`).

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) the Event Horizon schema to reflect any new or changed analytics.

#### I have tested any UI changes...
No app UI changes (Cast notification, managed by the Cast SDK).
