### PR TITLE
[TV] Keep episode row width constant when focused to stop layout jumps

### DIFF
--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeListItem.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeListItem.kt
@@ -79,7 +79,7 @@ private fun MoreButtonSlot(
         contentAlignment = Alignment.Center,
         modifier = Modifier
             .padding(start = 12.dp)
-            .size(36.dp),
+            .size(TvMoreButtonSize),
     ) {
         AnimatedVisibility(
             visible = visible,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeListItem.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeListItem.kt
@@ -2,16 +2,13 @@ package au.com.shiftyjelly.pocketcasts.component
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
-import androidx.compose.animation.expandHorizontally
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.animation.shrinkHorizontally
-import androidx.compose.animation.slideInHorizontally
-import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -66,19 +63,30 @@ fun TvEpisodeListItemContainer(
             .onFocusChanged { isItemFocused = it.hasFocus },
     ) {
         content(Modifier.weight(1f))
-        AnimatedVisibility(
+        MoreButtonSlot(
             visible = isItemFocused,
-            enter = expandHorizontally(tween(MORE_BUTTON_ANIMATION_DURATION_MS), expandFrom = Alignment.Start) +
-                slideInHorizontally(tween(MORE_BUTTON_ANIMATION_DURATION_MS), initialOffsetX = { it }) +
-                fadeIn(tween(MORE_BUTTON_ANIMATION_DURATION_MS)),
-            exit = shrinkHorizontally(tween(MORE_BUTTON_ANIMATION_DURATION_MS), shrinkTowards = Alignment.Start) +
-                slideOutHorizontally(tween(MORE_BUTTON_ANIMATION_DURATION_MS), targetOffsetX = { it }) +
-                fadeOut(tween(MORE_BUTTON_ANIMATION_DURATION_MS)),
+            onClick = onOpenActions,
+        )
+    }
+}
+
+@Composable
+private fun MoreButtonSlot(
+    visible: Boolean,
+    onClick: () -> Unit,
+) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier
+            .padding(start = 12.dp)
+            .size(36.dp),
+    ) {
+        AnimatedVisibility(
+            visible = visible,
+            enter = fadeIn(tween(MORE_BUTTON_ANIMATION_DURATION_MS)),
+            exit = fadeOut(tween(MORE_BUTTON_ANIMATION_DURATION_MS)),
         ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Spacer(Modifier.width(12.dp))
-                TvMoreButton(onClick = onOpenActions)
-            }
+            TvMoreButton(onClick = onClick)
         }
     }
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvMoreButton.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvMoreButton.kt
@@ -20,7 +20,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 fun TvMoreButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    buttonSize: Dp = 36.dp,
+    buttonSize: Dp = TvMoreButtonSize,
     iconSize: Dp = 15.dp,
     colors: ButtonColors = TvButtonDefaults.iconButtonColors(),
 ) {
@@ -36,6 +36,8 @@ fun TvMoreButton(
         )
     }
 }
+
+val TvMoreButtonSize = 36.dp
 
 @Preview
 @Composable


### PR DESCRIPTION
## Description
Episode rows changed width when focused because the more-options button expanded into the row, shrinking the title area. Long titles re-wrapped (sometimes 1 line -> 2 lines), so the row height changed and everything below it jumped.

The more-button slot is now permanently reserved next to every row and the button simply fades in/out on focus, mirroring the tvOS fix (titles are slightly shorter, but never change with focus).

This applies to all episode lists sharing `TvEpisodeListItemContainer`: podcast details, playlist details, listening history, starred and Up Next.

Fixes POC-881 https://linear.app/a8c/issue/POC-881/fix-episode-row-height-jump

## Testing Instructions
1. Open a podcast with long episode titles (e.g. Timcast IRL) on a TV device
2. Move focus up/down the episode list
3. Titles keep the exact same wrap in focused and unfocused states; rows never change height and the list does not jump
4. Press right from a row: the fading more-button still receives focus and opens the actions modal

## Screenshots or Screencast

https://github.com/user-attachments/assets/c7f89ff2-00bf-40dd-a5a8-3df457856eb8



## Checklist
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] Any jetpack compose components I added or changed are covered by compose previews