### PR TITLE
Announce Pocket Casts Android rollouts on Slack from CI

### DIFF
--- a/.buildkite/commands/update-rollouts.sh
+++ b/.buildkite/commands/update-rollouts.sh
@@ -2,9 +2,20 @@
 
 set -euo pipefail
 
-: "${TRACK:?Missing value}"
-: "${ROLLOUT_PERCENT:?Missing value}"
-: "${RELEASE_VERSION:?Missing value}"
+REQUIRED_ENV_VARS=(TRACK ROLLOUT_PERCENT RELEASE_VERSION)
+
+missing=()
+for var in "${REQUIRED_ENV_VARS[@]}"; do
+  if [[ -z "${!var:-}" ]]; then
+    missing+=("$var")
+  fi
+done
+
+if [[ ${#missing[@]} -gt 0 ]]; then
+  echo "Error: missing or empty environment variables: ${missing[*]}" >&2
+  echo "They are passed by the ReleasesV2 scenario that triggers this pipeline." >&2
+  exit 1
+fi
 
 echo '--- :ruby: Setup Ruby Tools'
 install_gems

--- a/.buildkite/commands/update-rollouts.sh
+++ b/.buildkite/commands/update-rollouts.sh
@@ -24,4 +24,8 @@ echo '--- 🔐 Access Secrets'
 bundle exec fastlane run configure_apply
 
 echo '--- 🚀 Update Rollouts'
-bundle exec fastlane update_rollouts track:"$TRACK" percent:"$ROLLOUT_PERCENT" version:"$RELEASE_VERSION" milestone:"${MILESTONE:-}"
+bundle exec fastlane update_rollouts \
+  track:"$TRACK" \
+  percent:"$ROLLOUT_PERCENT" \
+  version:"$RELEASE_VERSION" \
+  milestone:"${MILESTONE:-}"

--- a/.buildkite/commands/update-rollouts.sh
+++ b/.buildkite/commands/update-rollouts.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${TRACK:?Missing value}"
+: "${ROLLOUT_PERCENT:?Missing value}"
+: "${RELEASE_VERSION:?Missing value}"
+
+echo '--- :ruby: Setup Ruby Tools'
+install_gems
+
+echo '--- 🔐 Access Secrets'
+bundle exec fastlane run configure_apply
+
+echo '--- 🚀 Update Rollouts'
+bundle exec fastlane update_rollouts track:"$TRACK" percent:"$ROLLOUT_PERCENT" version:"$RELEASE_VERSION" milestone:"${MILESTONE:-}"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -31,10 +31,11 @@ steps:
         artifact_paths:
           - "**/build/reports/lint-results*.*"
 
+  # Not on the `linter` queue: those agents only accept an allowlist of commands
+  # (danger, rubocop, swiftlint, validate_gradle_wrapper).
   - label: ":fastlane: fastlane Helper Tests"
     command: ruby fastlane/test/helpers_test.rb
-    agents:
-      queue: "linter"
+    plugins: [ $CI_TOOLKIT ]
 
   - label: 'Unit tests'
     command: ".buildkite/commands/run-unit-tests.sh"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -31,6 +31,11 @@ steps:
         artifact_paths:
           - "**/build/reports/lint-results*.*"
 
+  - label: ":fastlane: fastlane Helper Tests"
+    command: ruby fastlane/test/helpers_test.rb
+    agents:
+      queue: "linter"
+
   - label: 'Unit tests'
     command: ".buildkite/commands/run-unit-tests.sh"
     plugins: [ $CI_TOOLKIT ]

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -31,8 +31,6 @@ steps:
         artifact_paths:
           - "**/build/reports/lint-results*.*"
 
-  # Not on the `linter` queue: those agents only accept an allowlist of commands
-  # (danger, rubocop, swiftlint, validate_gradle_wrapper).
   - label: ":fastlane: fastlane Helper Tests"
     command: ruby fastlane/test/helpers_test.rb
     plugins: [ $CI_TOOLKIT ]

--- a/.buildkite/release-pipelines/update-rollouts.yml
+++ b/.buildkite/release-pipelines/update-rollouts.yml
@@ -3,7 +3,7 @@
 
 # This pipeline is meant to be triggered by the MC scenario in ReleasesV2
 
-# Expected variables passed to the pipeline by ReleasesV2: `TRACK`, `ROLLOUT_PERCENT`
+# Expected variables passed to the pipeline by ReleasesV2: `TRACK`, `ROLLOUT_PERCENT`, `RELEASE_VERSION`, `MILESTONE`
 
 steps:
   - label: "🚂 Update Rollouts"
@@ -15,7 +15,7 @@ steps:
       bundle exec fastlane run configure_apply
 
       echo '--- 🚀 Update Rollouts'
-      bundle exec fastlane update_rollouts track:"$TRACK" percent:"$ROLLOUT_PERCENT"
+      bundle exec fastlane update_rollouts track:"$TRACK" percent:"$ROLLOUT_PERCENT" version:"${RELEASE_VERSION}" milestone:"${MILESTONE}"
     plugins: [$CI_TOOLKIT]
     agents:
       queue: "mac-metal"

--- a/.buildkite/release-pipelines/update-rollouts.yml
+++ b/.buildkite/release-pipelines/update-rollouts.yml
@@ -15,7 +15,7 @@ steps:
       bundle exec fastlane run configure_apply
 
       echo '--- 🚀 Update Rollouts'
-      bundle exec fastlane update_rollouts track:"$TRACK" percent:"$ROLLOUT_PERCENT" version:"${RELEASE_VERSION}" milestone:"${MILESTONE}"
+      bundle exec fastlane update_rollouts track:"$TRACK" percent:"$ROLLOUT_PERCENT" version:"$RELEASE_VERSION" milestone:"$MILESTONE"
     plugins: [$CI_TOOLKIT]
     agents:
       queue: "mac-metal"

--- a/.buildkite/release-pipelines/update-rollouts.yml
+++ b/.buildkite/release-pipelines/update-rollouts.yml
@@ -7,15 +7,7 @@
 
 steps:
   - label: "🚂 Update Rollouts"
-    command: |
-      echo '--- :ruby: Setup Ruby Tools'
-      install_gems
-
-      echo '--- 🔐 Access Secrets'
-      bundle exec fastlane run configure_apply
-
-      echo '--- 🚀 Update Rollouts'
-      bundle exec fastlane update_rollouts track:"$TRACK" percent:"$ROLLOUT_PERCENT" version:"$RELEASE_VERSION" milestone:"$MILESTONE"
+    command: .buildkite/commands/update-rollouts.sh
     plugins: [$CI_TOOLKIT]
     agents:
       queue: "mac-metal"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1020,7 +1020,7 @@ platform :android do
   # usually run from `main`, whose `version.properties` has already moved on to the next
   # version, so the fallback is only right for a run from the release branch.
   def rollout_announcement(track:, percent:)
-    version = ENV.fetch('RELEASE_VERSION', nil).to_s
+    version = ENV.fetch('RELEASE_VERSION', nil).to_s.strip
     version = release_version_current if version.empty?
 
     # The scenario submits a build for Google to review by rolling production out to 1%, so that

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -341,11 +341,11 @@ platform :android do
   #
   # @param percent [Float] The rollout percentage, between 0 and 1
   # @param track [String] The Google Play track for which to update the rollout of. Must be either `beta` or `production`.
-  # @param version [String] (optional) The release version the announcement is about.
-  #                Typically provided by Releases V2. When omitted, uses the current project version, which on
-  #                `main` has already moved on to the next one.
+  # @param version [String] (optional) The release version the announcement is about. Provided by
+  #                Releases V2. When omitted, uses the current project version, which is only correct
+  #                on a release branch.
   # @param milestone [String] (optional) The milestone to name alongside the version.
-  #                  Typically provided by Releases V2.
+  #                  Provided by Releases V2, which is the only place it can come from.
   #
   lane :update_rollouts do |percent:, track:, version: release_version_current, milestone: nil|
     UI.user_error!('percent parameter must be between 0.0 and 1.0') if percent.to_f.negative? || percent.to_f > 1
@@ -1004,8 +1004,6 @@ platform :android do
   # Slack helpers
   #####################################################################################
 
-  # Sends a Slack message via the incoming webhook.
-  #
   # `channel` is not optional in practice: `SLACK_WEBHOOK` holds the webhook shared across
   # products, which posts to a test channel unless told otherwise.
   def send_slack_message(message:, channel: SLACK_CHANNEL)
@@ -1022,10 +1020,9 @@ platform :android do
     )
   end
 
-  # Posts to Slack without letting the caller fail over it. A rollout that reached Google Play
-  # must not be reported as failed because the announcement did not land. The failure is annotated
-  # and not just logged, because an announcement that quietly stops posting is the one nobody
-  # notices.
+  # Posts to Slack without letting the caller fail over it, reporting loudly and annotating the CI build
+  # (if any) instead. Rationale: A hard failure in the release process is costly to address. A missing
+  # Slack message is not worth halting the release process.
   #
   # Takes a block rather than a string so that building the message is covered too, not just
   # sending it.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1025,9 +1025,7 @@ platform :android do
 
     # The scenario submits a build for Google to review by rolling production out to 1%, so that
     # one rollout announces a submission instead of a percentage.
-    if track == 'production' && (percent - 0.01).abs < 0.001
-      return ":announcement: `#{version}` has been submitted to the Production track for Google to review."
-    end
+    return ":announcement: `#{version}` has been submitted to the Production track for Google to review." if track == 'production' && (percent - 0.01).abs < 0.001
 
     milestone = ENV.fetch('MILESTONE', nil).to_s.strip
     subject = ["`#{version}`", milestone].reject(&:empty?).join(' ')

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1003,9 +1003,13 @@ platform :android do
   # `channel` is not optional in practice: `SLACK_WEBHOOK` holds the webhook shared across
   # products, which posts to a test channel unless told otherwise.
   def send_slack_message(message:, channel: SLACK_CHANNEL)
+    webhook = ENV.fetch('SLACK_WEBHOOK') do
+      UI.user_error!("Environment variable 'SLACK_WEBHOOK' is not set. See `fastlane/env/user.env-example`.")
+    end
+
     slack(
       username: 'Pocket Cats',
-      slack_url: ENV.fetch('SLACK_WEBHOOK'),
+      slack_url: webhook,
       channel: channel,
       message: message,
       default_payloads: []

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -341,8 +341,13 @@ platform :android do
   #
   # @param percent [Float] The rollout percentage, between 0 and 1
   # @param track [String] The Google Play track for which to update the rollout of. Must be either `beta` or `production`.
+  # @param version [String] (optional) The release version the announcement is about.
+  #                Typically provided by Releases V2. When omitted, uses the current project version, which on
+  #                `main` has already moved on to the next one.
+  # @param milestone [String] (optional) The milestone to name alongside the version.
+  #                  Typically provided by Releases V2.
   #
-  lane :update_rollouts do |percent:, track:|
+  lane :update_rollouts do |percent:, track:, version: release_version_current, milestone: nil|
     UI.user_error!('percent parameter must be between 0.0 and 1.0') if percent.to_f.negative? || percent.to_f > 1
     UI.user_error!('track parameter must be either `beta` or `production`') unless %w[beta production].include?(track)
 
@@ -382,7 +387,8 @@ platform :android do
       rollout_announcement(
         track: track,
         percent: percent.to_f,
-        fallback_version: release_version_current,
+        version: version,
+        milestone: milestone,
         skipped_apps: not_found_variants.map { |variant| variant[:app] }
       )
     end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -376,7 +376,7 @@ platform :android do
     end
     UI.user_error!('None of the 3 app variants were found in Google Play Console. We expected at least one') if not_found_variants.count == APPS.count
 
-    notify_slack(rollout_announcement(track: track, percent: percent.to_f))
+    notify_slack { rollout_announcement(track: track, percent: percent.to_f) }
   end
 
   # Downloads the latest translations from GlotPress and creates a PR to integrate them into the current `release/*` branch
@@ -1003,10 +1003,13 @@ platform :android do
     )
   end
 
-  # Posts to Slack without letting a webhook hiccup abort the caller. A rollout that reached
-  # Google Play must not be reported as failed because the announcement did not land.
-  def notify_slack(message)
-    send_slack_message(message: message)
+  # Posts to Slack without letting the caller fail over it. A rollout that reached Google Play
+  # must not be reported as failed because the announcement did not land.
+  #
+  # Takes a block rather than a string so that building the message is covered too, not just
+  # sending it.
+  def notify_slack(&message)
+    send_slack_message(message: message.call)
   rescue StandardError => e
     UI.important("Slack notification failed (#{e.message}); continuing without it.")
   end
@@ -1031,7 +1034,6 @@ platform :android do
 
     ":announcement: #{subject} has started rolling out to #{(percent * 100).round}% of users."
   end
-
 
   # Reports a milestone-related error, both in the logs and — on CI — as a Buildkite annotation,
   # clarifying that the error is expected when the release task is not being run for the first time.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -91,6 +91,8 @@ SLACK_CHANNEL = '#pocket-casts-android'
 FIREBASE_APP_ID = '1:124902176124:android:ad0ff1c7193b55ee1620f9'
 FIREBASE_TESTERS_GROUP = 'pocketcasts-android---prototype-builds'
 
+import 'lib/helpers.rb'
+
 before_all do |_lane|
   # Ensure we use the latest version of the toolkit
   check_for_toolkit_updates unless is_ci || ENV['FASTLANE_SKIP_TOOLKIT_UPDATE_CHECK']
@@ -376,7 +378,7 @@ platform :android do
     end
     UI.user_error!('None of the 3 app variants were found in Google Play Console. We expected at least one') if not_found_variants.count == APPS.count
 
-    notify_slack { rollout_announcement(track: track, percent: percent.to_f) }
+    notify_slack { rollout_announcement(track: track, percent: percent.to_f, fallback_version: release_version_current) }
   end
 
   # Downloads the latest translations from GlotPress and creates a PR to integrate them into the current `release/*` branch
@@ -1012,25 +1014,6 @@ platform :android do
     send_slack_message(message: message.call)
   rescue StandardError => e
     UI.important("Slack notification failed (#{e.message}); continuing without it.")
-  end
-
-  # Wording for a rollout update, matching what the release scenario used to post by hand.
-  #
-  # `RELEASE_VERSION` and `MILESTONE` are passed by the Releases V2 Buildkite action. Rollouts
-  # usually run from `main`, whose `version.properties` has already moved on to the next
-  # version, so the fallback is only right for a run from the release branch.
-  def rollout_announcement(track:, percent:)
-    version = ENV.fetch('RELEASE_VERSION', nil).to_s.strip
-    version = release_version_current if version.empty?
-
-    # The scenario submits a build for Google to review by rolling production out to 1%, so that
-    # one rollout announces a submission instead of a percentage.
-    return ":announcement: `#{version}` has been submitted to the Production track for Google to review." if track == 'production' && (percent - 0.01).abs < 0.001
-
-    milestone = ENV.fetch('MILESTONE', nil).to_s.strip
-    subject = ["`#{version}`", milestone].reject(&:empty?).join(' ')
-
-    ":announcement: #{subject} has started rolling out to #{(percent * 100).round}% of users."
   end
 
   # Reports a milestone-related error, both in the logs and — on CI — as a Buildkite annotation,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -341,9 +341,8 @@ platform :android do
   #
   # @param percent [Float] The rollout percentage, between 0 and 1
   # @param track [String] The Google Play track for which to update the rollout of. Must be either `beta` or `production`.
-  # @param version [String] (optional) The release version the announcement is about. Provided by
-  #                Releases V2. When omitted, uses the current project version, which is only correct
-  #                on a release branch.
+  # @param version [String] (optional) The release version the announcement is about. When
+  #                omitted, uses the current project version, which is only correct on a release branch.
   # @param milestone [String] (optional) The milestone to name alongside the version.
   #                  Provided by Releases V2, which is the only place it can come from.
   #
@@ -1004,8 +1003,6 @@ platform :android do
   # Slack helpers
   #####################################################################################
 
-  # `channel` is not optional in practice: `SLACK_WEBHOOK` holds the webhook shared across
-  # products, which posts to a test channel unless told otherwise.
   def send_slack_message(message:, channel: SLACK_CHANNEL)
     webhook = ENV.fetch('SLACK_WEBHOOK') do
       UI.user_error!("Environment variable 'SLACK_WEBHOOK' is not set. See `fastlane/env/user.env-example`.")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1013,14 +1013,18 @@ platform :android do
   end
 
   # Posts to Slack without letting the caller fail over it. A rollout that reached Google Play
-  # must not be reported as failed because the announcement did not land.
+  # must not be reported as failed because the announcement did not land. The failure is annotated
+  # and not just logged, because an announcement that quietly stops posting is the one nobody
+  # notices.
   #
   # Takes a block rather than a string so that building the message is covered too, not just
   # sending it.
   def notify_slack(&message)
     send_slack_message(message: message.call)
   rescue StandardError => e
-    UI.important("Slack notification failed (#{e.message}); continuing without it.")
+    warning = "Slack notification failed (#{e.message}); continuing without it."
+    UI.important(warning)
+    buildkite_annotate(style: 'warning', context: 'slack-notification-failed', message: warning) if is_ci
   end
 
   # Reports a milestone-related error, both in the logs and — on CI — as a Buildkite annotation,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -81,6 +81,11 @@ UPLOAD_TO_PLAY_STORE_COMMON_OPTIONS = {
 }.freeze
 
 ########################################################################
+# Slack
+########################################################################
+SLACK_CHANNEL = '#pocket-casts-android'
+
+########################################################################
 # Firebase App Distribution (FAD)
 ########################################################################
 FIREBASE_APP_ID = '1:124902176124:android:ad0ff1c7193b55ee1620f9'
@@ -370,6 +375,8 @@ platform :android do
       UI.important(message)
     end
     UI.user_error!('None of the 3 app variants were found in Google Play Console. We expected at least one') if not_found_variants.count == APPS.count
+
+    notify_slack(rollout_announcement(track: track, percent: percent.to_f))
   end
 
   # Downloads the latest translations from GlotPress and creates a PR to integrate them into the current `release/*` branch
@@ -977,6 +984,54 @@ platform :android do
 
     UI.user_error!(error_message)
   end
+
+  #####################################################################################
+  # Slack helpers
+  #####################################################################################
+
+  # Sends a Slack message via the incoming webhook.
+  #
+  # `channel` is not optional in practice: `SLACK_WEBHOOK` holds the webhook shared across
+  # products, which posts to a test channel unless told otherwise.
+  def send_slack_message(message:, channel: SLACK_CHANNEL)
+    slack(
+      username: 'Pocket Cats',
+      slack_url: ENV.fetch('SLACK_WEBHOOK'),
+      channel: channel,
+      message: message,
+      default_payloads: []
+    )
+  end
+
+  # Posts to Slack without letting a webhook hiccup abort the caller. A rollout that reached
+  # Google Play must not be reported as failed because the announcement did not land.
+  def notify_slack(message)
+    send_slack_message(message: message)
+  rescue StandardError => e
+    UI.important("Slack notification failed (#{e.message}); continuing without it.")
+  end
+
+  # Wording for a rollout update, matching what the release scenario used to post by hand.
+  #
+  # `RELEASE_VERSION` and `MILESTONE` are passed by the Releases V2 Buildkite action. Rollouts
+  # usually run from `main`, whose `version.properties` has already moved on to the next
+  # version, so the fallback is only right for a run from the release branch.
+  def rollout_announcement(track:, percent:)
+    version = ENV.fetch('RELEASE_VERSION', nil).to_s
+    version = release_version_current if version.empty?
+
+    # The scenario submits a build for Google to review by rolling production out to 1%, so that
+    # one rollout announces a submission instead of a percentage.
+    if track == 'production' && (percent - 0.01).abs < 0.001
+      return ":announcement: `#{version}` has been submitted to the Production track for Google to review."
+    end
+
+    milestone = ENV.fetch('MILESTONE', nil).to_s.strip
+    subject = ["`#{version}`", milestone].reject(&:empty?).join(' ')
+
+    ":announcement: #{subject} has started rolling out to #{(percent * 100).round}% of users."
+  end
+
 
   # Reports a milestone-related error, both in the logs and — on CI — as a Buildkite annotation,
   # clarifying that the error is expected when the release task is not being run for the first time.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -370,15 +370,22 @@ platform :android do
     rescue FastlaneCore::Interface::FastlaneError => e
       raise unless e.message =~ /Unable to find the requested release on track/
 
-      not_found_variants << "'#{app}' variant with version code `#{variant_version_code}` was not found in `#{variant_track}` track in Google Play Console"
+      not_found_variants << { app: app, version_code: variant_version_code, track: variant_track }
     end
 
-    not_found_variants.each do |message|
-      UI.important(message)
+    not_found_variants.each do |variant|
+      UI.important("'#{variant[:app]}' variant with version code `#{variant[:version_code]}` was not found in `#{variant[:track]}` track in Google Play Console")
     end
     UI.user_error!('None of the 3 app variants were found in Google Play Console. We expected at least one') if not_found_variants.count == APPS.count
 
-    notify_slack { rollout_announcement(track: track, percent: percent.to_f, fallback_version: release_version_current) }
+    notify_slack do
+      rollout_announcement(
+        track: track,
+        percent: percent.to_f,
+        fallback_version: release_version_current,
+        skipped_apps: not_found_variants.map { |variant| variant[:app] }
+      )
+    end
   end
 
   # Downloads the latest translations from GlotPress and creates a PR to integrate them into the current `release/*` branch

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -346,7 +346,9 @@ platform :android do
   # @param milestone [String] (optional) The milestone to name alongside the version.
   #                  Provided by Releases V2, which is the only place it can come from.
   #
-  lane :update_rollouts do |percent:, track:, version: release_version_current, milestone: nil|
+  lane :update_rollouts do |percent:, track:, version: nil, milestone: nil|
+    version = version.to_s.strip
+    version = release_version_current if version.empty?
     UI.user_error!('percent parameter must be between 0.0 and 1.0') if percent.to_f.negative? || percent.to_f > 1
     UI.user_error!('track parameter must be either `beta` or `production`') unless %w[beta production].include?(track)
 

--- a/fastlane/env/user.env-example
+++ b/fastlane/env/user.env-example
@@ -5,3 +5,7 @@ GITHUB_TOKEN=<GitHub access token>
 #   Organizations: 'Automattic',
 #   REST Scopes: 'write_builds'
 BUILDKITE_TOKEN=<Buildkite Personal Access Token>
+
+# The Slack incoming webhook used to announce rollouts.
+# Shared across products, so every message must pass an explicit channel.
+SLACK_WEBHOOK=<Slack incoming webhook URL>

--- a/fastlane/env/user.env-example
+++ b/fastlane/env/user.env-example
@@ -7,5 +7,4 @@ GITHUB_TOKEN=<GitHub access token>
 BUILDKITE_TOKEN=<Buildkite Personal Access Token>
 
 # The Slack incoming webhook used to announce rollouts.
-# Shared across products, so every message must pass an explicit channel.
 SLACK_WEBHOOK=<Slack incoming webhook URL>

--- a/fastlane/lib/helpers.rb
+++ b/fastlane/lib/helpers.rb
@@ -17,7 +17,6 @@ def rollout_announcement(track:, percent:, version:, milestone: nil, skipped_app
   version = version.to_s.strip
   subject = ["`#{version}`", milestone.to_s.strip].reject(&:empty?).join(' ')
 
-  # Derived once so the announced percentage and the submission check cannot disagree.
   percentage = (percent * 100).round
   message = if track == 'production' && percentage == SUBMISSION_ROLLOUT_PERCENTAGE
               ":announcement: `#{version}` has been submitted to the Production track for Google to review."

--- a/fastlane/lib/helpers.rb
+++ b/fastlane/lib/helpers.rb
@@ -11,18 +11,27 @@
 # @param fallback_version [String] Version to announce when `RELEASE_VERSION` is not set. Rollouts
 #   usually run from `main`, whose `version.properties` has already moved on to the next version,
 #   so this is only right for a run from the release branch.
+# @param skipped_apps [Array<String>] Variants Google Play had no matching release for. The lane
+#   treats those as non-fatal as long as one variant rolled out, so the message has to say which
+#   ones did not.
 # @return [String] The slack message body to use, typically in a call to the `slack()` fastlane action
 #
-def rollout_announcement(track:, percent:, fallback_version:)
+def rollout_announcement(track:, percent:, fallback_version:, skipped_apps: [])
   version = ENV.fetch('RELEASE_VERSION', nil).to_s.strip
   version = fallback_version if version.empty?
-
-  # The scenario submits a build for Google to review by rolling production out to 1%, so that
-  # one rollout announces a submission instead of a percentage.
-  return ":announcement: `#{version}` has been submitted to the Production track for Google to review." if track == 'production' && (percent - 0.01).abs < 0.001
 
   milestone = ENV.fetch('MILESTONE', nil).to_s.strip
   subject = ["`#{version}`", milestone].reject(&:empty?).join(' ')
 
-  ":announcement: #{subject} has started rolling out to #{(percent * 100).round}% of users."
+  # The scenario submits a build for Google to review by rolling production out to 1%, so that
+  # one rollout announces a submission instead of a percentage.
+  message = if track == 'production' && (percent - 0.01).abs < 0.001
+              ":announcement: `#{version}` has been submitted to the Production track for Google to review."
+            else
+              ":announcement: #{subject} has started rolling out to #{(percent * 100).round}% of users."
+            end
+
+  return message if skipped_apps.empty?
+
+  "#{message}\n:warning: Not rolled out to #{skipped_apps.join(', ')} — Google Play had no matching release."
 end

--- a/fastlane/lib/helpers.rb
+++ b/fastlane/lib/helpers.rb
@@ -6,26 +6,18 @@ SUBMISSION_ROLLOUT_PERCENTAGE = 1
 
 # Wording for a rollout update, matching what the release scenario used to post by hand.
 #
-# `RELEASE_VERSION` and `MILESTONE` are passed by the Releases V2 Buildkite action. `MILESTONE` is
-# only sent once the Releases V2 side stops posting these messages by hand, so the milestone-less
-# wording is what ships until then.
-#
 # @param track [String] The Google Play track the rollout is for, either `beta` or `production`.
 # @param percent [Float] The rollout percentage, between 0 and 1.
-# @param fallback_version [String] Version to announce when `RELEASE_VERSION` is not set. Rollouts
-#   usually run from `main`, whose `version.properties` has already moved on to the next version,
-#   so this is only right for a run from the release branch.
+# @param version [String] The version the announcement is about.
+# @param milestone [String, nil] The milestone to name alongside the version, when there is one.
 # @param skipped_apps [Array<String>] Variants Google Play had no matching release for. The lane
 #   treats those as non-fatal as long as one variant rolled out, so the message has to say which
 #   ones did not.
 # @return [String] The slack message body to use, typically in a call to the `slack()` fastlane action
 #
-def rollout_announcement(track:, percent:, fallback_version:, skipped_apps: [])
-  version = ENV.fetch('RELEASE_VERSION', nil).to_s.strip
-  version = fallback_version if version.empty?
-
-  milestone = ENV.fetch('MILESTONE', nil).to_s.strip
-  subject = ["`#{version}`", milestone].reject(&:empty?).join(' ')
+def rollout_announcement(track:, percent:, version:, milestone: nil, skipped_apps: [])
+  version = version.to_s.strip
+  subject = ["`#{version}`", milestone.to_s.strip].reject(&:empty?).join(' ')
 
   # Derived once so the announced percentage and the submission check cannot disagree.
   percentage = (percent * 100).round

--- a/fastlane/lib/helpers.rb
+++ b/fastlane/lib/helpers.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+# The scenario submits a build for Google to review by rolling production out to 1%, so that one
+# rollout announces a submission instead of a percentage.
+SUBMISSION_ROLLOUT_PERCENTAGE = 1
+
 # Wording for a rollout update, matching what the release scenario used to post by hand.
 #
 # `RELEASE_VERSION` and `MILESTONE` are passed by the Releases V2 Buildkite action. `MILESTONE` is
@@ -23,12 +27,12 @@ def rollout_announcement(track:, percent:, fallback_version:, skipped_apps: [])
   milestone = ENV.fetch('MILESTONE', nil).to_s.strip
   subject = ["`#{version}`", milestone].reject(&:empty?).join(' ')
 
-  # The scenario submits a build for Google to review by rolling production out to 1%, so that
-  # one rollout announces a submission instead of a percentage.
-  message = if track == 'production' && (percent - 0.01).abs < 0.001
+  # Derived once so the announced percentage and the submission check cannot disagree.
+  percentage = (percent * 100).round
+  message = if track == 'production' && percentage == SUBMISSION_ROLLOUT_PERCENTAGE
               ":announcement: `#{version}` has been submitted to the Production track for Google to review."
             else
-              ":announcement: #{subject} has started rolling out to #{(percent * 100).round}% of users."
+              ":announcement: #{subject} has started rolling out to #{percentage}% of users."
             end
 
   return message if skipped_apps.empty?

--- a/fastlane/lib/helpers.rb
+++ b/fastlane/lib/helpers.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Wording for a rollout update, matching what the release scenario used to post by hand.
+#
+# `RELEASE_VERSION` and `MILESTONE` are passed by the Releases V2 Buildkite action. `MILESTONE` is
+# only sent once the Releases V2 side stops posting these messages by hand, so the milestone-less
+# wording is what ships until then.
+#
+# @param track [String] The Google Play track the rollout is for, either `beta` or `production`.
+# @param percent [Float] The rollout percentage, between 0 and 1.
+# @param fallback_version [String] Version to announce when `RELEASE_VERSION` is not set. Rollouts
+#   usually run from `main`, whose `version.properties` has already moved on to the next version,
+#   so this is only right for a run from the release branch.
+# @return [String] The slack message body to use, typically in a call to the `slack()` fastlane action
+#
+def rollout_announcement(track:, percent:, fallback_version:)
+  version = ENV.fetch('RELEASE_VERSION', nil).to_s.strip
+  version = fallback_version if version.empty?
+
+  # The scenario submits a build for Google to review by rolling production out to 1%, so that
+  # one rollout announces a submission instead of a percentage.
+  return ":announcement: `#{version}` has been submitted to the Production track for Google to review." if track == 'production' && (percent - 0.01).abs < 0.001
+
+  milestone = ENV.fetch('MILESTONE', nil).to_s.strip
+  subject = ["`#{version}`", milestone].reject(&:empty?).join(' ')
+
+  ":announcement: #{subject} has started rolling out to #{(percent * 100).round}% of users."
+end

--- a/fastlane/lib/helpers.rb
+++ b/fastlane/lib/helpers.rb
@@ -4,15 +4,13 @@
 # rollout announces a submission instead of a percentage.
 SUBMISSION_ROLLOUT_PERCENTAGE = 1
 
-# Wording for a rollout update, matching what the release scenario used to post by hand.
+# The rollout announcement.
 #
 # @param track [String] The Google Play track the rollout is for, either `beta` or `production`.
 # @param percent [Float] The rollout percentage, between 0 and 1.
 # @param version [String] The version the announcement is about.
 # @param milestone [String, nil] The milestone to name alongside the version, when there is one.
-# @param skipped_apps [Array<String>] Variants Google Play had no matching release for. The lane
-#   treats those as non-fatal as long as one variant rolled out, so the message has to say which
-#   ones did not.
+# @param skipped_apps [Array<String>] Variants Google Play had no matching release for.
 # @return [String] The slack message body to use, typically in a call to the `slack()` fastlane action
 #
 def rollout_announcement(track:, percent:, version:, milestone: nil, skipped_apps: [])

--- a/fastlane/lib/helpers.rb
+++ b/fastlane/lib/helpers.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
-# The scenario submits a build for Google to review by rolling production out to 1%, so that one
-# rollout announces a submission instead of a percentage.
 SUBMISSION_ROLLOUT_PERCENTAGE = 1
 
-# The rollout announcement.
+# The rollout announcement message for Slack.
 #
 # @param track [String] The Google Play track the rollout is for, either `beta` or `production`.
 # @param percent [Float] The rollout percentage, between 0 and 1.

--- a/fastlane/test/helpers_test.rb
+++ b/fastlane/test/helpers_test.rb
@@ -6,17 +6,13 @@ require_relative '../lib/helpers'
 # Tests the project-specific helpers used to build the release Slack announcements.
 class FastlaneHelpersTest < Minitest::Test
   def test_rollout_announcement_omits_the_milestone_when_it_is_not_set
-    with_env('RELEASE_VERSION' => '7.94', 'MILESTONE' => nil) do
-      assert_equal ':announcement: `7.94` has started rolling out to 20% of users.',
-                   rollout_announcement(track: 'beta', percent: 0.2, fallback_version: 'unused')
-    end
+    assert_equal ':announcement: `7.94` has started rolling out to 20% of users.',
+                 rollout_announcement(track: 'beta', percent: 0.2, version: '7.94')
   end
 
   def test_rollout_announcement_includes_the_milestone_when_it_is_set
-    with_env('RELEASE_VERSION' => '7.94', 'MILESTONE' => '(Milestone 7.94)') do
-      assert_equal ':announcement: `7.94` (Milestone 7.94) has started rolling out to 50% of users.',
-                   rollout_announcement(track: 'production', percent: 0.5, fallback_version: 'unused')
-    end
+    assert_equal ':announcement: `7.94` (Milestone 7.94) has started rolling out to 50% of users.',
+                 rollout_announcement(track: 'production', percent: 0.5, version: '7.94', milestone: '(Milestone 7.94)')
   end
 
   def test_rollout_announcement_covers_the_percentages_the_scenarios_use
@@ -28,95 +24,58 @@ class FastlaneHelpersTest < Minitest::Test
       ['production', 1.0] => ':announcement: `7.94` has started rolling out to 100% of users.'
     }
 
-    with_env('RELEASE_VERSION' => '7.94', 'MILESTONE' => nil) do
-      expected.each do |(track, percent), message|
-        assert_equal message, rollout_announcement(track: track, percent: percent, fallback_version: 'unused')
-      end
+    expected.each do |(track, percent), message|
+      assert_equal message, rollout_announcement(track: track, percent: percent, version: '7.94')
     end
   end
 
   def test_rollout_announcement_reports_a_1_percent_production_rollout_as_a_submission
-    with_env('RELEASE_VERSION' => '7.94', 'MILESTONE' => '(Milestone 7.94)') do
-      assert_equal ':announcement: `7.94` has been submitted to the Production track for Google to review.',
-                   rollout_announcement(track: 'production', percent: 0.01, fallback_version: 'unused')
-    end
+    assert_equal ':announcement: `7.94` has been submitted to the Production track for Google to review.',
+                 rollout_announcement(track: 'production', percent: 0.01, version: '7.94', milestone: '(Milestone 7.94)')
   end
 
   def test_rollout_announcement_treats_1_percent_beta_as_an_ordinary_rollout
-    with_env('RELEASE_VERSION' => '7.94', 'MILESTONE' => nil) do
-      assert_equal ':announcement: `7.94` has started rolling out to 1% of users.',
-                   rollout_announcement(track: 'beta', percent: 0.01, fallback_version: 'unused')
-    end
-  end
-
-  def test_rollout_announcement_trims_surrounding_whitespace
-    with_env('RELEASE_VERSION' => "\t7.94\n", 'MILESTONE' => ' (Milestone 7.94) ') do
-      assert_equal ':announcement: `7.94` (Milestone 7.94) has started rolling out to 20% of users.',
-                   rollout_announcement(track: 'beta', percent: 0.2, fallback_version: 'unused')
-    end
-  end
-
-  def test_rollout_announcement_falls_back_when_the_version_is_unset_or_blank
-    ['', "  \n", nil].each do |release_version|
-      with_env('RELEASE_VERSION' => release_version, 'MILESTONE' => nil) do
-        assert_equal ':announcement: `7.94` has started rolling out to 20% of users.',
-                     rollout_announcement(track: 'beta', percent: 0.2, fallback_version: '7.94')
-      end
-    end
-  end
-
-  def test_rollout_announcement_drops_a_blank_milestone_rather_than_padding_the_subject
-    with_env('RELEASE_VERSION' => '7.94', 'MILESTONE' => "  \n") do
-      assert_equal ':announcement: `7.94` has started rolling out to 20% of users.',
-                   rollout_announcement(track: 'beta', percent: 0.2, fallback_version: 'unused')
-    end
-  end
-
-  def test_rollout_announcement_names_the_variants_that_were_not_rolled_out
-    with_env('RELEASE_VERSION' => '7.94', 'MILESTONE' => nil) do
-      assert_equal <<~MESSAGE.chomp,
-        :announcement: `7.94` has started rolling out to 20% of users.
-        :warning: Not rolled out to automotive, wear — Google Play had no matching release.
-      MESSAGE
-                   rollout_announcement(track: 'beta', percent: 0.2, fallback_version: 'unused', skipped_apps: %w[automotive wear])
-    end
-  end
-
-  def test_rollout_announcement_flags_skipped_variants_on_the_submission_message_too
-    with_env('RELEASE_VERSION' => '7.94', 'MILESTONE' => nil) do
-      assert_equal <<~MESSAGE.chomp,
-        :announcement: `7.94` has been submitted to the Production track for Google to review.
-        :warning: Not rolled out to wear — Google Play had no matching release.
-      MESSAGE
-                   rollout_announcement(track: 'production', percent: 0.01, fallback_version: 'unused', skipped_apps: ['wear'])
-    end
-  end
-
-  def test_rollout_announcement_keeps_the_original_wording_when_every_variant_rolled_out
-    with_env('RELEASE_VERSION' => '7.94', 'MILESTONE' => nil) do
-      assert_equal ':announcement: `7.94` has started rolling out to 20% of users.',
-                   rollout_announcement(track: 'beta', percent: 0.2, fallback_version: 'unused', skipped_apps: [])
-    end
+    assert_equal ':announcement: `7.94` has started rolling out to 1% of users.',
+                 rollout_announcement(track: 'beta', percent: 0.01, version: '7.94')
   end
 
   # A percentage the message would round to 1% must take the submission branch, otherwise the
   # announced number and the submission check disagree.
   def test_rollout_announcement_ties_the_submission_check_to_the_announced_percentage
-    with_env('RELEASE_VERSION' => '7.94', 'MILESTONE' => nil) do
-      assert_equal ':announcement: `7.94` has been submitted to the Production track for Google to review.',
-                   rollout_announcement(track: 'production', percent: 0.014, fallback_version: 'unused')
+    assert_equal ':announcement: `7.94` has been submitted to the Production track for Google to review.',
+                 rollout_announcement(track: 'production', percent: 0.014, version: '7.94')
+  end
+
+  def test_rollout_announcement_trims_surrounding_whitespace
+    assert_equal ':announcement: `7.94` (Milestone 7.94) has started rolling out to 20% of users.',
+                 rollout_announcement(track: 'beta', percent: 0.2, version: "\t7.94\n", milestone: ' (Milestone 7.94) ')
+  end
+
+  def test_rollout_announcement_drops_a_blank_milestone_rather_than_padding_the_subject
+    ['', "  \n", nil].each do |milestone|
+      assert_equal ':announcement: `7.94` has started rolling out to 20% of users.',
+                   rollout_announcement(track: 'beta', percent: 0.2, version: '7.94', milestone: milestone)
     end
   end
 
-  private
+  def test_rollout_announcement_names_the_variants_that_were_not_rolled_out
+    assert_equal <<~MESSAGE.chomp,
+      :announcement: `7.94` has started rolling out to 20% of users.
+      :warning: Not rolled out to automotive, wear — Google Play had no matching release.
+    MESSAGE
+                 rollout_announcement(track: 'beta', percent: 0.2, version: '7.94', skipped_apps: %w[automotive wear])
+  end
 
-  # Sets the given environment variables for the duration of the block, then puts back what was
-  # there. A `nil` value means the variable is unset for the block.
-  def with_env(vars)
-    original = vars.keys.to_h { |key| [key, ENV.fetch(key, nil)] }
-    vars.each { |key, value| value.nil? ? ENV.delete(key) : ENV[key] = value }
-    yield
-  ensure
-    original.each { |key, value| value.nil? ? ENV.delete(key) : ENV[key] = value }
+  def test_rollout_announcement_flags_skipped_variants_on_the_submission_message_too
+    assert_equal <<~MESSAGE.chomp,
+      :announcement: `7.94` has been submitted to the Production track for Google to review.
+      :warning: Not rolled out to wear — Google Play had no matching release.
+    MESSAGE
+                 rollout_announcement(track: 'production', percent: 0.01, version: '7.94', skipped_apps: ['wear'])
+  end
+
+  def test_rollout_announcement_keeps_the_original_wording_when_every_variant_rolled_out
+    assert_equal ':announcement: `7.94` has started rolling out to 20% of users.',
+                 rollout_announcement(track: 'beta', percent: 0.2, version: '7.94', skipped_apps: [])
   end
 end

--- a/fastlane/test/helpers_test.rb
+++ b/fastlane/test/helpers_test.rb
@@ -99,6 +99,15 @@ class FastlaneHelpersTest < Minitest::Test
     end
   end
 
+  # A percentage the message would round to 1% must take the submission branch, otherwise the
+  # announced number and the submission check disagree.
+  def test_rollout_announcement_ties_the_submission_check_to_the_announced_percentage
+    with_env('RELEASE_VERSION' => '7.94', 'MILESTONE' => nil) do
+      assert_equal ':announcement: `7.94` has been submitted to the Production track for Google to review.',
+                   rollout_announcement(track: 'production', percent: 0.014, fallback_version: 'unused')
+    end
+  end
+
   private
 
   # Sets the given environment variables for the duration of the block, then puts back what was

--- a/fastlane/test/helpers_test.rb
+++ b/fastlane/test/helpers_test.rb
@@ -72,6 +72,33 @@ class FastlaneHelpersTest < Minitest::Test
     end
   end
 
+  def test_rollout_announcement_names_the_variants_that_were_not_rolled_out
+    with_env('RELEASE_VERSION' => '7.94', 'MILESTONE' => nil) do
+      assert_equal <<~MESSAGE.chomp,
+        :announcement: `7.94` has started rolling out to 20% of users.
+        :warning: Not rolled out to automotive, wear — Google Play had no matching release.
+      MESSAGE
+                   rollout_announcement(track: 'beta', percent: 0.2, fallback_version: 'unused', skipped_apps: %w[automotive wear])
+    end
+  end
+
+  def test_rollout_announcement_flags_skipped_variants_on_the_submission_message_too
+    with_env('RELEASE_VERSION' => '7.94', 'MILESTONE' => nil) do
+      assert_equal <<~MESSAGE.chomp,
+        :announcement: `7.94` has been submitted to the Production track for Google to review.
+        :warning: Not rolled out to wear — Google Play had no matching release.
+      MESSAGE
+                   rollout_announcement(track: 'production', percent: 0.01, fallback_version: 'unused', skipped_apps: ['wear'])
+    end
+  end
+
+  def test_rollout_announcement_keeps_the_original_wording_when_every_variant_rolled_out
+    with_env('RELEASE_VERSION' => '7.94', 'MILESTONE' => nil) do
+      assert_equal ':announcement: `7.94` has started rolling out to 20% of users.',
+                   rollout_announcement(track: 'beta', percent: 0.2, fallback_version: 'unused', skipped_apps: [])
+    end
+  end
+
   private
 
   # Sets the given environment variables for the duration of the block, then puts back what was

--- a/fastlane/test/helpers_test.rb
+++ b/fastlane/test/helpers_test.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require_relative '../lib/helpers'
+
+# Tests the project-specific helpers used to build the release Slack announcements.
+class FastlaneHelpersTest < Minitest::Test
+  def test_rollout_announcement_omits_the_milestone_when_it_is_not_set
+    with_env('RELEASE_VERSION' => '7.94', 'MILESTONE' => nil) do
+      assert_equal ':announcement: `7.94` has started rolling out to 20% of users.',
+                   rollout_announcement(track: 'beta', percent: 0.2, fallback_version: 'unused')
+    end
+  end
+
+  def test_rollout_announcement_includes_the_milestone_when_it_is_set
+    with_env('RELEASE_VERSION' => '7.94', 'MILESTONE' => '(Milestone 7.94)') do
+      assert_equal ':announcement: `7.94` (Milestone 7.94) has started rolling out to 50% of users.',
+                   rollout_announcement(track: 'production', percent: 0.5, fallback_version: 'unused')
+    end
+  end
+
+  def test_rollout_announcement_covers_the_percentages_the_scenarios_use
+    expected = {
+      ['beta', 0.2] => ':announcement: `7.94` has started rolling out to 20% of users.',
+      ['beta', 1.0] => ':announcement: `7.94` has started rolling out to 100% of users.',
+      ['production', 0.1] => ':announcement: `7.94` has started rolling out to 10% of users.',
+      ['production', 0.5] => ':announcement: `7.94` has started rolling out to 50% of users.',
+      ['production', 1.0] => ':announcement: `7.94` has started rolling out to 100% of users.'
+    }
+
+    with_env('RELEASE_VERSION' => '7.94', 'MILESTONE' => nil) do
+      expected.each do |(track, percent), message|
+        assert_equal message, rollout_announcement(track: track, percent: percent, fallback_version: 'unused')
+      end
+    end
+  end
+
+  def test_rollout_announcement_reports_a_1_percent_production_rollout_as_a_submission
+    with_env('RELEASE_VERSION' => '7.94', 'MILESTONE' => '(Milestone 7.94)') do
+      assert_equal ':announcement: `7.94` has been submitted to the Production track for Google to review.',
+                   rollout_announcement(track: 'production', percent: 0.01, fallback_version: 'unused')
+    end
+  end
+
+  def test_rollout_announcement_treats_1_percent_beta_as_an_ordinary_rollout
+    with_env('RELEASE_VERSION' => '7.94', 'MILESTONE' => nil) do
+      assert_equal ':announcement: `7.94` has started rolling out to 1% of users.',
+                   rollout_announcement(track: 'beta', percent: 0.01, fallback_version: 'unused')
+    end
+  end
+
+  def test_rollout_announcement_trims_surrounding_whitespace
+    with_env('RELEASE_VERSION' => "\t7.94\n", 'MILESTONE' => ' (Milestone 7.94) ') do
+      assert_equal ':announcement: `7.94` (Milestone 7.94) has started rolling out to 20% of users.',
+                   rollout_announcement(track: 'beta', percent: 0.2, fallback_version: 'unused')
+    end
+  end
+
+  def test_rollout_announcement_falls_back_when_the_version_is_unset_or_blank
+    ['', "  \n", nil].each do |release_version|
+      with_env('RELEASE_VERSION' => release_version, 'MILESTONE' => nil) do
+        assert_equal ':announcement: `7.94` has started rolling out to 20% of users.',
+                     rollout_announcement(track: 'beta', percent: 0.2, fallback_version: '7.94')
+      end
+    end
+  end
+
+  def test_rollout_announcement_drops_a_blank_milestone_rather_than_padding_the_subject
+    with_env('RELEASE_VERSION' => '7.94', 'MILESTONE' => "  \n") do
+      assert_equal ':announcement: `7.94` has started rolling out to 20% of users.',
+                   rollout_announcement(track: 'beta', percent: 0.2, fallback_version: 'unused')
+    end
+  end
+
+  private
+
+  # Sets the given environment variables for the duration of the block, then puts back what was
+  # there. A `nil` value means the variable is unset for the block.
+  def with_env(vars)
+    original = vars.keys.to_h { |key| [key, ENV.fetch(key, nil)] }
+    vars.each { |key, value| value.nil? ? ENV.delete(key) : ENV[key] = value }
+    yield
+  ensure
+    original.each { |key, value| value.nil? ? ENV.delete(key) : ENV[key] = value }
+  end
+end


### PR DESCRIPTION
## Description

The job that rolls out a Pocket Casts Android build now posts the Slack announcement that used to be a manual Releases V2 click.

Closes [AINFRA-3066](https://linear.app/a8c/issue/AINFRA-3066), part of [AINFRA-3063](https://linear.app/a8c/issue/AINFRA-3063).

Land this before the Releases V2 change that removes those clicks. Until that side sends `MILESTONE`, the message omits it.

`channel:` is required: `SLACK_WEBHOOK` is shared across products and posts to a test channel unless told otherwise.

A 1% production rollout announces a submission, not a percentage — that is how the scenario submits a build for Google to review.

## Testing Instructions

Wording is covered by `ruby fastlane/test/helpers_test.rb`, which this PR also adds as a CI step.

Slack wiring was checked on throwaway PR #5830 ([build 18722](https://buildkite.com/automattic/pocket-casts-android/builds/18722)): posting to `#pocket-casts-android` as Pocket Cats, and an invalid webhook leaving the job green.

End to end it only runs on a real rollout.

## Checklist

- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md — n/a, CI only
- [x] Ensure the linter passes
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `strings.xml` — n/a
- [x] Any jetpack compose components I added or changed are covered by compose previews — n/a
- [x] I have updated the Event Horizon schema — n/a
