### PR TITLE
[TV] Soften modal dim/blur and add modal exit animation

### DIFF
--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvModal.kt
@@ -2,6 +2,14 @@ package au.com.shiftyjelly.pocketcasts.component
 
 import android.os.Build
 import android.view.WindowManager
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.MutableTransitionState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
@@ -18,6 +26,8 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -42,19 +52,39 @@ fun TvModal(
     contentPadding: PaddingValues = DefaultContentPadding,
     content: @Composable ColumnScope.() -> Unit,
 ) {
+    var visible by remember { mutableStateOf(true) }
+    val currentOnDismissRequest by rememberUpdatedState(onDismissRequest)
     Dialog(
-        onDismissRequest = onDismissRequest,
+        onDismissRequest = { visible = false },
         properties = DialogProperties(usePlatformDefaultWidth = false),
     ) {
+        val transitionState = remember { MutableTransitionState(false) }
+        transitionState.targetState = visible
         val isBlurBehindEnabled by rememberIsBlurBehindEnabled()
-        TvModalWindowEffects(isBlurBehindEnabled = isBlurBehindEnabled)
-        TvModalSurface(
-            isTranslucent = isBlurBehindEnabled,
-            width = width,
-            contentPadding = contentPadding,
-            modifier = modifier,
-            content = content,
+        val dimAmount by animateFloatAsState(
+            targetValue = if (visible) MODAL_DIM_AMOUNT else 0f,
+            animationSpec = tween(MODAL_ANIMATION_MILLIS),
+            label = "TvModalDim",
         )
+        TvModalWindowEffects(isBlurBehindEnabled = isBlurBehindEnabled, dimAmount = dimAmount)
+        LaunchedEffect(transitionState.isIdle) {
+            if (!visible && transitionState.isIdle && !transitionState.currentState) {
+                currentOnDismissRequest()
+            }
+        }
+        AnimatedVisibility(
+            visibleState = transitionState,
+            enter = fadeIn(tween(MODAL_ANIMATION_MILLIS)) + scaleIn(tween(MODAL_ANIMATION_MILLIS), initialScale = 0.92f),
+            exit = fadeOut(tween(MODAL_ANIMATION_MILLIS)) + scaleOut(tween(MODAL_ANIMATION_MILLIS), targetScale = 0.92f),
+        ) {
+            TvModalSurface(
+                isTranslucent = isBlurBehindEnabled,
+                width = width,
+                contentPadding = contentPadding,
+                modifier = modifier,
+                content = content,
+            )
+        }
     }
 }
 
@@ -86,11 +116,16 @@ internal fun TvModalSurface(
 }
 
 @Composable
-private fun TvModalWindowEffects(isBlurBehindEnabled: Boolean) {
+private fun TvModalWindowEffects(isBlurBehindEnabled: Boolean, dimAmount: Float) {
     val window = (LocalView.current.parent as? DialogWindowProvider)?.window ?: return
-    val blurRadius = with(LocalDensity.current) { 45.dp.roundToPx() }
+    val blurRadius = with(LocalDensity.current) { ModalBlurRadius.roundToPx() }
+    LaunchedEffect(window) {
+        window.setWindowAnimations(0)
+    }
+    LaunchedEffect(window, dimAmount) {
+        window.setDimAmount(dimAmount)
+    }
     LaunchedEffect(window, isBlurBehindEnabled, blurRadius) {
-        window.setDimAmount(0.55f)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             if (isBlurBehindEnabled) {
                 window.addFlags(WindowManager.LayoutParams.FLAG_BLUR_BEHIND)
@@ -119,6 +154,9 @@ private fun rememberIsBlurBehindEnabled(): State<Boolean> {
     return isBlurBehindEnabled
 }
 
+private const val MODAL_ANIMATION_MILLIS = 200
+private const val MODAL_DIM_AMOUNT = 0.4f
+private val ModalBlurRadius = 30.dp
 private val DefaultModalWidth = 300.dp
 private val DefaultContentPadding = PaddingValues(horizontal = 40.dp, vertical = 30.dp)
 private val ModalShape = RoundedCornerShape(21.dp)

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvModal.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -33,6 +34,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.unit.Dp
@@ -62,8 +64,8 @@ fun TvModal(
         transitionState.targetState = visible
         val isBlurBehindEnabled by rememberIsBlurBehindEnabled()
         val dimAmount by animateFloatAsState(
-            targetValue = if (visible) MODAL_DIM_AMOUNT else 0f,
-            animationSpec = tween(MODAL_ANIMATION_MILLIS),
+            targetValue = if (visible) ModalDimAmount else 0f,
+            animationSpec = tween(ModalAnimationDuration),
             label = "TvModalDim",
         )
         TvModalWindowEffects(isBlurBehindEnabled = isBlurBehindEnabled, dimAmount = dimAmount)
@@ -74,14 +76,14 @@ fun TvModal(
         }
         AnimatedVisibility(
             visibleState = transitionState,
-            enter = fadeIn(tween(MODAL_ANIMATION_MILLIS)) + scaleIn(tween(MODAL_ANIMATION_MILLIS), initialScale = 0.92f),
-            exit = fadeOut(tween(MODAL_ANIMATION_MILLIS)) + scaleOut(tween(MODAL_ANIMATION_MILLIS), targetScale = 0.92f),
+            enter = fadeIn(tween(ModalAnimationDuration)) + scaleIn(tween(ModalAnimationDuration), initialScale = 0.92f),
+            exit = fadeOut(tween(ModalAnimationDuration)) + scaleOut(tween(ModalAnimationDuration), targetScale = 0.92f),
         ) {
             TvModalSurface(
                 isTranslucent = isBlurBehindEnabled,
                 width = width,
                 contentPadding = contentPadding,
-                modifier = modifier,
+                modifier = modifier.onPreviewKeyEvent { visible.not() },
                 content = content,
             )
         }
@@ -119,10 +121,8 @@ internal fun TvModalSurface(
 private fun TvModalWindowEffects(isBlurBehindEnabled: Boolean, dimAmount: Float) {
     val window = (LocalView.current.parent as? DialogWindowProvider)?.window ?: return
     val blurRadius = with(LocalDensity.current) { ModalBlurRadius.roundToPx() }
-    LaunchedEffect(window) {
+    SideEffect {
         window.setWindowAnimations(0)
-    }
-    LaunchedEffect(window, dimAmount) {
         window.setDimAmount(dimAmount)
     }
     LaunchedEffect(window, isBlurBehindEnabled, blurRadius) {
@@ -154,8 +154,8 @@ private fun rememberIsBlurBehindEnabled(): State<Boolean> {
     return isBlurBehindEnabled
 }
 
-private const val MODAL_ANIMATION_MILLIS = 200
-private const val MODAL_DIM_AMOUNT = 0.4f
+private val ModalAnimationDuration = 200
+private val ModalDimAmount = 0.4f
 private val ModalBlurRadius = 30.dp
 private val DefaultModalWidth = 300.dp
 private val DefaultContentPadding = PaddingValues(horizontal = 40.dp, vertical = 30.dp)


### PR DESCRIPTION
## Description

Fixes POC-891 https://linear.app/a8c/issue/POC-891/modal-background-opacity

- **Dim** reduced `0.55` → `0.4` so the background reads through more (less heavy).
- **Blur** reduced `45dp` → `30dp` (cross-window blur, Android 12+ devices that support it).
- **Exit animation** — modals appeared with a fade but disappeared abruptly. Both the modal (fade + slight scale) and the dim scrim now animate out. Implemented by driving a `MutableTransitionState`/`AnimatedVisibility` and an animated dim amount, deferring the real dismissal until the exit finishes.

Applies to all `TvModal` surfaces (Profile menu, episode info, podcast info, etc.).

Device-verified on the Google TV Streamer (dim + exit fade). Note: the Streamer reports cross-window blur unavailable, so the blur radius change is a value-only tweak there.

## Testing Instructions

1. Open any modal (e.g. the Profile menu from the avatar).
2. The background should be dimmed but clearly visible through the scrim (less opaque than before).
3. Press Back — the modal and the dim should fade out smoothly rather than snapping away.

## Screenshots or Screencast

<img width="1920" height="1080" alt="p891_modal_open" src="https://github.com/user-attachments/assets/9cc1e1db-e07f-4d46-aed9-7284ad031f97" />


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews

#### I have tested any UI changes...
- [x] with different themes <!-- TV is dark-only -->
