### PR TITLE
Prioritise release jobs ahead of feature builds

### DIFF
--- a/.buildkite/release-pipelines/code-freeze.yml
+++ b/.buildkite/release-pipelines/code-freeze.yml
@@ -3,6 +3,8 @@
 
 # This pipeline is meant to be triggered by the MC scenario in ReleasesV2
 
+priority: 1
+
 steps:
   - label: "🚂 Code Freeze"
     command: |

--- a/.buildkite/release-pipelines/download-translations.yml
+++ b/.buildkite/release-pipelines/download-translations.yml
@@ -3,6 +3,8 @@
 
 # This pipeline is meant to be triggered by the MC scenario in ReleasesV2
 
+priority: 1
+
 steps:
   - label: "🚂 Download Translations"
     command: |

--- a/.buildkite/release-pipelines/finalize-hotfix-release.yml
+++ b/.buildkite/release-pipelines/finalize-hotfix-release.yml
@@ -3,6 +3,8 @@
 
 # This pipeline is meant to be triggered by the MC scenario in ReleasesV2
 
+priority: 1
+
 steps:
   - label: "🚂 Finalize Hotfix Release"
     command: |

--- a/.buildkite/release-pipelines/finalize-release.yml
+++ b/.buildkite/release-pipelines/finalize-release.yml
@@ -3,6 +3,8 @@
 
 # This pipeline is meant to be triggered by the MC scenario in ReleasesV2
 
+priority: 1
+
 steps:
   - label: "🚂 Finalize Release"
     command: |

--- a/.buildkite/release-pipelines/new-beta-release.yml
+++ b/.buildkite/release-pipelines/new-beta-release.yml
@@ -3,6 +3,8 @@
 
 # This pipeline is meant to be triggered by the MC scenario in ReleasesV2
 
+priority: 1
+
 steps:
   - label: "🚂 New Beta Release"
     command: |

--- a/.buildkite/release-pipelines/new-hotfix-release.yml
+++ b/.buildkite/release-pipelines/new-hotfix-release.yml
@@ -3,6 +3,8 @@
 
 # This pipeline is meant to be triggered by the MC scenario in ReleasesV2
 
+priority: 1
+
 steps:
   - label: "🚂 New Hotfix Release"
     command: |

--- a/.buildkite/release-pipelines/update-rollouts.yml
+++ b/.buildkite/release-pipelines/update-rollouts.yml
@@ -5,6 +5,8 @@
 
 # Expected variables passed to the pipeline by ReleasesV2: `TRACK`, `ROLLOUT_PERCENT`
 
+priority: 1
+
 steps:
   - label: "🚂 Update Rollouts"
     command: |


### PR DESCRIPTION
Adds `priority: 1` to the release pipelines so release jobs jump the queue ahead of feature builds, and the release train stalls less.

Closes [AINFRA-3044](https://linear.app/a8c/issue/AINFRA-3044).

<details>
<summary>AI-generated details.</summary>

## Description

The Releases V2 tasks run on the same pipeline and queue as every PR build, so a release manager waits behind queued feature work. The release build files already had `priority`; `release-pipelines/*` never did.

Set pipeline-wide rather than per step so that steps added later inherit it.

Part of [AINFRA-3038](https://linear.app/a8c/issue/AINFRA-3038); audit in [AINFRA-3032](https://linear.app/a8c/issue/AINFRA-3032).

## Testing instructions

CI here does not exercise these files — the upload step only uploads `pipeline.yml`. Locally, all 7 parse and every step resolves to priority `1`.

Real confirmation is the next release: the job should show **Priority** `1` in Buildkite, against `0` for a PR build.

</details>
