### PR TITLE
Apply the Sentry Gradle plugin to the tv module (on #5708)

### DIFF
--- a/.configure
+++ b/.configure
@@ -1,7 +1,7 @@
 {
   "project_name": "pocketcasts-android",
   "branch": "trunk",
-  "pinned_hash": "789d0d6ec3d5e23886ca25d767fb63452082412c",
+  "pinned_hash": "1e17440ffb52c59087b22337fccfcfcdb8b4aa8f",
   "files_to_copy": [
     {
       "file": "android/pocket-casts/secret.properties",

--- a/tv/build.gradle.kts
+++ b/tv/build.gradle.kts
@@ -2,8 +2,13 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
+    alias(libs.plugins.sentry)
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.google.services)
+}
+
+sentry {
+    projectName = "pocket-casts-tv"
 }
 
 android {


### PR DESCRIPTION
## Description

Same change as #5840 — apply the Sentry Gradle plugin to `tv`, which is the only app module that never has, leaving the Android TV app's crashes unsymbolicated — but built on top of #5708 instead of `main`.

There the Sentry project slugs are inlined as the public identifiers they are, so `tv` follows suit with `projectName = "pocket-casts-tv"` and needs no `mobile-secrets` entry for the slug at all. The DSN stays a secret, as it does for every other module on that branch.

**Do not merge this and #5840.** They are the same change in the two worlds; whichever base lands first, close the other. This one exists so that the TV work isn't held hostage to #5708's review, and #5708 isn't held hostage to the TV beta.

## Gotchas

Stacked on `ainfra-2790-remove-sentryproperties-in-favor-of-public-values-and-env`, so the diff against `main` will show #5708's changes too until that merges. Review only the `tv/build.gradle.kts` commit.

`sentryTvDsn` still needs a `mobile-secrets` entry, and still needs #5682's `IS_TV_BUILD` to take effect at release time. Neither blocks this.

## Testing Instructions

`./gradlew :tv:tasks --all | grep -i sentry` lists the same Sentry tasks as `:wear:tasks --all`. `./gradlew spotlessCheck` passes.
