### PR TITLE
Network Discovery foundation: feature flag, lists_list decoding and unknown-type safety

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/lists/ListRepository.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/lists/ListRepository.kt
@@ -6,6 +6,8 @@ import au.com.shiftyjelly.pocketcasts.servers.model.Discover
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
 import au.com.shiftyjelly.pocketcasts.servers.model.ListFeed
 import au.com.shiftyjelly.pocketcasts.servers.server.ListWebService
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import timber.log.Timber
 
 class ListRepository(
@@ -15,19 +17,20 @@ class ListRepository(
 ) {
 
     suspend fun getDiscoverFeed(): Discover {
-        return listWebService.getDiscoverFeed(platform = platform, version = 3)
+        return listWebService.getDiscoverFeed(platform = platform, version = discoverFeedVersion())
     }
 
     suspend fun getSearchDiscoverFeed(): Discover {
-        return listWebService.getSearchDiscoverFeed(platform = platform, version = 3)
+        return listWebService.getSearchDiscoverFeed(platform = platform, version = discoverFeedVersion())
     }
 
     /** Auth-specific home discover feed. Only served for the TV platform. */
     suspend fun getHomeDiscoverFeed(isLoggedIn: Boolean): Discover {
+        val version = discoverFeedVersion()
         return if (isLoggedIn) {
-            listWebService.getLoggedInDiscoverFeed(platform = platform, version = 3)
+            listWebService.getLoggedInDiscoverFeed(platform = platform, version = version)
         } else {
-            listWebService.getLoggedOutDiscoverFeed(platform = platform, version = 3)
+            listWebService.getLoggedOutDiscoverFeed(platform = platform, version = version)
         }
     }
 
@@ -61,9 +64,19 @@ class ListRepository(
         return getListFeed(url = "${Settings.SERVER_API_URL}/recommendations/podcast/$podcastUuid?country=${countryCode ?: "global"}")
     }
 
+    /** v4 is the first layout to carry `lists_list` rows, so it is only requested once networks are enabled. */
+    private fun discoverFeedVersion() = if (FeatureFlag.isEnabled(Feature.NETWORK_DISCOVERY)) {
+        DISCOVER_FEED_VERSION_NETWORKS
+    } else {
+        DISCOVER_FEED_VERSION
+    }
+
     companion object {
         const val PLATFORM_ANDROID = "android"
         const val PLATFORM_AUTOMOTIVE = "automotive"
         const val PLATFORM_TV = "tv"
+
+        private const val DISCOVER_FEED_VERSION = 3
+        private const val DISCOVER_FEED_VERSION_NETWORKS = 4
     }
 }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/lists/ListRepositoryTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/lists/ListRepositoryTest.kt
@@ -1,0 +1,119 @@
+package au.com.shiftyjelly.pocketcasts.repositories.lists
+
+import au.com.shiftyjelly.pocketcasts.servers.model.Discover
+import au.com.shiftyjelly.pocketcasts.servers.server.ListWebService
+import au.com.shiftyjelly.pocketcasts.sharedtest.InMemoryFeatureFlagRule
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+class ListRepositoryTest {
+
+    @get:Rule
+    val featureFlagRule = InMemoryFeatureFlagRule()
+
+    private val webService = mock<ListWebService> {
+        on { getDiscoverFeed(any(), any()) } doReturn EMPTY_DISCOVER
+        on { getSearchDiscoverFeed(any(), any()) } doReturn EMPTY_DISCOVER
+        on { getLoggedInDiscoverFeed(any(), any()) } doReturn EMPTY_DISCOVER
+        on { getLoggedOutDiscoverFeed(any(), any()) } doReturn EMPTY_DISCOVER
+    }
+
+    private val repository = ListRepository(
+        listWebService = webService,
+        syncManager = mock(),
+        platform = PLATFORM,
+    )
+
+    @Test
+    fun `discover feed uses v3 when networks are disabled`() = runTest {
+        FeatureFlag.setEnabled(Feature.NETWORK_DISCOVERY, false)
+
+        repository.getDiscoverFeed()
+
+        verify(webService).getDiscoverFeed(PLATFORM, VERSION_WITHOUT_NETWORKS)
+    }
+
+    @Test
+    fun `discover feed uses v4 when networks are enabled`() = runTest {
+        FeatureFlag.setEnabled(Feature.NETWORK_DISCOVERY, true)
+
+        repository.getDiscoverFeed()
+
+        verify(webService).getDiscoverFeed(PLATFORM, VERSION_WITH_NETWORKS)
+    }
+
+    @Test
+    fun `search discover feed uses v3 when networks are disabled`() = runTest {
+        FeatureFlag.setEnabled(Feature.NETWORK_DISCOVERY, false)
+
+        repository.getSearchDiscoverFeed()
+
+        verify(webService).getSearchDiscoverFeed(PLATFORM, VERSION_WITHOUT_NETWORKS)
+    }
+
+    @Test
+    fun `search discover feed uses v4 when networks are enabled`() = runTest {
+        FeatureFlag.setEnabled(Feature.NETWORK_DISCOVERY, true)
+
+        repository.getSearchDiscoverFeed()
+
+        verify(webService).getSearchDiscoverFeed(PLATFORM, VERSION_WITH_NETWORKS)
+    }
+
+    @Test
+    fun `logged in home discover feed uses v3 when networks are disabled`() = runTest {
+        FeatureFlag.setEnabled(Feature.NETWORK_DISCOVERY, false)
+
+        repository.getHomeDiscoverFeed(isLoggedIn = true)
+
+        verify(webService).getLoggedInDiscoverFeed(PLATFORM, VERSION_WITHOUT_NETWORKS)
+    }
+
+    @Test
+    fun `logged in home discover feed uses v4 when networks are enabled`() = runTest {
+        FeatureFlag.setEnabled(Feature.NETWORK_DISCOVERY, true)
+
+        repository.getHomeDiscoverFeed(isLoggedIn = true)
+
+        verify(webService).getLoggedInDiscoverFeed(PLATFORM, VERSION_WITH_NETWORKS)
+    }
+
+    @Test
+    fun `logged out home discover feed uses v3 when networks are disabled`() = runTest {
+        FeatureFlag.setEnabled(Feature.NETWORK_DISCOVERY, false)
+
+        repository.getHomeDiscoverFeed(isLoggedIn = false)
+
+        verify(webService).getLoggedOutDiscoverFeed(PLATFORM, VERSION_WITHOUT_NETWORKS)
+    }
+
+    @Test
+    fun `logged out home discover feed uses v4 when networks are enabled`() = runTest {
+        FeatureFlag.setEnabled(Feature.NETWORK_DISCOVERY, true)
+
+        repository.getHomeDiscoverFeed(isLoggedIn = false)
+
+        verify(webService).getLoggedOutDiscoverFeed(PLATFORM, VERSION_WITH_NETWORKS)
+    }
+
+    companion object {
+        private const val PLATFORM = ListRepository.PLATFORM_ANDROID
+        private const val VERSION_WITHOUT_NETWORKS = 3
+        private const val VERSION_WITH_NETWORKS = 4
+
+        private val EMPTY_DISCOVER = Discover(
+            layout = emptyList(),
+            regions = emptyMap(),
+            regionCodeToken = "[regionCode]",
+            regionNameToken = "[regionName]",
+            defaultRegionCode = "us",
+        )
+    }
+}

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/model/DiscoverModel.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/model/DiscoverModel.kt
@@ -146,7 +146,14 @@ data class ListFeed(
     @Json(name = "paid") val paid: Boolean? = false,
     @Json(name = "author") val author: String? = null,
     @Json(name = "list_id") val listId: String? = null,
+    @Json(name = "type") val type: ListType? = null,
+    @Json(name = "summary_style") val summaryStyle: DisplayStyle? = null,
+    @Json(name = "expanded_style") val expandedStyle: ExpandedStyle? = null,
+    @Json(name = "lists") val lists: List<NetworkListSummary> = emptyList(),
 ) {
+    /** A `lists_list` may only carry `podcast_list` entries, so anything else the server adds is dropped here. */
+    val networks get() = lists.filter { it.type is ListType.PodcastList }
+
     val displayList: List<Any>
         get() {
             return if (promotion != null) {
@@ -156,6 +163,21 @@ data class ListFeed(
             }
         }
 }
+
+/** An entry inside a `lists_list`. */
+@JsonClass(generateAdapter = true)
+data class NetworkListSummary(
+    @Json(name = "uuid") val uuid: String,
+    @Json(name = "title") val title: String?,
+    @Json(name = "description") val description: String?,
+    @Json(name = "type") val type: ListType?,
+    @Json(name = "summary_style") val summaryStyle: DisplayStyle?,
+    @Json(name = "expanded_style") val expandedStyle: ExpandedStyle?,
+    @Json(name = "source") val source: String?,
+    @Json(name = "collection_image") val collectionImage: String?,
+    @Json(name = "item_count") val itemCount: Int?,
+    @Json(name = "url_path") val urlPath: String?,
+)
 
 @JsonClass(generateAdapter = true)
 data class ListPayment(

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/model/ExpandedStyle.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/model/ExpandedStyle.kt
@@ -10,6 +10,7 @@ sealed class ExpandedStyle(val stringValue: String) {
         private const val DESCRIPTIVE_LIST = "descriptive_list"
         private const val GRID_LIST = "grid"
         private const val POPOVER = "popover"
+        private const val NETWORK_GRID = "network_grid"
 
         fun fromString(value: String?): ExpandedStyle? {
             return when (value) {
@@ -18,6 +19,7 @@ sealed class ExpandedStyle(val stringValue: String) {
                 DESCRIPTIVE_LIST -> DescriptiveList()
                 GRID_LIST -> GridList()
                 POPOVER -> Popover()
+                NETWORK_GRID -> NetworkGrid()
                 else -> PlainList()
             }
         }
@@ -28,6 +30,7 @@ sealed class ExpandedStyle(val stringValue: String) {
     class DescriptiveList : ExpandedStyle(DESCRIPTIVE_LIST)
     class GridList : ExpandedStyle(GRID_LIST)
     class Popover : ExpandedStyle(POPOVER)
+    class NetworkGrid : ExpandedStyle(NETWORK_GRID)
 }
 
 class ExpandedStyleMoshiAdapter {

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/model/ListType.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/model/ListType.kt
@@ -7,12 +7,14 @@ sealed class ListType(val stringValue: String) {
     companion object {
         private const val PODCAST_LIST = "podcast_list"
         private const val EPISODE_LIST = "episode_list"
+        private const val LISTS_LIST = "lists_list"
         private const val CATEGORIES = "categories"
 
         fun fromString(value: String): ListType {
             return when (value) {
                 PODCAST_LIST -> PodcastList
                 EPISODE_LIST -> EpisodeList
+                LISTS_LIST -> ListsList
                 CATEGORIES -> Categories
                 else -> Unknown(value)
             }
@@ -21,6 +23,7 @@ sealed class ListType(val stringValue: String) {
 
     data object PodcastList : ListType(PODCAST_LIST)
     data object EpisodeList : ListType(EPISODE_LIST)
+    data object ListsList : ListType(LISTS_LIST)
     data object Categories : ListType(CATEGORIES)
     data class Unknown(val value: String) : ListType(value)
 

--- a/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/model/DiscoverModelTest.kt
+++ b/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/model/DiscoverModelTest.kt
@@ -32,6 +32,47 @@ class DiscoverModelTest {
     }
 
     @Test
+    fun `discover row parses the networks lists list row`() {
+        val row = adapter.fromJson(
+            """
+            {
+              "id": "0b370140-ae34-4f10-9b6f-301820de0605",
+              "uuid": "networks",
+              "title": "Networks",
+              "type": "lists_list",
+              "summary_style": "large_list",
+              "expanded_style": "network_grid",
+              "curated": true,
+              "source": "https://lists.pocketcasts.net/0b370140-ae34-4f10-9b6f-301820de0605.json",
+              "category_id": null,
+              "authenticated": false,
+              "regions": ["us"]
+            }
+            """.trimIndent(),
+        )
+
+        assertTrue(row?.type is ListType.ListsList)
+        assertTrue(row?.displayStyle is DisplayStyle.LargeList)
+        assertTrue(row?.expandedStyle is ExpandedStyle.NetworkGrid)
+    }
+
+    @Test
+    fun `discover row keeps an unrecognised type as unknown`() {
+        val row = adapter.fromJson(
+            """
+            {
+              "type": "video_list",
+              "summary_style": "small_list",
+              "title": "Watch",
+              "regions": ["us"]
+            }
+            """.trimIndent(),
+        )
+
+        assertEquals(ListType.Unknown("video_list"), row?.type)
+    }
+
+    @Test
     fun `discover row parses the video preview list summary style`() {
         val row = adapter.fromJson(
             """

--- a/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/model/ListFeedTest.kt
+++ b/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/model/ListFeedTest.kt
@@ -1,0 +1,118 @@
+package au.com.shiftyjelly.pocketcasts.servers.model
+
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.adapters.Rfc3339DateJsonAdapter
+import java.util.Date
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ListFeedTest {
+
+    private val adapter = Moshi.Builder()
+        .add(Date::class.java, Rfc3339DateJsonAdapter().nullSafe())
+        .add(ListTypeMoshiAdapter())
+        .add(DisplayStyleMoshiAdapter())
+        .add(ExpandedStyleMoshiAdapter())
+        .build()
+        .adapter(ListFeed::class.java)
+
+    @Test
+    fun `networks feed describes itself and decodes its entries`() {
+        val feed = adapter.fromJson(NETWORKS_FEED)
+
+        assertTrue(feed?.type is ListType.ListsList)
+        assertTrue(feed?.summaryStyle is DisplayStyle.LargeList)
+        assertTrue(feed?.expandedStyle is ExpandedStyle.NetworkGrid)
+        assertEquals("0b370140-ae34-4f10-9b6f-301820de0605", feed?.listId)
+        assertEquals(listOf("Relay", "The New York Times"), feed?.networks?.map { it.title })
+
+        val relay = feed?.networks?.first()
+        assertEquals("cdb75bc0-9f5a-4217-b1ca-f573821a7913", relay?.uuid)
+        assertEquals("https://lists.pocketcasts.net/cdb75bc0-9f5a-4217-b1ca-f573821a7913.json", relay?.source)
+        assertEquals("https://static.pocketcasts.net/share/images/cdb75bc0-9f5a-4217-b1ca-f573821a7913-author.png", relay?.collectionImage)
+        assertEquals(4, relay?.itemCount)
+        assertEquals("relay-network", relay?.urlPath)
+        assertEquals("The Relay network of podcasts.", relay?.description)
+        assertTrue(relay?.type is ListType.PodcastList)
+        assertTrue(relay?.summaryStyle is DisplayStyle.CollectionList)
+        assertTrue(relay?.expandedStyle is ExpandedStyle.NetworkGrid)
+    }
+
+    @Test
+    fun `entries that are not podcast lists are dropped without failing the feed`() {
+        val feed = adapter.fromJson(
+            """
+            {
+              "title": "Networks",
+              "type": "lists_list",
+              "lists": [
+                {"uuid": "podcasts", "title": "Relay", "type": "podcast_list"},
+                {"uuid": "episodes", "title": "Latest", "type": "episode_list"},
+                {"uuid": "future", "title": "Something New", "type": "video_list"}
+              ]
+            }
+            """.trimIndent(),
+        )
+
+        assertEquals(listOf("podcasts"), feed?.networks?.map { it.uuid })
+        assertEquals(3, feed?.lists?.size)
+    }
+
+    @Test
+    fun `a feed without a lists array decodes to no entries`() {
+        val feed = adapter.fromJson("""{"title": "Featured", "type": "podcast_list"}""")
+
+        assertEquals(emptyList<NetworkListSummary>(), feed?.networks)
+    }
+
+    companion object {
+        // The staging payload from https://lists.pocketcasts.net/0b370140-ae34-4f10-9b6f-301820de0605.json, trimmed to two entries.
+        private val NETWORKS_FEED = """
+            {
+              "title": "Networks",
+              "description": "Podcast Networks",
+              "short_description": "",
+              "author": null,
+              "datetime": "2026-09-03T05:27:38Z",
+              "list_id": "0b370140-ae34-4f10-9b6f-301820de0605",
+              "type": "lists_list",
+              "summary_style": "large_list",
+              "expanded_style": "network_grid",
+              "collection_image": null,
+              "colors": {"onLightBackground": "", "onDarkBackground": ""},
+              "subtitle": "",
+              "web_url": "",
+              "web_title": "",
+              "collage_images": [],
+              "podcasts": [],
+              "lists": [
+                {
+                  "uuid": "cdb75bc0-9f5a-4217-b1ca-f573821a7913",
+                  "title": "Relay",
+                  "type": "podcast_list",
+                  "summary_style": "collection",
+                  "expanded_style": "network_grid",
+                  "source": "https://lists.pocketcasts.net/cdb75bc0-9f5a-4217-b1ca-f573821a7913.json",
+                  "collection_image": "https://static.pocketcasts.net/share/images/cdb75bc0-9f5a-4217-b1ca-f573821a7913-author.png",
+                  "item_count": 4,
+                  "description": "The Relay network of podcasts.",
+                  "url_path": "relay-network"
+                },
+                {
+                  "uuid": "e07f76d0-0064-48d9-81a3-895de009f5c7",
+                  "title": "The New York Times",
+                  "type": "podcast_list",
+                  "summary_style": "collection",
+                  "expanded_style": "network_grid",
+                  "source": "https://lists.pocketcasts.net/e07f76d0-0064-48d9-81a3-895de009f5c7.json",
+                  "collection_image": "https://static.pocketcasts.net/share/images/e07f76d0-0064-48d9-81a3-895de009f5c7-author.svg",
+                  "item_count": 8,
+                  "description": "The New York Times collection of podcasts",
+                  "url_path": "nytimes-network"
+                }
+              ]
+            }
+        """.trimIndent()
+    }
+}

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -374,7 +374,7 @@ enum class Feature(
         title = "Networks in Discover, search and the podcast page",
         defaultValue = isDebugOrPrototypeBuild,
         tier = FeatureTier.Free,
-        hasFirebaseRemoteFlag = true,
+        hasFirebaseRemoteFlag = false,
         hasDevToggle = true,
         addedOn = LocalDate.parse("2026-09-04"),
     ),

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -369,6 +369,15 @@ enum class Feature(
         hasDevToggle = true,
         addedOn = LocalDate.parse("2026-07-02"),
     ),
+    NETWORK_DISCOVERY(
+        key = "network_discovery",
+        title = "Networks in Discover, search and the podcast page",
+        defaultValue = isDebugOrPrototypeBuild,
+        tier = FeatureTier.Free,
+        hasFirebaseRemoteFlag = true,
+        hasDevToggle = true,
+        addedOn = LocalDate.parse("2026-09-04"),
+    ),
 }
 
 sealed class FeatureTier {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/discover/TvDiscoverFeedLoader.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/discover/TvDiscoverFeedLoader.kt
@@ -173,6 +173,9 @@ class TvDiscoverFeedLoader @Inject constructor(
 
             is ListType.Categories -> if (includeHomeSections) loadCategoriesRow(row, replacements) else null
 
+            // Networks are a mobile feature, so TV has no row to render them in.
+            is ListType.ListsList -> null
+
             is ListType.Unknown -> {
                 Timber.w("Dropping unknown TV discover row type '${(row.type as ListType.Unknown).value}' for ${row.rowId()}")
                 null

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/discover/TvDiscoverFeedLoaderTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/discover/TvDiscoverFeedLoaderTest.kt
@@ -141,17 +141,26 @@ class TvDiscoverFeedLoaderTest {
         assertEquals(null, episodes.single().videoPreviewUrl)
     }
 
+    @Test
+    fun `a networks row is dropped because tv has nowhere to render it`() = runTest {
+        stubCountry()
+
+        val rows = loader().buildRows(discoverWith(DisplayStyle.LargeList(), type = ListType.ListsList), isLoggedIn = true)
+
+        assertEquals(emptyList<TvDiscoverRow>(), rows)
+    }
+
     private fun stubCountry() {
         val countrySetting = mock<UserSetting<String>> { on { value } doReturn REGION }
         whenever(settings.discoverCountryCode).doReturn(countrySetting)
         whenever(context.resources).doReturn(mock<Resources>())
     }
 
-    private fun discoverWith(displayStyle: DisplayStyle) = Discover(
+    private fun discoverWith(displayStyle: DisplayStyle, type: ListType = ListType.EpisodeList) = Discover(
         layout = listOf(
             DiscoverRow(
                 id = "made-for-tv",
-                type = ListType.EpisodeList,
+                type = type,
                 displayStyle = displayStyle,
                 expandedTopItemLabel = null,
                 title = "Made for TV",


### PR DESCRIPTION
## Description

Teaches the app to understand a new kind of Discover section that lists podcast networks rather than podcasts or episodes. Nothing is visible to users yet: this is the foundation every other Network Discovery change builds on, and it is behind a feature flag that is off in production.

The server has added a `lists_list` item type to the Discover layout, served from `content_v4.json`. Its source payload carries a `lists` array of network summaries instead of the usual `podcasts` or `episodes`, and each entry brings its own artwork and item count so a row can render without fetching every network's JSON. Lists published after this change also describe themselves (`type`, `summary_style`, `expanded_style`), which is how the client will later recognise a network outside a Discover layout.

Three things make this safe to land ahead of the UI:

- The layout version is flag-gated. With `NETWORK_DISCOVERY` off the app keeps requesting `content_v3.json` exactly as before; only with the flag on does it ask for `content_v4.json`. Both versions are live on staging and production for all platforms.
- A `lists_list` row that does reach the mobile Discover list falls through to the existing zero-height error row, so it renders nothing rather than crashing. The dev guide relies on this for older clients.
- A `lists_list` may only carry `podcast_list` entries. Anything else the server adds later is dropped rather than treated as fatal, via `ListFeed.networks`. Unrecognised values already decode to `ListType.Unknown`, so no payload fails on account of a type this build has not seen.

TV gets an explicit branch that drops networks rows, since it has nowhere to render them and its `when` over the list type is exhaustive.

Fixes https://linear.app/a8c/issue/PCDROID-754/network-discovery-feature-flag-lists-list-decoding-and-unknown-type

## Testing Instructions

The green CI status should be enough

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
