### PR TITLE
Remove the search_predictive feature flag

### DIFF
--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
@@ -42,8 +42,6 @@ import au.com.shiftyjelly.pocketcasts.search.searchhistory.SearchHistoryPage
 import au.com.shiftyjelly.pocketcasts.search.searchhistory.SearchHistoryViewModel
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
 import au.com.shiftyjelly.pocketcasts.utils.extensions.pxToDp
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.extensions.hide
 import au.com.shiftyjelly.pocketcasts.views.extensions.show
 import au.com.shiftyjelly.pocketcasts.views.extensions.showKeyboard
@@ -258,7 +256,7 @@ class SearchFragment : BaseFragment() {
 
         searchView.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
             override fun onQueryTextSubmit(query: String): Boolean {
-                viewModel.updateSearchQuery(query, immediate = true)
+                viewModel.updateSearchQuery(query)
                 binding.searchHistoryPanel.hide()
                 UiUtil.hideKeyboard(searchView)
                 return true
@@ -283,7 +281,7 @@ class SearchFragment : BaseFragment() {
         binding.searchHistoryPanel.apply {
             setContentWithViewCompositionStrategy {
                 val state = viewModel.state.collectAsState()
-                if ((state.value is SearchUiState.Suggestions || !FeatureFlag.isEnabled(Feature.IMPROVED_SEARCH_SUGGESTIONS)) && state.value.searchTerm.isNullOrBlank()) {
+                if (state.value is SearchUiState.Suggestions && state.value.searchTerm.isNullOrBlank()) {
                     searchHistoryViewModel.start()
                 }
 

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchHandler.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchHandler.kt
@@ -15,8 +15,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.servers.ServiceManager
 import au.com.shiftyjelly.pocketcasts.servers.discover.GlobalServerSearch
 import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServiceManager
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import com.automattic.eventhorizon.EventHorizon
 import com.automattic.eventhorizon.SearchFailedEvent
 import com.automattic.eventhorizon.SearchPerformedEvent
@@ -55,7 +53,7 @@ class SearchHandler @Inject constructor(
 ) {
     private var source: SourceView = SourceView.UNKNOWN
     private val searchQuery = BehaviorRelay.create<Query>().apply {
-        accept(if (FeatureFlag.isEnabled(Feature.IMPROVED_SEARCH_SUGGESTIONS)) Query.Suggestions("") else Query.SearchResults(""))
+        accept(Query.Suggestions(""))
     }
 
     private val loadingObservable = BehaviorRelay.create<Boolean>().apply {

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchViewModel.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchViewModel.kt
@@ -11,8 +11,6 @@ import au.com.shiftyjelly.pocketcasts.models.to.SearchAutoCompleteItem
 import au.com.shiftyjelly.pocketcasts.models.to.SearchHistoryEntry
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.searchhistory.SearchHistoryManager
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import com.automattic.eventhorizon.EventHorizon
 import com.automattic.eventhorizon.PodcastSubscribedEvent
 import com.automattic.eventhorizon.SearchDismissedEvent
@@ -54,73 +52,64 @@ class SearchViewModel @Inject constructor(
     val state: StateFlow<SearchUiState> = _state
 
     init {
-        if (FeatureFlag.isEnabled(Feature.IMPROVED_SEARCH_SUGGESTIONS)) {
-            viewModelScope.launch {
-                searchHandler.searchSuggestions
-                    .collect { operation ->
-                        showSearchHistory = false
-                        _state.update { uiState ->
-                            when (operation) {
-                                is SearchUiState.SearchOperation.Error -> {
+        viewModelScope.launch {
+            searchHandler.searchSuggestions
+                .collect { operation ->
+                    showSearchHistory = false
+                    _state.update { uiState ->
+                        when (operation) {
+                            is SearchUiState.SearchOperation.Error -> {
+                                eventHorizon.track(
+                                    SearchPredictiveFailedEvent(
+                                        source = source.analyticsValue,
+                                        term = operation.searchTerm,
+                                    ),
+                                )
+                            }
+
+                            is SearchUiState.SearchOperation.Success -> {
+                                if (operation.results.isEmpty() && operation.searchTerm.isNotEmpty()) {
                                     eventHorizon.track(
-                                        SearchPredictiveFailedEvent(
+                                        SearchEmptyResultsEvent(
                                             source = source.analyticsValue,
                                             term = operation.searchTerm,
                                         ),
                                     )
                                 }
-
-                                is SearchUiState.SearchOperation.Success -> {
-                                    if (operation.results.isEmpty() && operation.searchTerm.isNotEmpty()) {
-                                        eventHorizon.track(
-                                            SearchEmptyResultsEvent(
-                                                source = source.analyticsValue,
-                                                term = operation.searchTerm,
-                                            ),
-                                        )
-                                    }
-                                }
-
-                                else -> Unit
                             }
 
-                            // only show loading for the initial query when autocomplete results are empty
-                            if (((uiState as? SearchUiState.Suggestions)?.operation as? SearchUiState.SearchOperation.Success)?.results?.isNotEmpty() == true && operation is SearchUiState.SearchOperation.Loading) {
-                                uiState
-                            } else {
-                                SearchUiState.Suggestions(operation = operation)
-                            }
+                            else -> Unit
+                        }
+
+                        // only show loading for the initial query when autocomplete results are empty
+                        if (((uiState as? SearchUiState.Suggestions)?.operation as? SearchUiState.SearchOperation.Success)?.results?.isNotEmpty() == true && operation is SearchUiState.SearchOperation.Loading) {
+                            uiState
+                        } else {
+                            SearchUiState.Suggestions(operation = operation)
                         }
                     }
-            }
+                }
         }
 
         viewModelScope.launch {
             searchHandler.improvedSearchResults.collect {
                 showSearchHistory = false
                 _state.value = SearchUiState.Results(operation = it)
-                if (!FeatureFlag.isEnabled(Feature.IMPROVED_SEARCH_SUGGESTIONS) && it is SearchUiState.SearchOperation.Loading) {
-                    saveSearchTerm(it.searchTerm)
-                }
             }
         }
     }
 
-    fun updateSearchQuery(query: String, immediate: Boolean = false) {
+    fun updateSearchQuery(query: String) {
         // Prevent updating the search query when navigating back to the search results after tapping on a result.
         if (query == _state.value.searchTerm) return
 
-        if (FeatureFlag.isEnabled(Feature.IMPROVED_SEARCH_SUGGESTIONS)) {
-            searchHandler.updateAutCompleteQuery(query)
-            _state.update {
-                if (it is SearchUiState.Results && it.searchTerm.orEmpty().length > query.length) {
-                    SearchUiState.Suggestions(operation = SearchUiState.SearchOperation.Success(searchTerm = query, results = emptyList()))
-                } else {
-                    it
-                }
+        searchHandler.updateAutCompleteQuery(query)
+        _state.update {
+            if (it is SearchUiState.Results && it.searchTerm.orEmpty().length > query.length) {
+                SearchUiState.Suggestions(operation = SearchUiState.SearchOperation.Success(searchTerm = query, results = emptyList()))
+            } else {
+                it
             }
-        } else {
-            searchHandler.updateSearchQuery(query, immediate)
         }
     }
 

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -152,15 +152,6 @@ enum class Feature(
         hasDevToggle = true,
         addedOn = LocalDate.parse("2025-08-29"),
     ),
-    IMPROVED_SEARCH_SUGGESTIONS(
-        key = "search_predictive",
-        title = "Predictive search suggestions",
-        defaultValue = isDebugOrPrototypeBuild,
-        tier = FeatureTier.Free,
-        hasFirebaseRemoteFlag = true,
-        hasDevToggle = true,
-        addedOn = LocalDate.parse("2025-10-07"),
-    ),
     IMPROVE_APP_RATINGS(
         key = "improve_app_ratings",
         title = "Banner prompting for app rating",


### PR DESCRIPTION
## Description

Removes the `search_predictive` feature flag (`Feature.IMPROVED_SEARCH_SUGGESTIONS`) and keeps the enabled behaviour permanently. Predictive search suggestions are now the only search experience.

## Testing Instructions

1. Open the Search tab. With an empty query, the search history panel is shown.
2. Type a few characters. Predictive suggestions appear, mixing local podcasts/folders with remote terms.
3. Tap a suggested term, or "view all", and confirm the full results list loads and the term is added to search history.
4. Delete characters back down and confirm the view returns to suggestions.
5. Paste a feed URL (`http...`) and confirm it is not auto-searched until submitted.
6. Go to Settings > Beta Features (dev builds) and confirm "Predictive search suggestions" is no longer listed.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md <!-- no changelog entry: the flagged behaviour has already shipped to users, this only removes the toggle -->
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes <!-- no behaviour change, so no new tests -->
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml` <!-- no string changes -->
- [x] Any jetpack compose components I added or changed are covered by compose previews <!-- no new components -->
- [x] I have updated (or requested that someone edit) the Event Horizon schema to reflect any new or changed analytics. <!-- no analytics changes -->

