### PR TITLE
[TV] Review follow-ups + focus-gated recent searches

### DIFF
--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvBannerRow.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvBannerRow.kt
@@ -37,6 +37,7 @@ import androidx.tv.material3.CardDefaults
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.discover.TvDiscoverBanner
+import au.com.shiftyjelly.pocketcasts.theme.TvCardShape
 import au.com.shiftyjelly.pocketcasts.theme.TvTheme
 import au.com.shiftyjelly.pocketcasts.theme.tvColors
 import au.com.shiftyjelly.pocketcasts.theme.tvTypography
@@ -54,7 +55,7 @@ fun TvBannerRow(
 
     TvTile(
         onClick = onClick,
-        shape = CardDefaults.shape(RoundedCornerShape(9.dp)),
+        shape = CardDefaults.shape(TvCardShape),
         scale = CardDefaults.scale(focusedScale = 1.05f),
         colors = CardDefaults.colors(
             containerColor = Color.Black,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvBannerRow.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvBannerRow.kt
@@ -64,7 +64,7 @@ fun TvBannerRow(
         interactionSource = interactionSource,
         modifier = modifier
             .fillMaxWidth()
-            .height(99.dp),
+            .height(153.dp),
     ) {
         Box(modifier = Modifier.fillMaxSize().clipToBounds()) {
             BackgroundLift()
@@ -167,8 +167,8 @@ private fun TvDiscoverBanner.artwork(): Int = when (this) {
 
 private val TvDiscoverBanner.artworkHeight: Dp
     get() = when (this) {
-        TvDiscoverBanner.CreateAccount -> 112.5.dp
-        TvDiscoverBanner.DiscoverMore -> 127.5.dp
+        TvDiscoverBanner.CreateAccount -> 174.dp
+        TvDiscoverBanner.DiscoverMore -> 197.dp
     }
 
 private val TvDiscoverBanner.contentWidthFraction: Float

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvBannerRow.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvBannerRow.kt
@@ -56,7 +56,7 @@ fun TvBannerRow(
     TvTile(
         onClick = onClick,
         shape = CardDefaults.shape(TvCardShape),
-        scale = CardDefaults.scale(focusedScale = 1.05f),
+        scale = CardDefaults.scale(focusedScale = TvFocusedCardScale),
         colors = CardDefaults.colors(
             containerColor = Color.Black,
             focusedContainerColor = Color.Black,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvCategoryTile.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvCategoryTile.kt
@@ -116,7 +116,7 @@ fun TvCategoryTile(
             .width(284.dp)
             .height(129.dp),
     ) {
-        Box(modifier = Modifier.fillMaxSize()) {
+        Box(modifier = Modifier.fillMaxSize().clip(TvCardShape)) {
             Box(
                 modifier = Modifier
                     .fillMaxSize()

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvCategoryTile.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvCategoryTile.kt
@@ -47,6 +47,7 @@ import androidx.tv.material3.Glow
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
+import au.com.shiftyjelly.pocketcasts.theme.TvCardShape
 import au.com.shiftyjelly.pocketcasts.theme.TvTheme
 import au.com.shiftyjelly.pocketcasts.theme.tvColors
 import au.com.shiftyjelly.pocketcasts.theme.tvTypography
@@ -57,7 +58,6 @@ import coil3.request.ImageRequest
 import coil3.request.crossfade
 import coil3.size.Size
 
-private val CardShape = RoundedCornerShape(9.dp)
 private val CoverSize = 78.dp
 private val CoverShape = RoundedCornerShape(6.dp)
 private const val COVER_VISIBLE_FRACTION = 0.55f
@@ -103,7 +103,7 @@ fun TvCategoryTile(
 
     TvTile(
         onClick = onClick,
-        shape = CardDefaults.shape(shape = CardShape),
+        shape = CardDefaults.shape(shape = TvCardShape),
         colors = CardDefaults.colors(
             containerColor = MaterialTheme.tvColors.backgroundOverlay,
             focusedContainerColor = MaterialTheme.tvColors.backgroundOverlay,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeInfoModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeInfoModal.kt
@@ -132,7 +132,7 @@ private fun EpisodeHeader(
             }
             Text(
                 text = episode.title,
-                style = MaterialTheme.tvTypography.headline,
+                style = MaterialTheme.tvTypography.body,
                 color = MaterialTheme.tvColors.textPrimary,
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeRow.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeRow.kt
@@ -54,6 +54,7 @@ val LocalUseEpisodeArtwork = staticCompositionLocalOf { false }
 fun TvEpisodeRow(
     episode: PodcastEpisode,
     onClick: () -> Unit,
+    onLongClick: (() -> Unit)? = null,
     dateFormatter: RelativeDateFormatter,
     modifier: Modifier = Modifier,
 ) {
@@ -68,6 +69,7 @@ fun TvEpisodeRow(
 
     TvTile(
         onClick = onClick,
+        onLongClick = onLongClick,
         scale = CardDefaults.scale(focusedScale = 1.02f),
         shape = CardDefaults.shape(RoundedCornerShape(8.dp)),
         colors = CardDefaults.colors(
@@ -144,6 +146,7 @@ fun TvEpisodeRow(
 fun TvResumeCard(
     episode: PodcastEpisode,
     onClick: () -> Unit,
+    onLongClick: (() -> Unit)? = null,
     dateFormatter: RelativeDateFormatter,
     modifier: Modifier = Modifier,
 ) {
@@ -158,6 +161,7 @@ fun TvResumeCard(
 
     TvTile(
         onClick = onClick,
+        onLongClick = onLongClick,
         scale = CardDefaults.scale(focusedScale = 1.02f),
         shape = CardDefaults.shape(RoundedCornerShape(8.dp)),
         colors = CardDefaults.colors(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeRow.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeRow.kt
@@ -70,7 +70,7 @@ fun TvEpisodeRow(
     TvTile(
         onClick = onClick,
         onLongClick = onLongClick,
-        scale = CardDefaults.scale(focusedScale = 1.02f),
+        scale = CardDefaults.scale(focusedScale = TvFocusedWideCardScale),
         shape = CardDefaults.shape(RoundedCornerShape(8.dp)),
         colors = CardDefaults.colors(
             containerColor = MaterialTheme.tvColors.backgroundBase,
@@ -162,7 +162,7 @@ fun TvResumeCard(
     TvTile(
         onClick = onClick,
         onLongClick = onLongClick,
-        scale = CardDefaults.scale(focusedScale = 1.02f),
+        scale = CardDefaults.scale(focusedScale = TvFocusedWideCardScale),
         shape = CardDefaults.shape(RoundedCornerShape(8.dp)),
         colors = CardDefaults.colors(
             containerColor = MaterialTheme.tvColors.backgroundBase,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvFeaturedTile.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvFeaturedTile.kt
@@ -58,7 +58,7 @@ fun TvFeaturedTile(
 
     TvTile(
         onClick = onPlayLastEpisode,
-        scale = CardDefaults.scale(focusedScale = 1.02f),
+        scale = CardDefaults.scale(focusedScale = TvFocusedWideCardScale),
         colors = CardDefaults.colors(
             containerColor = Color.Transparent,
             focusedContainerColor = Color.Transparent,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvModal.kt
@@ -49,7 +49,6 @@ fun TvModal(
         val isBlurBehindEnabled by rememberIsBlurBehindEnabled()
         TvModalWindowEffects(isBlurBehindEnabled = isBlurBehindEnabled)
         TvModalSurface(
-            isTranslucent = isBlurBehindEnabled,
             width = width,
             contentPadding = contentPadding,
             modifier = modifier,
@@ -61,16 +60,11 @@ fun TvModal(
 @Composable
 internal fun TvModalSurface(
     modifier: Modifier = Modifier,
-    isTranslucent: Boolean = false,
     width: Dp = DefaultModalWidth,
     contentPadding: PaddingValues = DefaultContentPadding,
     content: @Composable ColumnScope.() -> Unit,
 ) {
-    val containerColor = if (isTranslucent) {
-        MaterialTheme.tvColors.translucentOverlayContainer
-    } else {
-        MaterialTheme.tvColors.overlayContainer
-    }
+    val containerColor = MaterialTheme.tvColors.translucentOverlayContainer
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(12.dp),

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvModal.kt
@@ -49,6 +49,7 @@ fun TvModal(
         val isBlurBehindEnabled by rememberIsBlurBehindEnabled()
         TvModalWindowEffects(isBlurBehindEnabled = isBlurBehindEnabled)
         TvModalSurface(
+            isTranslucent = isBlurBehindEnabled,
             width = width,
             contentPadding = contentPadding,
             modifier = modifier,
@@ -60,11 +61,16 @@ fun TvModal(
 @Composable
 internal fun TvModalSurface(
     modifier: Modifier = Modifier,
+    isTranslucent: Boolean = false,
     width: Dp = DefaultModalWidth,
     contentPadding: PaddingValues = DefaultContentPadding,
     content: @Composable ColumnScope.() -> Unit,
 ) {
-    val containerColor = MaterialTheme.tvColors.translucentOverlayContainer
+    val containerColor = if (isTranslucent) {
+        MaterialTheme.tvColors.translucentOverlayContainer
+    } else {
+        MaterialTheme.tvColors.overlayContainer
+    }
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(12.dp),

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPlaylistCard.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPlaylistCard.kt
@@ -85,7 +85,7 @@ fun TvPlaylistCard(
 
     TvTile(
         onClick = onClick,
-        scale = CardDefaults.scale(focusedScale = 1.05f),
+        scale = CardDefaults.scale(focusedScale = TvFocusedCardScale),
         shape = CardDefaults.shape(RoundedCornerShape(11.dp)),
         colors = CardDefaults.colors(
             containerColor = Color.Transparent,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvSinglePodcastTile.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvSinglePodcastTile.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.unit.dp
 import androidx.tv.material3.CardDefaults
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
+import au.com.shiftyjelly.pocketcasts.theme.TvCardShape
 import au.com.shiftyjelly.pocketcasts.theme.TvTheme
 import au.com.shiftyjelly.pocketcasts.theme.tvColors
 import au.com.shiftyjelly.pocketcasts.theme.tvTypography
@@ -52,7 +53,7 @@ fun TvSinglePodcastTile(
     TvTile(
         onClick = onClick,
         scale = CardDefaults.scale(focusedScale = 1.02f),
-        shape = CardDefaults.shape(shape = RoundedCornerShape(9.dp)),
+        shape = CardDefaults.shape(shape = TvCardShape),
         colors = CardDefaults.colors(
             containerColor = MaterialTheme.tvColors.backgroundSunken,
             focusedContainerColor = MaterialTheme.tvColors.backgroundActive,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvSinglePodcastTile.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvSinglePodcastTile.kt
@@ -52,7 +52,7 @@ fun TvSinglePodcastTile(
 
     TvTile(
         onClick = onClick,
-        scale = CardDefaults.scale(focusedScale = 1.02f),
+        scale = CardDefaults.scale(focusedScale = TvFocusedWideCardScale),
         shape = CardDefaults.shape(shape = TvCardShape),
         colors = CardDefaults.colors(
             containerColor = MaterialTheme.tvColors.backgroundSunken,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvTile.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvTile.kt
@@ -26,12 +26,15 @@ import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.theme.TvTheme
 import au.com.shiftyjelly.pocketcasts.theme.tvColors
 
+val TvFocusedCardScale = 1.05f
+val TvFocusedWideCardScale = 1.02f
+
 @Composable
 fun TvTile(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     onLongClick: (() -> Unit)? = null,
-    scale: CardScale = CardDefaults.scale(focusedScale = 1.1f),
+    scale: CardScale = CardDefaults.scale(focusedScale = TvFocusedCardScale),
     shape: CardShape = CardDefaults.shape(),
     colors: CardColors = CardDefaults.colors(
         containerColor = MaterialTheme.tvColors.backgroundBase,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvVideoTile.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvVideoTile.kt
@@ -58,7 +58,7 @@ fun TvVideoTile(
     TvTile(
         onClick = onPlayEpisode,
         onLongClick = onGoToPodcast,
-        scale = CardDefaults.scale(focusedScale = 1.05f),
+        scale = CardDefaults.scale(focusedScale = TvFocusedCardScale),
         modifier = modifier.onFocusChanged { isFocused = it.hasFocus },
     ) {
         Box(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/discover/TvDiscoverRows.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/discover/TvDiscoverRows.kt
@@ -115,12 +115,14 @@ fun LazyListScope.tvDiscoverRow(
                         TvProgressCardStyle.Resume -> TvResumeCard(
                             episode = podcastEpisode,
                             onClick = { onEpisodePlay(row, episode) },
+                            onLongClick = { onEpisodePodcastClick(row, episode) },
                             dateFormatter = dateFormatter,
                         )
 
                         TvProgressCardStyle.Queue -> TvEpisodeRow(
                             episode = podcastEpisode,
                             onClick = { onEpisodePlay(row, episode) },
+                            onLongClick = { onEpisodePodcastClick(row, episode) },
                             dateFormatter = dateFormatter,
                             modifier = Modifier.width(431.dp),
                         )

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signedout/TvSignedOutScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signedout/TvSignedOutScreen.kt
@@ -1,6 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.onboarding.signedout
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -17,7 +16,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Devices
@@ -32,7 +30,6 @@ import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
 import au.com.shiftyjelly.pocketcasts.theme.TvTheme
 import au.com.shiftyjelly.pocketcasts.theme.tvColors
 import au.com.shiftyjelly.pocketcasts.theme.tvTypography
-import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
@@ -70,11 +67,6 @@ private fun TvSignedOutContent(
             verticalArrangement = Arrangement.spacedBy(12.dp),
             modifier = Modifier.padding(horizontal = 36.dp),
         ) {
-            Image(
-                painter = painterResource(IR.drawable.ic_pocket_casts_logo),
-                contentDescription = null,
-                modifier = Modifier.size(27.dp),
-            )
             Text(
                 text = stringResource(LR.string.tv_account_signed_out_alert_title),
                 color = MaterialTheme.tvColors.textPrimary,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSignInScreen.kt
@@ -109,12 +109,6 @@ private fun TvSignInContent(
                 .padding(vertical = 48.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            Image(
-                painter = painterResource(IR.drawable.ic_pocket_casts_logo),
-                contentDescription = null,
-                modifier = Modifier.size(36.dp),
-            )
-            Spacer(modifier = Modifier.height(8.dp))
             Text(
                 text = stringResource(LR.string.tv_sign_in_title),
                 color = MaterialTheme.tvColors.textPrimary,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSyncingScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/signin/TvSyncingScreen.kt
@@ -50,7 +50,6 @@ import au.com.shiftyjelly.pocketcasts.theme.tvTypography
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 private const val COVER_SIZE_DP = 140
@@ -104,12 +103,6 @@ private fun TvSyncingScreenContent(
             verticalArrangement = Arrangement.Center,
             modifier = Modifier.fillMaxSize(),
         ) {
-            Image(
-                painter = painterResource(IR.drawable.ic_pocket_casts_logo),
-                contentDescription = null,
-                modifier = Modifier.size(27.dp),
-            )
-            Spacer(modifier = Modifier.height(12.dp))
             Text(
                 text = stringResource(LR.string.tv_onboarding_welcome_back),
                 color = MaterialTheme.tvColors.textPrimary,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
@@ -145,7 +145,7 @@ private fun TvPodcastDetailsContent(
                 var isShowingInfoModal by remember { mutableStateOf(false) }
                 var isShowingAccountModal by rememberSaveable { mutableStateOf(false) }
                 Row(
-                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    horizontalArrangement = Arrangement.spacedBy(60.dp),
                     modifier = Modifier
                         .fillMaxSize()
                         .padding(start = 42.dp, top = 16.dp, end = 42.dp),

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchEpisodeRow.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchEpisodeRow.kt
@@ -28,6 +28,7 @@ import androidx.tv.material3.CardDefaults
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.component.TvArtworkImage
+import au.com.shiftyjelly.pocketcasts.component.TvFocusedWideCardScale
 import au.com.shiftyjelly.pocketcasts.component.TvTile
 import au.com.shiftyjelly.pocketcasts.localization.helper.TimeHelper
 import au.com.shiftyjelly.pocketcasts.models.to.ImprovedSearchResultItem
@@ -58,7 +59,7 @@ internal fun TvSearchEpisodeCard(
     TvTile(
         onClick = onClick,
         onLongClick = onLongClick,
-        scale = CardDefaults.scale(focusedScale = 1.02f),
+        scale = CardDefaults.scale(focusedScale = TvFocusedWideCardScale),
         shape = CardDefaults.shape(shape = TvCardShape),
         colors = CardDefaults.colors(
             containerColor = MaterialTheme.tvColors.backgroundSunken,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchEpisodeRow.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchEpisodeRow.kt
@@ -32,6 +32,7 @@ import au.com.shiftyjelly.pocketcasts.component.TvTile
 import au.com.shiftyjelly.pocketcasts.localization.helper.TimeHelper
 import au.com.shiftyjelly.pocketcasts.models.to.ImprovedSearchResultItem
 import au.com.shiftyjelly.pocketcasts.repositories.images.PodcastImage
+import au.com.shiftyjelly.pocketcasts.theme.TvCardShape
 import au.com.shiftyjelly.pocketcasts.theme.TvTheme
 import au.com.shiftyjelly.pocketcasts.theme.tvColors
 import au.com.shiftyjelly.pocketcasts.theme.tvTypography
@@ -58,7 +59,7 @@ internal fun TvSearchEpisodeCard(
         onClick = onClick,
         onLongClick = onLongClick,
         scale = CardDefaults.scale(focusedScale = 1.02f),
-        shape = CardDefaults.shape(shape = RoundedCornerShape(9.dp)),
+        shape = CardDefaults.shape(shape = TvCardShape),
         colors = CardDefaults.colors(
             containerColor = MaterialTheme.tvColors.backgroundSunken,
             focusedContainerColor = MaterialTheme.tvColors.backgroundActive,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
@@ -1,5 +1,10 @@
 package au.com.shiftyjelly.pocketcasts.search
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.layout.Arrangement
@@ -298,9 +303,13 @@ private fun TvSearchContent(
     restoreFocusTrigger: Int = 0,
 ) {
     val searchFieldFocusRequester = remember { FocusRequester() }
+    val dropdownFocusRequester = remember { FocusRequester() }
     var isEditing by remember { mutableStateOf(false) }
+    var searchFieldFocused by remember { mutableStateOf(false) }
     var suggestionsFocused by remember { mutableStateOf(false) }
+    var historyFocused by remember { mutableStateOf(false) }
     val showSuggestions = (isEditing || suggestionsFocused) && suggestions.isNotEmpty()
+    val showHistory = (searchFieldFocused || historyFocused || isEditing) && !showSuggestions && query.isBlank() && history.isNotEmpty()
     Column(modifier = modifier.fillMaxSize()) {
         Column(modifier = Modifier.padding(ContentPadding)) {
             Spacer(modifier = Modifier.height(30.dp))
@@ -315,18 +324,38 @@ private fun TvSearchContent(
                 },
                 modifier = Modifier
                     .fillMaxWidth()
-                    .focusRequester(searchFieldFocusRequester),
+                    .focusRequester(searchFieldFocusRequester)
+                    .onFocusChanged { searchFieldFocused = it.hasFocus }
+                    .focusProperties { if (showSuggestions || showHistory) down = dropdownFocusRequester },
             )
             Spacer(modifier = Modifier.height(18.dp))
         }
 
-        if (showSuggestions) {
-            TvSearchSuggestions(
-                suggestions = suggestions,
-                onSuggestionSelect = onSuggestionSelect,
-                modifier = Modifier.onFocusChanged { suggestionsFocused = it.hasFocus },
-            )
-            Spacer(modifier = Modifier.height(18.dp))
+        AnimatedVisibility(
+            visible = showSuggestions || showHistory,
+            enter = fadeIn() + expandVertically(),
+            exit = fadeOut() + shrinkVertically(),
+        ) {
+            Column(
+                modifier = Modifier
+                    .focusRequester(dropdownFocusRequester)
+                    .focusGroup(),
+            ) {
+                if (showSuggestions) {
+                    TvSearchSuggestions(
+                        suggestions = suggestions,
+                        onSuggestionSelect = onSuggestionSelect,
+                        modifier = Modifier.onFocusChanged { suggestionsFocused = it.hasFocus },
+                    )
+                } else if (history.isNotEmpty()) {
+                    TvSearchHistory(
+                        history = history,
+                        onHistorySelect = onHistorySelect,
+                        modifier = Modifier.onFocusChanged { historyFocused = it.hasFocus },
+                    )
+                }
+                Spacer(modifier = Modifier.height(18.dp))
+            }
         }
 
         val filters = remember(hasFolderResults) { TvSearchFilter.entries.filter { it != TvSearchFilter.Folders || hasFolderResults } }
@@ -350,10 +379,8 @@ private fun TvSearchContent(
         ) {
             when (searchState) {
                 is TvSearchState.Idle -> TvSearchIdle(
-                    history = history,
                     categories = categories,
                     discoverRows = discoverRows,
-                    onHistorySelect = onHistorySelect,
                     onDiscoverPodcastClick = onDiscoverPodcastClick,
                     onDiscoverEpisodePodcastClick = onDiscoverEpisodePodcastClick,
                     onDiscoverEpisodePlay = onDiscoverEpisodePlay,
@@ -396,10 +423,8 @@ private fun TvSearchContent(
 
 @Composable
 private fun TvSearchIdle(
-    history: List<String>,
     categories: List<DiscoverCategory>,
     discoverRows: List<TvDiscoverRow>,
-    onHistorySelect: (String) -> Unit,
     onDiscoverPodcastClick: (TvDiscoverRow, TvDiscoverPodcast) -> Unit,
     onDiscoverEpisodePodcastClick: (TvDiscoverRow, TvDiscoverEpisode) -> Unit,
     onDiscoverEpisodePlay: (TvDiscoverRow, TvDiscoverEpisode) -> Unit,
@@ -411,24 +436,6 @@ private fun TvSearchIdle(
     loadCategoryCovers: (suspend (DiscoverCategory) -> List<String>)? = null,
 ) {
     Column(modifier = Modifier.fillMaxSize()) {
-        if (history.isNotEmpty()) {
-            TvRow(
-                title = stringResource(LR.string.tv_search_recent),
-                items = history,
-                contentPadding = ContentPadding,
-                key = { it },
-            ) { term ->
-                TvTile(onClick = { onHistorySelect(term) }) {
-                    Text(
-                        text = term,
-                        style = MaterialTheme.tvTypography.body,
-                        color = MaterialTheme.tvColors.textPrimary,
-                        modifier = Modifier.padding(horizontal = 15.dp, vertical = 9.dp),
-                    )
-                }
-            }
-            Spacer(modifier = Modifier.height(18.dp))
-        }
         TvSearchDiscover(
             categories = categories,
             discoverRows = discoverRows,
@@ -874,6 +881,30 @@ private fun TvSearchSuggestions(
 }
 
 @Composable
+private fun TvSearchHistory(
+    history: List<String>,
+    onHistorySelect: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    TvRow(
+        title = stringResource(LR.string.tv_search_recent),
+        items = history,
+        contentPadding = ContentPadding,
+        key = { it },
+        modifier = modifier,
+    ) { term ->
+        TvTile(onClick = { onHistorySelect(term) }) {
+            Text(
+                text = term,
+                style = MaterialTheme.tvTypography.body,
+                color = MaterialTheme.tvColors.textPrimary,
+                modifier = Modifier.padding(horizontal = 15.dp, vertical = 9.dp),
+            )
+        }
+    }
+}
+
+@Composable
 private fun TvSearchLoading() {
     Column(
         modifier = Modifier.fillMaxSize(),
@@ -927,28 +958,12 @@ private fun TvSearchScreenPreview() {
 
 @Preview(device = Devices.TV_1080p)
 @Composable
-private fun TvSearchIdleWithHistoryPreview() {
+private fun TvSearchHistoryPreview() {
     TvTheme {
-        Box(modifier = Modifier.fillMaxSize().background(MaterialTheme.tvColors.backgroundSunken)) {
-            TvSearchContent(
-                query = "",
-                searchState = TvSearchState.Idle,
-                filter = TvSearchFilter.TopResults,
-                hasFolderResults = false,
-                categories = emptyList(),
-                discoverRows = emptyList(),
-                onQueryChange = {},
-                onFilterSelect = {},
-                onPodcastResultClick = {},
-                onDiscoverPodcastClick = { _, _ -> },
-                onDiscoverEpisodePodcastClick = { _, _ -> },
-                onDiscoverEpisodePlay = { _, _ -> },
-                onDiscoverPlayLatestEpisode = { _, _ -> },
-                onDiscoverCategoryClick = { _, _ -> },
-                onPlayEpisode = {},
-                onOpenEpisodeActions = {},
-                onOpenFolder = {},
+        Box(modifier = Modifier.background(MaterialTheme.tvColors.backgroundSunken).padding(36.dp)) {
+            TvSearchHistory(
                 history = listOf("Freakonomics", "Business Daily", "Science Weekly"),
+                onHistorySelect = {},
             )
         }
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
@@ -518,7 +518,7 @@ private fun TvSearchDiscover(
 
         discoverRows.forEachIndexed { index, row ->
             val rowIndex = categoryOffset + index
-            item { Spacer(modifier = Modifier.height(18.dp)) }
+            item { Spacer(modifier = Modifier.height(40.dp)) }
             tvDiscoverRow(
                 row = row,
                 onPodcastClick = onDiscoverPodcastClick,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvColorScheme.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvColorScheme.kt
@@ -18,7 +18,7 @@ data class TvColorScheme(
     val backgroundSurface: Color = Color(0xFF1F2123),
     val backgroundBase: Color = Color(0xFF292B2E),
     val backgroundOverlay: Color = Color(0xFF323538),
-    val backgroundActive: Color = Color(0xFFD4D6DB),
+    val backgroundActive: Color = Color(0xFFFBFBFC),
     val backgroundActive50: Color = Color(0x80FBFBFC),
     val backgroundActive20: Color = Color(0x33FBFBFC),
     val overlayContainer: Color = backgroundSunken.copy(alpha = 0.94f),

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvShapes.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvShapes.kt
@@ -1,0 +1,6 @@
+package au.com.shiftyjelly.pocketcasts.theme
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.unit.dp
+
+val TvCardShape = RoundedCornerShape(9.dp)


### PR DESCRIPTION
## Description

Follow-ups to #5816 (TV Figma density parity), which has since merged to `main` — so this targets `main` directly. Addresses the deferred Claude-bot review comments and @geekygecko's review feedback (treated as mandatory), plus one new search-behaviour tweak. Values taken from the Pocket Casts TV Figma and the Apple TV app.

**Search — recent searches is now focus-gated (new tweak):** instead of permanently occupying vertical space in the idle body, "Recent searches" now lives in the under-field dropdown slot (Apple TV `.searchSuggestions` parity). It animates in when the search field is focused and the query is empty, swaps to autocomplete while typing, and animates out when focus moves to the pills / results / discover / top tab. Down-focus is routed into the slot so the chips are selectable.

**Review fixes:**
- Shared `TvCardShape` token across the 9dp card tiles (was redefined per file).
- Restored long-press **Go to podcast** on the Keep Listening + Up Next cards.
- Focus colour reverted to the Figma value `#FBFBFC` (was dimmed to `#D4D6DB` app-wide).
- Episode-details modal title reduced to Figma **Body** size.
- Removed the logo from **Sign In / Syncing / Signed-out** — Apple TV shows it only on Welcome.
- **Modals are now translucent** (Figma frosted look) instead of the opaque fallback the Streamer used with no cross-window blur.
- Podcast-details pane gutter (12→60dp) and search discover row gap (18→40dp) aligned to the playlist screen / home / Figma.
- Discover **banner height** increased to the Figma value (306px → 153dp) with the cover collage scaled to match.

Bot comment on `TvPlayerEffectsControls` `-64dp` offset was intentionally skipped per author.

## Testing Instructions

1. **Search** → focus the field: *Recent searches* animates in. Press down into a chip (stays visible), down again to *Browse categories* (animates out), up to the top tab (gone).
2. **Now Playing → Episode details**: the modal is translucent (player controls / title show through) and the title is body-sized.
3. **Home** → scroll to the bottom: the *Discover more* banner is taller with the cover collage + gradient.
4. **Keep Listening / Up Next** cards: long-press opens the podcast.

## Screenshots or Screencast

https://github.com/user-attachments/assets/5742d80c-5f50-4d2e-bfd3-845839843ab1




## Checklist
- [ ] If this is a user-facing change, I added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply`)
- [x] I considered whether it makes sense to add tests
- [x] All strings that need to be localized are in `strings.xml` (no new strings)
- [x] Any Jetpack Compose components I added or changed are covered by Compose previews
- [x] No new/changed analytics (no Event Horizon schema change)

