### PR TITLE
Support video/mp4 alternate enclosures

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AlternateEnclosureDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AlternateEnclosureDaoTest.kt
@@ -9,7 +9,6 @@ import au.com.shiftyjelly.pocketcasts.models.db.dao.EpisodeDao
 import au.com.shiftyjelly.pocketcasts.models.di.ModelModule
 import au.com.shiftyjelly.pocketcasts.models.di.addTypeConverters
 import au.com.shiftyjelly.pocketcasts.models.entity.AlternateEnclosureSource
-import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.EpisodeAlternateEnclosure
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.MediaKind
@@ -19,7 +18,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -108,42 +106,24 @@ class AlternateEnclosureDaoTest {
     }
 
     @Test
-    fun hasVideoEnclosureMatchesHlsAndVideoMediaKind() = runTest {
-        episodeDao.insertBlocking(PodcastEpisode(uuid = "hls-episode", publishedDate = Date()))
+    fun observeByEpisodeUuidEmitsStoredEnclosuresInPositionOrder() = runTest {
         episodeDao.insertBlocking(PodcastEpisode(uuid = "video-episode", publishedDate = Date()))
-        episodeDao.insertBlocking(PodcastEpisode(uuid = "audio-episode", publishedDate = Date()))
 
-        alternateEnclosureDao.replaceForEpisode(
-            "hls-episode",
-            listOf(enclosure(position = 0, type = "APPLICATION/X-MPEGURL", uri = "https://example.com/master.m3u8").copy(episodeUuid = "hls-episode")),
-        )
         alternateEnclosureDao.replaceForEpisode(
             "video-episode",
             listOf(
-                enclosure(position = 0, type = "video/mp4", uri = "https://example.com/file.mp4", mediaKind = MediaKind.Video)
+                enclosure(position = 1, type = "video/mp4", uri = "https://example.com/file.mp4", mediaKind = MediaKind.Video)
+                    .copy(episodeUuid = "video-episode"),
+                enclosure(position = 0, type = "APPLICATION/X-MPEGURL", uri = "https://example.com/master.m3u8")
                     .copy(episodeUuid = "video-episode"),
             ),
         )
-        alternateEnclosureDao.replaceForEpisode(
-            "audio-episode",
-            listOf(
-                // A video MIME type the server did not mark as video must not count.
-                enclosure(position = 0, type = "video/mp4", uri = "https://example.com/file.mp4", mediaKind = MediaKind.Audio)
-                    .copy(episodeUuid = "audio-episode"),
-            ),
-        )
 
-        assertTrue(hasVideoEnclosure("hls-episode"))
-        assertTrue(hasVideoEnclosure("video-episode"))
-        assertFalse(hasVideoEnclosure("audio-episode"))
-        assertFalse(hasVideoEnclosure("unknown-episode"))
+        val observed = alternateEnclosureDao.observeByEpisodeUuid("video-episode").first()
+        assertEquals(listOf(0, 1), observed.map { it.position })
+        assertEquals(MediaKind.Video, observed[1].mediaKind)
+        assertTrue(alternateEnclosureDao.observeByEpisodeUuid("unknown-episode").first().isEmpty())
     }
-
-    private suspend fun hasVideoEnclosure(episodeUuid: String) = alternateEnclosureDao.hasVideoEnclosure(
-        episodeUuid = episodeUuid,
-        hlsMimeTypes = BaseEpisode.HLS_MIME_TYPES,
-        videoMediaKind = MediaKind.Video.stringValue,
-    ).first()
 
     private fun enclosure(position: Int, type: String, uri: String, mediaKind: MediaKind? = null) = EpisodeAlternateEnclosure(
         episodeUuid = "episode-1",

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AlternateEnclosureDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AlternateEnclosureDaoTest.kt
@@ -127,7 +127,8 @@ class AlternateEnclosureDaoTest {
         alternateEnclosureDao.replaceForEpisode(
             "audio-episode",
             listOf(
-                enclosure(position = 0, type = "audio/mp3", uri = "https://example.com/file.mp3", mediaKind = MediaKind.Audio)
+                // A video MIME type the server did not mark as video must not count.
+                enclosure(position = 0, type = "video/mp4", uri = "https://example.com/file.mp4", mediaKind = MediaKind.Audio)
                     .copy(episodeUuid = "audio-episode"),
             ),
         )

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AlternateEnclosureDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AlternateEnclosureDaoTest.kt
@@ -9,15 +9,19 @@ import au.com.shiftyjelly.pocketcasts.models.db.dao.EpisodeDao
 import au.com.shiftyjelly.pocketcasts.models.di.ModelModule
 import au.com.shiftyjelly.pocketcasts.models.di.addTypeConverters
 import au.com.shiftyjelly.pocketcasts.models.entity.AlternateEnclosureSource
+import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.EpisodeAlternateEnclosure
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.MediaKind
 import com.squareup.moshi.Moshi
 import java.util.Date
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -102,6 +106,43 @@ class AlternateEnclosureDaoTest {
         assertNull(stored[1].mediaKind)
         assertEquals(MediaKind.Unknown("hologram"), stored[2].mediaKind)
     }
+
+    @Test
+    fun hasVideoEnclosureMatchesHlsAndVideoMediaKind() = runTest {
+        episodeDao.insertBlocking(PodcastEpisode(uuid = "hls-episode", publishedDate = Date()))
+        episodeDao.insertBlocking(PodcastEpisode(uuid = "video-episode", publishedDate = Date()))
+        episodeDao.insertBlocking(PodcastEpisode(uuid = "audio-episode", publishedDate = Date()))
+
+        alternateEnclosureDao.replaceForEpisode(
+            "hls-episode",
+            listOf(enclosure(position = 0, type = "APPLICATION/X-MPEGURL", uri = "https://example.com/master.m3u8").copy(episodeUuid = "hls-episode")),
+        )
+        alternateEnclosureDao.replaceForEpisode(
+            "video-episode",
+            listOf(
+                enclosure(position = 0, type = "video/mp4", uri = "https://example.com/file.mp4", mediaKind = MediaKind.Video)
+                    .copy(episodeUuid = "video-episode"),
+            ),
+        )
+        alternateEnclosureDao.replaceForEpisode(
+            "audio-episode",
+            listOf(
+                enclosure(position = 0, type = "audio/mp3", uri = "https://example.com/file.mp3", mediaKind = MediaKind.Audio)
+                    .copy(episodeUuid = "audio-episode"),
+            ),
+        )
+
+        assertTrue(hasVideoEnclosure("hls-episode"))
+        assertTrue(hasVideoEnclosure("video-episode"))
+        assertFalse(hasVideoEnclosure("audio-episode"))
+        assertFalse(hasVideoEnclosure("unknown-episode"))
+    }
+
+    private suspend fun hasVideoEnclosure(episodeUuid: String) = alternateEnclosureDao.hasVideoEnclosure(
+        episodeUuid = episodeUuid,
+        hlsMimeTypes = BaseEpisode.HLS_MIME_TYPES,
+        videoMediaKind = MediaKind.Video.stringValue,
+    ).first()
 
     private fun enclosure(position: Int, type: String, uri: String, mediaKind: MediaKind? = null) = EpisodeAlternateEnclosure(
         episodeUuid = "episode-1",

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ShelfSharedViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ShelfSharedViewModel.kt
@@ -93,11 +93,11 @@ class ShelfSharedViewModel @Inject constructor(
 
     private val videoStateFlow = combine(
         playbackManager.streamVideoState,
-        playbackManager.streamHlsAvailable,
+        playbackManager.streamVideoAvailable,
         playbackManager.videoRenderingEnabled,
         settings.audioOnly.flow,
-    ) { streamVideoState, hlsAvailable, renderingEnabled, audioOnly ->
-        VideoState(streamVideoState, hlsAvailable, renderingEnabled, audioOnly)
+    ) { streamVideoState, videoStreamAvailable, renderingEnabled, audioOnly ->
+        VideoState(streamVideoState, videoStreamAvailable, renderingEnabled, audioOnly)
     }
 
     val uiState = combine(
@@ -123,9 +123,9 @@ class ShelfSharedViewModel @Inject constructor(
         val episode = (shelfUpNext as? UpNextQueue.State.Loaded)?.episode
         val streamHasVideo = videoState.streamVideoState == StreamVideoState.HasVideo || videoState.streamVideoState == StreamVideoState.Unknown
         val canToggleVideo = !videoState.audioOnly &&
-            FeatureFlag.isEnabled(Feature.HLS_STREAMING) &&
+            (FeatureFlag.isEnabled(Feature.HLS_STREAMING) || FeatureFlag.isEnabled(Feature.VIDEO_ALTERNATE_ENCLOSURES)) &&
             episode is PodcastEpisode &&
-            (streamHasVideo || videoState.hlsAvailable)
+            (streamHasVideo || videoState.videoStreamAvailable)
         return uiState.value.copy(
             shelfItems = shelfItems.filter { it.showIf(episode) && (it != ShelfItem.StreamSelector || canToggleVideo) },
             episode = episode,
@@ -136,7 +136,7 @@ class ShelfSharedViewModel @Inject constructor(
 
     private data class VideoState(
         val streamVideoState: StreamVideoState,
-        val hlsAvailable: Boolean,
+        val videoStreamAvailable: Boolean,
         val renderingEnabled: Boolean,
         val audioOnly: Boolean,
     )

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ShelfSharedViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ShelfSharedViewModelTest.kt
@@ -326,11 +326,11 @@ class ShelfSharedViewModelTest {
     }
 
     @Test
-    fun `given hls stream available and no video, then stream selector is shown`() = runTest {
+    fun `given a video stream is available and no video, then stream selector is shown`() = runTest {
         val episode = PodcastEpisode("uuid", publishedDate = Date())
         initViewModel(
             currentEpisode = episode,
-            hlsAvailable = true,
+            videoStreamAvailable = true,
             streamVideoState = StreamVideoState.NotVideo,
         )
 
@@ -349,7 +349,7 @@ class ShelfSharedViewModelTest {
         val episode = PodcastEpisode("uuid", publishedDate = Date())
         initViewModel(
             currentEpisode = episode,
-            hlsAvailable = true,
+            videoStreamAvailable = true,
             streamVideoState = StreamVideoState.AudioOnly,
             audioOnly = true,
         )
@@ -365,11 +365,11 @@ class ShelfSharedViewModelTest {
     }
 
     @Test
-    fun `given no hls stream and no video, then stream selector is hidden`() = runTest {
+    fun `given no video stream and no video, then stream selector is hidden`() = runTest {
         val episode = PodcastEpisode("uuid", publishedDate = Date())
         initViewModel(
             currentEpisode = episode,
-            hlsAvailable = false,
+            videoStreamAvailable = false,
             streamVideoState = StreamVideoState.NotVideo,
         )
 
@@ -420,7 +420,7 @@ class ShelfSharedViewModelTest {
     private fun initViewModel(
         subscription: Subscription? = plusSubscription,
         currentEpisode: PodcastEpisode? = null,
-        hlsAvailable: Boolean = false,
+        videoStreamAvailable: Boolean = false,
         streamVideoState: StreamVideoState = StreamVideoState.NotVideo,
         audioOnly: Boolean = false,
     ) {
@@ -452,7 +452,7 @@ class ShelfSharedViewModelTest {
         whenever(settings.cachedSubscription).thenReturn(userSubscriptionSetting)
 
         whenever(playbackManager.streamVideoState).thenReturn(MutableStateFlow(streamVideoState))
-        whenever(playbackManager.streamHlsAvailable).thenReturn(MutableStateFlow(hlsAvailable))
+        whenever(playbackManager.streamVideoAvailable).thenReturn(MutableStateFlow(videoStreamAvailable))
         whenever(playbackManager.videoRenderingEnabled).thenReturn(MutableStateFlow(true))
 
         val audioOnlySetting = mock<UserSetting<Boolean>>()

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -469,7 +469,7 @@ class EpisodeFragment : BaseFragment() {
                                 LR.string.podcasts_download_download,
                             ),
                         )
-                        binding.btnDownload.isVisible = !state.episode.isStreamOnly
+                        binding.btnDownload.isVisible = !state.episode.isHlsOnly
                         val episodeStatus = state.episode.downloadStatus
                         binding.btnDownload.state = when (episodeStatus) {
                             EpisodeDownloadStatus.DownloadNotRequested -> DownloadButtonState.NotDownloaded(downloadSize)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -469,7 +469,7 @@ class EpisodeFragment : BaseFragment() {
                                 LR.string.podcasts_download_download,
                             ),
                         )
-                        binding.btnDownload.isVisible = !state.episode.isHlsOnly
+                        binding.btnDownload.isVisible = !state.episode.isStreamOnly
                         val episodeStatus = state.episode.downloadStatus
                         binding.btnDownload.state = when (episodeStatus) {
                             EpisodeDownloadStatus.DownloadNotRequested -> DownloadButtonState.NotDownloaded(downloadSize)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/BaseEpisodeViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/BaseEpisodeViewHolder.kt
@@ -68,7 +68,7 @@ abstract class BaseEpisodeViewHolder<T : Any>(
 
     private var isObservingRowData = false
 
-    private var hasHlsAlternateEnclosure = false
+    private var hasVideoAlternateEnclosure = false
 
     @Suppress("UNCHECKED_CAST")
     private val swipeLayout = binding.root as SwipeRowLayout<SwipeAction>
@@ -164,12 +164,12 @@ abstract class BaseEpisodeViewHolder<T : Any>(
 
     private fun observeRowData() {
         disposable.clear()
-        hasHlsAlternateEnclosure = false
+        hasVideoAlternateEnclosure = false
         disposable += rowDataProvider.episodeRowDataObservable(episode.uuid)
             .doOnSubscribe { isObservingRowData = true }
             .doOnDispose { isObservingRowData = false }
             .subscribeBy(onNext = { data ->
-                hasHlsAlternateEnclosure = data.hasHlsAlternateEnclosure
+                hasVideoAlternateEnclosure = data.hasVideoAlternateEnclosure
                 isPlaying = data.playbackState.isPlaying && data.playbackState.episodeUuid == episode.uuid
                 bindPlaybackButton()
 
@@ -206,7 +206,7 @@ abstract class BaseEpisodeViewHolder<T : Any>(
 
     private fun bindStatus(downloadProgress: Int) {
         binding.star.isVisible = episode.isStarred
-        binding.video.isVisible = episode.showsVideoIcon(hasHlsAlternateEnclosure)
+        binding.video.isVisible = episode.showsVideoIcon(hasVideoAlternateEnclosure)
         binding.progressBar.isVisible = false
         binding.progressCircle.isVisible = false
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/AlternateEnclosureDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/AlternateEnclosureDao.kt
@@ -12,8 +12,11 @@ abstract class AlternateEnclosureDao {
     @Query("SELECT * FROM episode_alternate_enclosures WHERE episode_uuid IS :episodeUuid ORDER BY position ASC")
     abstract suspend fun findByEpisodeUuid(episodeUuid: String): List<EpisodeAlternateEnclosure>
 
-    @Query("SELECT EXISTS(SELECT 1 FROM episode_alternate_enclosures WHERE episode_uuid IS :episodeUuid AND LOWER(type) IN (:hlsMimeTypes))")
-    abstract fun hasHlsEnclosure(episodeUuid: String, hlsMimeTypes: Set<String>): Flow<Boolean>
+    @Query(
+        "SELECT EXISTS(SELECT 1 FROM episode_alternate_enclosures WHERE episode_uuid IS :episodeUuid " +
+            "AND (LOWER(type) IN (:hlsMimeTypes) OR media_kind IS :videoMediaKind))",
+    )
+    abstract fun hasVideoEnclosure(episodeUuid: String, hlsMimeTypes: Set<String>, videoMediaKind: String): Flow<Boolean>
 
     @Insert
     protected abstract suspend fun insertAll(enclosures: List<EpisodeAlternateEnclosure>)

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/AlternateEnclosureDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/AlternateEnclosureDao.kt
@@ -12,11 +12,8 @@ abstract class AlternateEnclosureDao {
     @Query("SELECT * FROM episode_alternate_enclosures WHERE episode_uuid IS :episodeUuid ORDER BY position ASC")
     abstract suspend fun findByEpisodeUuid(episodeUuid: String): List<EpisodeAlternateEnclosure>
 
-    @Query(
-        "SELECT EXISTS(SELECT 1 FROM episode_alternate_enclosures WHERE episode_uuid IS :episodeUuid " +
-            "AND (LOWER(type) IN (:hlsMimeTypes) OR media_kind IS :videoMediaKind))",
-    )
-    abstract fun hasVideoEnclosure(episodeUuid: String, hlsMimeTypes: Set<String>, videoMediaKind: String): Flow<Boolean>
+    @Query("SELECT * FROM episode_alternate_enclosures WHERE episode_uuid IS :episodeUuid ORDER BY position ASC")
+    abstract fun observeByEpisodeUuid(episodeUuid: String): Flow<List<EpisodeAlternateEnclosure>>
 
     @Insert
     protected abstract suspend fun insertAll(enclosures: List<EpisodeAlternateEnclosure>)

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/AlternateEnclosures.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/AlternateEnclosures.kt
@@ -7,6 +7,7 @@ data class AlternateEnclosureStream(
     val url: String,
     val contentType: String?,
     val isHls: Boolean,
+    val isVideo: Boolean,
 )
 
 /** First HLS enclosure's first http(s) source URI, or null if none can be streamed. */
@@ -25,9 +26,6 @@ fun List<EpisodeAlternateEnclosure>?.firstProgressiveVideoStream(): AlternateEnc
     ?.filter { it.isProgressiveVideo }
     ?.firstNotNullOfOrNull { it.toStream(isHls = false) }
 
-/** Whether any enclosure offers video, whether or not it has a source we can actually stream. */
-fun List<EpisodeAlternateEnclosure>?.hasVideoEnclosure(): Boolean = this?.any { BaseEpisode.isHlsMimeType(it.type) || it.isProgressiveVideo } == true
-
 /** MIME type to record on an episode the server sent no progressive enclosure for. */
 fun List<EpisodeAlternateEnclosure>?.firstStreamOnlyMimeType(): String? = firstHlsMimeType() ?: this?.firstOrNull { it.isProgressiveVideo }?.type
 
@@ -36,7 +34,9 @@ private val EpisodeAlternateEnclosure.isProgressiveVideo: Boolean
 
 private fun EpisodeAlternateEnclosure.toStream(isHls: Boolean): AlternateEnclosureStream? {
     val source = sources.firstOrNull { it.uri.isPlayableHttpUri() } ?: return null
-    return AlternateEnclosureStream(url = source.uri, contentType = source.contentType?.takeIf { it.isNotBlank() } ?: type, isHls = isHls)
+    // The enclosure's own type describes the rendition; a source may declare a generic type such as application/octet-stream.
+    val contentType = type?.takeIf { it.isNotBlank() } ?: source.contentType?.takeIf { it.isNotBlank() }
+    return AlternateEnclosureStream(url = source.uri, contentType = contentType, isHls = isHls, isVideo = mediaKind == MediaKind.Video)
 }
 
 private fun String.isPlayableHttpUri(): Boolean {

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/AlternateEnclosures.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/AlternateEnclosures.kt
@@ -5,9 +5,18 @@ import au.com.shiftyjelly.pocketcasts.models.type.MediaKind
 data class AlternateEnclosureStream(
     val url: String,
     val contentType: String?,
-    val isHls: Boolean,
-    val isVideo: Boolean,
-)
+    val mediaKind: MediaKind?,
+) {
+    val isHls: Boolean
+        get() = BaseEpisode.isHlsMimeType(contentType) || BaseEpisode.isHlsUrl(url)
+
+    val isVideo: Boolean
+        get() = mediaKind == MediaKind.Video
+
+    /** The server said audio explicitly, which is not the same as leaving the kind unstated. */
+    val isAudioOnly: Boolean
+        get() = mediaKind == MediaKind.Audio
+}
 
 /** First HLS enclosure's first http(s) source URI, or null if none can be streamed. */
 fun List<EpisodeAlternateEnclosure>?.firstHlsStreamUrl(): String? = firstHlsStream()?.url
@@ -15,15 +24,15 @@ fun List<EpisodeAlternateEnclosure>?.firstHlsStreamUrl(): String? = firstHlsStre
 /** The first HLS enclosure's MIME type, or null if none. Lets HLS-only episodes be detected synchronously. */
 fun List<EpisodeAlternateEnclosure>?.firstHlsMimeType(): String? = this?.firstOrNull { BaseEpisode.isHlsMimeType(it.type) }?.type
 
-/** The streamable HLS encoding, preferred over [firstProgressiveVideoStream] because it adapts to bandwidth. */
+/** The streamable HLS encoding, which adapts to bandwidth where a progressive rendition cannot. */
 fun List<EpisodeAlternateEnclosure>?.firstHlsStream(): AlternateEnclosureStream? = this
     ?.filter { BaseEpisode.isHlsMimeType(it.type) }
-    ?.firstNotNullOfOrNull { it.toStream(isHls = true) }
+    ?.firstNotNullOfOrNull { it.toStream() }
 
 /** The streamable non-HLS encoding the server marked `media_kind = "video"`, such as a `video/mp4` enclosure. */
 fun List<EpisodeAlternateEnclosure>?.firstProgressiveVideoStream(): AlternateEnclosureStream? = this
     ?.filter { it.isProgressiveVideo }
-    ?.firstNotNullOfOrNull { it.toStream(isHls = false) }
+    ?.firstNotNullOfOrNull { it.toStream() }
 
 /** MIME type to record on an episode the server sent no progressive enclosure for. */
 fun List<EpisodeAlternateEnclosure>?.firstStreamOnlyMimeType(): String? = firstHlsMimeType() ?: this?.firstOrNull { it.isProgressiveVideo }?.type
@@ -31,11 +40,11 @@ fun List<EpisodeAlternateEnclosure>?.firstStreamOnlyMimeType(): String? = firstH
 private val EpisodeAlternateEnclosure.isProgressiveVideo: Boolean
     get() = mediaKind == MediaKind.Video && !BaseEpisode.isHlsMimeType(type)
 
-private fun EpisodeAlternateEnclosure.toStream(isHls: Boolean): AlternateEnclosureStream? {
+private fun EpisodeAlternateEnclosure.toStream(): AlternateEnclosureStream? {
     val source = sources.firstOrNull { it.uri.isPlayableHttpUri() } ?: return null
     // The enclosure's own type describes the encoding; a source may declare a generic type such as application/octet-stream.
     val contentType = type?.takeIf { it.isNotBlank() } ?: source.contentType?.takeIf { it.isNotBlank() }
-    return AlternateEnclosureStream(url = source.uri, contentType = contentType, isHls = isHls, isVideo = mediaKind == MediaKind.Video)
+    return AlternateEnclosureStream(url = source.uri, contentType = contentType, mediaKind = mediaKind)
 }
 
 private fun String.isPlayableHttpUri(): Boolean {

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/AlternateEnclosures.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/AlternateEnclosures.kt
@@ -15,12 +15,12 @@ fun List<EpisodeAlternateEnclosure>?.firstHlsStreamUrl(): String? = firstHlsStre
 /** The first HLS enclosure's MIME type, or null if none. Lets HLS-only episodes be detected synchronously. */
 fun List<EpisodeAlternateEnclosure>?.firstHlsMimeType(): String? = this?.firstOrNull { BaseEpisode.isHlsMimeType(it.type) }?.type
 
-/** The streamable HLS rendition, preferred over [firstProgressiveVideoStream] because it adapts to bandwidth. */
+/** The streamable HLS encoding, preferred over [firstProgressiveVideoStream] because it adapts to bandwidth. */
 fun List<EpisodeAlternateEnclosure>?.firstHlsStream(): AlternateEnclosureStream? = this
     ?.filter { BaseEpisode.isHlsMimeType(it.type) }
     ?.firstNotNullOfOrNull { it.toStream(isHls = true) }
 
-/** The streamable non-HLS rendition the server marked `media_kind = "video"`, such as a `video/mp4` enclosure. */
+/** The streamable non-HLS encoding the server marked `media_kind = "video"`, such as a `video/mp4` enclosure. */
 fun List<EpisodeAlternateEnclosure>?.firstProgressiveVideoStream(): AlternateEnclosureStream? = this
     ?.filter { it.isProgressiveVideo }
     ?.firstNotNullOfOrNull { it.toStream(isHls = false) }
@@ -33,7 +33,7 @@ private val EpisodeAlternateEnclosure.isProgressiveVideo: Boolean
 
 private fun EpisodeAlternateEnclosure.toStream(isHls: Boolean): AlternateEnclosureStream? {
     val source = sources.firstOrNull { it.uri.isPlayableHttpUri() } ?: return null
-    // The enclosure's own type describes the rendition; a source may declare a generic type such as application/octet-stream.
+    // The enclosure's own type describes the encoding; a source may declare a generic type such as application/octet-stream.
     val contentType = type?.takeIf { it.isNotBlank() } ?: source.contentType?.takeIf { it.isNotBlank() }
     return AlternateEnclosureStream(url = source.uri, contentType = contentType, isHls = isHls, isVideo = mediaKind == MediaKind.Video)
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/AlternateEnclosures.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/AlternateEnclosures.kt
@@ -2,7 +2,6 @@ package au.com.shiftyjelly.pocketcasts.models.entity
 
 import au.com.shiftyjelly.pocketcasts.models.type.MediaKind
 
-/** A playable rendition resolved from an alternate enclosure. */
 data class AlternateEnclosureStream(
     val url: String,
     val contentType: String?,

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/AlternateEnclosures.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/AlternateEnclosures.kt
@@ -1,17 +1,43 @@
 package au.com.shiftyjelly.pocketcasts.models.entity
 
+import au.com.shiftyjelly.pocketcasts.models.type.MediaKind
+
+/** A playable rendition resolved from an alternate enclosure. */
+data class AlternateEnclosureStream(
+    val url: String,
+    val contentType: String?,
+    val isHls: Boolean,
+)
+
 /** First HLS enclosure's first http(s) source URI, or null if none can be streamed. */
-fun List<EpisodeAlternateEnclosure>?.firstHlsStreamUrl(): String? {
-    val enclosures = this ?: return null
-    return enclosures
-        .firstOrNull { BaseEpisode.isHlsMimeType(it.type) }
-        ?.sources
-        ?.firstOrNull { it.uri.isPlayableHttpUri() }
-        ?.uri
-}
+fun List<EpisodeAlternateEnclosure>?.firstHlsStreamUrl(): String? = firstHlsStream()?.url
 
 /** The first HLS enclosure's MIME type, or null if none. Lets HLS-only episodes be detected synchronously. */
 fun List<EpisodeAlternateEnclosure>?.firstHlsMimeType(): String? = this?.firstOrNull { BaseEpisode.isHlsMimeType(it.type) }?.type
+
+/** The streamable HLS rendition, preferred over [firstProgressiveVideoStream] because it adapts to bandwidth. */
+fun List<EpisodeAlternateEnclosure>?.firstHlsStream(): AlternateEnclosureStream? = this
+    ?.filter { BaseEpisode.isHlsMimeType(it.type) }
+    ?.firstNotNullOfOrNull { it.toStream(isHls = true) }
+
+/** The streamable non-HLS rendition the server marked `media_kind = "video"`, such as a `video/mp4` enclosure. */
+fun List<EpisodeAlternateEnclosure>?.firstProgressiveVideoStream(): AlternateEnclosureStream? = this
+    ?.filter { it.isProgressiveVideo }
+    ?.firstNotNullOfOrNull { it.toStream(isHls = false) }
+
+/** Whether any enclosure offers video, whether or not it has a source we can actually stream. */
+fun List<EpisodeAlternateEnclosure>?.hasVideoEnclosure(): Boolean = this?.any { BaseEpisode.isHlsMimeType(it.type) || it.isProgressiveVideo } == true
+
+/** MIME type to record on an episode the server sent no progressive enclosure for. */
+fun List<EpisodeAlternateEnclosure>?.firstStreamOnlyMimeType(): String? = firstHlsMimeType() ?: this?.firstOrNull { it.isProgressiveVideo }?.type
+
+private val EpisodeAlternateEnclosure.isProgressiveVideo: Boolean
+    get() = mediaKind == MediaKind.Video && !BaseEpisode.isHlsMimeType(type)
+
+private fun EpisodeAlternateEnclosure.toStream(isHls: Boolean): AlternateEnclosureStream? {
+    val source = sources.firstOrNull { it.uri.isPlayableHttpUri() } ?: return null
+    return AlternateEnclosureStream(url = source.uri, contentType = source.contentType ?: type, isHls = isHls)
+}
 
 private fun String.isPlayableHttpUri(): Boolean {
     return startsWith("http://", ignoreCase = true) || startsWith("https://", ignoreCase = true)

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/AlternateEnclosures.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/AlternateEnclosures.kt
@@ -36,7 +36,7 @@ private val EpisodeAlternateEnclosure.isProgressiveVideo: Boolean
 
 private fun EpisodeAlternateEnclosure.toStream(isHls: Boolean): AlternateEnclosureStream? {
     val source = sources.firstOrNull { it.uri.isPlayableHttpUri() } ?: return null
-    return AlternateEnclosureStream(url = source.uri, contentType = source.contentType ?: type, isHls = isHls)
+    return AlternateEnclosureStream(url = source.uri, contentType = source.contentType?.takeIf { it.isNotBlank() } ?: type, isHls = isHls)
 }
 
 private fun String.isPlayableHttpUri(): Boolean {

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/BaseEpisode.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/BaseEpisode.kt
@@ -130,7 +130,7 @@ sealed interface BaseEpisode {
         get() = autoDownloadStatus == AUTO_DOWNLOAD_STATUS_IGNORE
 
     val canQueueForAutoDownload
-        get() = !isFinished && !isArchived && !isAutoDownloadDisabled && !isStreamOnly
+        get() = !isFinished && !isArchived && !isAutoDownloadDisabled && !isHlsOnly
 
     val isInProgress: Boolean
         get() = EpisodePlayingStatus.IN_PROGRESS == playingStatus
@@ -142,15 +142,14 @@ sealed interface BaseEpisode {
     val isHlsOnly: Boolean
         get() = isHlsUrl(downloadUrl) || isHlsMimeType(fileType)
 
-    /** Playable only by streaming an alternate enclosure: HLS, or the server sent no progressive enclosure at all. */
-    val isStreamOnly: Boolean
-        get() = isHlsOnly || (this is PodcastEpisode && downloadUrl.isNullOrBlank())
-
     /** A runtime-only resolved stream (e.g. the HLS alternate enclosure); overrides [streamUrl] when set. */
     var overrideStreamUrl: String?
 
     /** The content type of [overrideStreamUrl], used to decide HLS/video handling. */
     var overrideStreamContentType: String?
+
+    /** Whether [overrideStreamUrl] is a video rendition, as the server's media kind declared it. */
+    var overrideStreamIsVideo: Boolean
 
     /**
      * The URL to use when streaming. Downloaded playback uses [downloadedFilePath] instead. Falls back
@@ -171,7 +170,7 @@ sealed interface BaseEpisode {
 
     /** Whether streaming will use an alternate rendition that carries video the progressive enclosure may not. */
     val isStreamUrlVideo: Boolean
-        get() = isStreamUrlHls || isVideoMimeType(overrideStreamContentType)
+        get() = isStreamUrlHls || (overrideStreamUrl != null && overrideStreamIsVideo)
 
     val isAudio: Boolean
         get() = !isVideo

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/BaseEpisode.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/BaseEpisode.kt
@@ -148,7 +148,7 @@ sealed interface BaseEpisode {
     /** The content type of [overrideStreamUrl], used to decide HLS/video handling. */
     var overrideStreamContentType: String?
 
-    /** Whether [overrideStreamUrl] is a video rendition, as the server's media kind declared it. */
+    /** Whether [overrideStreamUrl] is a video encoding, as the server's media kind declared it. */
     var overrideStreamIsVideo: Boolean
 
     /**
@@ -168,7 +168,7 @@ sealed interface BaseEpisode {
             return isHlsUrl(url) || (url == downloadUrl && isHlsMimeType(fileType))
         }
 
-    /** Whether streaming will use an alternate rendition that carries video the progressive enclosure may not. */
+    /** Whether streaming will use an alternate encoding that carries video the progressive enclosure may not. */
     val isStreamUrlVideo: Boolean
         get() = isStreamUrlHls || (overrideStreamUrl != null && overrideStreamIsVideo)
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/BaseEpisode.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/BaseEpisode.kt
@@ -130,7 +130,7 @@ sealed interface BaseEpisode {
         get() = autoDownloadStatus == AUTO_DOWNLOAD_STATUS_IGNORE
 
     val canQueueForAutoDownload
-        get() = !isFinished && !isArchived && !isAutoDownloadDisabled && !isHlsOnly
+        get() = !isFinished && !isArchived && !isAutoDownloadDisabled && !isStreamOnly
 
     val isInProgress: Boolean
         get() = EpisodePlayingStatus.IN_PROGRESS == playingStatus
@@ -142,35 +142,42 @@ sealed interface BaseEpisode {
     val isHlsOnly: Boolean
         get() = isHlsUrl(downloadUrl) || isHlsMimeType(fileType)
 
-    /** A runtime-only resolved stream (e.g. the HLS alternate enclosure); overrides [streamUrl] when set. */
-    var overrideStreamUrl: String?
+    /** No progressive file to download. A blank [downloadUrl] alone will not do: the download worker refetches one. */
+    val isStreamOnly: Boolean
+        get() = isHlsOnly || (isVideo && downloadUrl.isNullOrBlank())
 
-    /** The content type of [overrideStreamUrl], used to decide HLS/video handling. */
-    var overrideStreamContentType: String?
-
-    /** Whether [overrideStreamUrl] is a video encoding, as the server's media kind declared it. */
-    var overrideStreamIsVideo: Boolean
+    /** A runtime-only resolved alternate encoding (HLS or progressive video); overrides [streamUrl] when set. */
+    var overrideStream: AlternateEnclosureStream?
 
     /**
      * The URL to use when streaming. Downloaded playback uses [downloadedFilePath] instead. Falls back
-     * to the progressive [downloadUrl] unless a stream has been resolved into [overrideStreamUrl].
+     * to the progressive [downloadUrl] unless a stream has been resolved into [overrideStream].
      */
     val streamUrl: String?
-        get() = overrideStreamUrl ?: downloadUrl
+        get() = overrideStream?.url ?: downloadUrl
+
+    /** The content type of [streamUrl]. A resolved encoding's own type wins even when it is unknown. */
+    val streamContentType: String?
+        get() {
+            val stream = overrideStream ?: return fileType
+            return stream.contentType
+        }
 
     /** Whether the URL that streaming will actually use is HLS. */
     val isStreamUrlHls: Boolean
         get() {
-            val url = streamUrl ?: return false
-            if (overrideStreamUrl != null) {
-                return isHlsMimeType(overrideStreamContentType) || isHlsUrl(url)
-            }
-            return isHlsUrl(url) || (url == downloadUrl && isHlsMimeType(fileType))
+            overrideStream?.let { return it.isHls }
+            val url = downloadUrl ?: return false
+            return isHlsUrl(url) || isHlsMimeType(fileType)
         }
 
     /** Whether streaming will use an alternate encoding that carries video the progressive enclosure may not. */
     val isStreamUrlVideo: Boolean
-        get() = isStreamUrlHls || (overrideStreamUrl != null && overrideStreamIsVideo)
+        get() = isStreamUrlHls || overrideStream?.isVideo == true
+
+    /** The player caches by episode uuid, so an alternate encoding must not share that entry with the progressive file. */
+    val usesSharedPlayerCache: Boolean
+        get() = !isDownloaded && !isDownloading && !isStreamUrlVideo
 
     val isAudio: Boolean
         get() = !isVideo
@@ -218,7 +225,7 @@ sealed interface BaseEpisode {
             fileType.equals("audio/x-ms-wma", ignoreCase = true) -> return ".wma"
             fileType.equals(MimeTypes.APPLICATION_M3U8, ignoreCase = true) -> return ".m3u8"
             fileType.equals("application/vnd.apple.mpegurl", ignoreCase = true) -> return ".m3u8"
-            else -> return if (fileType.startsWith("video/")) ".mp4" else ".mp3"
+            else -> return if (isVideoMimeType(fileType)) ".mp4" else ".mp3"
         }
     }
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/BaseEpisode.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/BaseEpisode.kt
@@ -135,9 +135,8 @@ sealed interface BaseEpisode {
     val isInProgress: Boolean
         get() = EpisodePlayingStatus.IN_PROGRESS == playingStatus
 
-    /** Video either because the episode's own enclosure is video, or because a video rendition was resolved to stream. */
     val isVideo: Boolean
-        get() = isVideoMimeType(fileType) || isVideoMimeType(overrideStreamContentType)
+        get() = isVideoMimeType(fileType)
 
     /** The enclosure itself is HLS, so there is no progressive file to download. */
     val isHlsOnly: Boolean

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/BaseEpisode.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/BaseEpisode.kt
@@ -30,6 +30,10 @@ sealed interface BaseEpisode {
             return type != null && type.lowercase() in HLS_MIME_TYPES
         }
 
+        fun isVideoMimeType(type: String?): Boolean {
+            return type?.startsWith("video/", ignoreCase = true) == true
+        }
+
         /**
          * Used to reduce the changes sent out by the media session.
          * Returns true if the objects are the same.
@@ -126,17 +130,22 @@ sealed interface BaseEpisode {
         get() = autoDownloadStatus == AUTO_DOWNLOAD_STATUS_IGNORE
 
     val canQueueForAutoDownload
-        get() = !isFinished && !isArchived && !isAutoDownloadDisabled && !isHlsOnly
+        get() = !isFinished && !isArchived && !isAutoDownloadDisabled && !isStreamOnly
 
     val isInProgress: Boolean
         get() = EpisodePlayingStatus.IN_PROGRESS == playingStatus
 
+    /** Video either because the episode's own enclosure is video, or because a video rendition was resolved to stream. */
     val isVideo: Boolean
-        get() = fileType?.startsWith("video/") ?: false
+        get() = isVideoMimeType(fileType) || isVideoMimeType(overrideStreamContentType)
 
     /** The enclosure itself is HLS, so there is no progressive file to download. */
     val isHlsOnly: Boolean
         get() = isHlsUrl(downloadUrl) || isHlsMimeType(fileType)
+
+    /** Playable only by streaming an alternate enclosure: HLS, or the server sent no progressive enclosure at all. */
+    val isStreamOnly: Boolean
+        get() = isHlsOnly || (this is PodcastEpisode && downloadUrl.isNullOrBlank())
 
     /** A runtime-only resolved stream (e.g. the HLS alternate enclosure); overrides [streamUrl] when set. */
     var overrideStreamUrl: String?
@@ -161,10 +170,14 @@ sealed interface BaseEpisode {
             return isHlsUrl(url) || (url == downloadUrl && isHlsMimeType(fileType))
         }
 
+    /** Whether streaming will use an alternate rendition that carries video the progressive enclosure may not. */
+    val isStreamUrlVideo: Boolean
+        get() = isStreamUrlHls || isVideoMimeType(overrideStreamContentType)
+
     val isAudio: Boolean
         get() = !isVideo
 
-    fun showsVideoIcon(hasHlsAlternateEnclosure: Boolean): Boolean = isVideo || isHlsOnly || hasHlsAlternateEnclosure
+    fun showsVideoIcon(hasVideoAlternateEnclosure: Boolean): Boolean = isVideo || isHlsOnly || hasVideoAlternateEnclosure
 
     val podcastOrSubstituteUuid: String
         get() = if (this is PodcastEpisode) this.podcastUuid else Podcast.userPodcast.uuid

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/PodcastEpisode.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/PodcastEpisode.kt
@@ -127,13 +127,7 @@ data class PodcastEpisode(
     var alternateEnclosures: List<EpisodeAlternateEnclosure> = emptyList()
 
     @Ignore
-    override var overrideStreamUrl: String? = null
-
-    @Ignore
-    override var overrideStreamContentType: String? = null
-
-    @Ignore
-    override var overrideStreamIsVideo: Boolean = false
+    override var overrideStream: AlternateEnclosureStream? = null
 
     val playedPercentage: Int
         get() {

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/PodcastEpisode.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/PodcastEpisode.kt
@@ -132,6 +132,9 @@ data class PodcastEpisode(
     @Ignore
     override var overrideStreamContentType: String? = null
 
+    @Ignore
+    override var overrideStreamIsVideo: Boolean = false
+
     val playedPercentage: Int
         get() {
             return if (isFinished) {

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/UserEpisode.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/UserEpisode.kt
@@ -69,13 +69,7 @@ data class UserEpisode(
     var hasBookmark: Boolean = false
 
     @Ignore
-    override var overrideStreamUrl: String? = null
-
-    @Ignore
-    override var overrideStreamContentType: String? = null
-
-    @Ignore
-    override var overrideStreamIsVideo: Boolean = false
+    override var overrideStream: AlternateEnclosureStream? = null
 
     override fun displaySubtitle(podcast: Podcast?): String {
         return Podcast.userPodcast.title

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/UserEpisode.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/UserEpisode.kt
@@ -74,6 +74,9 @@ data class UserEpisode(
     @Ignore
     override var overrideStreamContentType: String? = null
 
+    @Ignore
+    override var overrideStreamIsVideo: Boolean = false
+
     override fun displaySubtitle(podcast: Podcast?): String {
         return Podcast.userPodcast.title
     }

--- a/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/entity/AlternateEnclosuresTest.kt
+++ b/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/entity/AlternateEnclosuresTest.kt
@@ -125,7 +125,6 @@ class AlternateEnclosuresTest {
         val stream = enclosures.firstProgressiveVideoStream()
 
         assertEquals("video/mp4", stream?.contentType)
-        // Video-ness comes from the media kind, so a generic source type cannot hide it.
         assertTrue(stream!!.isVideo)
     }
 

--- a/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/entity/AlternateEnclosuresTest.kt
+++ b/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/entity/AlternateEnclosuresTest.kt
@@ -107,6 +107,26 @@ class AlternateEnclosuresTest {
         assertEquals("https://example.com/episode.mp4", stream?.url)
         assertEquals("video/mp4", stream?.contentType)
         assertFalse(stream!!.isHls)
+        assertTrue(stream.isVideo)
+    }
+
+    @Test
+    fun `keeps the enclosure type when a source declares a generic content type`() {
+        val enclosures = listOf(
+            EpisodeAlternateEnclosure(
+                episodeUuid = "episode-uuid",
+                position = 0,
+                type = "video/mp4",
+                mediaKind = MediaKind.Video,
+                sources = listOf(AlternateEnclosureSource(uri = "https://example.com/episode.mp4", contentType = "application/octet-stream")),
+            ),
+        )
+
+        val stream = enclosures.firstProgressiveVideoStream()
+
+        assertEquals("video/mp4", stream?.contentType)
+        // Video-ness comes from the media kind, so a generic source type cannot hide it.
+        assertTrue(stream!!.isVideo)
     }
 
     @Test
@@ -119,7 +139,7 @@ class AlternateEnclosuresTest {
     }
 
     @Test
-    fun `ignores video enclosures we cannot stream directly`() {
+    fun `ignores a video enclosure whose media kind we cannot stream directly`() {
         val enclosures = listOf(
             EpisodeAlternateEnclosure(
                 episodeUuid = "episode-uuid",
@@ -170,17 +190,6 @@ class AlternateEnclosuresTest {
         )
 
         assertEquals("https://example.com/master.m3u8", enclosures.firstHlsStreamUrl())
-    }
-
-    @Test
-    fun `detects video enclosures for the episode row icon`() {
-        assertTrue(listOf(enclosure(MimeTypes.APPLICATION_M3U8, "https://example.com/master.m3u8")).hasVideoEnclosure())
-        assertTrue(listOf(videoEnclosure("video/mp4", "https://example.com/episode.mp4")).hasVideoEnclosure())
-        // The icon reflects what the server offers, even when no source can be streamed.
-        assertTrue(listOf(videoEnclosure("video/mp4")).hasVideoEnclosure())
-        assertFalse(listOf(enclosure("audio/mp3", "https://example.com/episode.mp3")).hasVideoEnclosure())
-        assertFalse(emptyList<EpisodeAlternateEnclosure>().hasVideoEnclosure())
-        assertFalse(null.hasVideoEnclosure())
     }
 
     @Test

--- a/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/entity/AlternateEnclosuresTest.kt
+++ b/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/entity/AlternateEnclosuresTest.kt
@@ -1,8 +1,11 @@
 package au.com.shiftyjelly.pocketcasts.models.entity
 
 import androidx.media3.common.MimeTypes
+import au.com.shiftyjelly.pocketcasts.models.type.MediaKind
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class AlternateEnclosuresTest {
@@ -93,10 +96,124 @@ class AlternateEnclosuresTest {
         assertNull(null.firstHlsStreamUrl())
     }
 
+    @Test
+    fun `selects the progressive video source marked as video media kind`() {
+        val enclosures = listOf(
+            videoEnclosure("video/mp4", "https://example.com/episode.mp4"),
+        )
+
+        val stream = enclosures.firstProgressiveVideoStream()
+
+        assertEquals("https://example.com/episode.mp4", stream?.url)
+        assertEquals("video/mp4", stream?.contentType)
+        assertFalse(stream!!.isHls)
+    }
+
+    @Test
+    fun `ignores a video mime type the server did not mark as video media kind`() {
+        val enclosures = listOf(
+            enclosure("video/mp4", "https://example.com/episode.mp4"),
+        )
+
+        assertNull(enclosures.firstProgressiveVideoStream())
+    }
+
+    @Test
+    fun `ignores video enclosures we cannot stream directly`() {
+        val enclosures = listOf(
+            EpisodeAlternateEnclosure(
+                episodeUuid = "episode-uuid",
+                position = 0,
+                type = "video/mp4",
+                mediaKind = MediaKind.YouTube,
+                sources = listOf(AlternateEnclosureSource(uri = "https://example.com/watch")),
+            ),
+        )
+
+        assertNull(enclosures.firstProgressiveVideoStream())
+    }
+
+    @Test
+    fun `skips non-http progressive video sources`() {
+        val enclosures = listOf(
+            videoEnclosure("video/mp4", "ipfs://QmEpisode", "https://example.com/episode.mp4"),
+        )
+
+        assertEquals("https://example.com/episode.mp4", enclosures.firstProgressiveVideoStream()?.url)
+    }
+
+    @Test
+    fun `hls and progressive video are resolved independently`() {
+        val enclosures = listOf(
+            videoEnclosure("video/mp4", "https://example.com/episode.mp4"),
+            videoEnclosure(MimeTypes.APPLICATION_M3U8, "https://example.com/master.m3u8"),
+        )
+
+        assertEquals("https://example.com/master.m3u8", enclosures.firstHlsStream()?.url)
+        assertEquals("https://example.com/episode.mp4", enclosures.firstProgressiveVideoStream()?.url)
+    }
+
+    @Test
+    fun `hls enclosure marked as video is not also a progressive video rendition`() {
+        val enclosures = listOf(
+            videoEnclosure(MimeTypes.APPLICATION_M3U8, "https://example.com/master.m3u8"),
+        )
+
+        assertNull(enclosures.firstProgressiveVideoStream())
+    }
+
+    @Test
+    fun `falls through to the next hls enclosure when the first has no playable source`() {
+        val enclosures = listOf(
+            enclosure(MimeTypes.APPLICATION_M3U8, "ipfs://QmManifest"),
+            enclosure(MimeTypes.APPLICATION_M3U8, "https://example.com/master.m3u8"),
+        )
+
+        assertEquals("https://example.com/master.m3u8", enclosures.firstHlsStreamUrl())
+    }
+
+    @Test
+    fun `detects video enclosures for the episode row icon`() {
+        assertTrue(listOf(enclosure(MimeTypes.APPLICATION_M3U8, "https://example.com/master.m3u8")).hasVideoEnclosure())
+        assertTrue(listOf(videoEnclosure("video/mp4", "https://example.com/episode.mp4")).hasVideoEnclosure())
+        // The icon reflects what the server offers, even when no source can be streamed.
+        assertTrue(listOf(videoEnclosure("video/mp4")).hasVideoEnclosure())
+        assertFalse(listOf(enclosure("audio/mp3", "https://example.com/episode.mp3")).hasVideoEnclosure())
+        assertFalse(emptyList<EpisodeAlternateEnclosure>().hasVideoEnclosure())
+        assertFalse(null.hasVideoEnclosure())
+    }
+
+    @Test
+    fun `stream only mime type prefers hls over progressive video`() {
+        val enclosures = listOf(
+            videoEnclosure("video/mp4", "https://example.com/episode.mp4"),
+            enclosure(MimeTypes.APPLICATION_M3U8, "https://example.com/master.m3u8"),
+        )
+
+        assertEquals(MimeTypes.APPLICATION_M3U8, enclosures.firstStreamOnlyMimeType())
+    }
+
+    @Test
+    fun `stream only mime type falls back to the progressive video type`() {
+        val enclosures = listOf(
+            videoEnclosure("video/mp4", "https://example.com/episode.mp4"),
+        )
+
+        assertEquals("video/mp4", enclosures.firstStreamOnlyMimeType())
+    }
+
+    @Test
+    fun `stream only mime type is null without a video enclosure`() {
+        assertNull(listOf(enclosure("audio/mp3", "https://example.com/episode.mp3")).firstStreamOnlyMimeType())
+        assertNull(null.firstStreamOnlyMimeType())
+    }
+
     private fun enclosure(type: String, vararg uris: String) = EpisodeAlternateEnclosure(
         episodeUuid = "episode-uuid",
         position = 0,
         type = type,
         sources = uris.map { AlternateEnclosureSource(uri = it) },
     )
+
+    private fun videoEnclosure(type: String, vararg uris: String) = enclosure(type, *uris).copy(mediaKind = MediaKind.Video)
 }

--- a/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/entity/BaseEpisodeHlsDetectionTest.kt
+++ b/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/entity/BaseEpisodeHlsDetectionTest.kt
@@ -2,9 +2,11 @@ package au.com.shiftyjelly.pocketcasts.models.entity
 
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeDownloadStatus
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
+import au.com.shiftyjelly.pocketcasts.models.type.MediaKind
 import java.util.Date
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -141,9 +143,7 @@ class BaseEpisodeHlsDetectionTest {
     @Test
     fun `episode streaming a video alternate enclosure is a video stream but not a video file`() {
         val episode = createEpisode(downloadUrl = "https://example.com/episode.mp3", fileType = "audio/mp3").apply {
-            overrideStreamUrl = "https://example.com/episode.mp4"
-            overrideStreamContentType = "video/mp4"
-            overrideStreamIsVideo = true
+            overrideStream = AlternateEnclosureStream(url = "https://example.com/episode.mp4", contentType = "video/mp4", mediaKind = MediaKind.Video)
         }
 
         assertTrue(episode.isStreamUrlVideo)
@@ -155,8 +155,7 @@ class BaseEpisodeHlsDetectionTest {
     @Test
     fun `episode streaming an hls alternate enclosure is a video stream but not a video file`() {
         val episode = createEpisode(downloadUrl = "https://example.com/episode.mp3", fileType = "audio/mp3").apply {
-            overrideStreamUrl = "https://example.com/master.m3u8"
-            overrideStreamContentType = "application/x-mpegURL"
+            overrideStream = AlternateEnclosureStream(url = "https://example.com/master.m3u8", contentType = "application/x-mpegURL", mediaKind = null)
         }
 
         assertFalse(episode.isVideo)
@@ -174,9 +173,7 @@ class BaseEpisodeHlsDetectionTest {
     @Test
     fun `video rendition is trusted from the media kind, not the content type the source declared`() {
         val episode = createEpisode(downloadUrl = "https://example.com/episode.mp3", fileType = "audio/mp3").apply {
-            overrideStreamUrl = "https://example.com/episode.mp4"
-            overrideStreamContentType = "application/octet-stream"
-            overrideStreamIsVideo = true
+            overrideStream = AlternateEnclosureStream(url = "https://example.com/episode.mp4", contentType = "application/octet-stream", mediaKind = MediaKind.Video)
         }
 
         assertTrue(episode.isStreamUrlVideo)
@@ -188,6 +185,64 @@ class BaseEpisodeHlsDetectionTest {
 
         assertTrue(episode.isVideo)
         assertFalse(episode.isStreamUrlVideo)
+    }
+
+    @Test
+    fun `episode whose feed sent no progressive url has nothing to download`() {
+        val episode = createEpisode(downloadUrl = "", fileType = "video/mp4")
+
+        assertTrue(episode.isStreamOnly)
+        assertFalse(episode.canQueueForAutoDownload)
+        // Its own enclosure is video, so isHlsOnly cannot be what guards the download.
+        assertFalse(episode.isHlsOnly)
+    }
+
+    @Test
+    fun `episode awaiting a refreshed download url is still downloadable`() {
+        val episode = createEpisode(downloadUrl = null, fileType = "audio/mp3")
+
+        assertFalse(episode.isStreamOnly)
+        assertTrue(episode.canQueueForAutoDownload)
+    }
+
+    @Test
+    fun `hls only episode is still stream only`() {
+        assertTrue(createEpisode(downloadUrl = "https://example.com/episode.m3u8").isStreamOnly)
+    }
+
+    @Test
+    fun `episode with a progressive url is not stream only`() {
+        val episode = createEpisode(downloadUrl = "https://example.com/episode.mp3", fileType = "audio/mp3")
+
+        assertFalse(episode.isStreamOnly)
+        assertTrue(episode.canQueueForAutoDownload)
+    }
+
+    @Test
+    fun `stream content type describes the resolved encoding, never the progressive enclosure`() {
+        val episode = createEpisode(downloadUrl = "https://example.com/episode.mp3", fileType = "audio/mpeg")
+        assertEquals("audio/mpeg", episode.streamContentType)
+
+        // A rendition the server sent no type for must not borrow the progressive enclosure's.
+        episode.overrideStream = AlternateEnclosureStream(
+            url = "https://example.com/episode.mp4",
+            contentType = null,
+            mediaKind = MediaKind.Video,
+        )
+        assertNull(episode.streamContentType)
+    }
+
+    @Test
+    fun `an alternate video rendition must not share the progressive file's cache entry`() {
+        val episode = createEpisode(downloadUrl = "https://example.com/episode.mp3", fileType = "audio/mp3")
+        assertTrue(episode.usesSharedPlayerCache)
+
+        episode.overrideStream = AlternateEnclosureStream(
+            url = "https://example.com/episode.mp4",
+            contentType = "video/mp4",
+            mediaKind = MediaKind.Video,
+        )
+        assertFalse(episode.usesSharedPlayerCache)
     }
 
     private fun createEpisode(

--- a/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/entity/BaseEpisodeHlsDetectionTest.kt
+++ b/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/entity/BaseEpisodeHlsDetectionTest.kt
@@ -117,25 +117,88 @@ class BaseEpisodeHlsDetectionTest {
     @Test
     fun `video episode shows the video icon`() {
         val episode = createEpisode(downloadUrl = "https://example.com/episode.mp4", fileType = "video/mp4")
-        assertTrue(episode.showsVideoIcon(hasHlsAlternateEnclosure = false))
+        assertTrue(episode.showsVideoIcon(hasVideoAlternateEnclosure = false))
     }
 
     @Test
     fun `HLS only episode shows the video icon`() {
         val episode = createEpisode(downloadUrl = "https://example.com/episode.m3u8")
-        assertTrue(episode.showsVideoIcon(hasHlsAlternateEnclosure = false))
+        assertTrue(episode.showsVideoIcon(hasVideoAlternateEnclosure = false))
     }
 
     @Test
     fun `episode with an HLS alternate enclosure shows the video icon`() {
         val episode = createEpisode(downloadUrl = "https://example.com/episode.mp3")
-        assertTrue(episode.showsVideoIcon(hasHlsAlternateEnclosure = true))
+        assertTrue(episode.showsVideoIcon(hasVideoAlternateEnclosure = true))
     }
 
     @Test
     fun `plain audio episode does not show the video icon`() {
         val episode = createEpisode(downloadUrl = "https://example.com/episode.mp3", fileType = "audio/mpeg")
-        assertFalse(episode.showsVideoIcon(hasHlsAlternateEnclosure = false))
+        assertFalse(episode.showsVideoIcon(hasVideoAlternateEnclosure = false))
+    }
+
+    @Test
+    fun `episode streaming a video alternate enclosure counts as video`() {
+        val episode = createEpisode(downloadUrl = "https://example.com/episode.mp3", fileType = "audio/mp3").apply {
+            overrideStreamUrl = "https://example.com/episode.mp4"
+            overrideStreamContentType = "video/mp4"
+        }
+
+        assertTrue(episode.isVideo)
+        assertTrue(episode.isStreamUrlVideo)
+        assertFalse(episode.isStreamUrlHls)
+    }
+
+    @Test
+    fun `episode streaming an hls alternate enclosure is a video stream but not a video file`() {
+        val episode = createEpisode(downloadUrl = "https://example.com/episode.mp3", fileType = "audio/mp3").apply {
+            overrideStreamUrl = "https://example.com/master.m3u8"
+            overrideStreamContentType = "application/x-mpegURL"
+        }
+
+        assertFalse(episode.isVideo)
+        assertTrue(episode.isStreamUrlVideo)
+    }
+
+    @Test
+    fun `audio episode without a resolved stream is neither video nor a video stream`() {
+        val episode = createEpisode(downloadUrl = "https://example.com/episode.mp3", fileType = "audio/mp3")
+
+        assertFalse(episode.isVideo)
+        assertFalse(episode.isStreamUrlVideo)
+    }
+
+    @Test
+    fun `video file episode is not treated as an alternate video stream`() {
+        val episode = createEpisode(downloadUrl = "https://example.com/episode.mp4", fileType = "video/mp4")
+
+        assertTrue(episode.isVideo)
+        assertFalse(episode.isStreamUrlVideo)
+    }
+
+    @Test
+    fun `episode without a progressive enclosure is stream only`() {
+        val episode = createEpisode(fileType = "video/mp4")
+
+        assertTrue(episode.isStreamOnly)
+        assertFalse(episode.isHlsOnly)
+        assertFalse(episode.canQueueForAutoDownload)
+    }
+
+    @Test
+    fun `episode with a progressive enclosure is not stream only`() {
+        val episode = createEpisode(downloadUrl = "https://example.com/episode.mp3", fileType = "audio/mp3")
+
+        assertFalse(episode.isStreamOnly)
+        assertTrue(episode.canQueueForAutoDownload)
+    }
+
+    @Test
+    fun `hls only episode is stream only`() {
+        val episode = createEpisode(downloadUrl = "https://example.com/episode.m3u8")
+
+        assertTrue(episode.isStreamOnly)
     }
 
     private fun createEpisode(

--- a/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/entity/BaseEpisodeHlsDetectionTest.kt
+++ b/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/entity/BaseEpisodeHlsDetectionTest.kt
@@ -139,15 +139,16 @@ class BaseEpisodeHlsDetectionTest {
     }
 
     @Test
-    fun `episode streaming a video alternate enclosure counts as video`() {
+    fun `episode streaming a video alternate enclosure is a video stream but not a video file`() {
         val episode = createEpisode(downloadUrl = "https://example.com/episode.mp3", fileType = "audio/mp3").apply {
             overrideStreamUrl = "https://example.com/episode.mp4"
             overrideStreamContentType = "video/mp4"
         }
 
-        assertTrue(episode.isVideo)
         assertTrue(episode.isStreamUrlVideo)
         assertFalse(episode.isStreamUrlHls)
+        // The episode's own enclosure is still audio, so anything reading it from the database sees audio.
+        assertFalse(episode.isVideo)
     }
 
     @Test

--- a/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/entity/BaseEpisodeHlsDetectionTest.kt
+++ b/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/entity/BaseEpisodeHlsDetectionTest.kt
@@ -143,6 +143,7 @@ class BaseEpisodeHlsDetectionTest {
         val episode = createEpisode(downloadUrl = "https://example.com/episode.mp3", fileType = "audio/mp3").apply {
             overrideStreamUrl = "https://example.com/episode.mp4"
             overrideStreamContentType = "video/mp4"
+            overrideStreamIsVideo = true
         }
 
         assertTrue(episode.isStreamUrlVideo)
@@ -171,35 +172,22 @@ class BaseEpisodeHlsDetectionTest {
     }
 
     @Test
+    fun `video rendition is trusted from the media kind, not the content type the source declared`() {
+        val episode = createEpisode(downloadUrl = "https://example.com/episode.mp3", fileType = "audio/mp3").apply {
+            overrideStreamUrl = "https://example.com/episode.mp4"
+            overrideStreamContentType = "application/octet-stream"
+            overrideStreamIsVideo = true
+        }
+
+        assertTrue(episode.isStreamUrlVideo)
+    }
+
+    @Test
     fun `video file episode is not treated as an alternate video stream`() {
         val episode = createEpisode(downloadUrl = "https://example.com/episode.mp4", fileType = "video/mp4")
 
         assertTrue(episode.isVideo)
         assertFalse(episode.isStreamUrlVideo)
-    }
-
-    @Test
-    fun `episode without a progressive enclosure is stream only`() {
-        val episode = createEpisode(fileType = "video/mp4")
-
-        assertTrue(episode.isStreamOnly)
-        assertFalse(episode.isHlsOnly)
-        assertFalse(episode.canQueueForAutoDownload)
-    }
-
-    @Test
-    fun `episode with a progressive enclosure is not stream only`() {
-        val episode = createEpisode(downloadUrl = "https://example.com/episode.mp3", fileType = "audio/mp3")
-
-        assertFalse(episode.isStreamOnly)
-        assertTrue(episode.canQueueForAutoDownload)
-    }
-
-    @Test
-    fun `hls only episode is stream only`() {
-        val episode = createEpisode(downloadUrl = "https://example.com/episode.m3u8")
-
-        assertTrue(episode.isStreamOnly)
     }
 
     private fun createEpisode(

--- a/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/entity/BaseEpisodeStreamOverrideTest.kt
+++ b/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/entity/BaseEpisodeStreamOverrideTest.kt
@@ -15,8 +15,7 @@ class BaseEpisodeStreamOverrideTest {
         val episode = createEpisode(
             downloadUrl = "https://example.com/episode.mp3",
         ).apply {
-            overrideStreamUrl = "https://example.com/video-1080.mp4"
-            overrideStreamContentType = "video/mp4"
+            overrideStream = AlternateEnclosureStream(url = "https://example.com/video-1080.mp4", contentType = "video/mp4", mediaKind = null)
         }
         assertEquals("https://example.com/video-1080.mp4", episode.streamUrl)
     }
@@ -32,14 +31,12 @@ class BaseEpisodeStreamOverrideTest {
     @Test
     fun `isStreamUrlHls reflects override content type`() {
         val hls = createEpisode(downloadUrl = "https://example.com/episode.mp3").apply {
-            overrideStreamUrl = "https://example.com/master.m3u8"
-            overrideStreamContentType = "application/x-mpegURL"
+            overrideStream = AlternateEnclosureStream(url = "https://example.com/master.m3u8", contentType = "application/x-mpegURL", mediaKind = null)
         }
         assertTrue(hls.isStreamUrlHls)
 
         val mp4 = createEpisode(downloadUrl = "https://example.com/episode.mp3").apply {
-            overrideStreamUrl = "https://example.com/video-1080.mp4"
-            overrideStreamContentType = "video/mp4"
+            overrideStream = AlternateEnclosureStream(url = "https://example.com/video-1080.mp4", contentType = "video/mp4", mediaKind = null)
         }
         assertFalse(mp4.isStreamUrlHls)
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadManager.kt
@@ -330,8 +330,8 @@ private class DownloadQueueController(
             is DownloadType.UserTriggered -> true
             is DownloadType.Automatic -> !episode.isDownloadFailure && (downloadType.bypassAutoDownloadStatus || !episode.isAutoDownloadDisabled)
         }
-        // Stream-only episodes have no progressive file to download, only an alternate enclosure.
-        return !episode.isDownloaded && isFileAvailable && isDownloadTypeAllowed && !episode.isStreamOnly
+        // HLS-only episodes have no progressive file to download, only a manifest.
+        return !episode.isDownloaded && isFileAvailable && isDownloadTypeAllowed && !episode.isHlsOnly
     }
 
     private fun BaseEpisode.toDownloadCommand(

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadManager.kt
@@ -330,8 +330,7 @@ private class DownloadQueueController(
             is DownloadType.UserTriggered -> true
             is DownloadType.Automatic -> !episode.isDownloadFailure && (downloadType.bypassAutoDownloadStatus || !episode.isAutoDownloadDisabled)
         }
-        // HLS-only episodes have no progressive file to download, only a manifest.
-        return !episode.isDownloaded && isFileAvailable && isDownloadTypeAllowed && !episode.isHlsOnly
+        return !episode.isDownloaded && isFileAvailable && isDownloadTypeAllowed && !episode.isStreamOnly
     }
 
     private fun BaseEpisode.toDownloadCommand(

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadManager.kt
@@ -330,8 +330,8 @@ private class DownloadQueueController(
             is DownloadType.UserTriggered -> true
             is DownloadType.Automatic -> !episode.isDownloadFailure && (downloadType.bypassAutoDownloadStatus || !episode.isAutoDownloadDisabled)
         }
-        // HLS-only episodes have no progressive file to download, only a manifest.
-        return !episode.isDownloaded && isFileAvailable && isDownloadTypeAllowed && !episode.isHlsOnly
+        // Stream-only episodes have no progressive file to download, only an alternate enclosure.
+        return !episode.isDownloaded && isFileAvailable && isDownloadTypeAllowed && !episode.isStreamOnly
     }
 
     private fun BaseEpisode.toDownloadCommand(

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
@@ -218,11 +218,11 @@ class FingerprintTimingManager @Inject constructor(
 
         val episodeUuid = episode.uuid
         val podcastUuid = episode.podcastOrSubstituteUuid
-        // Fingerprint the progressive enclosure, not the HLS rendition; timings may drift if the renditions differ.
+        // Fingerprint the progressive enclosure, not the alternate rendition; timings may drift if they differ.
         val audioSource = episode.downloadedFilePath ?: episode.downloadUrl
         // Reuse the player's on-disk cache (same UUID key) instead of a second download when it applies.
         val sharedCacheKey = episodeUuid.takeIf {
-            !episode.isDownloaded && !episode.isDownloading && !episode.isStreamUrlHls && settings.cacheEntirePlayingEpisode.value
+            episode.usesSharedPlayerCache && settings.cacheEntirePlayingEpisode.value
         }
 
         scope.launch {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CastPlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CastPlayer.kt
@@ -238,7 +238,7 @@ class CastPlayer(
     }
 
     override fun setEpisode(episode: BaseEpisode, preferStream: Boolean) {
-        this.episodeLocation = EpisodeLocation.Stream(episode, episode.streamUrl, episode.isStreamUrlHls)
+        this.episodeLocation = EpisodeLocation.Stream(episode, episode.streamUrl, episode.isStreamUrlHls, episode.isStreamUrlVideo)
         localEpisodeUuid = episode.uuid
         buildCustomData()
     }
@@ -280,7 +280,8 @@ class CastPlayer(
     }
 
     private fun buildMediaInfo(url: String, episode: BaseEpisode, podcast: Podcast): MediaInfo {
-        val mediaMetadata = MediaMetadata(if (episode.isVideo) MediaMetadata.MEDIA_TYPE_MOVIE else MediaMetadata.MEDIA_TYPE_MUSIC_TRACK).apply {
+        val isVideo = episode.isVideo || episodeLocation.isVideoStream
+        val mediaMetadata = MediaMetadata(if (isVideo) MediaMetadata.MEDIA_TYPE_MOVIE else MediaMetadata.MEDIA_TYPE_MUSIC_TRACK).apply {
             putString(MediaMetadata.KEY_TITLE, episode.title)
             putString(MediaMetadata.KEY_SUBTITLE, podcast.title)
             putString(MediaMetadata.KEY_ALBUM_ARTIST, podcast.author)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CastPlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CastPlayer.kt
@@ -291,7 +291,7 @@ class CastPlayer(
         // STREAM_TYPE_BUFFERED is correct for VOD podcasts (including VOD HLS). Live HLS would
         // need STREAM_TYPE_LIVE, but we don't currently serve live streams.
         var mediaInfo = MediaInfo.Builder(url).setStreamType(MediaInfo.STREAM_TYPE_BUFFERED).setMetadata(mediaMetadata)
-        // An alternate rendition has its own type; the episode's own fileType describes the progressive enclosure.
+        // An alternate encoding has its own type; the episode's own fileType describes the progressive enclosure.
         val contentType = if (episodeLocation.isHlsStream) {
             MimeTypes.APPLICATION_M3U8
         } else {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CastPlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CastPlayer.kt
@@ -291,13 +291,11 @@ class CastPlayer(
         // STREAM_TYPE_BUFFERED is correct for VOD podcasts (including VOD HLS). Live HLS would
         // need STREAM_TYPE_LIVE, but we don't currently serve live streams.
         var mediaInfo = MediaInfo.Builder(url).setStreamType(MediaInfo.STREAM_TYPE_BUFFERED).setMetadata(mediaMetadata)
-        val contentType = when {
-            episodeLocation.isHlsStream -> MimeTypes.APPLICATION_M3U8
-
-            // An alternate rendition has its own type; the episode's own fileType describes the progressive enclosure.
-            episodeLocation is EpisodeLocation.Stream -> episode.overrideStreamContentType ?: episode.fileType
-
-            else -> episode.fileType
+        // An alternate rendition has its own type; the episode's own fileType describes the progressive enclosure.
+        val contentType = if (episodeLocation.isHlsStream) {
+            MimeTypes.APPLICATION_M3U8
+        } else {
+            episode.overrideStreamContentType ?: episode.fileType
         }
         contentType?.let {
             mediaInfo = mediaInfo.setContentType(it)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CastPlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CastPlayer.kt
@@ -291,11 +291,10 @@ class CastPlayer(
         // STREAM_TYPE_BUFFERED is correct for VOD podcasts (including VOD HLS). Live HLS would
         // need STREAM_TYPE_LIVE, but we don't currently serve live streams.
         var mediaInfo = MediaInfo.Builder(url).setStreamType(MediaInfo.STREAM_TYPE_BUFFERED).setMetadata(mediaMetadata)
-        // An alternate encoding has its own type; the episode's own fileType describes the progressive enclosure.
         val contentType = if (episodeLocation.isHlsStream) {
             MimeTypes.APPLICATION_M3U8
         } else {
-            episode.overrideStreamContentType ?: episode.fileType
+            episode.streamContentType
         }
         contentType?.let {
             mediaInfo = mediaInfo.setContentType(it)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CastPlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CastPlayer.kt
@@ -290,10 +290,13 @@ class CastPlayer(
         // STREAM_TYPE_BUFFERED is correct for VOD podcasts (including VOD HLS). Live HLS would
         // need STREAM_TYPE_LIVE, but we don't currently serve live streams.
         var mediaInfo = MediaInfo.Builder(url).setStreamType(MediaInfo.STREAM_TYPE_BUFFERED).setMetadata(mediaMetadata)
-        val contentType = if (episodeLocation.isHlsStream) {
-            MimeTypes.APPLICATION_M3U8
-        } else {
-            episode.fileType
+        val contentType = when {
+            episodeLocation.isHlsStream -> MimeTypes.APPLICATION_M3U8
+
+            // An alternate rendition has its own type; the episode's own fileType describes the progressive enclosure.
+            episodeLocation is EpisodeLocation.Stream -> episode.overrideStreamContentType ?: episode.fileType
+
+            else -> episode.fileType
         }
         contentType?.let {
             mediaInfo = mediaInfo.setContentType(it)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ExoPlayerDataSourceFactory.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ExoPlayerDataSourceFactory.kt
@@ -168,8 +168,7 @@ class ExoPlayerDataSourceFactory @Inject constructor(
         }
     }
 
-    // The cache is keyed by episode uuid, so an alternate encoding would collide with the progressive enclosure.
-    private fun EpisodeLocation.shouldUseCache() = !episode.isDownloaded && !episode.isDownloading && !isVideoStream && settings.cacheEntirePlayingEpisode.value
+    private fun EpisodeLocation.shouldUseCache() = episode.usesSharedPlayerCache && settings.cacheEntirePlayingEpisode.value
 
     private fun ClosedRange<Long>.toClippingConfiguration() = ClippingConfiguration.Builder()
         .setStartPositionMs(start)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ExoPlayerDataSourceFactory.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ExoPlayerDataSourceFactory.kt
@@ -125,7 +125,7 @@ class ExoPlayerDataSourceFactory @Inject constructor(
         episodeLocation: EpisodeLocation,
         onCachingComplete: (String) -> Unit,
     ) {
-        if (episodeLocation.isHlsStream) return
+        if (episodeLocation.isVideoStream) return
         val episodeUri = episodeLocation.uri ?: return
         val cacheFactory = cacheDataSourceFactory ?: cacheFactory
             .setCacheWriteDataSinkFactory(null)
@@ -168,7 +168,8 @@ class ExoPlayerDataSourceFactory @Inject constructor(
         }
     }
 
-    private fun EpisodeLocation.shouldUseCache() = !episode.isDownloaded && !episode.isDownloading && !isHlsStream && settings.cacheEntirePlayingEpisode.value
+    // The cache is keyed by episode uuid, so an alternate rendition would collide with the progressive enclosure.
+    private fun EpisodeLocation.shouldUseCache() = !episode.isDownloaded && !episode.isDownloading && !isVideoStream && settings.cacheEntirePlayingEpisode.value
 
     private fun ClosedRange<Long>.toClippingConfiguration() = ClippingConfiguration.Builder()
         .setStartPositionMs(start)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ExoPlayerDataSourceFactory.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ExoPlayerDataSourceFactory.kt
@@ -168,7 +168,7 @@ class ExoPlayerDataSourceFactory @Inject constructor(
         }
     }
 
-    // The cache is keyed by episode uuid, so an alternate rendition would collide with the progressive enclosure.
+    // The cache is keyed by episode uuid, so an alternate encoding would collide with the progressive enclosure.
     private fun EpisodeLocation.shouldUseCache() = !episode.isDownloaded && !episode.isDownloading && !isVideoStream && settings.cacheEntirePlayingEpisode.value
 
     private fun ClosedRange<Long>.toClippingConfiguration() = ClippingConfiguration.Builder()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -22,12 +22,16 @@ import androidx.work.NetworkType
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.coroutines.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.localization.BuildConfig
+import au.com.shiftyjelly.pocketcasts.models.entity.AlternateEnclosureStream
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
+import au.com.shiftyjelly.pocketcasts.models.entity.EpisodeAlternateEnclosure
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast.AutoAddUpNext
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
+import au.com.shiftyjelly.pocketcasts.models.entity.firstHlsStream
 import au.com.shiftyjelly.pocketcasts.models.entity.firstHlsStreamUrl
+import au.com.shiftyjelly.pocketcasts.models.entity.firstProgressiveVideoStream
 import au.com.shiftyjelly.pocketcasts.models.to.Chapter
 import au.com.shiftyjelly.pocketcasts.models.to.ChapterOrigin
 import au.com.shiftyjelly.pocketcasts.models.to.Chapters
@@ -277,8 +281,12 @@ open class PlaybackManager @Inject constructor(
     private val _videoRenderingEnabled = MutableStateFlow(true)
     val videoRenderingEnabled = _videoRenderingEnabled.asStateFlow()
 
+    // Strictly whether an HLS rendition exists, which is what the analytics schema's hls_available means.
     private val _streamHlsAvailable = MutableStateFlow(false)
-    val streamHlsAvailable = _streamHlsAvailable.asStateFlow()
+
+    // Whether an alternate video rendition (HLS or progressive) is available and enabled for this episode.
+    private val _streamVideoAvailable = MutableStateFlow(false)
+    val streamVideoAvailable = _streamVideoAvailable.asStateFlow()
 
     private var videoStreamPreferred = false
     private var videoStreamPreferredEpisodeUuid: String? = null
@@ -363,7 +371,12 @@ open class PlaybackManager @Inject constructor(
                 .map { state -> (state as? UpNextQueue.State.Loaded)?.episode?.uuid }
                 .distinctUntilChanged()
                 .collect { uuid ->
-                    _streamHlsAvailable.value = uuid != null && alternateEnclosureManager.findForEpisode(uuid).firstHlsStreamUrl() != null
+                    val enclosures = uuid?.let { alternateEnclosureManager.findForEpisode(it) }.orEmpty()
+                    _streamHlsAvailable.value = enclosures.firstHlsStreamUrl() != null
+                    _streamVideoAvailable.value = selectAlternateStream(
+                        enclosures = enclosures,
+                        hasProgressiveEnclosure = upNextQueue.currentEpisode?.downloadUrl.isNullOrBlank() != true,
+                    ) != null
                 }
         }
     }
@@ -416,23 +429,33 @@ open class PlaybackManager @Inject constructor(
     private suspend fun applyStreamOverride(episode: BaseEpisode) {
         episode.overrideStreamUrl = null
         episode.overrideStreamContentType = null
-        // Stream the first HLS alternate enclosure when streaming is on, or when the episode is HLS-only.
-        val hlsUrl = alternateEnclosureManager.findForEpisode(episode.uuid).firstHlsStreamUrl()
-        _streamHlsAvailable.value = hlsUrl != null
-        val hlsStreamingEnabled = FeatureFlag.isEnabled(Feature.HLS_STREAMING)
-        if (hlsUrl != null && (hlsStreamingEnabled || episode.downloadUrl.isNullOrBlank())) {
-            episode.overrideStreamUrl = hlsUrl
-            episode.overrideStreamContentType = MimeTypes.APPLICATION_M3U8
+        val enclosures = alternateEnclosureManager.findForEpisode(episode.uuid)
+        _streamHlsAvailable.value = enclosures.firstHlsStreamUrl() != null
+        val stream = selectAlternateStream(
+            enclosures = enclosures,
+            hasProgressiveEnclosure = !episode.downloadUrl.isNullOrBlank(),
+        )
+        _streamVideoAvailable.value = stream != null
+        if (stream != null) {
+            episode.overrideStreamUrl = stream.url
+            // Normalise the manifest type so ExoPlayer and Cast agree, whichever HLS MIME the server sent.
+            episode.overrideStreamContentType = if (stream.isHls) MimeTypes.APPLICATION_M3U8 else stream.contentType
         }
     }
+
+    private fun selectAlternateStream(enclosures: List<EpisodeAlternateEnclosure>, hasProgressiveEnclosure: Boolean) = selectAlternateStream(
+        enclosures = enclosures,
+        isHlsEnabled = FeatureFlag.isEnabled(Feature.HLS_STREAMING),
+        isVideoEnclosureEnabled = FeatureFlag.isEnabled(Feature.VIDEO_ALTERNATE_ENCLOSURES),
+        hasProgressiveEnclosure = hasProgressiveEnclosure,
+    )
 
     fun videoToggleRequiresStreamSwitch(): Boolean {
         val episode = getCurrentEpisode() ?: return false
         return episode.isDownloaded &&
-            _streamHlsAvailable.value &&
+            _streamVideoAvailable.value &&
             !videoStreamPreferred &&
-            player?.isRemote != true &&
-            FeatureFlag.isEnabled(Feature.HLS_STREAMING)
+            player?.isRemote != true
     }
 
     fun toggleVideoRendering(streamWarningConfirmed: Boolean = false) {
@@ -2157,7 +2180,7 @@ open class PlaybackManager @Inject constructor(
             }
         }
 
-        // Resolve the HLS alternate enclosure so streamUrl reflects the stream that will play.
+        // Resolve the alternate enclosure so streamUrl reflects the stream that will play.
         applyStreamOverride(episode)
 
         if (videoStreamPreferred && episode.uuid != videoStreamPreferredEpisodeUuid) {
@@ -2166,7 +2189,7 @@ open class PlaybackManager @Inject constructor(
         }
 
         val castConnected = castManager.isConnected()
-        val playingStream = !episode.isDownloaded || (videoStreamPreferred && episode.isStreamUrlHls && !castConnected)
+        val playingStream = !episode.isDownloaded || (videoStreamPreferred && episode.isStreamUrlVideo && !castConnected)
 
         flushPendingContentTypeEvents()
 
@@ -2814,18 +2837,22 @@ open class PlaybackManager @Inject constructor(
         val prefetchEnabled = FeatureFlag.isEnabled(Feature.NEXT_EPISODE_PREFETCH)
         val nextEpisode = upNextQueue.queueEpisodes.firstOrNull()
         launch {
-            // The next episode isn't run through applyStreamOverride, so resolve its HLS default here
-            // and skip prefetching a progressive file that streaming would bypass.
-            val isHlsDefault = prefetchEnabled &&
-                FeatureFlag.isEnabled(Feature.HLS_STREAMING) &&
-                (nextEpisode as? PodcastEpisode)?.let { alternateEnclosureManager.findForEpisode(it.uuid).firstHlsStreamUrl() != null } == true
+            // The next episode isn't run through applyStreamOverride, so resolve its alternate stream default
+            // here and skip prefetching a progressive file that streaming would bypass.
+            val isAlternateStreamDefault = prefetchEnabled &&
+                (nextEpisode as? PodcastEpisode)?.let {
+                    selectAlternateStream(
+                        enclosures = alternateEnclosureManager.findForEpisode(it.uuid),
+                        hasProgressiveEnclosure = !it.downloadUrl.isNullOrBlank(),
+                    ) != null
+                } == true
             val request = buildPrefetchRequest(
                 isFeatureEnabled = prefetchEnabled,
                 isPlayerRemote = player?.isRemote,
                 nextEpisode = nextEpisode,
                 warnOnMeteredNetwork = settings.warnOnMeteredNetwork.value,
                 appPlatform = Util.getAppPlatform(application),
-                isHlsDefault = isHlsDefault,
+                isAlternateStreamDefault = isAlternateStreamDefault,
             ) ?: return@launch
 
             if (lastPrefetchedEpisodeUuid.getAndSet(request.episodeUuid) == request.episodeUuid) return@launch
@@ -3029,6 +3056,19 @@ open class PlaybackManager @Inject constructor(
     }
 }
 
+/** The alternate rendition to stream: HLS when enabled, otherwise a progressive video rendition. */
+internal fun selectAlternateStream(
+    enclosures: List<EpisodeAlternateEnclosure>,
+    isHlsEnabled: Boolean,
+    isVideoEnclosureEnabled: Boolean,
+    hasProgressiveEnclosure: Boolean,
+): AlternateEnclosureStream? {
+    // An episode with no progressive enclosure has nothing else to play, so the flags can't gate it.
+    val hls = enclosures.firstHlsStream()?.takeIf { isHlsEnabled || !hasProgressiveEnclosure }
+    val video = enclosures.firstProgressiveVideoStream()?.takeIf { isVideoEnclosureEnabled || !hasProgressiveEnclosure }
+    return hls ?: video
+}
+
 internal data class PrefetchRequest(
     val episodeUuid: String,
     val downloadUrl: String,
@@ -3041,7 +3081,7 @@ internal fun buildPrefetchRequest(
     nextEpisode: BaseEpisode?,
     warnOnMeteredNetwork: Boolean,
     appPlatform: AppPlatform = AppPlatform.Phone,
-    isHlsDefault: Boolean = false,
+    isAlternateStreamDefault: Boolean = false,
 ): PrefetchRequest? {
     if (!isFeatureEnabled) return null
     if (appPlatform == AppPlatform.WearOs) return null
@@ -3050,9 +3090,9 @@ internal fun buildPrefetchRequest(
     val episode = nextEpisode ?: return null
     if (episode.isDownloaded) return null
     if (episode.isDownloading) return null
-    if (episode.isStreamUrlHls) return null
-    // The next episode will stream HLS by default, so there is no progressive file worth prefetching.
-    if (isHlsDefault) return null
+    if (episode.isStreamUrlVideo) return null
+    // The next episode will stream an alternate rendition by default, so there is no progressive file worth prefetching.
+    if (isAlternateStreamDefault) return null
     val url = episode.downloadUrl ?: return null
 
     return PrefetchRequest(

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -273,8 +273,8 @@ open class PlaybackManager @Inject constructor(
     private val _playerFlow = MutableStateFlow<Player?>(null)
     val playerFlow = _playerFlow.asStateFlow()
 
-    // HLS starts Unknown until the player's tracks resolve it to HasVideo or AudioOnly; the video
-    // surface is shown only once HasVideo is known.
+    // A resolved video rendition starts Unknown until the player's tracks resolve it to HasVideo or
+    // AudioOnly; the video surface is shown only once HasVideo is known.
     private val _streamVideoState = MutableStateFlow(StreamVideoState.NotVideo)
     val streamVideoState = _streamVideoState.asStateFlow()
 
@@ -2193,12 +2193,13 @@ open class PlaybackManager @Inject constructor(
 
         flushPendingContentTypeEvents()
 
-        // Audio only forces video content to audio. Otherwise HLS starts Unknown until the tracks resolve it; non-HLS keeps its own flag.
+        // Audio only forces video content to audio. Otherwise a resolved video rendition starts Unknown until the
+        // tracks resolve it; an episode playing its own enclosure keeps its file type's flag.
         synchronized(pendingContentTypeEvents) {
             _streamVideoState.value = StreamVideoState.initialFor(
                 episode,
                 audioOnly = settings.audioOnly.value,
-                playingHlsStream = playingStream && episode.isStreamUrlHls,
+                playingVideoStream = playingStream && episode.isStreamUrlVideo,
                 isRemote = castConnected,
             )
         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -14,7 +14,6 @@ import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.toLiveData
-import androidx.media3.common.MimeTypes
 import androidx.media3.common.util.StuckPlayerException
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.HttpDataSource
@@ -410,12 +409,17 @@ open class PlaybackManager @Inject constructor(
             }
         }
 
-        val autoPlayOffersHls = alternateEnclosureManager.findForEpisode(autoPlayEpisode.uuid).firstHlsStreamUrl() != null
+        val autoPlayEnclosures = alternateEnclosureManager.findForEpisode(autoPlayEpisode.uuid)
+        val autoPlayOffersHls = autoPlayEnclosures.firstHlsStreamUrl() != null
+        val autoPlayStreamsVideo = selectAlternateStream(
+            enclosures = autoPlayEnclosures,
+            hasProgressiveEnclosure = !autoPlayEpisode.downloadUrl.isNullOrBlank(),
+        ) != null
         eventHorizon.track(
             PlaybackEpisodeAutoplayedEvent(
                 episodeUuid = autoPlayEpisode.uuid,
                 hlsAvailable = autoPlayOffersHls,
-                audioOnlyMode = if (autoPlayOffersHls || autoPlayEpisode.isVideo) settings.audioOnly.value else null,
+                audioOnlyMode = if (autoPlayStreamsVideo || autoPlayEpisode.isVideo) settings.audioOnly.value else null,
             ),
         )
         return autoPlayEpisode
@@ -426,9 +430,7 @@ open class PlaybackManager @Inject constructor(
     }
 
     private suspend fun applyStreamOverride(episode: BaseEpisode) {
-        episode.overrideStreamUrl = null
-        episode.overrideStreamContentType = null
-        episode.overrideStreamIsVideo = false
+        episode.overrideStream = null
         val enclosures = alternateEnclosureManager.findForEpisode(episode.uuid)
         _streamHlsAvailable.value = enclosures.firstHlsStreamUrl() != null
         val stream = selectAlternateStream(
@@ -436,20 +438,8 @@ open class PlaybackManager @Inject constructor(
             hasProgressiveEnclosure = !episode.downloadUrl.isNullOrBlank(),
         )
         _streamVideoAvailable.value = stream != null
-        if (stream != null) {
-            episode.overrideStreamUrl = stream.url
-            // Normalise the manifest type so ExoPlayer and Cast agree, whichever HLS MIME the server sent.
-            episode.overrideStreamContentType = if (stream.isHls) MimeTypes.APPLICATION_M3U8 else stream.contentType
-            episode.overrideStreamIsVideo = stream.isVideo
-        }
+        episode.overrideStream = stream
     }
-
-    private fun selectAlternateStream(enclosures: List<EpisodeAlternateEnclosure>, hasProgressiveEnclosure: Boolean) = selectAlternateStream(
-        enclosures = enclosures,
-        isHlsEnabled = FeatureFlag.isEnabled(Feature.HLS_STREAMING),
-        isVideoEnclosureEnabled = FeatureFlag.isEnabled(Feature.VIDEO_ALTERNATE_ENCLOSURES),
-        hasProgressiveEnclosure = hasProgressiveEnclosure,
-    )
 
     fun videoToggleRequiresStreamSwitch(): Boolean {
         val episode = getCurrentEpisode() ?: return false
@@ -3065,8 +3055,17 @@ internal fun selectAlternateStream(
     // An episode with no progressive enclosure has nothing else to play, so the flags can't gate it.
     val hls = enclosures.firstHlsStream()?.takeIf { isHlsEnabled || !hasProgressiveEnclosure }
     val video = enclosures.firstProgressiveVideoStream()?.takeIf { isVideoEnclosureEnabled || !hasProgressiveEnclosure }
-    return hls ?: video
+    // HLS adapts to bandwidth, but not when the server marked it audio and a video rendition sits beside it.
+    return if (hls != null && !hls.isAudioOnly) hls else video ?: hls
 }
+
+/** The stream playback would resolve for these enclosures, with the encoding feature flags applied. */
+internal fun selectAlternateStream(enclosures: List<EpisodeAlternateEnclosure>, hasProgressiveEnclosure: Boolean) = selectAlternateStream(
+    enclosures = enclosures,
+    isHlsEnabled = FeatureFlag.isEnabled(Feature.HLS_STREAMING),
+    isVideoEnclosureEnabled = FeatureFlag.isEnabled(Feature.VIDEO_ALTERNATE_ENCLOSURES),
+    hasProgressiveEnclosure = hasProgressiveEnclosure,
+)
 
 internal data class PrefetchRequest(
     val episodeUuid: String,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -273,8 +273,7 @@ open class PlaybackManager @Inject constructor(
     private val _playerFlow = MutableStateFlow<Player?>(null)
     val playerFlow = _playerFlow.asStateFlow()
 
-    // A resolved video rendition starts Unknown until the player's tracks resolve it to HasVideo or
-    // AudioOnly; the video surface is shown only once HasVideo is known.
+    // A resolved rendition starts Unknown until the player's tracks resolve it; the surface shows only at HasVideo.
     private val _streamVideoState = MutableStateFlow(StreamVideoState.NotVideo)
     val streamVideoState = _streamVideoState.asStateFlow()
 
@@ -284,7 +283,7 @@ open class PlaybackManager @Inject constructor(
     // Strictly whether an HLS rendition exists, which is what the analytics schema's hls_available means.
     private val _streamHlsAvailable = MutableStateFlow(false)
 
-    // Whether an alternate video rendition (HLS or progressive) is available and enabled for this episode.
+    // Unlike _streamHlsAvailable this also requires the rendition's feature flag to be on.
     private val _streamVideoAvailable = MutableStateFlow(false)
     val streamVideoAvailable = _streamVideoAvailable.asStateFlow()
 
@@ -2195,8 +2194,7 @@ open class PlaybackManager @Inject constructor(
 
         flushPendingContentTypeEvents()
 
-        // Audio only forces video content to audio. Otherwise a resolved video rendition starts Unknown until the
-        // tracks resolve it; an episode playing its own enclosure keeps its file type's flag.
+        // Audio only forces video content to audio; otherwise only a rendition we are actually playing starts Unknown.
         synchronized(pendingContentTypeEvents) {
             _streamVideoState.value = StreamVideoState.initialFor(
                 episode,
@@ -2840,8 +2838,7 @@ open class PlaybackManager @Inject constructor(
         val prefetchEnabled = FeatureFlag.isEnabled(Feature.NEXT_EPISODE_PREFETCH)
         val nextEpisode = upNextQueue.queueEpisodes.firstOrNull()
         launch {
-            // The next episode isn't run through applyStreamOverride, so resolve its alternate stream default
-            // here and skip prefetching a progressive file that streaming would bypass.
+            // The next episode never goes through applyStreamOverride, so resolve here whether streaming would bypass the file.
             val isAlternateStreamDefault = prefetchEnabled &&
                 (nextEpisode as? PodcastEpisode)?.let {
                     selectAlternateStream(
@@ -3059,7 +3056,6 @@ open class PlaybackManager @Inject constructor(
     }
 }
 
-/** The alternate rendition to stream: HLS when enabled, otherwise a progressive video rendition. */
 internal fun selectAlternateStream(
     enclosures: List<EpisodeAlternateEnclosure>,
     isHlsEnabled: Boolean,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -273,17 +273,17 @@ open class PlaybackManager @Inject constructor(
     private val _playerFlow = MutableStateFlow<Player?>(null)
     val playerFlow = _playerFlow.asStateFlow()
 
-    // A resolved rendition starts Unknown until the player's tracks resolve it; the surface shows only at HasVideo.
+    // A resolved encoding starts Unknown until the player's tracks resolve it; the surface shows only at HasVideo.
     private val _streamVideoState = MutableStateFlow(StreamVideoState.NotVideo)
     val streamVideoState = _streamVideoState.asStateFlow()
 
     private val _videoRenderingEnabled = MutableStateFlow(true)
     val videoRenderingEnabled = _videoRenderingEnabled.asStateFlow()
 
-    // Strictly whether an HLS rendition exists, which is what the analytics schema's hls_available means.
+    // Strictly whether an HLS encoding exists, which is what the analytics schema's hls_available means.
     private val _streamHlsAvailable = MutableStateFlow(false)
 
-    // Unlike _streamHlsAvailable this also requires the rendition's feature flag to be on.
+    // Unlike _streamHlsAvailable this also requires the encoding's feature flag to be on.
     private val _streamVideoAvailable = MutableStateFlow(false)
     val streamVideoAvailable = _streamVideoAvailable.asStateFlow()
 
@@ -2194,7 +2194,7 @@ open class PlaybackManager @Inject constructor(
 
         flushPendingContentTypeEvents()
 
-        // Audio only forces video content to audio; otherwise only a rendition we are actually playing starts Unknown.
+        // Audio only forces video content to audio; otherwise only an encoding we are actually playing starts Unknown.
         synchronized(pendingContentTypeEvents) {
             _streamVideoState.value = StreamVideoState.initialFor(
                 episode,
@@ -3090,7 +3090,7 @@ internal fun buildPrefetchRequest(
     if (episode.isDownloaded) return null
     if (episode.isDownloading) return null
     if (episode.isStreamUrlVideo) return null
-    // The next episode will stream an alternate rendition by default, so there is no progressive file worth prefetching.
+    // The next episode will stream an alternate encoding by default, so there is no progressive file worth prefetching.
     if (isAlternateStreamDefault) return null
     val url = episode.downloadUrl ?: return null
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -368,14 +368,14 @@ open class PlaybackManager @Inject constructor(
 
         launch {
             upNextQueue.changesObservable.asFlow()
-                .map { state -> (state as? UpNextQueue.State.Loaded)?.episode?.uuid }
-                .distinctUntilChanged()
-                .collect { uuid ->
-                    val enclosures = uuid?.let { alternateEnclosureManager.findForEpisode(it) }.orEmpty()
+                .map { state -> (state as? UpNextQueue.State.Loaded)?.episode }
+                .distinctUntilChanged { old, new -> old?.uuid == new?.uuid }
+                .collect { episode ->
+                    val enclosures = episode?.let { alternateEnclosureManager.findForEpisode(it.uuid) }.orEmpty()
                     _streamHlsAvailable.value = enclosures.firstHlsStreamUrl() != null
                     _streamVideoAvailable.value = selectAlternateStream(
                         enclosures = enclosures,
-                        hasProgressiveEnclosure = upNextQueue.currentEpisode?.downloadUrl.isNullOrBlank() != true,
+                        hasProgressiveEnclosure = !episode?.downloadUrl.isNullOrBlank(),
                     ) != null
                 }
         }
@@ -429,6 +429,7 @@ open class PlaybackManager @Inject constructor(
     private suspend fun applyStreamOverride(episode: BaseEpisode) {
         episode.overrideStreamUrl = null
         episode.overrideStreamContentType = null
+        episode.overrideStreamIsVideo = false
         val enclosures = alternateEnclosureManager.findForEpisode(episode.uuid)
         _streamHlsAvailable.value = enclosures.firstHlsStreamUrl() != null
         val stream = selectAlternateStream(
@@ -440,6 +441,7 @@ open class PlaybackManager @Inject constructor(
             episode.overrideStreamUrl = stream.url
             // Normalise the manifest type so ExoPlayer and Cast agree, whichever HLS MIME the server sent.
             episode.overrideStreamContentType = if (stream.isHls) MimeTypes.APPLICATION_M3U8 else stream.contentType
+            episode.overrideStreamIsVideo = stream.isVideo
         }
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Player.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Player.kt
@@ -32,12 +32,12 @@ sealed interface EpisodeLocation {
 val EpisodeLocation?.isHlsStream: Boolean
     get() = (this as? EpisodeLocation.Stream)?.isHls == true
 
-/** Whether the stream is a video rendition, which the episode's own file type may not advertise. */
+/** Whether the stream is a video encoding, which the episode's own file type may not advertise. */
 val EpisodeLocation?.isVideoStream: Boolean
     get() = (this as? EpisodeLocation.Stream)?.isVideo == true
 
 /**
- * Whether the stream the player prepared carries video. A resolved video rendition starts [Unknown] until
+ * Whether the stream the player prepared carries video. A resolved video encoding starts [Unknown] until
  * the player's tracks resolve it to [HasVideo] or [AudioOnly]; the surface is shown only once it reaches [HasVideo].
  */
 enum class StreamVideoState {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Player.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Player.kt
@@ -20,7 +20,7 @@ sealed interface EpisodeLocation {
     ) : EpisodeLocation
 
     companion object {
-        fun create(episode: BaseEpisode, preferStream: Boolean = false) = if (episode.isDownloaded && !(preferStream && episode.isStreamUrlHls)) {
+        fun create(episode: BaseEpisode, preferStream: Boolean = false) = if (episode.isDownloaded && !(preferStream && episode.isStreamUrlVideo)) {
             EpisodeLocation.Downloaded(episode, episode.downloadedFilePath)
         } else {
             EpisodeLocation.Stream(episode, episode.streamUrl, episode.isStreamUrlHls)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Player.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Player.kt
@@ -12,6 +12,7 @@ sealed interface EpisodeLocation {
         override val episode: BaseEpisode,
         override val uri: String?,
         val isHls: Boolean,
+        val isVideo: Boolean,
     ) : EpisodeLocation
 
     data class Downloaded(
@@ -23,7 +24,7 @@ sealed interface EpisodeLocation {
         fun create(episode: BaseEpisode, preferStream: Boolean = false) = if (episode.isDownloaded && !(preferStream && episode.isStreamUrlVideo)) {
             EpisodeLocation.Downloaded(episode, episode.downloadedFilePath)
         } else {
-            EpisodeLocation.Stream(episode, episode.streamUrl, episode.isStreamUrlHls)
+            EpisodeLocation.Stream(episode, episode.streamUrl, episode.isStreamUrlHls, episode.isStreamUrlVideo)
         }
     }
 }
@@ -31,9 +32,13 @@ sealed interface EpisodeLocation {
 val EpisodeLocation?.isHlsStream: Boolean
     get() = (this as? EpisodeLocation.Stream)?.isHls == true
 
+/** Whether the stream is a video rendition, which the episode's own file type may not advertise. */
+val EpisodeLocation?.isVideoStream: Boolean
+    get() = (this as? EpisodeLocation.Stream)?.isVideo == true
+
 /**
- * Whether the stream the player prepared carries video. HLS starts [Unknown] until the player's tracks
- * resolve it to [HasVideo] or [AudioOnly]; the video surface is shown only once it reaches [HasVideo].
+ * Whether the stream the player prepared carries video. A resolved video rendition starts [Unknown] until
+ * the player's tracks resolve it to [HasVideo] or [AudioOnly]; the surface is shown only once it reaches [HasVideo].
  */
 enum class StreamVideoState {
     NotVideo,
@@ -43,9 +48,9 @@ enum class StreamVideoState {
     ;
 
     companion object {
-        fun initialFor(episode: BaseEpisode, audioOnly: Boolean, playingHlsStream: Boolean, isRemote: Boolean) = when {
-            audioOnly && (episode.isVideo || playingHlsStream) -> AudioOnly
-            playingHlsStream && !isRemote -> Unknown
+        fun initialFor(episode: BaseEpisode, audioOnly: Boolean, playingVideoStream: Boolean, isRemote: Boolean) = when {
+            audioOnly && (episode.isVideo || playingVideoStream) -> AudioOnly
+            playingVideoStream && !isRemote -> Unknown
             else -> NotVideo
         }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -344,7 +344,7 @@ class SimplePlayer(
     private fun applyVideoTrackSelection() {
         val trackSelector = trackSelector ?: return
         trackSelector.parameters = trackSelector.buildUponParameters()
-            .setTrackTypeDisabled(C.TRACK_TYPE_VIDEO, shouldDisableVideoTrack(settings.audioOnly.value, hasVideoSurface, episodeLocation.isHlsStream))
+            .setTrackTypeDisabled(C.TRACK_TYPE_VIDEO, shouldDisableVideoTrack(settings.audioOnly.value, hasVideoSurface, episodeLocation.isVideoStream))
             .build()
     }
 
@@ -438,8 +438,9 @@ class SimplePlayer(
     }
 }
 
-internal fun shouldDisableVideoTrack(audioOnly: Boolean, hasVideoSurface: Boolean, isHlsStream: Boolean): Boolean {
-    return audioOnly || (!hasVideoSurface && !isHlsStream)
+// A resolved video rendition keeps its video track so the player can report whether the stream carries video.
+internal fun shouldDisableVideoTrack(audioOnly: Boolean, hasVideoSurface: Boolean, isVideoStream: Boolean): Boolean {
+    return audioOnly || (!hasVideoSurface && !isVideoStream)
 }
 
 private class PlayPauseListener(

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -344,7 +344,7 @@ class SimplePlayer(
     private fun applyVideoTrackSelection() {
         val trackSelector = trackSelector ?: return
         trackSelector.parameters = trackSelector.buildUponParameters()
-            .setTrackTypeDisabled(C.TRACK_TYPE_VIDEO, shouldDisableVideoTrack(settings.audioOnly.value, hasVideoSurface, episodeLocation.isVideoStream))
+            .setTrackTypeDisabled(C.TRACK_TYPE_VIDEO, shouldDisableVideoTrack(settings.audioOnly.value, hasVideoSurface, episodeLocation.isHlsStream))
             .build()
     }
 
@@ -438,9 +438,9 @@ class SimplePlayer(
     }
 }
 
-// A resolved video encoding keeps its video track so the player can report whether the stream carries video.
-internal fun shouldDisableVideoTrack(audioOnly: Boolean, hasVideoSurface: Boolean, isVideoStream: Boolean): Boolean {
-    return audioOnly || (!hasVideoSurface && !isVideoStream)
+// HLS can mux audio into the video track, so it keeps that track even with no surface to draw on.
+internal fun shouldDisableVideoTrack(audioOnly: Boolean, hasVideoSurface: Boolean, isHlsStream: Boolean): Boolean {
+    return audioOnly || (!hasVideoSurface && !isHlsStream)
 }
 
 private class PlayPauseListener(

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -438,7 +438,7 @@ class SimplePlayer(
     }
 }
 
-// A resolved video rendition keeps its video track so the player can report whether the stream carries video.
+// A resolved video encoding keeps its video track so the player can report whether the stream carries video.
 internal fun shouldDisableVideoTrack(audioOnly: Boolean, hasVideoSurface: Boolean, isVideoStream: Boolean): Boolean {
     return audioOnly || (!hasVideoSurface && !isVideoStream)
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/AlternateEnclosureManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/AlternateEnclosureManager.kt
@@ -6,5 +6,5 @@ import kotlinx.coroutines.flow.Flow
 interface AlternateEnclosureManager {
     suspend fun findForEpisode(episodeUuid: String): List<EpisodeAlternateEnclosure>
 
-    fun hasHlsAlternateEnclosure(episodeUuid: String): Flow<Boolean>
+    fun hasVideoAlternateEnclosure(episodeUuid: String): Flow<Boolean>
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/AlternateEnclosureManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/AlternateEnclosureManagerImpl.kt
@@ -1,20 +1,18 @@
 package au.com.shiftyjelly.pocketcasts.repositories.podcast
 
 import au.com.shiftyjelly.pocketcasts.models.db.dao.AlternateEnclosureDao
-import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.EpisodeAlternateEnclosure
-import au.com.shiftyjelly.pocketcasts.models.type.MediaKind
+import au.com.shiftyjelly.pocketcasts.repositories.playback.selectAlternateStream
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 
 class AlternateEnclosureManagerImpl @Inject constructor(
     private val alternateEnclosureDao: AlternateEnclosureDao,
 ) : AlternateEnclosureManager {
     override suspend fun findForEpisode(episodeUuid: String): List<EpisodeAlternateEnclosure> = alternateEnclosureDao.findByEpisodeUuid(episodeUuid)
 
-    override fun hasVideoAlternateEnclosure(episodeUuid: String): Flow<Boolean> = alternateEnclosureDao.hasVideoEnclosure(
-        episodeUuid = episodeUuid,
-        hlsMimeTypes = BaseEpisode.HLS_MIME_TYPES,
-        videoMediaKind = MediaKind.Video.stringValue,
-    )
+    // A stream-only episode already earns the icon from its own file type, so assume a progressive file here.
+    override fun hasVideoAlternateEnclosure(episodeUuid: String): Flow<Boolean> = alternateEnclosureDao.observeByEpisodeUuid(episodeUuid)
+        .map { enclosures -> selectAlternateStream(enclosures, hasProgressiveEnclosure = true) != null }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/AlternateEnclosureManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/AlternateEnclosureManagerImpl.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.repositories.podcast
 import au.com.shiftyjelly.pocketcasts.models.db.dao.AlternateEnclosureDao
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.EpisodeAlternateEnclosure
+import au.com.shiftyjelly.pocketcasts.models.type.MediaKind
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 
@@ -11,5 +12,9 @@ class AlternateEnclosureManagerImpl @Inject constructor(
 ) : AlternateEnclosureManager {
     override suspend fun findForEpisode(episodeUuid: String): List<EpisodeAlternateEnclosure> = alternateEnclosureDao.findByEpisodeUuid(episodeUuid)
 
-    override fun hasHlsAlternateEnclosure(episodeUuid: String): Flow<Boolean> = alternateEnclosureDao.hasHlsEnclosure(episodeUuid, BaseEpisode.HLS_MIME_TYPES)
+    override fun hasVideoAlternateEnclosure(episodeUuid: String): Flow<Boolean> = alternateEnclosureDao.hasVideoEnclosure(
+        episodeUuid = episodeUuid,
+        hlsMimeTypes = BaseEpisode.HLS_MIME_TYPES,
+        videoMediaKind = MediaKind.Video.stringValue,
+    )
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeRowData.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeRowData.kt
@@ -28,7 +28,7 @@ data class EpisodeRowData(
     val playbackState: PlaybackState,
     val isInUpNext: Boolean,
     val hasBookmarks: Boolean,
-    val hasHlsAlternateEnclosure: Boolean,
+    val hasVideoAlternateEnclosure: Boolean,
 )
 
 data class UserEpisodeRowData(
@@ -73,7 +73,7 @@ class EpisodeRowDataProvider @Inject constructor(
                     playbackStatusObservable(episodeUuid),
                     isInUpNextObservable(episodeUuid),
                     hasBookmarksObservable(episodeUuid),
-                    hasHlsAlternateEnclosureObservable(episodeUuid),
+                    hasVideoAlternateEnclosureObservable(episodeUuid),
                     ::EpisodeRowData,
                 )
             }
@@ -110,8 +110,8 @@ class EpisodeRowDataProvider @Inject constructor(
             }
     }
 
-    private fun hasHlsAlternateEnclosureObservable(episodeUuid: String): Observable<Boolean> {
-        return alternateEnclosureManager.hasHlsAlternateEnclosure(episodeUuid)
+    private fun hasVideoAlternateEnclosureObservable(episodeUuid: String): Observable<Boolean> {
+        return alternateEnclosureManager.hasVideoAlternateEnclosure(episodeUuid)
             .asObservable()
             .startWith(false)
             .distinctUntilChanged()

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/download/AutoDownloadEpisodeProviderTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/download/AutoDownloadEpisodeProviderTest.kt
@@ -553,6 +553,8 @@ private class EpisodeDsl {
     fun toPodcastEpisode() = PodcastEpisode(
         uuid = uuid,
         publishedDate = Date(),
+        // An episode with no progressive enclosure is stream-only and never queued for auto download.
+        downloadUrl = "https://example.com/$uuid.mp3",
         isArchived = isArchived,
         playingStatus = if (isCompleted) {
             EpisodePlayingStatus.COMPLETED

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/download/AutoDownloadEpisodeProviderTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/download/AutoDownloadEpisodeProviderTest.kt
@@ -553,8 +553,6 @@ private class EpisodeDsl {
     fun toPodcastEpisode() = PodcastEpisode(
         uuid = uuid,
         publishedDate = Date(),
-        // An episode with no progressive enclosure is stream-only and never queued for auto download.
-        downloadUrl = "https://example.com/$uuid.mp3",
         isArchived = isArchived,
         playingStatus = if (isCompleted) {
             EpisodePlayingStatus.COMPLETED

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/EpisodeLocationTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/EpisodeLocationTest.kt
@@ -1,7 +1,9 @@
 package au.com.shiftyjelly.pocketcasts.repositories.playback
 
+import au.com.shiftyjelly.pocketcasts.models.entity.AlternateEnclosureStream
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeDownloadStatus
+import au.com.shiftyjelly.pocketcasts.models.type.MediaKind
 import java.util.Date
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -38,8 +40,7 @@ class EpisodeLocationTest {
     @Test
     fun `streams a selected hls override`() {
         val episode = createEpisode().apply {
-            overrideStreamUrl = "https://example.com/episode.m3u8"
-            overrideStreamContentType = "application/x-mpegURL"
+            overrideStream = AlternateEnclosureStream(url = "https://example.com/episode.m3u8", contentType = "application/x-mpegURL", mediaKind = null)
         }
 
         val location = EpisodeLocation.create(episode)
@@ -54,8 +55,7 @@ class EpisodeLocationTest {
             downloadStatus = EpisodeDownloadStatus.Downloaded,
             downloadedFilePath = "/path/episode.mp3",
         ).apply {
-            overrideStreamUrl = "https://example.com/episode.m3u8"
-            overrideStreamContentType = "application/x-mpegURL"
+            overrideStream = AlternateEnclosureStream(url = "https://example.com/episode.m3u8", contentType = "application/x-mpegURL", mediaKind = null)
         }
 
         val location = EpisodeLocation.create(episode, preferStream = true)
@@ -71,9 +71,7 @@ class EpisodeLocationTest {
             downloadStatus = EpisodeDownloadStatus.Downloaded,
             downloadedFilePath = "/path/episode.mp3",
         ).apply {
-            overrideStreamUrl = "https://example.com/episode.mp4"
-            overrideStreamContentType = "video/mp4"
-            overrideStreamIsVideo = true
+            overrideStream = AlternateEnclosureStream(url = "https://example.com/episode.mp4", contentType = "video/mp4", mediaKind = MediaKind.Video)
         }
 
         val location = EpisodeLocation.create(episode, preferStream = true)

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/EpisodeLocationTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/EpisodeLocationTest.kt
@@ -22,6 +22,7 @@ class EpisodeLocationTest {
         assertTrue(location is EpisodeLocation.Downloaded)
         assertEquals("/path/episode.mp3", location.uri)
         assertFalse(location.isHlsStream)
+        assertFalse(location.isVideoStream)
     }
 
     @Test
@@ -65,7 +66,25 @@ class EpisodeLocationTest {
     }
 
     @Test
-    fun `downloaded episode without hls stays downloaded when preferring stream`() {
+    fun `downloaded episode prefers a video alternate enclosure override stream`() {
+        val episode = createEpisode(
+            downloadStatus = EpisodeDownloadStatus.Downloaded,
+            downloadedFilePath = "/path/episode.mp3",
+        ).apply {
+            overrideStreamUrl = "https://example.com/episode.mp4"
+            overrideStreamContentType = "video/mp4"
+        }
+
+        val location = EpisodeLocation.create(episode, preferStream = true)
+
+        assertTrue(location is EpisodeLocation.Stream)
+        assertEquals("https://example.com/episode.mp4", location.uri)
+        assertFalse(location.isHlsStream)
+        assertTrue(location.isVideoStream)
+    }
+
+    @Test
+    fun `downloaded episode without a video rendition stays downloaded when preferring stream`() {
         val episode = createEpisode(
             downloadStatus = EpisodeDownloadStatus.Downloaded,
             downloadedFilePath = "/path/episode.mp3",
@@ -76,6 +95,7 @@ class EpisodeLocationTest {
         assertTrue(location is EpisodeLocation.Downloaded)
         assertEquals("/path/episode.mp3", location.uri)
         assertFalse(location.isHlsStream)
+        assertFalse(location.isVideoStream)
     }
 
     @Test

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/EpisodeLocationTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/EpisodeLocationTest.kt
@@ -73,6 +73,7 @@ class EpisodeLocationTest {
         ).apply {
             overrideStreamUrl = "https://example.com/episode.mp4"
             overrideStreamContentType = "video/mp4"
+            overrideStreamIsVideo = true
         }
 
         val location = EpisodeLocation.create(episode, preferStream = true)

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PrefetchNextEpisodeTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PrefetchNextEpisodeTest.kt
@@ -110,13 +110,13 @@ class PrefetchNextEpisodeTest {
     }
 
     @Test
-    fun `should not prefetch when the next episode streams hls by default`() {
+    fun `should not prefetch when the next episode streams an alternate rendition by default`() {
         val result = buildPrefetchRequest(
             isFeatureEnabled = true,
             isPlayerRemote = false,
             nextEpisode = createEpisode(),
             warnOnMeteredNetwork = false,
-            isHlsDefault = true,
+            isAlternateStreamDefault = true,
         )
 
         assertNull(result)

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PrefetchNextEpisodeTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PrefetchNextEpisodeTest.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.repositories.playback
 
 import androidx.work.NetworkType
+import au.com.shiftyjelly.pocketcasts.models.entity.AlternateEnclosureStream
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeDownloadStatus
 import au.com.shiftyjelly.pocketcasts.utils.AppPlatform
@@ -125,8 +126,7 @@ class PrefetchNextEpisodeTest {
     @Test
     fun `should not prefetch when a selected stream override is HLS`() {
         val episode = createEpisode().apply {
-            overrideStreamUrl = "https://example.com/episode.m3u8"
-            overrideStreamContentType = "application/x-mpegURL"
+            overrideStream = AlternateEnclosureStream(url = "https://example.com/episode.m3u8", contentType = "application/x-mpegURL", mediaKind = null)
         }
         val result = buildPrefetchRequest(
             isFeatureEnabled = true,

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SelectAlternateStreamTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SelectAlternateStreamTest.kt
@@ -20,6 +20,29 @@ class SelectAlternateStreamTest {
     }
 
     @Test
+    fun `prefers the video rendition over an hls rendition the server marked audio`() {
+        val audioHls = enclosure(MimeTypes.APPLICATION_M3U8, HLS_URL).copy(mediaKind = MediaKind.Audio)
+
+        val stream = select(listOf(audioHls, videoEnclosure("video/mp4", MP4_URL)))
+
+        assertEquals(MP4_URL, stream?.url)
+    }
+
+    @Test
+    fun `keeps an audio hls rendition when there is no video rendition beside it`() {
+        val audioHls = enclosure(MimeTypes.APPLICATION_M3U8, HLS_URL).copy(mediaKind = MediaKind.Audio)
+
+        assertEquals(HLS_URL, select(listOf(audioHls))?.url)
+    }
+
+    @Test
+    fun `prefers hls when the server left its media kind unstated`() {
+        val stream = select(listOf(enclosure(MimeTypes.APPLICATION_M3U8, HLS_URL), videoEnclosure("video/mp4", MP4_URL)))
+
+        assertEquals(HLS_URL, stream?.url)
+    }
+
+    @Test
     fun `falls back to the progressive video rendition when hls is disabled`() {
         val enclosures = listOf(videoEnclosure("video/mp4", MP4_URL), videoEnclosure(MimeTypes.APPLICATION_M3U8, HLS_URL))
 

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SelectAlternateStreamTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SelectAlternateStreamTest.kt
@@ -49,6 +49,23 @@ class SelectAlternateStreamTest {
     }
 
     @Test
+    fun `streams an hls-only episode even when the hls flag is off`() {
+        val enclosures = listOf(videoEnclosure(MimeTypes.APPLICATION_M3U8, HLS_URL))
+
+        val stream = select(enclosures, isHlsEnabled = false, hasProgressiveEnclosure = false)
+
+        assertEquals(HLS_URL, stream?.url)
+        assertTrue(stream!!.isHls)
+    }
+
+    @Test
+    fun `selects nothing when both flags are off and the episode has a progressive enclosure`() {
+        val enclosures = listOf(videoEnclosure("video/mp4", MP4_URL), videoEnclosure(MimeTypes.APPLICATION_M3U8, HLS_URL))
+
+        assertNull(select(enclosures, isHlsEnabled = false, isVideoEnclosureEnabled = false))
+    }
+
+    @Test
     fun `selects nothing when no enclosure offers video`() {
         assertNull(select(listOf(enclosure("audio/mp3", "https://example.com/episode.mp3"))))
         assertNull(select(emptyList()))

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SelectAlternateStreamTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SelectAlternateStreamTest.kt
@@ -1,0 +1,82 @@
+package au.com.shiftyjelly.pocketcasts.repositories.playback
+
+import androidx.media3.common.MimeTypes
+import au.com.shiftyjelly.pocketcasts.models.entity.AlternateEnclosureSource
+import au.com.shiftyjelly.pocketcasts.models.entity.EpisodeAlternateEnclosure
+import au.com.shiftyjelly.pocketcasts.models.type.MediaKind
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SelectAlternateStreamTest {
+
+    @Test
+    fun `prefers hls over a progressive video rendition`() {
+        val stream = select(listOf(videoEnclosure("video/mp4", MP4_URL), videoEnclosure(MimeTypes.APPLICATION_M3U8, HLS_URL)))
+
+        assertEquals(HLS_URL, stream?.url)
+        assertTrue(stream!!.isHls)
+    }
+
+    @Test
+    fun `falls back to the progressive video rendition when hls is disabled`() {
+        val enclosures = listOf(videoEnclosure("video/mp4", MP4_URL), videoEnclosure(MimeTypes.APPLICATION_M3U8, HLS_URL))
+
+        val stream = select(enclosures, isHlsEnabled = false)
+
+        assertEquals(MP4_URL, stream?.url)
+        assertEquals("video/mp4", stream?.contentType)
+    }
+
+    @Test
+    fun `selects the progressive video rendition when there is no hls`() {
+        assertEquals(MP4_URL, select(listOf(videoEnclosure("video/mp4", MP4_URL)))?.url)
+    }
+
+    @Test
+    fun `does not select a progressive video rendition when its flag is off`() {
+        assertNull(select(listOf(videoEnclosure("video/mp4", MP4_URL)), isVideoEnclosureEnabled = false))
+    }
+
+    @Test
+    fun `selects a disabled rendition when the episode has no progressive enclosure to fall back on`() {
+        val enclosures = listOf(videoEnclosure("video/mp4", MP4_URL))
+
+        val stream = select(enclosures, isVideoEnclosureEnabled = false, hasProgressiveEnclosure = false)
+
+        assertEquals(MP4_URL, stream?.url)
+    }
+
+    @Test
+    fun `selects nothing when no enclosure offers video`() {
+        assertNull(select(listOf(enclosure("audio/mp3", "https://example.com/episode.mp3"))))
+        assertNull(select(emptyList()))
+    }
+
+    private fun select(
+        enclosures: List<EpisodeAlternateEnclosure>,
+        isHlsEnabled: Boolean = true,
+        isVideoEnclosureEnabled: Boolean = true,
+        hasProgressiveEnclosure: Boolean = true,
+    ) = selectAlternateStream(
+        enclosures = enclosures,
+        isHlsEnabled = isHlsEnabled,
+        isVideoEnclosureEnabled = isVideoEnclosureEnabled,
+        hasProgressiveEnclosure = hasProgressiveEnclosure,
+    )
+
+    private fun enclosure(type: String, uri: String) = EpisodeAlternateEnclosure(
+        episodeUuid = "episode-uuid",
+        position = 0,
+        type = type,
+        sources = listOf(AlternateEnclosureSource(uri = uri)),
+    )
+
+    private fun videoEnclosure(type: String, uri: String) = enclosure(type, uri).copy(mediaKind = MediaKind.Video)
+
+    private companion object {
+        const val HLS_URL = "https://example.com/master.m3u8"
+        const val MP4_URL = "https://example.com/episode.mp4"
+    }
+}

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/StreamVideoStateTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/StreamVideoStateTest.kt
@@ -11,70 +11,90 @@ class StreamVideoStateTest {
     fun `audio episode starts not video`() {
         val episode = createEpisode(fileType = "audio/mpeg")
 
-        assertEquals(StreamVideoState.NotVideo, StreamVideoState.initialFor(episode, audioOnly = false, playingHlsStream = false, isRemote = false))
+        assertEquals(StreamVideoState.NotVideo, StreamVideoState.initialFor(episode, audioOnly = false, playingVideoStream = false, isRemote = false))
     }
 
     @Test
     fun `audio episode ignores audio only`() {
         val episode = createEpisode(fileType = "audio/mpeg")
 
-        assertEquals(StreamVideoState.NotVideo, StreamVideoState.initialFor(episode, audioOnly = true, playingHlsStream = false, isRemote = false))
+        assertEquals(StreamVideoState.NotVideo, StreamVideoState.initialFor(episode, audioOnly = true, playingVideoStream = false, isRemote = false))
     }
 
     @Test
     fun `video episode starts not video so its own flag decides`() {
         val episode = createEpisode(fileType = "video/mp4")
 
-        assertEquals(StreamVideoState.NotVideo, StreamVideoState.initialFor(episode, audioOnly = false, playingHlsStream = false, isRemote = false))
+        assertEquals(StreamVideoState.NotVideo, StreamVideoState.initialFor(episode, audioOnly = false, playingVideoStream = false, isRemote = false))
     }
 
     @Test
     fun `audio only forces a video episode to audio`() {
         val episode = createEpisode(fileType = "video/mp4")
 
-        assertEquals(StreamVideoState.AudioOnly, StreamVideoState.initialFor(episode, audioOnly = true, playingHlsStream = false, isRemote = false))
+        assertEquals(StreamVideoState.AudioOnly, StreamVideoState.initialFor(episode, audioOnly = true, playingVideoStream = false, isRemote = false))
+    }
+
+    @Test
+    fun `video alternate enclosure stream starts unknown like hls`() {
+        val episode = createEpisode(fileType = "audio/mp3").apply {
+            overrideStreamUrl = "https://example.com/episode.mp4"
+            overrideStreamContentType = "video/mp4"
+        }
+
+        assertEquals(StreamVideoState.Unknown, StreamVideoState.initialFor(episode, audioOnly = false, playingVideoStream = true, isRemote = false))
+    }
+
+    @Test
+    fun `downloaded episode with a resolved video stream it is not playing stays not video`() {
+        val episode = createEpisode(fileType = "audio/mp3").apply {
+            overrideStreamUrl = "https://example.com/episode.mp4"
+            overrideStreamContentType = "video/mp4"
+        }
+
+        assertEquals(StreamVideoState.NotVideo, StreamVideoState.initialFor(episode, audioOnly = false, playingVideoStream = false, isRemote = false))
     }
 
     @Test
     fun `hls stream starts unknown`() {
         val episode = createHlsEpisode()
 
-        assertEquals(StreamVideoState.Unknown, StreamVideoState.initialFor(episode, audioOnly = false, playingHlsStream = true, isRemote = false))
+        assertEquals(StreamVideoState.Unknown, StreamVideoState.initialFor(episode, audioOnly = false, playingVideoStream = true, isRemote = false))
     }
 
     @Test
     fun `audio only forces an hls stream to audio`() {
         val episode = createHlsEpisode()
 
-        assertEquals(StreamVideoState.AudioOnly, StreamVideoState.initialFor(episode, audioOnly = true, playingHlsStream = true, isRemote = false))
+        assertEquals(StreamVideoState.AudioOnly, StreamVideoState.initialFor(episode, audioOnly = true, playingVideoStream = true, isRemote = false))
     }
 
     @Test
     fun `remote hls stream resolves without waiting for tracks`() {
         val episode = createHlsEpisode()
 
-        assertEquals(StreamVideoState.NotVideo, StreamVideoState.initialFor(episode, audioOnly = false, playingHlsStream = true, isRemote = true))
+        assertEquals(StreamVideoState.NotVideo, StreamVideoState.initialFor(episode, audioOnly = false, playingVideoStream = true, isRemote = true))
     }
 
     @Test
     fun `audio only forces a remote hls stream to audio`() {
         val episode = createHlsEpisode()
 
-        assertEquals(StreamVideoState.AudioOnly, StreamVideoState.initialFor(episode, audioOnly = true, playingHlsStream = true, isRemote = true))
+        assertEquals(StreamVideoState.AudioOnly, StreamVideoState.initialFor(episode, audioOnly = true, playingVideoStream = true, isRemote = true))
     }
 
     @Test
     fun `downloaded hls episode playing its local file starts not video`() {
         val episode = createHlsEpisode()
 
-        assertEquals(StreamVideoState.NotVideo, StreamVideoState.initialFor(episode, audioOnly = false, playingHlsStream = false, isRemote = false))
+        assertEquals(StreamVideoState.NotVideo, StreamVideoState.initialFor(episode, audioOnly = false, playingVideoStream = false, isRemote = false))
     }
 
     @Test
     fun `downloaded hls episode playing its local audio file ignores audio only`() {
         val episode = createHlsEpisode()
 
-        assertEquals(StreamVideoState.NotVideo, StreamVideoState.initialFor(episode, audioOnly = true, playingHlsStream = false, isRemote = false))
+        assertEquals(StreamVideoState.NotVideo, StreamVideoState.initialFor(episode, audioOnly = true, playingVideoStream = false, isRemote = false))
     }
 
     private fun createEpisode(fileType: String) = PodcastEpisode(

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/StreamVideoStateTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/StreamVideoStateTest.kt
@@ -1,6 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.repositories.playback
 
+import au.com.shiftyjelly.pocketcasts.models.entity.AlternateEnclosureStream
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.type.MediaKind
 import java.util.Date
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -38,9 +40,7 @@ class StreamVideoStateTest {
     @Test
     fun `video alternate enclosure stream starts unknown like hls`() {
         val episode = createEpisode(fileType = "audio/mp3").apply {
-            overrideStreamUrl = "https://example.com/episode.mp4"
-            overrideStreamContentType = "video/mp4"
-            overrideStreamIsVideo = true
+            overrideStream = AlternateEnclosureStream(url = "https://example.com/episode.mp4", contentType = "video/mp4", mediaKind = MediaKind.Video)
         }
 
         assertEquals(StreamVideoState.Unknown, StreamVideoState.initialFor(episode, audioOnly = false, playingVideoStream = true, isRemote = false))
@@ -49,9 +49,7 @@ class StreamVideoStateTest {
     @Test
     fun `downloaded episode with a resolved video stream it is not playing stays not video`() {
         val episode = createEpisode(fileType = "audio/mp3").apply {
-            overrideStreamUrl = "https://example.com/episode.mp4"
-            overrideStreamContentType = "video/mp4"
-            overrideStreamIsVideo = true
+            overrideStream = AlternateEnclosureStream(url = "https://example.com/episode.mp4", contentType = "video/mp4", mediaKind = MediaKind.Video)
         }
 
         assertEquals(StreamVideoState.NotVideo, StreamVideoState.initialFor(episode, audioOnly = false, playingVideoStream = false, isRemote = false))
@@ -107,7 +105,6 @@ class StreamVideoStateTest {
     )
 
     private fun createHlsEpisode() = createEpisode(fileType = "audio/mpeg").apply {
-        overrideStreamUrl = "https://example.com/episode.m3u8"
-        overrideStreamContentType = "application/x-mpegURL"
+        overrideStream = AlternateEnclosureStream(url = "https://example.com/episode.m3u8", contentType = "application/x-mpegURL", mediaKind = null)
     }
 }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/StreamVideoStateTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/StreamVideoStateTest.kt
@@ -40,6 +40,7 @@ class StreamVideoStateTest {
         val episode = createEpisode(fileType = "audio/mp3").apply {
             overrideStreamUrl = "https://example.com/episode.mp4"
             overrideStreamContentType = "video/mp4"
+            overrideStreamIsVideo = true
         }
 
         assertEquals(StreamVideoState.Unknown, StreamVideoState.initialFor(episode, audioOnly = false, playingVideoStream = true, isRemote = false))
@@ -50,6 +51,7 @@ class StreamVideoStateTest {
         val episode = createEpisode(fileType = "audio/mp3").apply {
             overrideStreamUrl = "https://example.com/episode.mp4"
             overrideStreamContentType = "video/mp4"
+            overrideStreamIsVideo = true
         }
 
         assertEquals(StreamVideoState.NotVideo, StreamVideoState.initialFor(episode, audioOnly = false, playingVideoStream = false, isRemote = false))

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/VideoTrackSelectionTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/VideoTrackSelectionTest.kt
@@ -8,22 +8,22 @@ class VideoTrackSelectionTest {
 
     @Test
     fun `disables video without a surface for progressive playback`() {
-        assertTrue(shouldDisableVideoTrack(audioOnly = false, hasVideoSurface = false, isVideoStream = false))
+        assertTrue(shouldDisableVideoTrack(audioOnly = false, hasVideoSurface = false, isHlsStream = false))
     }
 
     @Test
     fun `keeps video when a surface is attached`() {
-        assertFalse(shouldDisableVideoTrack(audioOnly = false, hasVideoSurface = true, isVideoStream = false))
+        assertFalse(shouldDisableVideoTrack(audioOnly = false, hasVideoSurface = true, isHlsStream = false))
     }
 
     @Test
     fun `audio only setting always disables video`() {
-        assertTrue(shouldDisableVideoTrack(audioOnly = true, hasVideoSurface = true, isVideoStream = false))
-        assertTrue(shouldDisableVideoTrack(audioOnly = true, hasVideoSurface = false, isVideoStream = true))
+        assertTrue(shouldDisableVideoTrack(audioOnly = true, hasVideoSurface = true, isHlsStream = false))
+        assertTrue(shouldDisableVideoTrack(audioOnly = true, hasVideoSurface = false, isHlsStream = true))
     }
 
     @Test
-    fun `keeps video for a resolved video stream without a surface so it can be detected`() {
-        assertFalse(shouldDisableVideoTrack(audioOnly = false, hasVideoSurface = false, isVideoStream = true))
+    fun `keeps video for hls streams without a surface because audio may be muxed into it`() {
+        assertFalse(shouldDisableVideoTrack(audioOnly = false, hasVideoSurface = false, isHlsStream = true))
     }
 }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/VideoTrackSelectionTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/VideoTrackSelectionTest.kt
@@ -8,22 +8,22 @@ class VideoTrackSelectionTest {
 
     @Test
     fun `disables video without a surface for progressive playback`() {
-        assertTrue(shouldDisableVideoTrack(audioOnly = false, hasVideoSurface = false, isHlsStream = false))
+        assertTrue(shouldDisableVideoTrack(audioOnly = false, hasVideoSurface = false, isVideoStream = false))
     }
 
     @Test
     fun `keeps video when a surface is attached`() {
-        assertFalse(shouldDisableVideoTrack(audioOnly = false, hasVideoSurface = true, isHlsStream = false))
+        assertFalse(shouldDisableVideoTrack(audioOnly = false, hasVideoSurface = true, isVideoStream = false))
     }
 
     @Test
     fun `audio only setting always disables video`() {
-        assertTrue(shouldDisableVideoTrack(audioOnly = true, hasVideoSurface = true, isHlsStream = false))
-        assertTrue(shouldDisableVideoTrack(audioOnly = true, hasVideoSurface = false, isHlsStream = true))
+        assertTrue(shouldDisableVideoTrack(audioOnly = true, hasVideoSurface = true, isVideoStream = false))
+        assertTrue(shouldDisableVideoTrack(audioOnly = true, hasVideoSurface = false, isVideoStream = true))
     }
 
     @Test
-    fun `keeps video for hls streams without a surface`() {
-        assertFalse(shouldDisableVideoTrack(audioOnly = false, hasVideoSurface = false, isHlsStream = true))
+    fun `keeps video for a resolved video stream without a surface so it can be detected`() {
+        assertFalse(shouldDisableVideoTrack(audioOnly = false, hasVideoSurface = false, isVideoStream = true))
     }
 }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/AlternateEnclosureManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/AlternateEnclosureManagerImplTest.kt
@@ -2,19 +2,27 @@ package au.com.shiftyjelly.pocketcasts.repositories.podcast
 
 import au.com.shiftyjelly.pocketcasts.models.db.dao.AlternateEnclosureDao
 import au.com.shiftyjelly.pocketcasts.models.entity.AlternateEnclosureSource
-import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.EpisodeAlternateEnclosure
 import au.com.shiftyjelly.pocketcasts.models.type.MediaKind
+import au.com.shiftyjelly.pocketcasts.sharedtest.InMemoryFeatureFlagRule
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
 class AlternateEnclosureManagerImplTest {
+
+    @get:Rule
+    val featureFlagRule = InMemoryFeatureFlagRule()
+
     private val alternateEnclosureDao = mock<AlternateEnclosureDao>()
     private val manager = AlternateEnclosureManagerImpl(alternateEnclosureDao)
 
@@ -34,10 +42,45 @@ class AlternateEnclosureManagerImplTest {
     }
 
     @Test
-    fun `hasVideoAlternateEnclosure queries the dao with the HLS mime types and the video media kind`() = runBlocking {
-        whenever(alternateEnclosureDao.hasVideoEnclosure("episode-uuid", BaseEpisode.HLS_MIME_TYPES, MediaKind.Video.stringValue)).thenReturn(flowOf(true))
+    fun `an hls enclosure counts as video`() = runBlocking {
+        FeatureFlag.setEnabled(Feature.HLS_STREAMING, true)
 
-        assertTrue(manager.hasVideoAlternateEnclosure("episode-uuid").first())
+        assertTrue(hasVideoEnclosure(listOf(enclosure(position = 0))))
+    }
+
+    @Test
+    fun `a video enclosure counts as video when its flag is on`() = runBlocking {
+        FeatureFlag.setEnabled(Feature.VIDEO_ALTERNATE_ENCLOSURES, true)
+
+        assertTrue(hasVideoEnclosure(listOf(videoEnclosure("https://example.com/episode.mp4"))))
+    }
+
+    @Test
+    fun `a video enclosure the flag hides from playback does not earn the icon`() = runBlocking {
+        FeatureFlag.setEnabled(Feature.VIDEO_ALTERNATE_ENCLOSURES, false)
+
+        assertFalse(hasVideoEnclosure(listOf(videoEnclosure("https://example.com/episode.mp4"))))
+    }
+
+    @Test
+    fun `a video enclosure with no playable source does not earn the icon`() = runBlocking {
+        FeatureFlag.setEnabled(Feature.VIDEO_ALTERNATE_ENCLOSURES, true)
+
+        assertFalse(hasVideoEnclosure(listOf(videoEnclosure("ipfs://QmEpisode"))))
+    }
+
+    @Test
+    fun `an audio enclosure does not earn the icon`() = runBlocking {
+        FeatureFlag.setEnabled(Feature.HLS_STREAMING, true)
+        FeatureFlag.setEnabled(Feature.VIDEO_ALTERNATE_ENCLOSURES, true)
+
+        val audio = enclosure(position = 0).copy(type = "audio/mpeg", mediaKind = MediaKind.Audio)
+        assertFalse(hasVideoEnclosure(listOf(audio)))
+    }
+
+    private suspend fun hasVideoEnclosure(enclosures: List<EpisodeAlternateEnclosure>): Boolean {
+        whenever(alternateEnclosureDao.observeByEpisodeUuid("episode-uuid")).thenReturn(flowOf(enclosures))
+        return manager.hasVideoAlternateEnclosure("episode-uuid").first()
     }
 
     private fun enclosure(position: Int) = EpisodeAlternateEnclosure(
@@ -45,5 +88,13 @@ class AlternateEnclosureManagerImplTest {
         position = position,
         type = "application/x-mpegURL",
         sources = listOf(AlternateEnclosureSource(uri = "https://example.com/master.m3u8")),
+    )
+
+    private fun videoEnclosure(uri: String) = EpisodeAlternateEnclosure(
+        episodeUuid = "episode-uuid",
+        position = 0,
+        type = "video/mp4",
+        mediaKind = MediaKind.Video,
+        sources = listOf(AlternateEnclosureSource(uri = uri)),
     )
 }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/AlternateEnclosureManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/AlternateEnclosureManagerImplTest.kt
@@ -4,6 +4,7 @@ import au.com.shiftyjelly.pocketcasts.models.db.dao.AlternateEnclosureDao
 import au.com.shiftyjelly.pocketcasts.models.entity.AlternateEnclosureSource
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.EpisodeAlternateEnclosure
+import au.com.shiftyjelly.pocketcasts.models.type.MediaKind
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
@@ -33,10 +34,10 @@ class AlternateEnclosureManagerImplTest {
     }
 
     @Test
-    fun `hasHlsAlternateEnclosure queries the dao with the HLS mime types`() = runBlocking {
-        whenever(alternateEnclosureDao.hasHlsEnclosure("episode-uuid", BaseEpisode.HLS_MIME_TYPES)).thenReturn(flowOf(true))
+    fun `hasVideoAlternateEnclosure queries the dao with the HLS mime types and the video media kind`() = runBlocking {
+        whenever(alternateEnclosureDao.hasVideoEnclosure("episode-uuid", BaseEpisode.HLS_MIME_TYPES, MediaKind.Video.stringValue)).thenReturn(flowOf(true))
 
-        assertTrue(manager.hasHlsAlternateEnclosure("episode-uuid").first())
+        assertTrue(manager.hasVideoAlternateEnclosure("episode-uuid").first())
     }
 
     private fun enclosure(position: Int) = EpisodeAlternateEnclosure(

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/DataParser.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/DataParser.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.servers
 
 import au.com.shiftyjelly.pocketcasts.models.entity.AlternateEnclosureSource
+import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.EpisodeAlternateEnclosure
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
@@ -148,7 +149,7 @@ object DataParser {
         val url = getString(jsonEpisode, "url")
         val fileType = getString(jsonEpisode, "file_type")
         // Stream-only episode (no progressive download): surface the alternate enclosure's MIME, but keep a real video type.
-        val resolvedFileType = if (url.isNullOrBlank() && fileType?.startsWith("video/") != true) {
+        val resolvedFileType = if (url.isNullOrBlank() && !BaseEpisode.isVideoMimeType(fileType)) {
             enclosures.firstStreamOnlyMimeType() ?: fileType
         } else {
             fileType

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/DataParser.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/DataParser.kt
@@ -4,7 +4,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.AlternateEnclosureSource
 import au.com.shiftyjelly.pocketcasts.models.entity.EpisodeAlternateEnclosure
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
-import au.com.shiftyjelly.pocketcasts.models.entity.firstHlsMimeType
+import au.com.shiftyjelly.pocketcasts.models.entity.firstStreamOnlyMimeType
 import au.com.shiftyjelly.pocketcasts.models.to.Share
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeDownloadStatus
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
@@ -147,9 +147,9 @@ object DataParser {
         val enclosures = parseAlternateEnclosures(jsonEpisode, uuid)
         val url = getString(jsonEpisode, "url")
         val fileType = getString(jsonEpisode, "file_type")
-        // HLS-only episode (no progressive download): surface the HLS MIME for isHlsOnly, but keep a real video type.
+        // Stream-only episode (no progressive download): surface the alternate enclosure's MIME, but keep a real video type.
         val resolvedFileType = if (url.isNullOrBlank() && fileType?.startsWith("video/") != true) {
-            enclosures.firstHlsMimeType() ?: fileType
+            enclosures.firstStreamOnlyMimeType() ?: fileType
         } else {
             fileType
         }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastResponse.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastResponse.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.servers.podcast
 
 import au.com.shiftyjelly.pocketcasts.models.entity.AlternateEnclosureSource
+import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.EpisodeAlternateEnclosure
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
@@ -105,7 +106,7 @@ data class EpisodeInfo(
         val episodeTitle = title.orEmpty()
         val enclosures = toAlternateEnclosures()
         // Stream-only episode (no progressive download): surface the alternate enclosure's MIME, but keep a real video type.
-        val resolvedFileType = if (url.isNullOrBlank() && fileType?.startsWith("video/") != true) {
+        val resolvedFileType = if (url.isNullOrBlank() && !BaseEpisode.isVideoMimeType(fileType)) {
             enclosures.firstStreamOnlyMimeType() ?: fileType
         } else {
             fileType

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastResponse.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastResponse.kt
@@ -4,7 +4,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.AlternateEnclosureSource
 import au.com.shiftyjelly.pocketcasts.models.entity.EpisodeAlternateEnclosure
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
-import au.com.shiftyjelly.pocketcasts.models.entity.firstHlsMimeType
+import au.com.shiftyjelly.pocketcasts.models.entity.firstStreamOnlyMimeType
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodesSortType
 import au.com.shiftyjelly.pocketcasts.models.type.MediaKind
 import au.com.shiftyjelly.pocketcasts.utils.extensions.parseIsoDate
@@ -104,9 +104,9 @@ data class EpisodeInfo(
         val publishedDate = published.parseIsoDate() ?: return null
         val episodeTitle = title.orEmpty()
         val enclosures = toAlternateEnclosures()
-        // HLS-only episode (no progressive download): surface the HLS MIME for isHlsOnly, but keep a real video type.
+        // Stream-only episode (no progressive download): surface the alternate enclosure's MIME, but keep a real video type.
         val resolvedFileType = if (url.isNullOrBlank() && fileType?.startsWith("video/") != true) {
-            enclosures.firstHlsMimeType() ?: fileType
+            enclosures.firstStreamOnlyMimeType() ?: fileType
         } else {
             fileType
         }

--- a/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/podcast/EpisodeInfoTest.kt
+++ b/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/podcast/EpisodeInfoTest.kt
@@ -221,7 +221,6 @@ class EpisodeInfoTest {
         assertEquals("video/mp4", episode?.fileType)
         assertEquals(true, episode?.isVideo)
         assertEquals(false, episode?.isHlsOnly)
-        assertEquals(true, episode?.isStreamOnly)
     }
 
     @Test
@@ -242,7 +241,6 @@ class EpisodeInfoTest {
 
         val episode = episodeInfo?.toEpisode("podcast-uuid")
         assertEquals("audio/mp3", episode?.fileType)
-        assertEquals(false, episode?.isStreamOnly)
         assertEquals(
             "https://example.com/episode.mp4",
             episode?.alternateEnclosures?.firstProgressiveVideoStream()?.url,

--- a/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/podcast/EpisodeInfoTest.kt
+++ b/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/podcast/EpisodeInfoTest.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.servers.podcast
 
 import androidx.media3.common.MimeTypes
 import au.com.shiftyjelly.pocketcasts.models.entity.firstHlsStreamUrl
+import au.com.shiftyjelly.pocketcasts.models.entity.firstProgressiveVideoStream
 import au.com.shiftyjelly.pocketcasts.models.type.MediaKind
 import au.com.shiftyjelly.pocketcasts.servers.di.NetworkModule
 import org.junit.Assert.assertEquals
@@ -199,6 +200,53 @@ class EpisodeInfoTest {
         val episode = episodeInfo?.toEpisode("podcast-uuid")
         assertEquals(MimeTypes.APPLICATION_M3U8, episode?.fileType)
         assertEquals(true, episode?.isHlsOnly)
+    }
+
+    @Test
+    fun `video-only episode without a progressive url takes the alternate enclosure file type`() {
+        val episodeInfo = adapter.fromJson(
+            """
+            {
+              "uuid": "episode-uuid",
+              "url": "",
+              "published": "2026-06-11T00:00:00Z",
+              "alternate_enclosures": [
+                { "type": "video/mp4", "media_kind": "video", "sources": [{ "uri": "https://example.com/episode.mp4" }] }
+              ]
+            }
+            """.trimIndent(),
+        )
+
+        val episode = episodeInfo?.toEpisode("podcast-uuid")
+        assertEquals("video/mp4", episode?.fileType)
+        assertEquals(true, episode?.isVideo)
+        assertEquals(false, episode?.isHlsOnly)
+        assertEquals(true, episode?.isStreamOnly)
+    }
+
+    @Test
+    fun `episode with a progressive url keeps its own file type alongside a video alternate enclosure`() {
+        val episodeInfo = adapter.fromJson(
+            """
+            {
+              "uuid": "episode-uuid",
+              "url": "https://example.com/episode.mp3",
+              "file_type": "audio/mp3",
+              "published": "2026-06-11T00:00:00Z",
+              "alternate_enclosures": [
+                { "type": "video/mp4", "media_kind": "video", "sources": [{ "uri": "https://example.com/episode.mp4" }] }
+              ]
+            }
+            """.trimIndent(),
+        )
+
+        val episode = episodeInfo?.toEpisode("podcast-uuid")
+        assertEquals("audio/mp3", episode?.fileType)
+        assertEquals(false, episode?.isStreamOnly)
+        assertEquals(
+            "https://example.com/episode.mp4",
+            episode?.alternateEnclosures?.firstProgressiveVideoStream()?.url,
+        )
     }
 
     @Test

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -360,6 +360,15 @@ enum class Feature(
         hasDevToggle = true,
         addedOn = LocalDate.parse("2026-06-11"),
     ),
+    VIDEO_ALTERNATE_ENCLOSURES(
+        key = "video_alternate_enclosures",
+        title = "Prefer video alternate enclosure when available",
+        defaultValue = isDebugOrPrototypeBuild,
+        tier = FeatureTier.Free,
+        hasFirebaseRemoteFlag = false,
+        hasDevToggle = true,
+        addedOn = LocalDate.parse("2026-09-02"),
+    ),
     STATS_HEATMAP(
         key = "stats_heatmap",
         title = "Show listening activity heatmap on Stats",


### PR DESCRIPTION
## Description
Episodes whose feed offers a video version alongside the audio one can now play that video version, not just the audio file, and they show the video badge in episode lists and the video toggle in the player.

Until now the app only recognised one kind of alternate enclosure: HLS. The server has started sending plain progressive video renditions too (a `video/mp4` enclosure carrying `media_kind = "video"`), and everything downstream of enclosure resolution was written around "is this HLS?", so those renditions were invisible: no video badge, no stream selector, and playback stayed on the audio enclosure.

The change widens that concept from "HLS" to "a video encoding we resolved for streaming". Enclosure resolution now returns a small stream description (URL, content type, whether it is HLS, whether it is video) instead of a bare HLS URL, and picks HLS first (it adapts to bandwidth) before falling back to a progressive video rendition. The chosen stream is recorded on the episode alongside a new `overrideStreamIsVideo` flag, and the playback layer keys off `isStreamUrlVideo` rather than `isStreamUrlHls` for the decisions that were really about video: video track selection, whether the video surface can appear, whether Cast is told this is a movie, whether the episode is worth prefetching, and whether the entire-episode cache should be skipped (that cache is keyed by episode uuid, so an alternate encoding would collide with the progressive file).

A couple of deliberate distinctions:
- Video is trusted from the server's `media_kind`, not from a MIME type, since a source may declare something generic like `application/octet-stream`. A `video/mp4` enclosure without `media_kind = "video"` is ignored, as is a video enclosure with a media kind we cannot stream directly (YouTube).
- `isVideo` still describes the episode's own progressive enclosure, so anything reading the episode from the database is unaffected. Only the resolved stream is treated as video.
- `_streamHlsAvailable` is kept internally and remains strictly "an HLS encoding exists", because that is what the analytics schema's `hls_available` means. The new `streamVideoAvailable` (which also honours the feature flags) is what the UI observes.

The new behaviour sits behind a `video_alternate_enclosures` feature flag, on by default in debug and prototype builds. An episode with no progressive enclosure at all is unaffected by both flags, since there is nothing else it could play.

Fixes POC-841: https://linear.app/a8c/issue/POC-841/android-support-alternate-enclosures-with-videomp4-mime-type

## Testing Instructions
Use a debug or debugProd build (the flag defaults on)

1. Subscribe to **Beyond the Bump** and open the episode list.
2. Confirm the episode *"Bumpie Group Chat: a not so romantic getaway, trenches be trenchin’ and a side of bunny lovin’"* (a `video/mp4` alternate enclosure) now shows the video badge, as does the HLS episode *"Bumpie Group Chat: when depression, a yellow submarine and book week walk into a recording studio"*.
3. Play the `video/mp4` episode. It should stream the video rendition, and the player should offer the stream/video toggle.
4. Toggle video on and confirm the video surface appears and renders; toggle it off and confirm playback continues as audio.
5. Turn on **Settings → Playback → Audio only** and confirm the toggle disappears and playback stays audio.
6. Repeat steps 3-4 with **Mac Geek Gab**, which has both HLS and `video/mp4` renditions, and confirm HLS is preferred.
7. Cast the `video/mp4` episode to a Chromecast and confirm it plays as video.
8. Download the `video/mp4` episode, play it, then hit the video toggle and confirm the "switch to streaming" prompt appears and switching works.
9. Turn the feature flag off, restart, and confirm those episodes go back to playing the plain audio enclosure with no video badge and no toggle (HLS episodes still behave as before under the HLS flag).
10. Confirm a plain audio podcast is entirely unchanged: no badge, no toggle, prefetch and episode caching still happen.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
