### PR TITLE
Fix Android 8 full-player crash from show-notes WebView by blocking remote content on in-process renderers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 *   Bug Fixes
     *   Closing the transcript search bar now keeps the transcript open at the same scroll position instead of exiting the transcript
         ([#5835](https://github.com/Automattic/pocket-casts-android/pull/5835))
+    *   Fix a crash on Android 8 devices when the full-screen player loaded show notes containing remote images
+        ([#5847](https://github.com/Automattic/pocket-casts-android/pull/5847))
 
 8.20
 -----

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/NotesFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/NotesFragment.kt
@@ -23,6 +23,7 @@ import au.com.shiftyjelly.pocketcasts.servers.shownotes.ShowNotesState
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
 import au.com.shiftyjelly.pocketcasts.utils.extensions.toSecondsFromColonFormattedString
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
+import au.com.shiftyjelly.pocketcasts.views.extensions.blockRemoteContentOnInProcessRenderer
 import au.com.shiftyjelly.pocketcasts.views.extensions.cleanup
 import au.com.shiftyjelly.pocketcasts.views.extensions.copyLinkOnLongPress
 import au.com.shiftyjelly.pocketcasts.views.extensions.show
@@ -120,6 +121,7 @@ class NotesFragment : BaseFragment() {
                 settings.javaScriptCanOpenWindowsAutomatically = false
                 settings.javaScriptEnabled = false
                 settings.loadsImagesAutomatically = true
+                blockRemoteContentOnInProcessRenderer()
                 isScrollbarFadingEnabled = false
                 isVerticalScrollBarEnabled = false
                 // stop the web view jumping after loading

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -151,6 +151,7 @@ import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.utils.parceler.DurationParceler
 import au.com.shiftyjelly.pocketcasts.views.dialog.OptionsDialog
+import au.com.shiftyjelly.pocketcasts.views.extensions.blockRemoteContentOnInProcessRenderer
 import au.com.shiftyjelly.pocketcasts.views.extensions.cleanup
 import au.com.shiftyjelly.pocketcasts.views.extensions.copyLinkOnLongPress
 import au.com.shiftyjelly.pocketcasts.views.extensions.hide
@@ -1336,6 +1337,7 @@ class EpisodeFragment : BaseFragment() {
                         javaScriptEnabled = false
                         loadsImagesAutomatically = true
                     }
+                    blockRemoteContentOnInProcessRenderer()
                     // stopping the white flash on web player load
                     setBackgroundColor(Color.argb(1, 0, 0, 0))
                     isVerticalScrollBarEnabled = false

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/extensions/WebView.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/extensions/WebView.kt
@@ -1,5 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.views.extensions
 
+import android.app.ActivityManager
+import android.content.Context
+import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.view.ViewGroup
@@ -46,6 +49,16 @@ internal fun webViewLinkUrl(
         else -> null
     }
     return url?.takeIf(String::isNotBlank)
+}
+
+fun WebView.blockRemoteContentOnInProcessRenderer() {
+    val activityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
+    val rendererLikelyInProcess = activityManager?.isLowRamDevice == true ||
+        Build.VERSION.SDK_INT <= Build.VERSION_CODES.O_MR1
+    if (rendererLikelyInProcess) {
+        settings.blockNetworkLoads = true
+        settings.loadsImagesAutomatically = false
+    }
 }
 
 @Suppress("DEPRECATION")


### PR DESCRIPTION
## Description

Fixes PCDROID-657 https://linear.app/a8c/issue/PCDROID-657/android-8-full-screen-player-crashes-20s-into-playback-for-episodes

It's been reported that on Android 8 tablets the app closes ~20s into playback whenever the full-screen player is open for an episode **without** a transcript.


### Root cause
The full-screen player renders episode **show notes** in a raw `android.webkit.WebView` (`NotesFragment`). With `blockNetworkLoads = false` + `loadsImagesAutomatically = true`, the WebView downloads and decodes the show-notes' **remote images** at native resolution. On an old, un-updatable Android 8 System WebView the renderer runs **in-process**, so that heavy decode (concurrent with the media decoder) triggers a native OOM/SIGSEGV that takes down the **whole app** ~20s in.

The existing `onRenderProcessGone` handlers only recover an **out-of-process** (sandboxed) renderer — they can't catch an in-process native crash, so the app dies. On modern Android the renderer is out-of-process and simply recovers, which is why this never reproduces on the reporter's Android 17 phone. The "only when there is no transcript" pattern is a **content correlation** (transcript-bearing shows tend to have lighter, less image-heavy notes), not a code path — the notes WebView is created identically either way.

### Fix
Add a small `WebView` extension `blockRemoteContentOnInProcessRenderer()` that, on devices whose renderer is likely in-process, sets `blockNetworkLoads = true` + `loadsImagesAutomatically = false` so the show-notes WebView never performs the heavy remote-image decode. It is called from the two WebViews that render show-notes HTML: `NotesFragment` (player) and `EpisodeFragment` (episode detail).

- **Notes still render.** The notes HTML is loaded inline via `loadDataWithBaseURL("file:///android_asset/", …)`, the CSS is inlined by `ShowNotesFormatter`, and the Roboto fonts resolve against the `file:///android_asset/` base URL. `blockNetworkLoads` blocks **http/https only, never `file://`** — so text, styling, fonts, and tappable/`playerJumpTo` links all keep working. Only remote images are suppressed (empty placeholders).
- **Gate = `ActivityManager.isLowRamDevice()` OR `SDK_INT <= O_MR1`.** The accurate signal for an in-process renderer is `isLowRamDevice()` — the out-of-process renderer is disabled on low-RAM devices regardless of OS version. The `SDK_INT <= 27` term is a coarse safety net guaranteeing coverage of the reported "Android 8" OS even if a cheap tablet under-reports low-RAM. On modern (non-low-RAM, API ≥ 28) devices the extension is a **true no-op**.

### Out of scope (noted, deliberately not touched)
Two other in-process WebViews exist but are unrelated to this crash and must not be network-blocked: `TranscriptWebView` (the *with-transcript* population, which per the report does **not** crash) and `PlaybackIssuesBottomSheetFragment` (a JS help page that needs network).

## Testing Instructions

1. On an Android 8.x device/emulator, subscribe to **"Off/On – der Podcast von netzpolitik.org"** (a no-transcript feed) and start playing an episode.
2. Open the full-screen player and its **Details** (show-notes) tab; leave it playing ~30s.
3. Verify the app does **not** crash and the show-notes text/links still render (remote images are simply absent on the affected device class).
4. On a modern device (API ≥ 28, non-low-RAM) verify show-notes images still load as before (no behavior change).

### Verification done
- Reproduced the exact environment on an **Android 8.1 (API 27)** emulator (WebView 61): fresh install, off/on feed, full player, Details tab.
- With the fix installed, the gate is active (`SDK 27 ≤ O_MR1`) and the Details/Notes tab renders correctly with **no crash** and **no `onRenderProcessGone`** in logcat.
- **Caveat:** a faithful whole-app-crash could not be forced on available emulators because their WebView keeps the renderer **out-of-process** (`dumpsys webviewupdate` → `Multiprocess enabled: true`) and recovers — the same reason modern devices don't crash. The crash requires the reporter's old **in-process** WebView. Correctness of the mitigation is established by the root-cause analysis + two independent reviews; on-device testing confirms **no rendering regression** on the affected device class.

## Screenshots or Screencast


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) the Event Horizon schema to reflect any new or changed analytics.

#### I have tested any UI changes...
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
