### PR TITLE
Add safeguards to "Cache entire playing episode" for oversized/video files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
         ([#5843](https://github.com/Automattic/pocket-casts-android/pull/5843))
     *   Closing the transcript search bar now keeps the transcript open at the same scroll position instead of exiting the transcript
         ([#5835](https://github.com/Automattic/pocket-casts-android/pull/5835))
+    *   Stop "Cache entire playing episode" from silently downloading oversized or video enclosures in the background
+        ([#5868](https://github.com/Automattic/pocket-casts-android/pull/5868))
 
 8.20
 -----

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/fingerprint/FingerprintTimingManager.kt
@@ -14,6 +14,7 @@ import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.BuildConfig
 import au.com.shiftyjelly.pocketcasts.repositories.playback.ExoPlayerDataSourceFactory
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.playback.shouldCacheEntireEpisode
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.ChapterManager
 import au.com.shiftyjelly.pocketcasts.utils.AppPlatform
 import au.com.shiftyjelly.pocketcasts.utils.Network
@@ -222,7 +223,12 @@ class FingerprintTimingManager @Inject constructor(
         val audioSource = episode.downloadedFilePath ?: episode.downloadUrl
         // Reuse the player's on-disk cache (same UUID key) instead of a second download when it applies.
         val sharedCacheKey = episodeUuid.takeIf {
-            !episode.isDownloaded && !episode.isDownloading && !episode.isStreamUrlHls && settings.cacheEntirePlayingEpisode.value
+            shouldCacheEntireEpisode(
+                episode = episode,
+                isHlsStream = episode.isStreamUrlHls,
+                cacheEntirePlayingEpisodeEnabled = settings.cacheEntirePlayingEpisode.value,
+                maxCacheSizeBytes = settings.getExoPlayerCacheEntirePlayingEpisodeSizeInMB() * 1024 * 1024L,
+            )
         }
 
         scope.launch {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CacheWorker.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CacheWorker.kt
@@ -18,6 +18,7 @@ import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import androidx.work.Worker
 import androidx.work.WorkerParameters
+import au.com.shiftyjelly.pocketcasts.utils.config.FirebaseConfig
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
@@ -93,7 +94,7 @@ class CacheWorker @AssistedInject constructor(
         private const val URL_KEY = "url_key"
         private const val EPISODE_UUID_KEY = "episode_uuid_key"
         private const val MAX_CACHE_BYTES_KEY = "max_cache_bytes_key"
-        private const val DEFAULT_MAX_CACHE_BYTES = 500L * 1024 * 1024
+        private val DEFAULT_MAX_CACHE_BYTES = (FirebaseConfig.defaults[FirebaseConfig.EXOPLAYER_CACHE_ENTIRE_PLAYING_EPISODE_SIZE_IN_MB] as Long) * 1024 * 1024
 
         fun startCachingEntireEpisode(
             context: Context,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CacheWorker.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CacheWorker.kt
@@ -33,10 +33,13 @@ class CacheWorker @AssistedInject constructor(
     private val sourceFactory: ExoPlayerDataSourceFactory,
 ) : Worker(context, params) {
     private var cacheWriter: CacheWriter? = null
+    private var cancelledForCap = false
     private val episodeUuid get() = inputData.getString(EPISODE_UUID_KEY)
     private val downloadUrl get() = inputData.getString(URL_KEY)
 
     override fun doWork(): Result {
+        val maxCacheBytes = inputData.getLong(MAX_CACHE_BYTES_KEY, DEFAULT_MAX_CACHE_BYTES)
+            .takeIf { it > 0 } ?: DEFAULT_MAX_CACHE_BYTES
         try {
             if (downloadUrl == null || episodeUuid == null) {
                 Timber.tag(TAG).e("Error: Episode download url or uuid is null, downloadUrl: '$downloadUrl' episodeUuid: '$episodeUuid' worker id: '$id'")
@@ -52,14 +55,22 @@ class CacheWorker @AssistedInject constructor(
                 cacheDataSourceFactory.createDataSource(),
                 dataSpec,
                 null,
-                null,
-            )
+            ) { _, bytesCached, _ ->
+                if (bytesCached >= maxCacheBytes) {
+                    cancelledForCap = true
+                    cacheWriter?.cancel()
+                }
+            }
             cacheWriter?.cache()
             LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Caching complete for episode id: $episodeUuid worker id: '$id'")
 
             val outputData = Data.Builder().putString(EPISODE_UUID_KEY, episodeUuid).build()
             return Result.success(outputData)
         } catch (exception: Exception) {
+            if (cancelledForCap) {
+                LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Caching stopped after reaching the $maxCacheBytes byte cap for episode id: $episodeUuid worker id: '$id'")
+                return Result.failure()
+            }
             val errorMessage = "Failed to cache episode '$episodeUuid' for url '$downloadUrl' worker id: '$id'"
             Timber.tag(TAG).e(exception, errorMessage)
             LogBuffer.e(LogBuffer.TAG_PLAYBACK, exception, errorMessage)
@@ -81,15 +92,18 @@ class CacheWorker @AssistedInject constructor(
         private const val CACHE_WORKER_TAG = "pocket_casts_cache_worker_tag"
         private const val URL_KEY = "url_key"
         private const val EPISODE_UUID_KEY = "episode_uuid_key"
+        private const val MAX_CACHE_BYTES_KEY = "max_cache_bytes_key"
+        private const val DEFAULT_MAX_CACHE_BYTES = 500L * 1024 * 1024
 
         fun startCachingEntireEpisode(
             context: Context,
             url: String,
             episodeUuid: String,
             networkConstraint: NetworkType,
+            maxCacheBytes: Long,
             onCachingComplete: (String) -> Unit,
         ) {
-            val cacheWorkRequest = buildCacheWorkRequest(url, episodeUuid, networkConstraint)
+            val cacheWorkRequest = buildCacheWorkRequest(url, episodeUuid, networkConstraint, maxCacheBytes)
 
             observeWorkerInfo(context, cacheWorkRequest, episodeUuid, onCachingComplete)
 
@@ -101,10 +115,12 @@ class CacheWorker @AssistedInject constructor(
             url: String,
             episodeUuid: String,
             networkConstraint: NetworkType,
+            maxCacheBytes: Long,
         ): OneTimeWorkRequest {
             val inputData = Data.Builder()
                 .putString(URL_KEY, url)
                 .putString(EPISODE_UUID_KEY, episodeUuid)
+                .putLong(MAX_CACHE_BYTES_KEY, maxCacheBytes)
                 .build()
 
             val constraints = Constraints.Builder()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ExoPlayerDataSourceFactory.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ExoPlayerDataSourceFactory.kt
@@ -42,9 +42,11 @@ class ExoPlayerDataSourceFactory @Inject constructor(
     private val settings: Settings,
     private val crashLogging: CrashLogging,
 ) {
+    private val maxCacheSizeBytes = settings.getExoPlayerCacheEntirePlayingEpisodeSizeInMB() * 1024 * 1024L
+
     private val cache = runCatching {
         val cacheDir = File(context.cacheDir, CACHE_DIR_NAME)
-        val evictor = LeastRecentlyUsedCacheEvictor(maxCacheSizeBytes())
+        val evictor = LeastRecentlyUsedCacheEvictor(maxCacheSizeBytes)
         SimpleCache(cacheDir, evictor, StandaloneDatabaseProvider(context))
     }.onFailure { e ->
         val errorMessage = "Failed to instantiate ExoPlayer cache ${e.message}"
@@ -137,7 +139,7 @@ class ExoPlayerDataSourceFactory @Inject constructor(
                 url = episodeUri,
                 episodeUuid = episodeLocation.episode.uuid,
                 networkConstraint = cacheNetworkConstraint(settings.warnOnMeteredNetwork.value),
-                maxCacheBytes = maxCacheSizeBytes(),
+                maxCacheBytes = maxCacheSizeBytes,
                 onCachingComplete = onCachingComplete,
             )
         }
@@ -173,10 +175,8 @@ class ExoPlayerDataSourceFactory @Inject constructor(
         episode = episode,
         isHlsStream = isHlsStream,
         cacheEntirePlayingEpisodeEnabled = settings.cacheEntirePlayingEpisode.value,
-        maxCacheSizeBytes = maxCacheSizeBytes(),
+        maxCacheSizeBytes = maxCacheSizeBytes,
     )
-
-    private fun maxCacheSizeBytes() = settings.getExoPlayerCacheEntirePlayingEpisodeSizeInMB() * 1024 * 1024L
 
     private fun ClosedRange<Long>.toClippingConfiguration() = ClippingConfiguration.Builder()
         .setStartPositionMs(start)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ExoPlayerDataSourceFactory.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ExoPlayerDataSourceFactory.kt
@@ -19,6 +19,7 @@ import androidx.media3.exoplayer.source.MediaSource
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
 import androidx.media3.extractor.DefaultExtractorsFactory
 import androidx.media3.extractor.mp3.Mp3Extractor
+import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.servers.di.Player
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
@@ -43,8 +44,7 @@ class ExoPlayerDataSourceFactory @Inject constructor(
 ) {
     private val cache = runCatching {
         val cacheDir = File(context.cacheDir, CACHE_DIR_NAME)
-        val size = settings.getExoPlayerCacheEntirePlayingEpisodeSizeInMB() * 1024 * 1024L
-        val evictor = LeastRecentlyUsedCacheEvictor(size)
+        val evictor = LeastRecentlyUsedCacheEvictor(maxCacheSizeBytes())
         SimpleCache(cacheDir, evictor, StandaloneDatabaseProvider(context))
     }.onFailure { e ->
         val errorMessage = "Failed to instantiate ExoPlayer cache ${e.message}"
@@ -168,7 +168,14 @@ class ExoPlayerDataSourceFactory @Inject constructor(
         }
     }
 
-    private fun EpisodeLocation.shouldUseCache() = !episode.isDownloaded && !episode.isDownloading && !isHlsStream && settings.cacheEntirePlayingEpisode.value
+    private fun EpisodeLocation.shouldUseCache() = shouldCacheEntireEpisode(
+        episode = episode,
+        isHlsStream = isHlsStream,
+        cacheEntirePlayingEpisodeEnabled = settings.cacheEntirePlayingEpisode.value,
+        maxCacheSizeBytes = maxCacheSizeBytes(),
+    )
+
+    private fun maxCacheSizeBytes() = settings.getExoPlayerCacheEntirePlayingEpisodeSizeInMB() * 1024 * 1024L
 
     private fun ClosedRange<Long>.toClippingConfiguration() = ClippingConfiguration.Builder()
         .setStartPositionMs(start)
@@ -179,3 +186,15 @@ class ExoPlayerDataSourceFactory @Inject constructor(
         const val CACHE_DIR_NAME = "pocketcasts-exoplayer-cache"
     }
 }
+
+internal fun shouldCacheEntireEpisode(
+    episode: BaseEpisode,
+    isHlsStream: Boolean,
+    cacheEntirePlayingEpisodeEnabled: Boolean,
+    maxCacheSizeBytes: Long,
+) = !episode.isDownloaded &&
+    !episode.isDownloading &&
+    !isHlsStream &&
+    !episode.isVideo &&
+    cacheEntirePlayingEpisodeEnabled &&
+    !(maxCacheSizeBytes > 0 && episode.sizeInBytes > maxCacheSizeBytes)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ExoPlayerDataSourceFactory.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ExoPlayerDataSourceFactory.kt
@@ -137,6 +137,7 @@ class ExoPlayerDataSourceFactory @Inject constructor(
                 url = episodeUri,
                 episodeUuid = episodeLocation.episode.uuid,
                 networkConstraint = cacheNetworkConstraint(settings.warnOnMeteredNetwork.value),
+                maxCacheBytes = maxCacheSizeBytes(),
                 onCachingComplete = onCachingComplete,
             )
         }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CacheWorkerRequestTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CacheWorkerRequestTest.kt
@@ -12,6 +12,7 @@ class CacheWorkerRequestTest {
             url = "https://example.com/episode.mp3",
             episodeUuid = "episode-uuid",
             networkConstraint = NetworkType.UNMETERED,
+            maxCacheBytes = MAX_CACHE_BYTES,
         )
 
         assertEquals(NetworkType.UNMETERED, request.requiredNetworkType())
@@ -23,11 +24,31 @@ class CacheWorkerRequestTest {
             url = "https://example.com/episode.mp3",
             episodeUuid = "episode-uuid",
             networkConstraint = NetworkType.CONNECTED,
+            maxCacheBytes = MAX_CACHE_BYTES,
         )
 
         assertEquals(NetworkType.CONNECTED, request.requiredNetworkType())
     }
 
+    @Test
+    fun `should carry the max cache bytes in the cache work request input data`() {
+        val request = CacheWorker.buildCacheWorkRequest(
+            url = "https://example.com/episode.mp3",
+            episodeUuid = "episode-uuid",
+            networkConstraint = NetworkType.UNMETERED,
+            maxCacheBytes = MAX_CACHE_BYTES,
+        )
+
+        assertEquals(MAX_CACHE_BYTES, request.maxCacheBytes())
+    }
+
     @Suppress("RestrictedApi")
     private fun androidx.work.OneTimeWorkRequest.requiredNetworkType() = workSpec.constraints.requiredNetworkType
+
+    @Suppress("RestrictedApi")
+    private fun androidx.work.OneTimeWorkRequest.maxCacheBytes() = workSpec.input.getLong("max_cache_bytes_key", -1L)
+
+    private companion object {
+        const val MAX_CACHE_BYTES = 500L * 1024 * 1024
+    }
 }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ShouldCacheEntireEpisodeTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ShouldCacheEntireEpisodeTest.kt
@@ -1,0 +1,95 @@
+package au.com.shiftyjelly.pocketcasts.repositories.playback
+
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.type.EpisodeDownloadStatus
+import java.util.Date
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ShouldCacheEntireEpisodeTest {
+
+    private fun createEpisode(
+        downloadStatus: EpisodeDownloadStatus = EpisodeDownloadStatus.DownloadNotRequested,
+        fileType: String? = "audio/mp3",
+        sizeInBytes: Long = 0,
+    ) = PodcastEpisode(
+        uuid = "episode-uuid",
+        publishedDate = Date(),
+        downloadStatus = downloadStatus,
+        fileType = fileType,
+        sizeInBytes = sizeInBytes,
+        downloadUrl = "https://example.com/episode.mp3",
+    )
+
+    private fun shouldCache(
+        episode: PodcastEpisode = createEpisode(),
+        isHlsStream: Boolean = false,
+        cacheEntirePlayingEpisodeEnabled: Boolean = true,
+        maxCacheSizeBytes: Long = CACHE_SIZE_BYTES,
+    ) = shouldCacheEntireEpisode(
+        episode = episode,
+        isHlsStream = isHlsStream,
+        cacheEntirePlayingEpisodeEnabled = cacheEntirePlayingEpisodeEnabled,
+        maxCacheSizeBytes = maxCacheSizeBytes,
+    )
+
+    @Test
+    fun `should cache a normal streamed audio episode`() {
+        assertTrue(shouldCache())
+    }
+
+    @Test
+    fun `should not cache a downloaded episode`() {
+        assertFalse(shouldCache(createEpisode(downloadStatus = EpisodeDownloadStatus.Downloaded)))
+    }
+
+    @Test
+    fun `should not cache a downloading episode`() {
+        assertFalse(shouldCache(createEpisode(downloadStatus = EpisodeDownloadStatus.Downloading)))
+    }
+
+    @Test
+    fun `should not cache an HLS stream`() {
+        assertFalse(shouldCache(isHlsStream = true))
+    }
+
+    @Test
+    fun `should not cache when the setting is disabled`() {
+        assertFalse(shouldCache(cacheEntirePlayingEpisodeEnabled = false))
+    }
+
+    @Test
+    fun `should not cache a video episode`() {
+        assertFalse(shouldCache(createEpisode(fileType = "video/mp4")))
+    }
+
+    @Test
+    fun `should not cache a small video episode`() {
+        assertFalse(shouldCache(createEpisode(fileType = "video/mp4", sizeInBytes = 1L * 1024 * 1024)))
+    }
+
+    @Test
+    fun `should not cache when the reported size exceeds the cache size`() {
+        assertFalse(shouldCache(createEpisode(sizeInBytes = CACHE_SIZE_BYTES + 1)))
+    }
+
+    @Test
+    fun `should cache when the reported size equals the cache size`() {
+        assertTrue(shouldCache(createEpisode(sizeInBytes = CACHE_SIZE_BYTES)))
+    }
+
+    @Test
+    fun `should cache when the reported size is unknown`() {
+        assertTrue(shouldCache(createEpisode(sizeInBytes = 0)))
+    }
+
+    @Test
+    fun `should cache a huge episode when there is no size cap`() {
+        assertTrue(shouldCache(createEpisode(sizeInBytes = 48_089_985_249), maxCacheSizeBytes = 0))
+    }
+
+    private companion object {
+        const val CACHE_SIZE_BYTES = 500L * 1024 * 1024
+    }
+}


### PR DESCRIPTION
## Description

Adds safeguards to the "Cache entire playing episode" feature (Settings → Advanced → Playback, on by default) so a single mis-published feed enclosure can no longer trigger a huge, silent background download.

**Root cause.** When an episode is streamed, `ExoPlayerDataSourceFactory.shouldUseCache()` gates a background `CacheWorker` that pulls the **entire** file into the ExoPlayer cache so scrubbing is instant. The predicate had no video exclusion and no size cap, and `CacheWorker` ran a media3 `CacheWriter` with an open-ended `DataSpec` (no length) — so it pulled however many bytes the resource had. A podcast feed pointed at a mis-published **44.8 GiB** raw `.mp4` export (`48,089,985,249` bytes); streaming it made `CacheWorker` try to pull all 48 GB in the background. A free-tier user burned ~23 GB of mobile data in ~30 min → a €750 carrier bill (Zendesk 11558980). Note `warnOnMeteredNetwork` defaults to `false`, so the cache job's network constraint is `CONNECTED` (cellular allowed) by default.

iOS already excludes video podcasts outright and checks reported size vs. free space before starting its parallel download. This brings Android to parity and adds one extra, metadata-independent backstop.

### Three layers of defence

1. **Exclude video + oversized episodes (reported-size pre-check).** Extracted the caching decision into a pure, testable `shouldCacheEntireEpisode(...)` that additionally rejects `episode.isVideo` (iOS `!videoPodcast()`) and episodes whose feed-reported `sizeInBytes` exceeds the ExoPlayer LRU cache size. The LRU cache can only retain `maxCacheSizeBytes` (Firebase default 500 MB), so pulling a larger file downloads the whole thing but immediately evicts most of it — pure waste. Unknown size (`0`) is allowed (matches iOS's residual behaviour); `maxCacheSizeBytes <= 0` is treated as "no size cap" so a transient `0` remote-config value can't disable the feature globally.

2. **Keep the fingerprint/transcript path in sync.** `FingerprintTimingManager` had a structurally identical copy of the predicate deciding whether to reuse the player's on-disk cache (`sharedCacheKey` → `followPlayerCache`). Left untouched it would diverge — the player would stop caching video/oversized episodes while the transcript pipeline still waited up to `FOLLOW_TIMEOUT_MS` (60 s) per region for cache writes that never arrive. It now calls the same shared `shouldCacheEntireEpisode(...)`.

3. **Metadata-independent hard byte-bound in `CacheWorker`.** The two guards above trust publisher metadata (`fileType`, `sizeInBytes`). A non-video enclosure that reports `length="0"` (or lies) but is actually enormous would still slip through. So `CacheWorker` now attaches a `CacheWriter.ProgressListener` that cancels the writer once the bytes pulled reach the cache size, landing in the existing catch as a `Result.failure()`. This bounds background network egress to ~500 MB regardless of what the feed claims. It is safe: `Result.failure()` never retries (no backoff is configured), and the fully-cached callback (`onCachingComplete`, which marks the episode 100 % buffered) only fires on `SUCCEEDED`, so a capped run never falsely marks the episode buffered. The request stays open-ended (`bytes=0-`), so there is no risk of a `416` from a bounded range on non-compliant CDNs — which is why this uses listener-cancel rather than `DataSpec.setLength`.

   **Scope of the byte-bound:** it caps egress **per worker run**. `CacheWriter` seeds its counter with bytes already present for the key, so re-runs of an already-capped episode are normally no-ops. The only residual is a slow "top-up drip": if other cache writes (1 MB next-episode prefetch, the fingerprint reader) evict part of a capped episode, a later player-prepare / `resetEpisodeCaching` re-enqueue pulls just the evicted delta back up to the cap. It is bounded (never a fresh full pull) and requires actively re-streaming a pathological enclosure while other content churns the shared cache — for the reported 48 GB file this is still a ~100× reduction. A persistent "already capped" marker to suppress the drip was considered and deliberately left out as disproportionate for this non-blocking edge case.

### Notes / trade-offs
- **Threshold = cache size** is stricter than iOS's free-space check: an episode only *modestly* larger than the cache (e.g. a 3 h+ high-bitrate show) loses the instant-scrub cache entirely rather than being partially cached. This is a conscious, documented choice — the cache can't hold the whole file anyway, and the byte-bound in layer 3 keeps the *unknown-size* case graceful.
- **Intentional "no cap" asymmetry:** in the predicate, `maxCacheSizeBytes <= 0` means "no size pre-check" (permissive, so we never disable the feature globally); in `CacheWorker`, a `<= 0` value falls back to a 500 MB hard cap. The worker must *always* have a bound — that's the whole point of layer 3.
- **Left out on purpose:** `PrefetchWorker` (the next-episode prefetch) is already hard-capped to 1 MB via `DataSpec.setLength`, so it can't reproduce this. No `UserEpisode` exclusion was added — the video + size guards already cover uploaded cloud files.

Fixes PCDROID-718

## Testing Instructions

This is a background/data-usage change with no UI surface, so there are no emulator screenshots.

1. Unit tests: `./gradlew :modules:services:repositories:testDebugUnitTest` — new `ShouldCacheEntireEpisodeTest` covers the guard truth table (video, downloaded/downloading, HLS, setting off, size > cap, size == cap boundary, unknown size, no-cap path) and `CacheWorkerRequestTest` covers the max-cache-bytes input-data plumbing.
2. Manual sanity (optional): with "Cache entire playing episode" on, stream a normal audio episode and confirm scrubbing is still instant (caching still runs). Stream a video podcast and confirm it plays via plain streaming with no background cache job.

The `CacheWorker` cap/cancel path itself isn't unit-tested — it needs media3/Robolectric infra, and this repo avoids player-state-machine tests. Its correctness (media3 1.10.1 `CacheWriter.cancel()` from within the progress listener terminates `cache()`) was verified by reading the media3 source and via an independent review.

## Screenshots or Screencast

N/A — no UI changes.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml` (no new strings)
- [x] Any jetpack compose components I added or changed are covered by compose previews (none)
- [x] I have updated (or requested that someone edit) the Event Horizon schema to reflect any new or changed analytics (no analytics changes)

#### I have tested any UI changes...
<!-- No UI changes in this PR -->
