### PR TITLE
Network Discovery: add networks to the search results

### DIFF
--- a/modules/features/search/build.gradle.kts
+++ b/modules/features/search/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
     implementation(libs.compose.material)
     implementation(libs.compose.ui)
     implementation(libs.compose.ui.tooling.preview)
+    implementation(libs.coil.compose)
     implementation(libs.coroutines.core)
     implementation(libs.coroutines.reactive)
     implementation(libs.fragment.compose)

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/ImprovedSearchResultsPage.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/ImprovedSearchResultsPage.kt
@@ -30,6 +30,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.ImprovedSearchResultItem
 import au.com.shiftyjelly.pocketcasts.search.component.ImprovedSearchEpisodeResultRow
 import au.com.shiftyjelly.pocketcasts.search.component.ImprovedSearchFolderResultRow
+import au.com.shiftyjelly.pocketcasts.search.component.ImprovedSearchNetworkResultRow
 import au.com.shiftyjelly.pocketcasts.search.component.ImprovedSearchPodcastResultRow
 import au.com.shiftyjelly.pocketcasts.search.component.NoResultsView
 import au.com.shiftyjelly.pocketcasts.search.component.SearchFailedView
@@ -44,6 +45,7 @@ fun ImprovedSearchResultsPage(
     onEpisodeClick: (ImprovedSearchResultItem.EpisodeItem) -> Unit,
     onPodcastClick: (ImprovedSearchResultItem.PodcastItem) -> Unit,
     onFolderClick: (Folder, List<Podcast>) -> Unit,
+    onNetworkClick: (ImprovedSearchResultItem.NetworkItem) -> Unit,
     onFollowPodcast: (ImprovedSearchResultItem.PodcastItem) -> Unit,
     onFilterSelect: (ResultsFilters) -> Unit,
     playButtonListener: PlayButtonListener,
@@ -71,6 +73,7 @@ fun ImprovedSearchResultsPage(
                     onEpisodeClick = onEpisodeClick,
                     onPodcastClick = onPodcastClick,
                     onFolderClick = onFolderClick,
+                    onNetworkClick = onNetworkClick,
                     onFollowPodcast = onFollowPodcast,
                     playButtonListener = playButtonListener,
                     onScroll = onScroll,
@@ -107,6 +110,7 @@ private fun ImprovedSearchResultsView(
     onEpisodeClick: (ImprovedSearchResultItem.EpisodeItem) -> Unit,
     onPodcastClick: (ImprovedSearchResultItem.PodcastItem) -> Unit,
     onFolderClick: (Folder, List<Podcast>) -> Unit,
+    onNetworkClick: (ImprovedSearchResultItem.NetworkItem) -> Unit,
     onFollowPodcast: (ImprovedSearchResultItem.PodcastItem) -> Unit,
     playButtonListener: PlayButtonListener,
     onScroll: () -> Unit,
@@ -182,6 +186,15 @@ private fun ImprovedSearchResultsView(
                                 podcastItem = item,
                                 onClick = { onPodcastClick(item) },
                                 onFollow = { onFollowPodcast(item) },
+                            )
+                        }
+                    }
+
+                    is ImprovedSearchResultItem.NetworkItem -> {
+                        item(key = "network-${item.uuid}", contentType = "network") {
+                            ImprovedSearchNetworkResultRow(
+                                networkItem = item,
+                                onClick = { onNetworkClick(item) },
                             )
                         }
                     }

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/ImprovedSearchResultsPage.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/ImprovedSearchResultsPage.kt
@@ -78,7 +78,7 @@ fun ImprovedSearchResultsPage(
                     playButtonListener = playButtonListener,
                     onScroll = onScroll,
                     selectedFilterIndex = state.selectedFilterIndex,
-                    filterOptions = state.filterOptions.toList(),
+                    filterOptions = state.filterOptions,
                     onFilterSelect = onFilterSelect,
                     onEmptyResultsShow = onEmptyResultsShow,
                     onResultsShow = onResultsShow,
@@ -131,7 +131,7 @@ private fun ImprovedSearchResultsView(
     }
     val listState = rememberLazyListState()
 
-    LaunchedEffect(state.searchTerm, state.results.filteredResults.size, onResultsShow, onEmptyResultsShow) {
+    LaunchedEffect(state.searchTerm, state.results.filter, state.results.filteredResults.size, onResultsShow, onEmptyResultsShow) {
         if (state.results.filteredResults.isNotEmpty()) {
             onResultsShow()
         } else if (state.searchTerm.isNotEmpty()) {

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchFragment.kt
@@ -32,6 +32,7 @@ import au.com.shiftyjelly.pocketcasts.compose.extensions.setContentWithViewCompo
 import au.com.shiftyjelly.pocketcasts.models.entity.Folder
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.EpisodeItem
+import au.com.shiftyjelly.pocketcasts.models.to.ImprovedSearchResultItem
 import au.com.shiftyjelly.pocketcasts.models.to.SearchHistoryEntry
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeViewSource
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -41,6 +42,7 @@ import au.com.shiftyjelly.pocketcasts.search.searchhistory.SearchHistoryClearAll
 import au.com.shiftyjelly.pocketcasts.search.searchhistory.SearchHistoryPage
 import au.com.shiftyjelly.pocketcasts.search.searchhistory.SearchHistoryViewModel
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
+import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.utils.extensions.pxToDp
 import au.com.shiftyjelly.pocketcasts.views.extensions.hide
 import au.com.shiftyjelly.pocketcasts.views.extensions.show
@@ -347,6 +349,7 @@ class SearchFragment : BaseFragment() {
                                 onEpisodeClick = { onEpisodeClick(episode = SearchHistoryEntry.fromImprovedEpisodeResult(it)) },
                                 onPodcastClick = { onPodcastClick(SearchHistoryEntry.fromImprovedPodcastResult(it), it.isFollowed) },
                                 onFolderClick = ::onFolderClick,
+                                onNetworkClick = ::onNetworkClick,
                                 onFollowPodcast = { viewModel.onSubscribeToPodcast(it.uuid) },
                                 playButtonListener = playButtonListener,
                                 onScroll = { UiUtil.hideKeyboard(searchView) },
@@ -415,6 +418,20 @@ class SearchFragment : BaseFragment() {
         )
         searchHistoryViewModel.add(folder)
         listener?.onSearchFolderClick(folder.uuid)
+        binding?.searchView?.let { UiUtil.hideKeyboard(it) }
+    }
+
+    private fun onNetworkClick(network: ImprovedSearchResultItem.NetworkItem) {
+        viewModel.trackSearchResultTapped(
+            source = source,
+            uuid = network.uuid,
+            type = SearchResultType.NETWORK,
+        )
+        (requireActivity() as FragmentHostListener).openNetworkPage(
+            listId = network.uuid,
+            title = network.title,
+            sourceView = SourceView.SEARCH_RESULTS,
+        )
         binding?.searchView?.let { UiUtil.hideKeyboard(it) }
     }
 

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchViewModel.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchViewModel.kt
@@ -325,17 +325,10 @@ class SearchViewModel @Inject constructor(
 private fun SearchUiState.SearchOperation<SearchResults.Results>.toResultsState(): SearchUiState.Results {
     val results = (this as? SearchUiState.SearchOperation.Success)?.results
     val hasNetworks = results?.results.orEmpty().any { it is ImprovedSearchResultItem.NetworkItem }
-    val filterOptions = ResultsFilters.entries.filter { it != ResultsFilters.NETWORKS || hasNetworks }
-    val selectedFilter = results?.filter?.takeIf { it in filterOptions } ?: ResultsFilters.TOP_RESULTS
-    val operation = if (results != null && results.filter != selectedFilter) {
-        SearchUiState.SearchOperation.Success(searchTerm = searchTerm, results = results.copy(filter = selectedFilter))
-    } else {
-        this
-    }
+    // Every result set arrives filtered to Top Results, so a filter that is no longer offered cannot strand the user.
     return SearchUiState.Results(
-        operation = operation,
-        filterOptions = filterOptions,
-        selectedFilterIndex = filterOptions.indexOf(selectedFilter),
+        operation = this,
+        filterOptions = ResultsFilters.entries.filter { it != ResultsFilters.NETWORKS || hasNetworks },
     )
 }
 

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchViewModel.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchViewModel.kt
@@ -312,6 +312,9 @@ class SearchViewModel @Inject constructor(
         EPISODE(
             analyticsValue = EventHorizonSearchResultType.Episode,
         ),
+        NETWORK(
+            analyticsValue = EventHorizonSearchResultType.Network,
+        ),
     }
 }
 

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchViewModel.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchViewModel.kt
@@ -23,6 +23,7 @@ import com.automattic.eventhorizon.SearchPredictiveShownEvent
 import com.automattic.eventhorizon.SearchPredictiveTermTappedEvent
 import com.automattic.eventhorizon.SearchPredictiveViewAllTappedEvent
 import com.automattic.eventhorizon.SearchResultFilterType
+import com.automattic.eventhorizon.SearchResultLegacyType
 import com.automattic.eventhorizon.SearchResultTappedEvent
 import com.automattic.eventhorizon.SearchShownEvent
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -94,7 +95,7 @@ class SearchViewModel @Inject constructor(
         viewModelScope.launch {
             searchHandler.improvedSearchResults.collect {
                 showSearchHistory = false
-                _state.value = SearchUiState.Results(operation = it)
+                _state.value = it.toResultsState()
             }
         }
     }
@@ -147,6 +148,7 @@ class SearchViewModel @Inject constructor(
         eventHorizon.track(
             SearchListShownEvent(
                 source = source.analyticsValue,
+                displaying = (_state.value as? SearchUiState.Results)?.selectedFilter?.displayingAnalyticsValue,
             ),
         )
     }
@@ -161,30 +163,32 @@ class SearchViewModel @Inject constructor(
     }
 
     fun selectFilter(filter: ResultsFilters) {
-        if (_state.value is SearchUiState.Results) {
-            eventHorizon.track(
-                SearchFilterTappedEvent(
-                    source = source.analyticsValue,
-                    filter = filter.analyticsValue,
-                ),
-            )
-            _state.update { state ->
-                when (state) {
-                    is SearchUiState.Results -> {
-                        if (state.operation is SearchUiState.SearchOperation.Success) {
-                            state.copy(
-                                selectedFilterIndex = ResultsFilters.entries.indexOf(filter),
-                                operation = state.operation.copy(
-                                    results = state.operation.results.copy(filter = filter),
-                                ),
-                            )
-                        } else {
-                            state
-                        }
-                    }
+        // A tap can land on a filter that the newest results no longer offer.
+        if ((_state.value as? SearchUiState.Results)?.filterOptions?.contains(filter) != true) return
 
-                    else -> state
+        eventHorizon.track(
+            SearchFilterTappedEvent(
+                source = source.analyticsValue,
+                filter = filter.analyticsValue,
+            ),
+        )
+        _state.update { state ->
+            when (state) {
+                is SearchUiState.Results -> {
+                    val filterIndex = state.filterOptions.indexOf(filter)
+                    if (filterIndex >= 0 && state.operation is SearchUiState.SearchOperation.Success) {
+                        state.copy(
+                            selectedFilterIndex = filterIndex,
+                            operation = state.operation.copy(
+                                results = state.operation.results.copy(filter = filter),
+                            ),
+                        )
+                    } else {
+                        state
+                    }
                 }
+
+                else -> state
             }
         }
     }
@@ -230,7 +234,7 @@ class SearchViewModel @Inject constructor(
         saveSearchTerm(term)
         searchHandler.updateSearchQuery(term, true)
 
-        _state.value = SearchUiState.Results(operation = SearchUiState.SearchOperation.Loading(term))
+        _state.value = SearchUiState.SearchOperation.Loading(term).toResultsState()
     }
 
     fun selectSuggestion(suggestion: String) {
@@ -318,6 +322,23 @@ class SearchViewModel @Inject constructor(
     }
 }
 
+private fun SearchUiState.SearchOperation<SearchResults.Results>.toResultsState(): SearchUiState.Results {
+    val results = (this as? SearchUiState.SearchOperation.Success)?.results
+    val hasNetworks = results?.results.orEmpty().any { it is ImprovedSearchResultItem.NetworkItem }
+    val filterOptions = ResultsFilters.entries.filter { it != ResultsFilters.NETWORKS || hasNetworks }
+    val selectedFilter = results?.filter?.takeIf { it in filterOptions } ?: ResultsFilters.TOP_RESULTS
+    val operation = if (results != null && results.filter != selectedFilter) {
+        SearchUiState.SearchOperation.Success(searchTerm = searchTerm, results = results.copy(filter = selectedFilter))
+    } else {
+        this
+    }
+    return SearchUiState.Results(
+        operation = operation,
+        filterOptions = filterOptions,
+        selectedFilterIndex = filterOptions.indexOf(selectedFilter),
+    )
+}
+
 sealed interface SearchResults {
     val isEmpty: Boolean
 
@@ -350,6 +371,7 @@ sealed interface SearchResults {
                     ResultsFilters.TOP_RESULTS -> true
                     ResultsFilters.EPISODES -> item is ImprovedSearchResultItem.EpisodeItem
                     ResultsFilters.PODCASTS -> item is ImprovedSearchResultItem.PodcastItem || item is ImprovedSearchResultItem.FolderItem
+                    ResultsFilters.NETWORKS -> item is ImprovedSearchResultItem.NetworkItem
                 }
             }
 
@@ -362,6 +384,7 @@ sealed interface SearchResults {
 enum class ResultsFilters(
     val resId: Int,
     val analyticsValue: SearchResultFilterType,
+    val displayingAnalyticsValue: SearchResultLegacyType? = null,
 ) {
     TOP_RESULTS(
         resId = LR.string.search_filters_top_results,
@@ -370,10 +393,17 @@ enum class ResultsFilters(
     PODCASTS(
         resId = LR.string.search_filters_podcasts,
         analyticsValue = SearchResultFilterType.Podcasts,
+        displayingAnalyticsValue = SearchResultLegacyType.Podcasts,
     ),
     EPISODES(
         resId = LR.string.search_filters_episodes,
         analyticsValue = SearchResultFilterType.Episodes,
+        displayingAnalyticsValue = SearchResultLegacyType.Episodes,
+    ),
+    NETWORKS(
+        resId = LR.string.search_filters_networks,
+        analyticsValue = SearchResultFilterType.Networks,
+        displayingAnalyticsValue = SearchResultLegacyType.Networks,
     ),
 }
 
@@ -405,7 +435,9 @@ sealed interface SearchUiState {
     data class Suggestions(val operation: SearchOperation<List<SearchAutoCompleteItem>>) : SearchUiState
     data class Results(
         val operation: SearchOperation<SearchResults.Results>,
-        val filterOptions: Set<ResultsFilters> = ResultsFilters.entries.toSet(),
+        val filterOptions: List<ResultsFilters>,
         val selectedFilterIndex: Int = 0,
-    ) : SearchUiState
+    ) : SearchUiState {
+        val selectedFilter get() = filterOptions.getOrElse(selectedFilterIndex) { ResultsFilters.TOP_RESULTS }
+    }
 }

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/component/ImprovedSearchNetworkResultRow.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/component/ImprovedSearchNetworkResultRow.kt
@@ -1,0 +1,119 @@
+package au.com.shiftyjelly.pocketcasts.search.component
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP50
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.models.to.ImprovedSearchResultItem
+import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory
+import au.com.shiftyjelly.pocketcasts.ui.extensions.themed
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import coil3.compose.rememberAsyncImagePainter
+
+private val imageSize = 56.dp
+
+@Composable
+fun ImprovedSearchNetworkResultRow(
+    networkItem: ImprovedSearchResultItem.NetworkItem,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    ImprovedSearchNetworkResultRow(
+        title = networkItem.title,
+        description = networkItem.description,
+        imageUrl = networkItem.imageUrl,
+        onClick = onClick,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun ImprovedSearchNetworkResultRow(
+    title: String,
+    description: String?,
+    imageUrl: String?,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        NetworkImage(imageUrl = imageUrl)
+        Column(modifier = Modifier.weight(1f)) {
+            TextH40(
+                text = title,
+                color = MaterialTheme.theme.colors.primaryText01,
+                maxLines = 1,
+            )
+            if (!description.isNullOrBlank()) {
+                TextP50(
+                    text = description,
+                    color = MaterialTheme.theme.colors.primaryText02,
+                    maxLines = 2,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun NetworkImage(
+    imageUrl: String?,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val imageRequest = remember(imageUrl, context) {
+        PocketCastsImageRequestFactory(
+            context = context,
+            placeholderType = PocketCastsImageRequestFactory.PlaceholderType.Small,
+            size = imageSize.value.toInt(),
+        ).themed().createForFileOrUrl(imageUrl.orEmpty())
+    }
+    Image(
+        painter = rememberAsyncImagePainter(imageRequest, contentScale = ContentScale.Crop),
+        contentScale = ContentScale.Crop,
+        contentDescription = null,
+        modifier = modifier
+            .size(imageSize)
+            .clip(CircleShape),
+    )
+}
+
+@Preview
+@Composable
+private fun PreviewNetworkRow(
+    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
+) {
+    AppThemeWithBackground(themeType) {
+        ImprovedSearchNetworkResultRow(
+            title = "WNYC",
+            description = "New York's flagship public radio station",
+            imageUrl = null,
+            onClick = {},
+        )
+    }
+}

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/component/SearchResultFilters.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/component/SearchResultFilters.kt
@@ -97,7 +97,7 @@ private fun PreviewSearchResultFilters(
 ) {
     AppThemeWithBackground(themeType) {
         SearchResultFilters(
-            items = listOf("Top Results", "Podcasts", "Episodes"),
+            items = listOf("Top Results", "Podcasts", "Episodes", "Networks"),
             selectedIndex = 1,
             onFilterSelect = {},
         )

--- a/modules/features/search/src/test/java/au/com/shiftyjelly/pocketcasts/search/SearchViewModelTest.kt
+++ b/modules/features/search/src/test/java/au/com/shiftyjelly/pocketcasts/search/SearchViewModelTest.kt
@@ -100,7 +100,7 @@ class SearchViewModelTest {
         viewModel.selectFilter(ResultsFilters.NETWORKS)
         assertEquals(listOf(networkItem), filteredResults())
 
-        emitResults(podcastItem, filter = ResultsFilters.NETWORKS)
+        emitResults(podcastItem)
 
         val state = resultsState()
         assertEquals(0, state.selectedFilterIndex)
@@ -154,11 +154,11 @@ class SearchViewModelTest {
         assertTrue(event.displaying == null)
     }
 
-    private fun emitResults(vararg items: ImprovedSearchResultItem, filter: ResultsFilters = ResultsFilters.TOP_RESULTS) {
+    private fun emitResults(vararg items: ImprovedSearchResultItem) {
         improvedSearchResults.tryEmit(
             SearchUiState.SearchOperation.Success(
                 searchTerm = "the times",
-                results = SearchResults.Results(results = items.toList(), filter = filter),
+                results = SearchResults.Results(results = items.toList(), filter = ResultsFilters.TOP_RESULTS),
             ),
         )
     }

--- a/modules/features/search/src/test/java/au/com/shiftyjelly/pocketcasts/search/SearchViewModelTest.kt
+++ b/modules/features/search/src/test/java/au/com/shiftyjelly/pocketcasts/search/SearchViewModelTest.kt
@@ -2,20 +2,32 @@ package au.com.shiftyjelly.pocketcasts.search
 
 import au.com.shiftyjelly.pocketcasts.analytics.testing.TestEventSink
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.to.ImprovedSearchResultItem
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.searchhistory.SearchHistoryManager
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import com.automattic.eventhorizon.EventHorizon
+import com.automattic.eventhorizon.SearchListShownEvent
+import com.automattic.eventhorizon.SearchResultLegacyType
+import java.util.Date
 import java.util.UUID
+import kotlin.time.Duration.Companion.minutes
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.emptyFlow
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(MockitoJUnitRunner::class)
@@ -34,13 +46,18 @@ class SearchViewModelTest {
 
     private lateinit var viewModel: SearchViewModel
 
+    private val eventSink = TestEventSink()
+    private val improvedSearchResults = MutableSharedFlow<SearchUiState.SearchOperation<SearchResults.Results>>(replay = 1)
+
     @Before
     fun setUp() {
+        whenever(searchHandler.searchSuggestions) doReturn emptyFlow()
+        whenever(searchHandler.improvedSearchResults) doReturn improvedSearchResults
         viewModel = SearchViewModel(
             searchHandler = searchHandler,
             searchHistoryManager = searchHistoryManager,
             podcastManager = podcastManager,
-            eventHorizon = EventHorizon(TestEventSink()),
+            eventHorizon = EventHorizon(eventSink),
         )
     }
 
@@ -59,4 +76,116 @@ class SearchViewModelTest {
 
         verify(podcastManager, never()).subscribeToPodcast(podcastUuid = uuid, sync = true)
     }
+
+    @Test
+    fun `given results contain a network, when results are shown, then the networks filter is offered`() {
+        emitResults(podcastItem, networkItem, episodeItem)
+
+        assertEquals(
+            listOf(ResultsFilters.TOP_RESULTS, ResultsFilters.PODCASTS, ResultsFilters.EPISODES, ResultsFilters.NETWORKS),
+            resultsState().filterOptions,
+        )
+    }
+
+    @Test
+    fun `given results contain no networks, when results are shown, then the networks filter is not offered`() {
+        emitResults(podcastItem, episodeItem)
+
+        assertFalse(ResultsFilters.NETWORKS in resultsState().filterOptions)
+    }
+
+    @Test
+    fun `given the networks filter is selected, when it is no longer offered, then the filter resets to top results`() {
+        emitResults(podcastItem, networkItem)
+        viewModel.selectFilter(ResultsFilters.NETWORKS)
+        assertEquals(listOf(networkItem), filteredResults())
+
+        emitResults(podcastItem, filter = ResultsFilters.NETWORKS)
+
+        val state = resultsState()
+        assertEquals(0, state.selectedFilterIndex)
+        assertEquals(ResultsFilters.TOP_RESULTS, state.selectedFilter)
+        assertEquals(listOf(podcastItem), filteredResults())
+    }
+
+    @Test
+    fun `given the networks filter is no longer offered, when it is selected, then the selection is ignored`() {
+        emitResults(podcastItem)
+
+        viewModel.selectFilter(ResultsFilters.NETWORKS)
+
+        val state = resultsState()
+        assertEquals(0, state.selectedFilterIndex)
+        assertEquals(ResultsFilters.TOP_RESULTS, state.selectedFilter)
+        assertEquals(listOf(podcastItem), filteredResults())
+        assertTrue(eventSink.isEmpty())
+    }
+
+    @Test
+    fun `when a filter is selected, then the selected index points at the offered filters`() {
+        emitResults(podcastItem, networkItem, episodeItem)
+
+        viewModel.selectFilter(ResultsFilters.NETWORKS)
+
+        val state = resultsState()
+        assertEquals(3, state.selectedFilterIndex)
+        assertEquals(ResultsFilters.NETWORKS, state.selectedFilter)
+    }
+
+    @Test
+    fun `given the networks filter is selected, when results are shown, then the shown list reports networks`() {
+        emitResults(networkItem)
+        viewModel.selectFilter(ResultsFilters.NETWORKS)
+        eventSink.skipEvent(eventSink.size)
+
+        viewModel.reportResultsShown()
+
+        val event = eventSink.pollEvent() as SearchListShownEvent
+        assertEquals(SearchResultLegacyType.Networks, event.displaying)
+    }
+
+    @Test
+    fun `given no filter is selected, when results are shown, then the shown list reports no filter`() {
+        emitResults(podcastItem, networkItem)
+
+        viewModel.reportResultsShown()
+
+        val event = eventSink.pollEvent() as SearchListShownEvent
+        assertTrue(event.displaying == null)
+    }
+
+    private fun emitResults(vararg items: ImprovedSearchResultItem, filter: ResultsFilters = ResultsFilters.TOP_RESULTS) {
+        improvedSearchResults.tryEmit(
+            SearchUiState.SearchOperation.Success(
+                searchTerm = "the times",
+                results = SearchResults.Results(results = items.toList(), filter = filter),
+            ),
+        )
+    }
+
+    private fun resultsState() = viewModel.state.value as SearchUiState.Results
+
+    private fun filteredResults() = (resultsState().operation as SearchUiState.SearchOperation.Success).results.filteredResults
+
+    private val podcastItem = ImprovedSearchResultItem.PodcastItem(
+        uuid = "podcast-uuid",
+        title = "The Daily",
+        author = "The New York Times",
+        isFollowed = false,
+    )
+
+    private val networkItem = ImprovedSearchResultItem.NetworkItem(
+        uuid = "network-uuid",
+        title = "The New York Times",
+        description = "The best audio journalism and storytelling in one place.",
+    )
+
+    private val episodeItem = ImprovedSearchResultItem.EpisodeItem(
+        uuid = "episode-uuid",
+        title = "Monday, March 3rd",
+        podcastUuid = "podcast-uuid",
+        podcastTitle = "The Daily",
+        publishedDate = Date(0),
+        duration = 25.minutes,
+    )
 }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2906,7 +2906,6 @@
     <string name="search_filters_podcasts" translatable="false">@string/podcasts</string>
     <string name="search_filters_episodes" translatable="false">@string/episodes</string>
     <string name="search_filters_folders" translatable="false">@string/folders</string>
-    <!-- translators: A search results filter that shows only podcast networks. A network is a company that publishes several podcasts. -->
     <string name="search_filters_networks">Networks</string>
     <string name="search_suggestions_view_all">View all for \"%1$s\"</string>
     <string name="search_suggestions_no_results_title">No Results</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2906,6 +2906,8 @@
     <string name="search_filters_podcasts" translatable="false">@string/podcasts</string>
     <string name="search_filters_episodes" translatable="false">@string/episodes</string>
     <string name="search_filters_folders" translatable="false">@string/folders</string>
+    <!-- translators: A search results filter that shows only podcast networks. A network is a company that publishes several podcasts. -->
+    <string name="search_filters_networks">Networks</string>
     <string name="search_suggestions_view_all">View all for \"%1$s\"</string>
     <string name="search_suggestions_no_results_title">No Results</string>
     <string name="search_suggestions_no_results_message">Try a new search, or by adding a podcast feed URL</string>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/ImprovedSearchResultItem.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/ImprovedSearchResultItem.kt
@@ -25,6 +25,13 @@ sealed interface ImprovedSearchResultItem {
         val isExplicit: Boolean = false,
     ) : ImprovedSearchResultItem
 
+    data class NetworkItem(
+        override val uuid: String,
+        override val title: String,
+        val description: String? = null,
+        val imageUrl: String? = null,
+    ) : ImprovedSearchResultItem
+
     data class EpisodeItem(
         override val uuid: String,
         override val title: String,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/search/ImprovedSearchManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/search/ImprovedSearchManagerImpl.kt
@@ -7,6 +7,8 @@ import au.com.shiftyjelly.pocketcasts.servers.search.AutoCompleteResult
 import au.com.shiftyjelly.pocketcasts.servers.search.AutoCompleteSearchService
 import au.com.shiftyjelly.pocketcasts.servers.search.CombinedResult
 import au.com.shiftyjelly.pocketcasts.servers.search.CombinedSearchRequest
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.seconds
 
@@ -56,6 +58,17 @@ class ImprovedSearchManagerImpl @Inject constructor(
                     duration = it.duration.seconds,
                     hasVideo = it.hasVideo == true,
                 )
+
+                is CombinedResult.NetworkResult -> {
+                    if (!FeatureFlag.isEnabled(Feature.NETWORK_DISCOVERY)) return@mapNotNull null
+                    val title = it.title?.takeIf { title -> title.isNotBlank() } ?: return@mapNotNull null
+                    ImprovedSearchResultItem.NetworkItem(
+                        uuid = it.uuid,
+                        title = title,
+                        description = it.shortDescription,
+                        imageUrl = it.collectionImage,
+                    )
+                }
 
                 CombinedResult.Unknown -> null
             }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/search/ImprovedSearchManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/search/ImprovedSearchManagerImpl.kt
@@ -61,9 +61,10 @@ class ImprovedSearchManagerImpl @Inject constructor(
 
                 is CombinedResult.NetworkResult -> {
                     if (!FeatureFlag.isEnabled(Feature.NETWORK_DISCOVERY)) return@mapNotNull null
+                    val uuid = it.uuid ?: return@mapNotNull null
                     val title = it.title?.takeIf { title -> title.isNotBlank() } ?: return@mapNotNull null
                     ImprovedSearchResultItem.NetworkItem(
-                        uuid = it.uuid,
+                        uuid = uuid,
                         title = title,
                         description = it.shortDescription,
                         imageUrl = it.collectionImage,

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/search/ImprovedSearchManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/search/ImprovedSearchManagerImplTest.kt
@@ -9,10 +9,14 @@ import au.com.shiftyjelly.pocketcasts.servers.search.AutoCompleteSearchService
 import au.com.shiftyjelly.pocketcasts.servers.search.CombinedResult
 import au.com.shiftyjelly.pocketcasts.servers.search.CombinedSearchResponse
 import au.com.shiftyjelly.pocketcasts.servers.search.PodcastResultValue
+import au.com.shiftyjelly.pocketcasts.sharedtest.InMemoryFeatureFlagRule
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import java.util.Date
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
@@ -21,6 +25,9 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
 class ImprovedSearchManagerImplTest {
+    @get:Rule
+    val featureFlagRule = InMemoryFeatureFlagRule()
+
     private val autoCompleteSearchService = mock<AutoCompleteSearchService>()
     private val combinedSearchService = mock<PodcastCacheService>()
     private val manager = ImprovedSearchManagerImpl(
@@ -114,4 +121,67 @@ class ImprovedSearchManagerImplTest {
             results,
         )
     }
+
+    @Test
+    fun `combined search maps networks when network discovery is enabled`() = runTest {
+        FeatureFlag.setEnabled(Feature.NETWORK_DISCOVERY, true)
+        whenever(combinedSearchService.combinedSearch(any())) doReturn CombinedSearchResponse(
+            results = listOf(networkResult, podcastResult),
+        )
+
+        val results = manager.combinedSearch("wnyc")
+
+        assertEquals(
+            ImprovedSearchResultItem.NetworkItem(
+                uuid = "network-uuid",
+                title = "WNYC",
+                description = "New York's flagship public radio station",
+                imageUrl = "https://static.pocketcasts.com/wnyc-author.png",
+            ),
+            results.filterIsInstance<ImprovedSearchResultItem.NetworkItem>().single(),
+        )
+    }
+
+    @Test
+    fun `combined search drops networks when network discovery is disabled`() = runTest {
+        FeatureFlag.setEnabled(Feature.NETWORK_DISCOVERY, false)
+        whenever(combinedSearchService.combinedSearch(any())) doReturn CombinedSearchResponse(
+            results = listOf(networkResult, podcastResult),
+        )
+
+        val results = manager.combinedSearch("wnyc")
+
+        assertEquals(listOf("podcast-uuid"), results.map { it.uuid })
+    }
+
+    @Test
+    fun `combined search drops networks with a blank title`() = runTest {
+        FeatureFlag.setEnabled(Feature.NETWORK_DISCOVERY, true)
+        whenever(combinedSearchService.combinedSearch(any())) doReturn CombinedSearchResponse(
+            results = listOf(
+                networkResult.copy(uuid = "no-title-uuid", title = null),
+                networkResult.copy(uuid = "blank-title-uuid", title = "  "),
+                networkResult,
+            ),
+        )
+
+        val results = manager.combinedSearch("wnyc")
+
+        assertEquals(listOf("network-uuid"), results.map { it.uuid })
+    }
+
+    private val networkResult = CombinedResult.NetworkResult(
+        uuid = "network-uuid",
+        title = "WNYC",
+        shortDescription = "New York's flagship public radio station",
+        collectionImage = "https://static.pocketcasts.com/wnyc-author.png",
+    )
+
+    private val podcastResult = CombinedResult.PodcastResult(
+        uuid = "podcast-uuid",
+        title = "Big Sugar",
+        author = "Weekday Fun Productions",
+        slug = "big-sugar",
+        explicit = false,
+    )
 }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/search/ImprovedSearchManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/search/ImprovedSearchManagerImplTest.kt
@@ -155,10 +155,11 @@ class ImprovedSearchManagerImplTest {
     }
 
     @Test
-    fun `combined search drops networks with a blank title`() = runTest {
+    fun `combined search drops networks without a uuid or a title`() = runTest {
         FeatureFlag.setEnabled(Feature.NETWORK_DISCOVERY, true)
         whenever(combinedSearchService.combinedSearch(any())) doReturn CombinedSearchResponse(
             results = listOf(
+                networkResult.copy(uuid = null),
                 networkResult.copy(uuid = "no-title-uuid", title = null),
                 networkResult.copy(uuid = "blank-title-uuid", title = "  "),
                 networkResult,

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/search/CombinedSearchResponse.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/search/CombinedSearchResponse.kt
@@ -40,7 +40,7 @@ sealed interface CombinedResult {
 
     @JsonClass(generateAdapter = true)
     data class NetworkResult(
-        val uuid: String,
+        val uuid: String? = null,
         val title: String? = null,
         @Json(name = "short_description")
         val shortDescription: String? = null,

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/search/CombinedSearchResponse.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/search/CombinedSearchResponse.kt
@@ -38,12 +38,23 @@ sealed interface CombinedResult {
         val hasVideo: Boolean? = null,
     ) : CombinedResult
 
+    @JsonClass(generateAdapter = true)
+    data class NetworkResult(
+        val uuid: String,
+        val title: String? = null,
+        @Json(name = "short_description")
+        val shortDescription: String? = null,
+        @Json(name = "collection_image")
+        val collectionImage: String? = null,
+    ) : CombinedResult
+
     data object Unknown : CombinedResult
 
     companion object {
         val jsonAdapter = PolymorphicJsonAdapterFactory.of(CombinedResult::class.java, "type")
             .withSubtype(PodcastResult::class.java, "podcast")
             .withSubtype(EpisodeResult::class.java, "episode")
+            .withSubtype(NetworkResult::class.java, "network")
             .withDefaultValue(Unknown)
     }
 }

--- a/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/search/CombinedSearchResponseTest.kt
+++ b/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/search/CombinedSearchResponseTest.kt
@@ -19,7 +19,7 @@ class CombinedSearchResponseTest {
             """
             {"results":[
               {"uuid":"p1","title":"Freakonomics Radio","slug":"freakonomics-radio","type":"podcast"},
-              {"uuid":"n1","title":"Some Network","type":"network"},
+              {"uuid":"c1","title":"Some Curated List","type":"curated_list"},
               {"uuid":"p2","title":"Another Show","slug":"another-show","type":"podcast"}
             ]}
             """.trimIndent(),
@@ -30,19 +30,57 @@ class CombinedSearchResponseTest {
     }
 
     @Test
-    fun `registered podcast and episode subtypes decode alongside the fallback`() {
+    fun `registered podcast, episode and network subtypes decode alongside the fallback`() {
         val response = adapter.fromJson(
             """
             {"results":[
               {"uuid":"p1","title":"Freakonomics Radio","slug":"freakonomics-radio","type":"podcast"},
               {"uuid":"e1","title":"Ep 1","url":"https://example.com/1.mp3","published_date":"2024-01-02T03:04:05Z","podcast_uuid":"p1","podcast_title":"Freakonomics Radio","podcast_slug":"freakonomics-radio","type":"episode"},
-              {"uuid":"n1","title":"Some Network","type":"network"}
+              {"uuid":"n1","title":"Some Network","type":"network"},
+              {"uuid":"c1","title":"Some Curated List","type":"curated_list"}
             ]}
             """.trimIndent(),
         )
 
         val types = response?.results?.map { it::class.simpleName }
-        assertEquals(listOf("PodcastResult", "EpisodeResult", "Unknown"), types)
+        assertEquals(listOf("PodcastResult", "EpisodeResult", "NetworkResult", "Unknown"), types)
+    }
+
+    @Test
+    fun `network results decode every field the server sends`() {
+        val response = adapter.fromJson(
+            """
+            {"results":[
+              {"uuid":"c73d120f-c174-4324-b0a3-18f9b239a59d","title":"WNYC","short_description":"New York's flagship public radio station","collection_image":"https://static.pocketcasts.com/wnyc-author.png","podcast_count":11,"type":"network"}
+            ]}
+            """.trimIndent(),
+        )
+
+        assertEquals(
+            CombinedResult.NetworkResult(
+                uuid = "c73d120f-c174-4324-b0a3-18f9b239a59d",
+                title = "WNYC",
+                shortDescription = "New York's flagship public radio station",
+                collectionImage = "https://static.pocketcasts.com/wnyc-author.png",
+            ),
+            response?.results?.single(),
+        )
+    }
+
+    @Test
+    fun `network results decode when the optional fields are missing`() {
+        val response = adapter.fromJson(
+            """
+            {"results":[
+              {"uuid":"n1","title":"WNYC","type":"network"}
+            ]}
+            """.trimIndent(),
+        )
+
+        assertEquals(
+            CombinedResult.NetworkResult(uuid = "n1", title = "WNYC"),
+            response?.results?.single(),
+        )
     }
 
     @Test

--- a/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/search/CombinedSearchResponseTest.kt
+++ b/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/search/CombinedSearchResponseTest.kt
@@ -68,6 +68,21 @@ class CombinedSearchResponseTest {
     }
 
     @Test
+    fun `a network missing its uuid does not fail the whole response`() {
+        val response = adapter.fromJson(
+            """
+            {"results":[
+              {"uuid":"p1","title":"Freakonomics Radio","slug":"freakonomics-radio","type":"podcast"},
+              {"title":"WNYC","type":"network"}
+            ]}
+            """.trimIndent(),
+        )
+
+        val types = response?.results?.map { it::class.simpleName }
+        assertEquals(listOf("PodcastResult", "NetworkResult"), types)
+    }
+
+    @Test
     fun `network results decode when the optional fields are missing`() {
         val response = adapter.fromJson(
             """


### PR DESCRIPTION
## Description
Searching now finds podcast networks, not just podcasts and episodes. A network shows up among the top results with its logo and a short description, there is a Networks filter to see only those, and tapping one opens that network's page.

Fixes https://linear.app/a8c/issue/PCDROID-760/network-discovery-add-networks-to-the-search-results

## Testing Instructions
1. Search for a term with networks behind it, for example "The New York Times" or "Relay".
1. Confirm networks appear among the top results with circular artwork, the network name and a description.
1. Confirm a Networks pill appears after Top Results, Podcasts and Episodes, and that selecting it shows only networks.
1. Tap a network and confirm its network page opens with the right title.
1. Go back, search a term with no networks, for example "swift". Confirm the Networks pill is gone.
1. Turn the `NETWORK_DISCOVERY` flag off, search "Relay" again, and confirm no networks appear anywhere and the pill is gone.
1. Confirm podcast, folder and episode results are unchanged throughout.

## Screenshots or Screencast

| Light | Dark |
| --- | --- |
| <img width="1080" height="2424" alt="Screenshot_20260907_125306" src="https://github.com/user-attachments/assets/5431a191-cff5-4767-ba02-b7d5393e46f4" /> | <img width="1080" height="2424" alt="Screenshot_20260907_125320" src="https://github.com/user-attachments/assets/0073b201-b938-4a78-b98b-903ca9d8dd62" /> | 

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
