### PR TITLE
Fix background OOM kills by pausing player recomposition when backgrounded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 8.21
 -----
+*   Bug Fixes
+    *   Prevent the app from being killed in the background on low-memory devices by pausing player UI updates while playing
+        ([#5843](https://github.com/Automattic/pocket-casts-android/pull/5843))
 
 8.20
 -----

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ChapterProgressBar.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ChapterProgressBar.kt
@@ -21,9 +21,10 @@ class ChapterProgressBar @JvmOverloads constructor(
 
     var progress: Float = 0.0f
         set(value) {
+            if (field == value) return
             field = value
             progressDrawRect = RectF(0f, 0f, backgroundDrawRect.right * progress, backgroundDrawRect.bottom)
-            invalidate()
+            if (isAttachedToWindow && isShown) invalidate()
         }
 
     val cornerRadius = 8.dpToPx(context).toFloat()

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ChapterProgressBar.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ChapterProgressBar.kt
@@ -24,7 +24,7 @@ class ChapterProgressBar @JvmOverloads constructor(
             if (field == value) return
             field = value
             progressDrawRect = RectF(0f, 0f, backgroundDrawRect.right * progress, backgroundDrawRect.bottom)
-            if (isAttachedToWindow && isShown) invalidate()
+            invalidate()
         }
 
     val cornerRadius = 8.dpToPx(context).toFloat()

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -76,6 +76,7 @@ import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.asFlow
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import au.com.shiftyjelly.pocketcasts.ads.AdReportFragment
@@ -223,15 +224,16 @@ class PlayerHeaderFragment :
         val isPortraitPlayer = isPortraitConfiguration || windowSize.isAtLeastMediumHeight()
         val maxWidthFraction = if (isPortraitConfiguration && windowSize.isAtLeastMediumWidth()) 0.8f else 1f
 
-        val podcastColors by remember { podcastColorsFlow() }.collectAsState(PodcastColors.ForUserEpisode)
-        val headerData by remember { playerHeaderFlow() }.collectAsState(PlayerViewModel.PlayerHeader())
+        val podcastColors by remember { podcastColorsFlow() }.collectAsStateWithLifecycle(PodcastColors.ForUserEpisode)
+        val headerData by remember { playerHeaderFlow() }.collectAsStateWithLifecycle(PlayerViewModel.PlayerHeader())
+        // Not lifecycle-gated: carries the video Player/surface and re-emitting it on resume can freeze the frame.
         val artworkOrVideoState by remember { playerVisualsStateFlow() }.collectAsState(ArtworkOrVideoState.NoContent)
-        val activeAd by viewModel.activeAd.collectAsState()
-        val playbackNotice by viewModel.playbackNotice.collectAsState()
+        val activeAd by viewModel.activeAd.collectAsStateWithLifecycle()
+        val playbackNotice by viewModel.playbackNotice.collectAsStateWithLifecycle()
 
-        val isPlayerOpen by isPlayerOpenFlow().collectAsState(false)
-        val isTranscriptOpen by shelfSharedViewModel.isTranscriptOpen.collectAsState()
-        val transcriptUiState by transcriptViewModel.uiState.collectAsState()
+        val isPlayerOpen by isPlayerOpenFlow().collectAsStateWithLifecycle(false)
+        val isTranscriptOpen by shelfSharedViewModel.isTranscriptOpen.collectAsStateWithLifecycle()
+        val transcriptUiState by transcriptViewModel.uiState.collectAsStateWithLifecycle()
 
         val transitionData = updateTranscriptTransitionData(
             isTranscriptOpen = isTranscriptOpen,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -231,7 +231,7 @@ class PlayerHeaderFragment :
         val activeAd by viewModel.activeAd.collectAsStateWithLifecycle()
         val playbackNotice by viewModel.playbackNotice.collectAsStateWithLifecycle()
 
-        val isPlayerOpen by isPlayerOpenFlow().collectAsStateWithLifecycle(false)
+        val isPlayerOpen by remember { isPlayerOpenFlow() }.collectAsStateWithLifecycle(false)
         val isTranscriptOpen by shelfSharedViewModel.isTranscriptOpen.collectAsStateWithLifecycle()
         val transcriptUiState by transcriptViewModel.uiState.collectAsStateWithLifecycle()
 
@@ -637,6 +637,7 @@ class PlayerHeaderFragment :
             override fun onSlide(bottomSheet: View, slideOffset: Float) = Unit
         }
         val hostListener = (requireActivity() as FragmentHostListener)
+        send(hostListener.getPlayerBottomSheetState() == BottomSheetBehavior.STATE_EXPANDED)
         hostListener.addPlayerBottomSheetCallback(callback)
         awaitClose {
             hostListener.removePlayerBottomSheetCallback(callback)


### PR DESCRIPTION
## Description

On low-memory devices (the reporter's Nokia G42, 4 GB RAM, Android 15) Pocket Casts is frequently OOM-killed while backgrounded during playback. The reporter supplied a Perfetto analysis: while an episode plays, `PlaybackManager` pushes a `PlaybackState` roughly once per second. The full player header (`PlayerHeaderFragment`) collects that state with `collectAsState()`, which is **not** lifecycle-aware, so the header keeps recomposing ~1×/sec even after the app is backgrounded. That keeps the process doing UI work, so Android's process-state heuristic weighs it as if it were foreground — and on a 4 GB device it loses the comparison to the actually-visible app and gets killed.

This PR stops the player header from doing UI work while backgrounded.

**Changes**
- `PlayerHeaderFragment`: switch the header's state collectors from `collectAsState()` to `collectAsStateWithLifecycle()`, so collection (and the recomposition it triggers) pauses below `STARTED`. The 1 Hz `playerHeaderFlow()` driving the seek bar is the one that actually matters; the rest are converted for consistency.
  - The `playerVisualsStateFlow()` collector is intentionally left as `collectAsState()` (with a code comment): it carries the video `Player`/surface, it is already `distinctUntilChanged` (not a 1 Hz source, so no benefit to gating it), and re-emitting it on resume risks freezing the video frame.
- `ChapterProgressBar`: guard the `progress` setter with an early return when the value is unchanged, and only `invalidate()` when the view is actually attached and shown. Defensive — its writer is already lifecycle-gated, but it avoids redundant/offscreen invalidations.

Not converting `EpisodeTitles` / `PlayerControls` is deliberate: they read the same 1 Hz state via `LiveData.observeAsState()`, and `LiveData` only dispatches to `STARTED` observers, so they already pause when backgrounded.

Fixes #5317
Linear: PCDROID-567 https://linear.app/a8c/issue/PCDROID-567/pocketcasts-keeps-ooming-due-to-background-bitmap-processing

## Testing Instructions

There is **no visible UI change** — this is a background-work fix. To verify the mechanism with `atrace`:

1. Play any episode and open the full-screen player.
2. `adb shell atrace --async_start -a au.com.shiftyjelly.pocketcasts.debug view` then press Home (audio keeps playing).
3. After ~10 s, `adb shell atrace --async_stop > trace.txt` and count `Compose:recompose` slices owned by the app process.
4. On `main` the player recomposes ~1×/sec while backgrounded; with this PR it drops to **0**.

Measured on a 2 GB Android 16 emulator, full player open + audio playing, 10 s backgrounded (3 runs each):

| Build | Compose recompositions while backgrounded (10 s) |
|-------|--------------------------------------------------|
| `main` (before) | 10, 11, 11 |
| this PR (after) | **0, 0, 0** |

Also verified: normal playback, seek bar/time updates, chapter progress, transcript open/close, and return-from-background all behave the same; video playback unaffected (the video surface collector was intentionally left ungated).

## Screenshots or Screencast

No visual change

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) the Event Horizon schema to reflect any new or changed analytics.

#### I have tested any UI changes...
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack