### PR TITLE
Fix referrals tooltip swallowing taps on the gift icon (PCDROID-583)

### DIFF
--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
@@ -88,6 +88,7 @@ class ProfileFragment :
             },
             onReferralsTooltipClick = {
                 referralsViewModel.onTooltipClick()
+                fragmentHostListener.showBottomSheet(ReferralsGuestPassFragment.newInstance(ReferralsPageType.Send))
             },
             onReferralsTooltipShow = {
                 referralsViewModel.onTooltipShown()

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsIconWithTooltip.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsIconWithTooltip.kt
@@ -70,6 +70,7 @@ private fun ReferralsIconWithTooltip(
                     title = stringResource(LR.string.referrals_tooltip_message, state.referralPlan.offerDurationText),
                     tipPosition = if (isLandscape) TipPosition.TopEnd else TipPosition.TopStart,
                     anchorOffset = DpOffset(0.dp, (-4).dp),
+                    clickableElevationPadding = true,
                     onClick = onTooltipClick,
                 )
             }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/Tooltip.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/Tooltip.kt
@@ -55,6 +55,7 @@ fun TooltipPopup(
     elevation: Dp = 16.dp,
     anchorOffset: DpOffset = DpOffset.Zero,
     properties: PopupProperties = PopupProperties(dismissOnClickOutside = false),
+    clickableElevationPadding: Boolean = false,
     onClick: (() -> Unit)? = null,
     onClickOutside: (() -> Unit)? = null,
 ) {
@@ -68,6 +69,17 @@ fun TooltipPopup(
     ) {
         Box(
             modifier = Modifier
+                .then(
+                    if (onClick != null && clickableElevationPadding) {
+                        Modifier.clickable(
+                            interactionSource = null,
+                            indication = null,
+                            onClick = onClick,
+                        )
+                    } else {
+                        Modifier
+                    },
+                )
                 .padding(elevationPadding)
                 .then(modifier),
         ) {


### PR DESCRIPTION
## Description

Fixes PCDROID-583 https://linear.app/a8c/issue/PCDROID-583/referrals-gift-icon-untappable-while-its-gift-2-months-tooltip-is

On the Profile screen, while the referrals "Gift 2 months of Pocket Casts Plus!" tooltip is showing, tapping the gift icon did nothing — the Guest Pass "Send" sheet only opened after the tooltip was dismissed (reproduces portrait and landscape, pre-existing on `main`).

### Root cause (verified in code)

The tooltip is a Compose `Popup` rendered via the shared `TooltipPopup` (`modules/services/compose/.../components/Tooltip.kt`). To avoid clipping the tooltip's drop shadow it wraps the tooltip in a **transparent** `elevationPadding` of `elevation * 1.5f` (~24dp), and `TooltipPositionProvider` shifts the popup window up by `elevationPx` for `TipPosition.TopStart` so the visible tooltip lands right below the anchor. The referrals caller additionally passes `anchorOffset = DpOffset(0, -4dp)`.

Net effect: the top ~28dp transparent band of the popup **window** overlays the bottom of the 48dp gift `IconButton` (the gift glyph sits inside that band). A Compose `Popup` consumes in-bounds touches, and unconsumed touches on that transparent band are **not** re-dispatched to the app window below — so they never reach the `IconButton`. On top of that, the tooltip's own `onClick` only hid the tooltip and tracked analytics; it never opened the Send sheet. So the promo tooltip blocked the very icon it promotes.

### Fix chosen and why it's the least-risky option

A hybrid of the ticket's directions #1 and #3, made **opt-in** on the shared component so other tooltip callers are byte-for-byte unchanged:

1. `TooltipPopup` gains an opt-in `clickableElevationPadding: Boolean = false`. When `true` (and `onClick != null`), the transparent elevation-padding halo becomes an active click target routed to `onClick`, using `indication = null` so no ripple appears in the empty halo. Default `false` preserves the exact current behaviour and visuals for the other two callers (`PlaylistPreviewRow`, `UpNextSortButton`) — they don't pass the flag, so they hit the identity-`Modifier` branch.
2. The referrals usage (`ReferralsIconWithTooltip`) opts in, so a tap anywhere on the gift-icon/tooltip region reaches `onClick`.
3. `ProfileFragment`'s `onReferralsTooltipClick` now also opens the Send sheet (in addition to the existing hide + `ReferralTooltipTappedEvent` tracking), so the promo tooltip performs the action it advertises.

Result: tapping the gift glyph (over the transparent halo), the visible tooltip, or the icon's still-exposed top all open the Send sheet — no need to dismiss the tooltip first.

Why not the alternatives:
- **Repositioning the popup so it no longer overlaps the anchor (direction #2)** would move the visible tooltip and/or clip the top drop-shadow, a visible change for referrals, and any change to the shared position provider risks regressing the other callers.
- **A pure referrals-only change with no shared edit (direction #3 alone)** cannot fix tapping the actual gift glyph: that glyph sits under the transparent halo, which is only part of the shared popup, so its taps stay swallowed. A shared change is unavoidable; making it opt-in keeps it safe.
- **Making the padding pass touches through to the icon (direction #1 literally)** is not achievable with a standard Compose `Popup`: in-bounds touches a `Popup` doesn't consume are dropped, not delivered to the window below. Routing the halo taps to `onClick` is the realizable form of "the padding is no longer a dead zone".

### Regression review of the other `TooltipPopup` callers
- `modules/features/filters/.../PlaylistPreviewRow.kt` (premade + rearrange tooltips) — no `clickableElevationPadding` passed → unchanged.
- `modules/features/player/.../UpNextSortButton.kt` (sort tooltip) — no `clickableElevationPadding` passed → unchanged.

## Testing Instructions

Prerequisite: signed in with a **Plus/Patron** account that is eligible for referrals (so the gift icon + "Gift … of Pocket Casts Plus!" tooltip appear on Profile), and the referrals tooltip not yet dismissed.

1. Open the Profile tab; confirm the gift icon (top-right) shows the referrals tooltip.
2. Tap directly on the gift icon while the tooltip is showing.
3. Expected: the Guest Pass "Send" sheet opens immediately (previously nothing happened until the tooltip was dismissed).
4. Repeat in landscape orientation (`TipPosition.TopEnd`) — same result.
5. Tapping the tooltip body itself also opens the Send sheet.

Regression checks:
6. Filters/Playlists list: premade + rearrange tooltips still appear and dismiss on tap as before.
7. Player → Up Next: the sort-duration tooltip still appears and dismisses on tap as before.

Before/after screen recordings will be attached to this PR separately.

## Screenshots or screencasts

https://github.com/user-attachments/assets/8a967bdf-68f4-40e1-b5f2-4d595f565350



## Checklist

- [ ] If this is a user-facing change, I added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` for automatic formatting/linting)
- [x] I considered whether it makes sense to add tests for the changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml` (no new strings)
- [x] Any jetpack compose components I added or changed are covered by compose previews (existing previews unchanged; the new flag defaults off)
- [x] I updated (or requested) the Event Horizon schema for any new/changed analytics (no analytics changes; existing `ReferralTooltipTappedEvent` still fires on tooltip tap)

