### PR TITLE
[TV] Video controls scrim, solid info icon, active scrubber timestamp

### DIFF
--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
@@ -288,12 +288,20 @@ private fun TvNowPlayingContent(
                 }
             }
         }
+        if (state.isVideo) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .graphicsLayer { alpha = chromeAlpha }
+                    .background(VideoControlsScrimBrush),
+            )
+        }
         Column(
             modifier = Modifier
                 .align(Alignment.BottomCenter)
                 .fillMaxWidth()
                 .graphicsLayer { alpha = chromeAlpha }
-                .background(ChromeScrimBrush)
+                .then(if (state.isVideo) Modifier else Modifier.background(ChromeScrimBrush))
                 .padding(horizontal = ChromeHorizontalInset)
                 .padding(top = ChromeScrimTopInset, bottom = 18.dp),
         ) {
@@ -528,6 +536,12 @@ private val ChromeScrimTopInset = 36.dp
 private val ChromeScrimBrush = Brush.verticalGradient(
     0f to Color.Transparent,
     1f to Color.Black.copy(alpha = 0.8f),
+)
+
+private val VideoControlsScrimBrush = Brush.verticalGradient(
+    0f to Color.Transparent,
+    0.5f to Color.Black.copy(alpha = 0.5f),
+    1f to Color.Black,
 )
 
 private val chromeRevealConsumedKeys = setOf(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvSeekBar.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvSeekBar.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
@@ -147,6 +148,7 @@ fun TvSeekBar(
 
             SeekBarLabel(
                 text = TimeHelper.formattedSeconds(positionMs / 1000.0),
+                color = if (isFocused) MaterialTheme.tvColors.textPrimary else MaterialTheme.tvColors.textTertiary,
                 modifier = Modifier
                     .align(Alignment.CenterStart)
                     .onSizeChanged { positionLabelWidth = it.width }
@@ -170,11 +172,12 @@ fun TvSeekBar(
 private fun SeekBarLabel(
     text: String,
     modifier: Modifier = Modifier,
+    color: Color = MaterialTheme.tvColors.textTertiary,
 ) {
     Text(
         text = text,
         style = MaterialTheme.tvTypography.caption1,
-        color = MaterialTheme.tvColors.textTertiary,
+        color = color,
         modifier = modifier,
     )
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvButtonDefaults.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvButtonDefaults.kt
@@ -54,6 +54,6 @@ object TvButtonDefaults {
 
     @Composable
     fun controlBarIconButtonColors() = iconButtonColors(
-        contentColor = MaterialTheme.tvColors.textPrimary70,
+        contentColor = MaterialTheme.tvColors.textSecondary,
     )
 }


### PR DESCRIPTION
## Description

Fixes POC-880 https://linear.app/a8c/issue/POC-880/adjust-player-opacity

1. **Video controls scrim** — added a full-screen vertical gradient (transparent → black, Figma node `3320-5797`) behind the player controls, shown only for video and only while the chrome is visible (it fades with the controls). Previously only a short band sat behind the controls, so the title/controls were hard to read over bright video. The audio player keeps its existing band scrim (a full-screen scrim would dim the centred artwork).
2. **Info icon** — the control-bar icons used `textPrimary` at 70% alpha; switched to the solid `textSecondary` token at full opacity per the spec.
3. **Scrubber timestamp** — the current-position label now uses `textPrimary` while the scrubber is focused/active (was always `textTertiary`), so the time you're scrubbing to stands out.

Device-verified on the Google TV Streamer.

## Testing Instructions

1. Play a **video** episode and open Now Playing; reveal the controls.
2. The lower portion of the video should darken smoothly so the title, control-bar icons and seek bar are clearly legible.
3. Focus the seek bar — the current-time label brightens to text-primary.
4. The info (ⓘ) icon should be solid (no transparency).

## Screenshots or Screencast
<img width="960" height="1178" alt="compare_880" src="https://github.com/user-attachments/assets/7f5e1441-645c-4a8c-a8a7-122e97c5c805" />


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews

#### I have tested any UI changes...
- [x] with different themes <!-- TV is dark-only -->
