### PR TITLE
[DO NOT MERGE] Probe where and how the Android SLACK_WEBHOOK posts

### DIFF
--- a/.buildkite/commands/slack-webhook-probe.sh
+++ b/.buildkite/commands/slack-webhook-probe.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# TEMPORARY — validation only, never to be merged. See the PR description.
+
+echo "--- :rubygems: Setting up Gems"
+install_gems
+
+echo "--- :slack: Probing the Slack webhook"
+log_file=$(mktemp)
+bundle exec fastlane slack_webhook_probe 2>&1 | tee "$log_file"
+
+echo "--- :white_check_mark: Asserting the invalid webhook degraded instead of failing"
+if ! grep -q "Slack notification failed" "$log_file"; then
+  echo "^^^ +++"
+  echo "Expected notify_slack to log a failure for the deliberately invalid webhook, but it did not."
+  echo "Either the invalid URL was accepted, or the rescue in notify_slack never fired."
+  exit 1
+fi
+
+echo "notify_slack degraded as expected, and the job stayed green."

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,6 +13,11 @@ steps:
   # Wait for Gradle Wrapper to be validated before running any other jobs
   - wait
 
+  # TEMPORARY — validation only (see the PR description). Never to be merged.
+  - label: ":slack: [TEMP] Slack webhook probe"
+    command: .buildkite/commands/slack-webhook-probe.sh
+    plugins: [ $CI_TOOLKIT ]
+
   - group: "Linters"
     steps:
       - label: ":danger: Danger - PR Check"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1015,10 +1015,9 @@ platform :android do
   lane :slack_webhook_probe do
     build_url = ENV.fetch('BUILDKITE_BUILD_URL', 'a local run')
 
-    UI.message('Probe 1/2 — real webhook, no channel override.')
+    UI.message("Probe 1/2 — real webhook, routed to #{SLACK_CHANNEL}.")
     send_slack_message(
-      message: ":test_tube: *Webhook wiring check — please ignore.* Confirming where `SLACK_WEBHOOK` posts, for AINFRA-3066. Triggered by #{build_url}",
-      channel: nil
+      message: ":test_tube: *Webhook wiring check — please ignore.* Confirming `SLACK_WEBHOOK` can deliver here, for AINFRA-3066. Triggered by #{build_url}"
     )
 
     UI.message('Probe 2/2 — invalid webhook, expecting a logged failure and a green job.')

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -81,6 +81,11 @@ UPLOAD_TO_PLAY_STORE_COMMON_OPTIONS = {
 }.freeze
 
 ########################################################################
+# Slack
+########################################################################
+SLACK_CHANNEL = '#pocket-casts-android'
+
+########################################################################
 # Firebase App Distribution (FAD)
 ########################################################################
 FIREBASE_APP_ID = '1:124902176124:android:ad0ff1c7193b55ee1620f9'
@@ -977,6 +982,55 @@ platform :android do
 
     UI.user_error!(error_message)
   end
+
+  #####################################################################################
+  # Slack helpers
+  #####################################################################################
+
+  # Sends a Slack message to the given channel via the incoming webhook.
+  def send_slack_message(message:, channel: SLACK_CHANNEL)
+    slack(
+      username: 'Pocket Casts Release Bot',
+      slack_url: ENV.fetch('SLACK_WEBHOOK'),
+      channel: channel,
+      message: message,
+      default_payloads: []
+    )
+  end
+
+  # Posts to Slack without letting a webhook hiccup abort the caller. A release job must not
+  # go red because a notification did not land.
+  def notify_slack(message)
+    send_slack_message(message: message)
+  rescue StandardError => e
+    UI.important("Slack notification failed (#{e.message}); continuing without it.")
+  end
+
+  # TEMPORARY — validation only, never to be merged. See the PR description.
+  #
+  # Posts one clearly-marked message through the real webhook with no channel override, so we
+  # can read back which channel it is bound to and whether the `username` override is honoured.
+  # Then posts through a deliberately invalid webhook to prove `notify_slack` degrades instead
+  # of failing the job.
+  lane :slack_webhook_probe do
+    build_url = ENV.fetch('BUILDKITE_BUILD_URL', 'a local run')
+
+    UI.message('Probe 1/2 — real webhook, no channel override.')
+    send_slack_message(
+      message: ":test_tube: *Webhook wiring check — please ignore.* Confirming where `SLACK_WEBHOOK` posts, for AINFRA-3066. Triggered by #{build_url}",
+      channel: nil
+    )
+
+    UI.message('Probe 2/2 — invalid webhook, expecting a logged failure and a green job.')
+    real_webhook = ENV.fetch('SLACK_WEBHOOK', nil)
+    begin
+      ENV['SLACK_WEBHOOK'] = 'https://hooks.slack.com/services/DELIBERATELY/INVALID/WEBHOOK'
+      notify_slack('This message must never reach Slack.')
+    ensure
+      ENV['SLACK_WEBHOOK'] = real_webhook
+    end
+  end
+
 
   # Reports a milestone-related error, both in the logs and — on CI — as a Buildkite annotation,
   # clarifying that the error is expected when the release task is not being run for the first time.


### PR DESCRIPTION
> **Validation only — DO NOT MERGE.** This branch exists to make CI answer one question, and gets closed once it has. Branched off `main`; it is not stacked on anything.

Part of [AINFRA-3066](https://linear.app/a8c/issue/AINFRA-3066) / [AINFRA-3063](https://linear.app/a8c/issue/AINFRA-3063).

## Why CI has to answer this

A `SLACK_WEBHOOK` was just provisioned on the `pocket-casts-android` pipeline. Nothing in this repo has ever used it — the only Slack references in `.buildkite/` are Buildkite's own `notify: - slack: "#build-and-ship"` hooks, which go through the Buildkite Slack integration and not this secret. There is no fastlane Slack code at all.

So two things are unknown and unknowable locally, because the secret exists only on CI:

1. **Which channel** the webhook is bound to.
2. **Whether `username` / `channel` payload overrides are honoured** — legacy incoming webhooks honour them, modern Slack-app webhooks silently ignore them. This decides whether one webhook can serve both Pocket Casts channels or whether each needs its own.

## What to read

The **`:slack: [TEMP] Slack webhook probe`** job. It is **expected to pass**. Two probes run in it:

| Probe | What it proves |
|---|---|
| Real webhook, **no** `channel:` override | Where the webhook actually posts, and whether the `username: 'Pocket Casts Release Bot'` override took effect |
| Deliberately invalid webhook URL | `notify_slack` degrades to a log line instead of failing the job — the job stays green and the script greps for `Slack notification failed` |

The second assertion is the one that could go red: if the invalid URL were accepted, or the rescue never fired, the script exits 1.

One clearly-marked test message will appear in whichever channel the webhook points at:

> :test_tube: **Webhook wiring check — please ignore.** Confirming where `SLACK_WEBHOOK` posts, for AINFRA-3066.

## What CI cannot answer

Whether the resulting message *reads well* to the team, and which bot identity we want long-term — the existing iOS webhook posts as "pocket cats", so we may prefer to match that rather than introduce a second name. Human call, once we see the message.

## Note on the helpers

`send_slack_message` / `notify_slack` are written in the shape intended for the real change, modelled on `wpandroid`'s (the most recently updated Slack implementation in the roster, 2026-08-18), so the probe exercises the actual implementation rather than a stand-in. The `slack_webhook_probe` lane, the probe script, and the pipeline step are the throwaway parts.
