### PR TITLE
[TV] featured carousel polish (buttons, centering, network, active scale)

### DIFF
--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvFeaturedTile.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvFeaturedTile.kt
@@ -1,10 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.component
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.expandVertically
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -32,9 +27,10 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.tv.material3.Button
 import androidx.tv.material3.CardDefaults
+import androidx.tv.material3.Glow
 import androidx.tv.material3.MaterialTheme
-import androidx.tv.material3.OutlinedButton
 import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.theme.TvTheme
 import au.com.shiftyjelly.pocketcasts.theme.tvColors
@@ -47,6 +43,7 @@ fun TvFeaturedTile(
     artworkUrl: String,
     isSponsored: Boolean,
     title: String,
+    author: String,
     description: String,
     onGoToPodcast: () -> Unit,
     onPlayLastEpisode: () -> Unit,
@@ -58,10 +55,13 @@ fun TvFeaturedTile(
 
     TvTile(
         onClick = onPlayLastEpisode,
-        scale = CardDefaults.scale(focusedScale = TvFocusedWideCardScale),
+        scale = CardDefaults.scale(focusedScale = 1.05f),
         colors = CardDefaults.colors(
             containerColor = Color.Transparent,
             focusedContainerColor = Color.Transparent,
+        ),
+        glow = CardDefaults.glow(
+            focusedGlow = Glow(elevationColor = Color.Black, elevation = 16.dp),
         ),
         modifier = modifier.tvTileButtonNavigation(buttonState, buttonActions),
     ) {
@@ -124,6 +124,17 @@ fun TvFeaturedTile(
                         Spacer(modifier = Modifier.height(4.dp))
                     }
 
+                    if (author.isNotBlank()) {
+                        Text(
+                            text = author,
+                            style = MaterialTheme.tvTypography.caption2,
+                            color = MaterialTheme.tvColors.textSecondary,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                        Spacer(modifier = Modifier.height(2.dp))
+                    }
+
                     Text(
                         text = title,
                         style = MaterialTheme.tvTypography.title2,
@@ -140,27 +151,21 @@ fun TvFeaturedTile(
                         overflow = TextOverflow.Ellipsis,
                     )
 
-                    AnimatedVisibility(
-                        visible = buttonState.isFocused,
-                        enter = fadeIn() + expandVertically(expandFrom = Alignment.Top),
-                        exit = fadeOut() + shrinkVertically(shrinkTowards = Alignment.Top),
+                    Row(
+                        modifier = Modifier.padding(top = 12.dp),
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
                     ) {
-                        Row(
-                            modifier = Modifier.padding(top = 12.dp),
-                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        Button(
+                            onClick = onPlayLastEpisode,
+                            colors = tileButtonColors(isSelected = buttonState.isButtonSelected(0)),
                         ) {
-                            OutlinedButton(
-                                onClick = onPlayLastEpisode,
-                                colors = tileButtonColors(isSelected = buttonState.isButtonSelected(0)),
-                            ) {
-                                Text(stringResource(LR.string.play_latest_episode))
-                            }
-                            OutlinedButton(
-                                onClick = onGoToPodcast,
-                                colors = tileButtonColors(isSelected = buttonState.isButtonSelected(1)),
-                            ) {
-                                Text(stringResource(LR.string.go_to_podcast))
-                            }
+                            Text(stringResource(LR.string.play_latest_episode))
+                        }
+                        Button(
+                            onClick = onGoToPodcast,
+                            colors = tileButtonColors(isSelected = buttonState.isButtonSelected(1)),
+                        ) {
+                            Text(stringResource(LR.string.go_to_podcast))
                         }
                     }
                 }
@@ -179,6 +184,7 @@ private fun TvFeaturedTilePreview() {
                 isSponsored = true,
                 sponsoredLabel = "Sponsored \u00B7 iHeartPodcasts and Kaleidoscope",
                 title = "Superhuman",
+                author = "iHeartPodcasts",
                 description = "SuperHuman is a high-stakes, edge-of-your-seat docuseries that dives into the launch of what many have called the \"Doping Olympics\"",
                 onGoToPodcast = {},
                 onPlayLastEpisode = {},

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvRow.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvRow.kt
@@ -11,7 +11,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -71,6 +73,7 @@ fun <T> TvRow(
     itemSpacing: Dp = 12.dp,
     key: ((T) -> Any)? = null,
     focusRequester: FocusRequester? = null,
+    centerFocusedItem: Boolean = false,
     content: @Composable (T) -> Unit,
 ) {
     var hasFocus by remember { mutableStateOf(false) }
@@ -94,8 +97,19 @@ fun <T> TvRow(
 
         var lastFocusedIndex by rememberSaveable(items) { mutableIntStateOf(0) }
         val focusRequesters = remember(items) { List(items.size) { FocusRequester() } }
+        val listState = rememberLazyListState()
+
+        if (centerFocusedItem) {
+            LaunchedEffect(lastFocusedIndex) {
+                val item = listState.layoutInfo.visibleItemsInfo.firstOrNull { it.index == lastFocusedIndex }
+                val viewport = listState.layoutInfo.viewportSize.width
+                val centerOffset = item?.let { -(viewport - it.size) / 2 } ?: 0
+                listState.animateScrollToItem(lastFocusedIndex, centerOffset)
+            }
+        }
 
         LazyRow(
+            state = listState,
             contentPadding = contentPadding,
             horizontalArrangement = Arrangement.spacedBy(itemSpacing),
             verticalAlignment = Alignment.CenterVertically,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/discover/TvDiscoverRows.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/discover/TvDiscoverRows.kt
@@ -61,12 +61,14 @@ fun LazyListScope.tvDiscoverRow(
                 contentPadding = contentPadding,
                 key = TvDiscoverPodcast::uuid,
                 focusRequester = focusRequester,
+                centerFocusedItem = true,
                 modifier = modifier,
             ) { podcast ->
                 TvFeaturedTile(
                     artworkUrl = podcast.artworkUrl,
                     isSponsored = podcast.isSponsored,
                     title = podcast.title,
+                    author = podcast.author,
                     description = podcast.description,
                     onGoToPodcast = { onPodcastClick(row, podcast) },
                     onPlayLastEpisode = { onPlayLatestEpisode(row, podcast) },

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvTabPlaceholder.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvTabPlaceholder.kt
@@ -47,6 +47,7 @@ fun TvTabPlaceholder(
                     isSponsored = true,
                     sponsoredLabel = "Sponsored \u00B7 iHeartPodcasts and Kaleidoscope",
                     title = "Superhuman",
+                    author = "iHeartPodcasts",
                     description = "SuperHuman is a high-stakes, edge-of-your-seat docuseries",
                     onGoToPodcast = {},
                     onPlayLastEpisode = {},


### PR DESCRIPTION
## Description

Fixes POC-888 https://linear.app/a8c/issue/POC-888/featured-carrousel-changes

1. **Buttons** — the Play latest / Go to podcast buttons were `OutlinedButton`s, so they carried a border no other tile buttons have. Switched to filled `Button`s (same `tileButtonColors`), removing the outline.
2. **No content jump on activation** — the buttons were revealed with an `AnimatedVisibility` expand/shrink that pushed the surrounding text around. They're now always present, so activating an item no longer animates/reflows the content.
3. **Centered active item + peek** — added an opt-in `centerFocusedItem` to `TvRow` (default off, enabled only for the featured carousel) that scrolls the focused item to the centre. LazyList clamping keeps the first item at the start and the last at the end, so only middle items centre — with just a small peek of the neighbour, like tvOS. No other row is affected.
4. **Network before title** — the podcast author/network now shows above the title (it was missing).
5. **Active scale + shadow** — the focused featured tile now scales a little more (`1.05`) and gets a drop shadow (`Glow`), matching POC-884 / tvOS.

## Testing Instructions

1. Open **Home** and scroll to the **Featured** carousel.
2. Move between items — the active item centres with a small peek of the next, scales up with a drop shadow, and its buttons have no outline.
3. The network/author appears above the title, and moving between items no longer animates/reflows the card content.

## Screenshots or Screencast
<img width="3920" height="1237" alt="carousel_POLISH_comparison" src="https://github.com/user-attachments/assets/b59da540-70a7-498c-a0ff-d1111b3ab845" />

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews

#### I have tested any UI changes...
- [x] with different themes <!-- TV is dark-only -->

