### PR TITLE
[TV] Podcast view — lower content, cover glow, animated follow button

### DIFF
--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.podcasts
 
+import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -8,6 +9,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -27,6 +29,9 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.BlurredEdgeTreatment
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -144,11 +149,20 @@ private fun TvPodcastDetailsContent(
                 val followFocusRequester = remember { FocusRequester() }
                 var isShowingInfoModal by remember { mutableStateOf(false) }
                 var isShowingAccountModal by rememberSaveable { mutableStateOf(false) }
+                TvArtworkImage(
+                    model = PodcastImage.getMediumArtworkUrl(uiState.podcast.uuid),
+                    modifier = Modifier
+                        .align(Alignment.TopStart)
+                        .offset(x = CoverGlowOffset, y = CoverGlowOffset)
+                        .size(CoverGlowSize)
+                        .blur(CoverGlowBlurRadius, BlurredEdgeTreatment.Unbounded)
+                        .alpha(0.4f),
+                )
                 Row(
                     horizontalArrangement = Arrangement.spacedBy(60.dp),
                     modifier = Modifier
                         .fillMaxSize()
-                        .padding(start = 42.dp, top = 16.dp, end = 42.dp),
+                        .padding(start = 42.dp, top = DetailsTopPadding, end = 42.dp),
                 ) {
                     PodcastInfo(
                         podcast = uiState.podcast,
@@ -261,7 +275,9 @@ private fun PodcastInfo(
             Button(
                 onClick = onFollow,
                 colors = TvButtonDefaults.filledButtonColors(),
-                modifier = Modifier.focusRequester(followFocusRequester),
+                modifier = Modifier
+                    .focusRequester(followFocusRequester)
+                    .animateContentSize(),
             ) {
                 Text(stringResource(if (podcast.isSubscribed) LR.string.podcast_subscribed else LR.string.tv_podcast_follow))
             }
@@ -392,6 +408,10 @@ private fun AllEpisodesArchived(
 }
 
 private const val INFO_PANE_WEIGHT = 0.35f
+private val DetailsTopPadding = 56.dp
+private val CoverGlowSize = 460.dp
+private val CoverGlowOffset = (-140).dp
+private val CoverGlowBlurRadius = 80.dp
 
 private val PodcastSortOptions = listOf(
     EpisodesSortType.EPISODES_SORT_BY_TITLE_ASC,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.podcasts
 
+import android.os.Build
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -149,15 +150,17 @@ private fun TvPodcastDetailsContent(
                 val followFocusRequester = remember { FocusRequester() }
                 var isShowingInfoModal by remember { mutableStateOf(false) }
                 var isShowingAccountModal by rememberSaveable { mutableStateOf(false) }
-                TvArtworkImage(
-                    model = PodcastImage.getMediumArtworkUrl(uiState.podcast.uuid),
-                    modifier = Modifier
-                        .align(Alignment.TopStart)
-                        .offset(x = CoverGlowOffset, y = CoverGlowOffset)
-                        .size(CoverGlowSize)
-                        .blur(CoverGlowBlurRadius, BlurredEdgeTreatment.Unbounded)
-                        .alpha(0.4f),
-                )
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                    TvArtworkImage(
+                        model = PodcastImage.getMediumArtworkUrl(uiState.podcast.uuid),
+                        modifier = Modifier
+                            .align(Alignment.TopStart)
+                            .offset(x = CoverGlowOffset, y = CoverGlowOffset)
+                            .size(CoverGlowSize)
+                            .blur(CoverGlowBlurRadius, BlurredEdgeTreatment.Unbounded)
+                            .alpha(0.4f),
+                    )
+                }
                 Row(
                     horizontalArrangement = Arrangement.spacedBy(60.dp),
                     modifier = Modifier


### PR DESCRIPTION
## Description

Fixes POC-882 https://linear.app/a8c/issue/POC-882/podcast-view-fixes

1. **Content sat too high** — the cover + info + episode list started with only 16dp of top padding. Bumped to `56dp` so the content sits lower, matching the spec.
2. **Missing background cover glow** — added a large, heavily-blurred copy of the podcast artwork bleeding out of the top-left corner (behind the content), like the spec.
3. **Follow → Following morph** — the follow button now `animateContentSize()`s, so it smoothly morphs its width when toggling between Follow and Following (a lightweight take on the tvOS animation).

Device-verified on the Google TV Streamer.

## Testing Instructions

1. Open any podcast's details screen.
2. The cover/title/episode list should sit a little lower, with a soft blurred glow of the cover in the top-left corner.
3. Toggle Follow/Following — the button width animates rather than snapping.

## Screenshots or Screencast
<img width="1920" height="1080" alt="after_882" src="https://github.com/user-attachments/assets/cc02a811-6ffa-479f-9391-5cf34cee22b0" />


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews

#### I have tested any UI changes...
- [x] with different themes <!-- TV is dark-only -->
