### PR TITLE
Fix new-episode notifications overwriting earlier unread ones (unique per-episode tag)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 *   Bug Fixes
     *   Closing the transcript search bar now keeps the transcript open at the same scroll position instead of exiting the transcript
         ([#5835](https://github.com/Automattic/pocket-casts-android/pull/5835))
+    *   New-episode notifications no longer replace earlier unread ones; notifications for episodes that arrive over time now stack
+        ([#5850](https://github.com/Automattic/pocket-casts-android/pull/5850))
 
 8.20
 -----

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
@@ -493,11 +493,7 @@ class RefreshPodcastsThread(
             }
             intentId += 1
 
-            val notificationTag = if (isGroupNotification) {
-                NotificationBroadcastReceiver.NOTIFICATION_TAG_NEW_EPISODES_PREFIX + episode.uuid
-            } else {
-                NotificationBroadcastReceiver.NOTIFICATION_TAG_NEW_EPISODES_PRIMARY
-            }
+            val notificationTag = NotificationBroadcastReceiver.NOTIFICATION_TAG_NEW_EPISODES_PREFIX + episode.uuid
 
             val userActions = settings.newEpisodeNotificationActions.value
 


### PR DESCRIPTION
## Description

Fixes PCDROID-691 https://linear.app/a8c/issue/PCDROID-691/new-episode-notifications-replace-earlier-unread-ones-across-refreshes

### Root cause
In `RefreshPodcastsThread.updateNotifications()`, the grouping decision is made **per refresh batch**: `isGroup = notificationsEpisodeAndPodcast.size > 1`. When a refresh yields a **single** new episode, `showEpisodeNotification()` posted it under a **constant** tag `NOTIFICATION_TAG_NEW_EPISODES_PRIMARY` (id `NOTIFICATION_ID = 541251`), whereas the multi-episode path already used a unique `NOTIFICATION_TAG_NEW_EPISODES_PREFIX + episode.uuid` tag per child.

Because `updateNotifications()` advances the "last seen" timestamp up front and the DAO only returns episodes added since the previous refresh, episodes that arrive **one-at-a-time across separate refresh cycles** each re-post to that same `(PRIMARY, 541251)` slot — Android treats each as an *update* and replaces the previous unread one, which is never re-queried and so is lost. (The summary also posts to `(PRIMARY, 541251)`, so a lone-episode refresh could even clobber a batch summary.)

### Fix
Give **every** new-episode notification the unique per-episode tag the group path already uses:

```kotlin
val notificationTag = NotificationBroadcastReceiver.NOTIFICATION_TAG_NEW_EPISODES_PREFIX + episode.uuid
```

Each episode notification now occupies its own `(PREFIX+uuid, 541251)` slot, so single-episode notifications **stack** instead of overwriting. `PRIMARY` becomes the summary-only slot (removing the latent lone-episode-vs-summary collision).

### Why this is safe (no functional regression)
- **Android keys notifications by the `(tag, id)` pair**, not id alone — the group path already proves distinct tags + the shared `541251` id coexist in the shade. This just extends that proven scheme to the single path.
- **Cancellation** is unaffected: the action-button cancel reads the tag back from the notification's own intent extra (`INTENT_EXTRA_NOTIFICATION_TAG`), so it self-matches the new tag; tap uses `setAutoCancel` (tag-independent); the swipe delete-intent is a no-op.
- **Tap / PendingIntent**: PendingIntent identity is action-string based (`action += System.currentTimeMillis() + intentId`), independent of the tag/id — no new collision; the deep link still targets the right episode.
- **Alerting is preserved and actually improved**: today, trickle-in singles re-post to the *existing* `PRIMARY` slot, so `setOnlyAlertOnce(true)` **suppresses** their sound (they're treated as an update); with unique tags each new episode is a fresh notification and correctly alerts once. Batches still alert once via the summary.
- `isGroupNotification` still governs grouping (`setGroup`) and the batch sound/vibrate behavior — untouched.

### Scope / follow-up
This is the minimal fix for the data-losing overwrite. A separate, nicer enhancement (route cross-refresh singles through the group with a summary whose count comes from the live active-notification total) is intentionally **not** included — it also fixes a pre-existing multi-batch summary undercount and is larger/riskier; it should be a follow-up. Two known-minor points: a single notification left on the old `PRIMARY` slot by a pre-update app version is self-healing (dismissed on tap/action); cross-refresh loose singles aren't bundled under our custom "N new episodes" summary (Android auto-bundles 4+).

## Testing Instructions

1. Subscribe to a podcast, enable its notifications, grant notification permission.
2. Cause new episodes to arrive **one at a time across separate refresh cycles** (each triggering a single-episode notification).
3. Leave the notifications unread. Verify each **new** single-episode notification now **adds to** the shade instead of replacing the previous unread one.
4. Multiple episodes arriving in one refresh still group under a single "N new episodes" summary (unchanged).

### Verification
- Root-caused with file:line and validated by **two independent adversarial code reviews** (both verdicts: logically correct, zero functional regression across cancellation, alerting, tap, and summary paths).
- The mechanism is Android-certain: notifications are keyed by the **`(tag, id)` pair**, and the existing group path already proves distinct tags + the shared id `541251` coexist in the shade — this fix extends that proven scheme to the single path.
- Spotless clean; `:modules:services:repositories` compiles and its unit tests pass.
- **On-device before/after not run here.** A faithful repro needs the *cross-refresh* timing (one new episode per refresh cycle), i.e. seeding `podcast_episodes` rows and advancing the `NOTIFICATION_LAST_SEEN` preference between refreshes — disproportionately fragile for a one-line change. Recommended QA check:
  1. Subscribe to a podcast, enable its notifications, grant notification permission.
  2. Cause two new episodes to arrive in **separate** refresh cycles (or seed two qualifying episodes and run `RefreshPodcastsTask.runNow` twice, advancing `NOTIFICATION_LAST_SEEN` before each).
  3. `adb shell dumpsys notification --noredact | grep NEW_EPISODE` → expect **two** distinct `PREFIX+<uuid>` tags (pre-fix: one, colliding on `PRIMARY`).

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply`)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) the Event Horizon schema to reflect any new or changed analytics.


#### I have tested any UI changes...
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
