### PR TITLE
Fix Android Auto mute button not resuming playback

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3SessionCallback.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3SessionCallback.kt
@@ -209,7 +209,13 @@ internal class Media3SessionCallback(
         // sequences, and the MediaEventQueue suppresses those duplicates.
         when (keyEvent.keyCode) {
             KeyEvent.KEYCODE_MEDIA_PAUSE -> {
-                scope.launch { playbackManager.pauseSuspend(sourceView = source) }
+                scope.launch {
+                    if (playbackManager.isPlaying()) {
+                        playbackManager.pauseSuspend(sourceView = source)
+                    } else {
+                        playbackManager.playQueueSuspend(sourceView = source)
+                    }
+                }
                 return true
             }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -329,7 +329,15 @@ class MediaSessionManager(
                 scope.launch { commandMutex.withLock { playbackManager.playQueueSuspend(sourceView = SourceView.MEDIA_BUTTON_BROADCAST_ACTION) } }
             },
             onPause = {
-                scope.launch { commandMutex.withLock { playbackManager.pauseSuspend(sourceView = SourceView.MEDIA_BUTTON_BROADCAST_ACTION) } }
+                scope.launch {
+                    commandMutex.withLock {
+                        if (playbackManager.isPlaying()) {
+                            playbackManager.pauseSuspend(sourceView = SourceView.MEDIA_BUTTON_BROADCAST_ACTION)
+                        } else {
+                            playbackManager.playQueueSuspend(sourceView = SourceView.MEDIA_BUTTON_BROADCAST_ACTION)
+                        }
+                    }
+                }
             },
             onSeekTo = { positionMs ->
                 scope.launch {
@@ -1235,6 +1243,14 @@ class MediaSessionManager(
                 val keyEvent = IntentCompat.getParcelableExtra(mediaButtonEvent, Intent.EXTRA_KEY_EVENT, KeyEvent::class.java) ?: return false
                 logEvent(keyEvent.toString())
                 if (keyEvent.action == KeyEvent.ACTION_DOWN) {
+                    if (keyEvent.keyCode == KeyEvent.KEYCODE_MEDIA_PAUSE) {
+                        if (playbackManager.isPlaying()) {
+                            enqueueCommand("pause") { playbackManager.pauseSuspend(sourceView = source) }
+                        } else {
+                            enqueueCommand("play") { playbackManager.playQueueSuspend(sourceView = source) }
+                        }
+                        return true
+                    }
                     LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Media button Android event: ${keyEvent.action}")
                     val inputEvent = when (keyEvent.keyCode) {
                         KeyEvent.KEYCODE_MEDIA_PLAY, KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE, KeyEvent.KEYCODE_HEADSETHOOK -> MediaEvent.SingleTap
@@ -1339,7 +1355,11 @@ class MediaSessionManager(
 
         override fun onPause() {
             logEvent("pause")
-            enqueueCommand("pause") { playbackManager.pauseSuspend(sourceView = source) }
+            if (playbackManager.isPlaying()) {
+                enqueueCommand("pause") { playbackManager.pauseSuspend(sourceView = source) }
+            } else {
+                enqueueCommand("play") { playbackManager.playQueueSuspend(sourceView = source) }
+            }
         }
 
         override fun onPlayFromSearch(query: String?, extras: Bundle?) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -1050,12 +1050,13 @@ class MediaSessionManager(
                 PlaybackStateCompat.ACTION_REWIND or
                 prepareActions
 
-            return if (useCustomSkipButtons()) {
-                actions
-            } else {
+            val includeSkipActions = !useCustomSkipButtons() || playbackManager.isCarConnected()
+            return if (includeSkipActions) {
                 PlaybackStateCompat.ACTION_SKIP_TO_PREVIOUS or
                     PlaybackStateCompat.ACTION_SKIP_TO_NEXT or
                     actions
+            } else {
+                actions
             }
         }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -8,6 +8,7 @@ import android.media.MediaPlayer
 import android.widget.Toast
 import androidx.annotation.MainThread
 import androidx.annotation.OptIn
+import androidx.annotation.VisibleForTesting
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
@@ -247,6 +248,29 @@ open class PlaybackManager @Inject constructor(
     private val resumptionHelper = ResumptionHelper(settings)
 
     private val errorClassifier = PlaybackErrorClassifier()
+
+    @VisibleForTesting
+    internal var isAndroidAutoConnected = false
+
+    fun isCarConnected(): Boolean {
+        return Util.isAutomotive(application) || Util.isCarUiMode(application) || isAndroidAutoConnected
+    }
+
+    init {
+        try {
+            Util.isAndroidAutoConnectedFlow(application)
+                .distinctUntilChanged()
+                .onEach { isConnected ->
+                    isAndroidAutoConnected = isConnected
+                    if (!isConnected && !isPlaying()) {
+                        focusManager.giveUpAudioFocus()
+                    }
+                }
+                .launchIn(applicationScope)
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to observe CarConnection")
+        }
+    }
 
     var episodeSubscription: Disposable? = null
 
@@ -1002,7 +1026,9 @@ open class PlaybackManager @Inject constructor(
 
     suspend fun pauseSuspend(transientLoss: Boolean = false, sourceView: SourceView = SourceView.UNKNOWN) {
         if (!transientLoss) {
-            focusManager.giveUpAudioFocus()
+            if (!isCarConnected()) {
+                focusManager.giveUpAudioFocus()
+            }
             playbackStateRelay.blockingFirst().let { playbackState ->
                 playbackStateRelay.accept(playbackState.copy(transientLoss = false))
             }
@@ -1059,6 +1085,8 @@ open class PlaybackManager @Inject constructor(
                 player = null
             }
         }
+
+        focusManager.giveUpAudioFocus()
 
         playbackStateRelay.blockingFirst().let {
             playbackStateRelay.accept(
@@ -2010,6 +2038,8 @@ open class PlaybackManager @Inject constructor(
             focusWasPlaying = Date()
 
             pause(transientLoss = transientLoss, sourceView = SourceView.AUTO_PAUSE)
+        } else if (focusWasPlaying != null) {
+            LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Focus lost while already paused from prior focus loss")
         } else {
             LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Focus lost not playing")
             focusWasPlaying = null

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3SessionCallbackTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Media3SessionCallbackTest.kt
@@ -349,13 +349,26 @@ class Media3SessionCallbackTest {
     }
 
     @Test
-    fun `KEYCODE_MEDIA_PAUSE calls pauseSuspend`() = runTest {
+    fun `KEYCODE_MEDIA_PAUSE calls pauseSuspend when playing`() = runTest {
+        whenever(playbackManager.isPlaying()).thenReturn(true)
         sendMediaButtonEvent(KeyEvent.KEYCODE_MEDIA_PAUSE)
         testScope.advanceUntilIdle()
 
         verify(playbackManager).pauseSuspend(
             transientLoss = any(),
             sourceView = any(),
+        )
+    }
+
+    @Test
+    fun `KEYCODE_MEDIA_PAUSE calls playQueueSuspend when already paused`() = runTest {
+        whenever(playbackManager.isPlaying()).thenReturn(false)
+        sendMediaButtonEvent(KeyEvent.KEYCODE_MEDIA_PAUSE)
+        testScope.advanceUntilIdle()
+
+        verify(playbackManager).playQueueSuspend(
+            sourceView = any(),
+            showedStreamWarning = any(),
         )
     }
 


### PR DESCRIPTION
## Description
In Android Auto and Automotive, pressing the physical mute button pauses playback, but pressing it again (unmute) fails to resume.

Many vehicle headunits treat mute/unmute as a toggle that dispatches `KEYCODE_MEDIA_PAUSE` (or triggers `onPause`) on both presses, expecting the media player to toggle playback if it is already paused. Because Pocket Casts treated pause commands strictly as pause-only, the unmute press was ignored.

Additionally, `pauseSuspend()` was immediately releasing audio focus via `giveUpAudioFocus()`. In car environments, relinquishing audio focus causes the headunit to close the audio channel after a brief timeout (~5s), preventing subsequent steering wheel events from reaching the app.

Fixes #149
Ref: https://forums.pocketcasts.com/forums/topic/android-auto-pocketcasts-treats-unmute-differently-to-other-audio-apps

## Changes
- Toggle to `playQueueSuspend()` when receiving `KEYCODE_MEDIA_PAUSE` or `onPause()` while playback is already paused.
- Retain audio focus while paused when connected to Android Auto or Automotive (`isCarConnected()`), releasing it only on explicit stop or car disconnection.
- Preserve `focusWasPlaying` in `onFocusLoss()` if paused from a prior focus loss so playback can resume when focus returns.
- Include skip actions in `MediaSessionManager.getSupportedActions()` when connected to a car.

### Testing Instructions
Tested using Desktop Head Unit (DHU):
1. Start DHU with phone connected:
   ```bash
   adb forward tcp:5277 tcp:5277
   ./desktop-head-unit
   ```
2. Play any podcast episode in Pocket Casts on Android Auto.
3. Simulate mute:
   ```bash
   adb shell input keyevent 127
   ```
   Playback pauses (`state=PAUSED(2)`), and audio focus is retained.
4. Simulate unmute (press mute again):
   ```bash
   adb shell input keyevent 127
   ```
   Playback resumes (`state=PLAYING(3)`).
5. Pause again, wait over 5-10 seconds, then send keyevent 127 again. Playback still resumes correctly without audio routing being torn down.