### PR TITLE
[TV] Exaggerate active podcast focus effect

### DIFF
--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvFolderCard.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvFolderCard.kt
@@ -46,6 +46,8 @@ fun TvFolderCard(
             containerColor = folderColor,
             focusedContainerColor = folderColor,
         ),
+        scale = tvFocusedCoverScale(),
+        glow = tvFocusedCoverGlow(),
         modifier = modifier,
     ) {
         BoxWithConstraints(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastGridScaffold.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastGridScaffold.kt
@@ -74,8 +74,8 @@ internal fun TvPodcastGridScaffold(
         LazyVerticalGrid(
             state = gridState,
             columns = GridCells.Fixed(GRID_COLUMNS),
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
             contentPadding = PaddingValues(start = horizontalContentPadding, top = 20.dp, end = horizontalContentPadding, bottom = 32.dp),
             modifier = Modifier
                 .focusRequester(gridFocusRequester)

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastGridScaffold.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastGridScaffold.kt
@@ -74,8 +74,8 @@ internal fun TvPodcastGridScaffold(
         LazyVerticalGrid(
             state = gridState,
             columns = GridCells.Fixed(GRID_COLUMNS),
-            horizontalArrangement = Arrangement.spacedBy(16.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(TvTileSpacing),
+            verticalArrangement = Arrangement.spacedBy(TvTileSpacing),
             contentPadding = PaddingValues(start = horizontalContentPadding, top = 20.dp, end = horizontalContentPadding, bottom = 32.dp),
             modifier = Modifier
                 .focusRequester(gridFocusRequester)

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastTile.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastTile.kt
@@ -9,11 +9,14 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.tv.material3.CardDefaults
+import androidx.tv.material3.Glow
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.theme.TvTheme
@@ -34,6 +37,10 @@ fun TvPodcastTile(
     TvTile(
         onClick = onClick,
         modifier = modifier,
+        scale = CardDefaults.scale(focusedScale = TvFocusedPodcastScale),
+        glow = CardDefaults.glow(
+            focusedGlow = Glow(elevationColor = Color.Black, elevation = 16.dp),
+        ),
     ) {
         if (isSponsored) {
             Column(horizontalAlignment = Alignment.CenterHorizontally) {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastTile.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastTile.kt
@@ -9,14 +9,11 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.tv.material3.CardDefaults
-import androidx.tv.material3.Glow
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.theme.TvTheme
@@ -37,10 +34,8 @@ fun TvPodcastTile(
     TvTile(
         onClick = onClick,
         modifier = modifier,
-        scale = CardDefaults.scale(focusedScale = TvFocusedPodcastScale),
-        glow = CardDefaults.glow(
-            focusedGlow = Glow(elevationColor = Color.Black, elevation = 16.dp),
-        ),
+        scale = tvFocusedCoverScale(),
+        glow = tvFocusedCoverGlow(),
     ) {
         if (isSponsored) {
             Column(horizontalAlignment = Alignment.CenterHorizontally) {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvRow.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvRow.kt
@@ -68,7 +68,7 @@ fun <T> TvRow(
     items: List<T>,
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues = PaddingValues(horizontal = 42.dp),
-    itemSpacing: Dp = 12.dp,
+    itemSpacing: Dp = TvTileSpacing,
     key: ((T) -> Any)? = null,
     focusRequester: FocusRequester? = null,
     content: @Composable (T) -> Unit,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvTile.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvTile.kt
@@ -27,6 +27,7 @@ import au.com.shiftyjelly.pocketcasts.theme.TvTheme
 import au.com.shiftyjelly.pocketcasts.theme.tvColors
 
 val TvFocusedCardScale = 1.05f
+val TvFocusedPodcastScale = 1.12f
 val TvFocusedWideCardScale = 1.02f
 
 @Composable

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvTile.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvTile.kt
@@ -21,6 +21,7 @@ import androidx.tv.material3.CardDefaults
 import androidx.tv.material3.CardGlow
 import androidx.tv.material3.CardScale
 import androidx.tv.material3.CardShape
+import androidx.tv.material3.Glow
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.theme.TvTheme
@@ -29,6 +30,13 @@ import au.com.shiftyjelly.pocketcasts.theme.tvColors
 val TvFocusedCardScale = 1.05f
 val TvFocusedPodcastScale = 1.12f
 val TvFocusedWideCardScale = 1.02f
+val TvTileSpacing = 20.dp
+
+fun tvFocusedCoverScale(): CardScale = CardDefaults.scale(focusedScale = TvFocusedPodcastScale)
+
+fun tvFocusedCoverGlow(): CardGlow = CardDefaults.glow(
+    focusedGlow = Glow(elevationColor = Color.Black, elevation = 16.dp),
+)
 
 @Composable
 fun TvTile(


### PR DESCRIPTION
## Description

Fixes POC-884 https://linear.app/a8c/issue/POC-884/exaggerate-active-podcast-effect

The focused/active podcast tile was hard to distinguish — the focus scale had been dialled back to `1.05`, which is barely perceptible on a grid of square covers.

Changes (scoped to the square podcast artwork, `TvPodcastTile`, used in every podcast grid and row):
- Focus scale `1.05` → **`1.12`** via a dedicated `TvFocusedPodcastScale` (the shared `TvFocusedCardScale` is left at `1.05` so the wide banner/playlist/video cards are unaffected).
- Added a focused **lift shadow** (`Glow(elevationColor = Black, elevation = 16.dp)`) so the active cover pops off the grid — the closest analog to the tvOS focus highlight.
- Widened the podcast grid spacing `12dp` → **`16dp`** so the larger focused cover has room and never overlaps its neighbours.

## Testing Instructions

1. Open **Your Podcasts** (or any podcast grid/row — Home, Search results, a folder).
2. Move focus between covers.
3. The active cover should now clearly scale up and lift above its neighbours, with no overlap.

## Screenshots or Screencast
<img width="1920" height="1080" alt="p884_scoped_focused" src="https://github.com/user-attachments/assets/f8d03f95-64a9-4e18-b843-8b004cda4709" />



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews

#### I have tested any UI changes...
- [x] with different themes <!-- TV is dark-only -->
