### PR TITLE
Fix transcript search close exiting the transcript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 8.21
 -----
+*   Bug Fixes
+    *   Closing the transcript search bar now keeps the transcript open at the same scroll position instead of exiting the transcript
+        ([#5835](https://github.com/Automattic/pocket-casts-android/pull/5835))
 
 8.20
 -----

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -251,6 +251,7 @@ class PlayerHeaderFragment :
                     TranscriptContent(
                         state = transcriptUiState,
                         isVisible = transitionData.isTranscriptOpen,
+                        isPlayerOpen = isPlayerOpen,
                         isPortraitPlayer = isPortraitPlayer,
                         modifier = Modifier
                             .fillMaxWidth(fraction = maxWidthFraction)
@@ -1005,6 +1006,7 @@ class PlayerHeaderFragment :
     private fun TranscriptContent(
         state: TranscriptsUiState,
         isVisible: Boolean,
+        isPlayerOpen: Boolean,
         isPortraitPlayer: Boolean,
         modifier: Modifier = Modifier,
     ) {
@@ -1034,6 +1036,7 @@ class PlayerHeaderFragment :
                 onSelectNextSearch = transcriptViewModel::selectNextSearchMatch,
                 onShowSearchBar = transcriptViewModel::openSearch,
                 onHideSearchBar = transcriptViewModel::hideSearch,
+                isBackHandlerEnabled = isPlayerOpen,
                 onClickSubscribe = {
                     transcriptViewModel.track { source, podcastUuid, episodeUuid ->
                         TranscriptGeneratedPaywallSubscribeTappedEvent(

--- a/modules/features/transcripts/build.gradle.kts
+++ b/modules/features/transcripts/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
     implementation(platform(libs.compose.bom))
 
     implementation(libs.androidx.webkit)
+    implementation(libs.compose.activity)
     implementation(libs.compose.material)
     implementation(libs.compose.material.icons.core)
     implementation(libs.compose.foundation)

--- a/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptPage.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptPage.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.transcripts.ui
 
 import android.os.SystemClock
 import android.widget.Toast
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.interaction.DragInteraction
 import androidx.compose.foundation.layout.Box
@@ -211,6 +212,10 @@ fun TranscriptPage(
                     .padding(start = 16.dp, end = 16.dp, bottom = debugBottomPadding),
             )
         }
+    }
+
+    BackHandler(enabled = isSearching) {
+        onHideSearchBar()
     }
 
     ScrollToItemEffect(

--- a/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptPage.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptPage.kt
@@ -72,6 +72,7 @@ fun TranscriptPage(
     transcriptPadding: PaddingValues = PaddingValues(0.dp),
     paywallPadding: PaddingValues = PaddingValues(0.dp),
     showCloseButton: Boolean = true,
+    isBackHandlerEnabled: Boolean = true,
     toolbarTrailingContent: (@Composable (ToolbarColors) -> Unit)? = null,
     onHighlightText: (() -> Unit)? = null,
 ) {
@@ -214,7 +215,7 @@ fun TranscriptPage(
         }
     }
 
-    BackHandler(enabled = isSearching) {
+    BackHandler(enabled = isSearching && isBackHandlerEnabled) {
         onHideSearchBar()
     }
 


### PR DESCRIPTION
## Description

When viewing an episode transcript and using the in-transcript search, pressing the system back button to dismiss the search bar exited the transcript entirely (in Now Playing it returned all the way out to the audio player), losing the reader's scroll position. This is especially painful for Plus users who use transcript search to find their place in episodes that aren't fingerprinted, since there's no auto-highlight to return to.

**Root cause:** The shared `TranscriptPage` component had no back handling of its own, so a back press while the search bar was open fell straight through to each host's default back behaviour, which closes/dismisses the transcript:
- **Now Playing** (`PlayerHeaderFragment` inside `PlayerContainerFragment`): back was handled by `PlayerContainerFragment.onBackPressed()`, whose `isTranscriptVisible` branch calls `shelfSharedViewModel.closeTranscript()` — closing the whole transcript overlay.
- **Episode details** (`TranscriptFragment`, a `BottomSheetDialogFragment`, and the embedded transcript tab in `EpisodeFragment`): back dismissed the dialog.

In every case the search bar's own close/hide handler (`onHideSearchBar` → `TranscriptViewModel.hideSearch()`) already does the right thing — it only resets the search state — but the system back press never reached it.

**The fix:** Add a single `BackHandler(enabled = isSearching) { onHideSearchBar() }` inside the shared `TranscriptPage`. When the search bar is open, back now closes only the search bar and leaves the transcript on screen. Because `TranscriptPage` stays composed, its `rememberLazyListState()` is retained, so the scroll position is preserved. When the search bar is not open, the handler is disabled and each host's existing back behaviour (close transcript / dismiss dialog) is unchanged.

This one shared change fixes all three hosts (Now Playing, the episode-details transcript dialog, and the episode-details embedded transcript tab) because they all render `TranscriptPage`. It reuses the existing `isSearching` state and `onHideSearchBar` handler rather than adding new plumbing. A small `activity-compose` dependency was added to the transcripts module for `BackHandler`.

Fixes PCDROID-643 https://linear.app/a8c/issue/PCDROID-643/closing-the-transcript-search-bar-exits-the-transcript-and-returns-to

## Testing Instructions

Prerequisites: a **Plus** account and an episode that **has a transcript** (ideally one that is not fingerprinted, so there is no auto-highlight).

Now Playing host:
1. Play an episode that has a transcript and open the full player (Now Playing).
2. Open the transcript, then tap the search icon to open the in-transcript search bar.
3. Type a query and scroll / jump to a match so you have a distinct scroll position.
4. Press the system back button.
5. Expected: the search bar closes and you remain in the transcript at the same scroll position. Only a second back press closes the transcript. Before this fix, the transcript closed immediately and returned you to the audio player.

Episode details host:
1. Open an episode's details, tap the transcript card to open the transcript.
2. Open search, type a query, scroll to a match.
3. Press back.
4. Expected: the search bar closes and the transcript stays open at the same scroll position (the transcript dialog is not dismissed).

Regression checks:
- With the search bar closed, back closes the transcript / dismisses the dialog exactly as before.

Before/after screen recordings will be attached to this PR separately.

## Screenshots or Screencast

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/5298e5a5-787f-4e97-b693-1489ea2a6fb9" /> | <video src="https://github.com/user-attachments/assets/d28d6879-5634-4939-ae5e-74ac182859d7" /> |



## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

