### PR TITLE
Fail truncated media responses instead of completing the episode

### DIFF
--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/di/InterceptorModule.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/di/InterceptorModule.kt
@@ -7,6 +7,7 @@ import au.com.shiftyjelly.pocketcasts.servers.BuildConfig
 import au.com.shiftyjelly.pocketcasts.servers.CleanAndRetryInterceptor
 import au.com.shiftyjelly.pocketcasts.servers.OkHttpInterceptor
 import au.com.shiftyjelly.pocketcasts.servers.interceptors.BasicAuthInterceptor
+import au.com.shiftyjelly.pocketcasts.servers.interceptors.ContentLengthValidatorInterceptor
 import au.com.shiftyjelly.pocketcasts.servers.interceptors.InternationalizationInterceptor
 import au.com.shiftyjelly.pocketcasts.servers.sync.TokenHandler
 import au.com.shiftyjelly.pocketcasts.servers.sync.exception.RefreshTokenExpiredException
@@ -96,6 +97,8 @@ object InterceptorModule {
     ).toClientInterceptor() // Must be client interceptor. Otherwise calls cannot be retried.
 
     private val basicAuthInterceptor = BasicAuthInterceptor().toClientInterceptor()
+
+    private val contentLengthValidatorInterceptor = ContentLengthValidatorInterceptor().toNetworkInterceptor()
 
     @Provides
     @TokenInterceptor
@@ -231,6 +234,7 @@ object InterceptorModule {
             add(crashLoggingInterceptor.toClientInterceptor())
             add(basicAuthInterceptor)
             add(cleanAndRetryInterceptor)
+            add(contentLengthValidatorInterceptor)
 
             if (BuildConfig.DEBUG) {
                 val loggingInterceptor = HttpLoggingInterceptor().apply {
@@ -274,6 +278,7 @@ object InterceptorModule {
             add(crashLoggingInterceptor.toClientInterceptor())
             add(basicAuthInterceptor)
             add(cleanAndRetryInterceptor)
+            add(contentLengthValidatorInterceptor)
 
             if (BuildConfig.DEBUG) {
                 val loggingInterceptor = HttpLoggingInterceptor().apply {

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/interceptors/ContentLengthValidatorInterceptor.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/interceptors/ContentLengthValidatorInterceptor.kt
@@ -1,0 +1,66 @@
+package au.com.shiftyjelly.pocketcasts.servers.interceptors
+
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
+import java.net.ProtocolException
+import okhttp3.Interceptor
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.asResponseBody
+import okio.Buffer
+import okio.ForwardingSource
+import okio.Source
+import okio.buffer
+
+internal class ContentLengthValidatorInterceptor : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+        val response = chain.proceed(request)
+
+        if (!FeatureFlag.isEnabled(Feature.VALIDATE_CONTENT_LENGTH)) {
+            return response
+        }
+        if (request.method != "GET" || response.code !in VALIDATED_STATUS_CODES) {
+            return response
+        }
+        val body = response.body ?: return response
+        val declaredLength = body.contentLength()
+        if (declaredLength <= 0) {
+            return response
+        }
+
+        val validatingSource = TruncationDetectingSource(body.source(), declaredLength, request.url.redact())
+        return response.newBuilder()
+            .body(validatingSource.buffer().asResponseBody(body.contentType(), declaredLength))
+            .build()
+    }
+
+    private companion object {
+        val VALIDATED_STATUS_CODES = setOf(200, 206)
+    }
+}
+
+private class TruncationDetectingSource(
+    delegate: Source,
+    private val declaredLength: Long,
+    private val redactedUrl: String,
+) : ForwardingSource(delegate) {
+    private var bytesRead = 0L
+
+    override fun read(sink: Buffer, byteCount: Long): Long {
+        val read = super.read(sink, byteCount)
+        if (read == -1L) {
+            val missing = declaredLength - bytesRead
+            if (missing > MIN_MISSING_BYTES && bytesRead < declaredLength * MIN_DELIVERED_FRACTION) {
+                throw ProtocolException("unexpected end of stream: received $bytesRead of $declaredLength bytes from $redactedUrl")
+            }
+        } else {
+            bytesRead += read
+        }
+        return read
+    }
+
+    private companion object {
+        const val MIN_MISSING_BYTES = 512L * 1024L
+        const val MIN_DELIVERED_FRACTION = 0.9
+    }
+}

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/interceptors/ContentLengthValidatorInterceptor.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/interceptors/ContentLengthValidatorInterceptor.kt
@@ -45,12 +45,12 @@ private class TruncationDetectingSource(
     private val redactedUrl: String,
 ) : ForwardingSource(delegate) {
     private var bytesRead = 0L
+    private val tolerance = maxOf(MIN_TOLERANCE_BYTES, minOf(declaredLength / 10, MAX_TOLERANCE_BYTES))
 
     override fun read(sink: Buffer, byteCount: Long): Long {
         val read = super.read(sink, byteCount)
         if (read == -1L) {
-            val missing = declaredLength - bytesRead
-            if (missing > MIN_MISSING_BYTES && bytesRead < declaredLength * MIN_DELIVERED_FRACTION) {
+            if (declaredLength - bytesRead > tolerance) {
                 throw ProtocolException(
                     "unexpected end of stream: received $bytesRead of $declaredLength bytes from $redactedUrl",
                 )
@@ -62,7 +62,7 @@ private class TruncationDetectingSource(
     }
 
     private companion object {
-        const val MIN_MISSING_BYTES = 512L * 1024L
-        const val MIN_DELIVERED_FRACTION = 0.9
+        const val MIN_TOLERANCE_BYTES = 512L * 1024L
+        const val MAX_TOLERANCE_BYTES = 2L * 1024L * 1024L
     }
 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/interceptors/ContentLengthValidatorInterceptor.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/interceptors/ContentLengthValidatorInterceptor.kt
@@ -22,7 +22,7 @@ internal class ContentLengthValidatorInterceptor : Interceptor {
         if (request.method != "GET" || response.code !in VALIDATED_STATUS_CODES) {
             return response
         }
-        val body = response.body ?: return response
+        val body = response.body
         val declaredLength = body.contentLength()
         if (declaredLength <= 0) {
             return response

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/interceptors/ContentLengthValidatorInterceptor.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/interceptors/ContentLengthValidatorInterceptor.kt
@@ -51,7 +51,9 @@ private class TruncationDetectingSource(
         if (read == -1L) {
             val missing = declaredLength - bytesRead
             if (missing > MIN_MISSING_BYTES && bytesRead < declaredLength * MIN_DELIVERED_FRACTION) {
-                throw ProtocolException("unexpected end of stream: received $bytesRead of $declaredLength bytes from $redactedUrl")
+                throw ProtocolException(
+                    "unexpected end of stream: received $bytesRead of $declaredLength bytes from $redactedUrl",
+                )
             }
         } else {
             bytesRead += read

--- a/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/interceptors/ContentLengthValidatorInterceptorTest.kt
+++ b/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/interceptors/ContentLengthValidatorInterceptorTest.kt
@@ -1,0 +1,135 @@
+package au.com.shiftyjelly.pocketcasts.servers.interceptors
+
+import au.com.shiftyjelly.pocketcasts.sharedtest.InMemoryFeatureFlagRule
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
+import java.net.ProtocolException
+import okhttp3.Interceptor
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.asResponseBody
+import okio.Buffer
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+class ContentLengthValidatorInterceptorTest {
+    @get:Rule
+    val featureFlagRule = InMemoryFeatureFlagRule()
+
+    @Test
+    fun `complete body passes through`() {
+        val body = readWholeBody(declaredLength = MB, deliveredBytes = MB.toInt())
+
+        assertEquals(MB.toInt(), body.size)
+    }
+
+    @Test
+    fun `grossly truncated body throws`() {
+        assertThrows(ProtocolException::class.java) {
+            readWholeBody(declaredLength = 2 * MB, deliveredBytes = MB.toInt())
+        }
+    }
+
+    @Test
+    fun `shortfall within absolute tolerance passes through`() {
+        val body = readWholeBody(declaredLength = MB, deliveredBytes = 600_000)
+
+        assertEquals(600_000, body.size)
+    }
+
+    @Test
+    fun `shortfall above ninety percent delivered passes through`() {
+        val deliveredBytes = (6 * MB - 600 * KB).toInt()
+
+        val body = readWholeBody(declaredLength = 6 * MB, deliveredBytes = deliveredBytes)
+
+        assertEquals(deliveredBytes, body.size)
+    }
+
+    @Test
+    fun `unknown content length is not validated`() {
+        val body = readWholeBody(declaredLength = -1L, deliveredBytes = 1_000)
+
+        assertEquals(1_000, body.size)
+    }
+
+    @Test
+    fun `head request is not validated`() {
+        val body = readWholeBody(declaredLength = 2 * MB, deliveredBytes = 1_000, method = "HEAD")
+
+        assertEquals(1_000, body.size)
+    }
+
+    @Test
+    fun `non success response is not validated`() {
+        val body = readWholeBody(declaredLength = 2 * MB, deliveredBytes = 1_000, code = 302)
+
+        assertEquals(1_000, body.size)
+    }
+
+    @Test
+    fun `disabled flag skips validation`() {
+        FeatureFlag.setEnabled(Feature.VALIDATE_CONTENT_LENGTH, false)
+
+        val body = readWholeBody(declaredLength = 2 * MB, deliveredBytes = 1_000)
+
+        assertEquals(1_000, body.size)
+    }
+
+    @Test
+    fun `closing before end of stream does not throw`() {
+        execute(declaredLength = 2 * MB, deliveredBytes = MB.toInt()).use { response ->
+            val read = response.body.source().read(Buffer(), 1_024)
+            assertTrue(read > 0)
+        }
+    }
+
+    private fun readWholeBody(
+        declaredLength: Long,
+        deliveredBytes: Int,
+        method: String = "GET",
+        code: Int = 200,
+    ): ByteArray {
+        return execute(declaredLength, deliveredBytes, method, code).use { response ->
+            response.body.source().readByteArray()
+        }
+    }
+
+    private fun execute(
+        declaredLength: Long,
+        deliveredBytes: Int,
+        method: String = "GET",
+        code: Int = 200,
+    ): Response {
+        val responder = Interceptor { chain ->
+            val payload = Buffer().write(ByteArray(deliveredBytes))
+            Response.Builder()
+                .request(chain.request())
+                .protocol(Protocol.HTTP_2)
+                .code(code)
+                .message("")
+                .body(payload.asResponseBody("audio/mpeg".toMediaType(), declaredLength))
+                .build()
+        }
+        val client = OkHttpClient.Builder()
+            .addInterceptor(ContentLengthValidatorInterceptor())
+            .addInterceptor(responder)
+            .build()
+        val request = Request.Builder()
+            .url("https://example.com/episode.mp3")
+            .method(method, null)
+            .build()
+        return client.newCall(request).execute()
+    }
+
+    private companion object {
+        const val KB = 1024L
+        const val MB = 1024L * 1024L
+    }
+}

--- a/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/interceptors/ContentLengthValidatorInterceptorTest.kt
+++ b/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/interceptors/ContentLengthValidatorInterceptorTest.kt
@@ -44,6 +44,20 @@ class ContentLengthValidatorInterceptorTest {
     }
 
     @Test
+    fun `shortfall equal to the absolute threshold passes through`() {
+        val body = readWholeBody(declaredLength = MB, deliveredBytes = (MB - 512 * KB).toInt())
+
+        assertEquals((MB - 512 * KB).toInt(), body.size)
+    }
+
+    @Test
+    fun `grossly truncated partial content throws`() {
+        assertThrows(ProtocolException::class.java) {
+            readWholeBody(declaredLength = 2 * MB, deliveredBytes = MB.toInt(), code = 206)
+        }
+    }
+
+    @Test
     fun `shortfall above ninety percent delivered passes through`() {
         val deliveredBytes = (6 * MB - 600 * KB).toInt()
 

--- a/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/interceptors/ContentLengthValidatorInterceptorTest.kt
+++ b/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/interceptors/ContentLengthValidatorInterceptorTest.kt
@@ -11,10 +11,15 @@ import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.Response
 import okhttp3.ResponseBody.Companion.asResponseBody
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
 import okio.Buffer
+import okio.Source
+import okio.Timeout
+import okio.blackholeSink
+import okio.buffer
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
-import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 
@@ -22,113 +27,121 @@ class ContentLengthValidatorInterceptorTest {
     @get:Rule
     val featureFlagRule = InMemoryFeatureFlagRule()
 
+    @get:Rule
+    val server = MockWebServer()
+
+    @Test
+    fun `complete response over the network passes through with body intact`() {
+        server.enqueue(MockResponse().setBody("hello world"))
+        val client = OkHttpClient.Builder()
+            .addNetworkInterceptor(ContentLengthValidatorInterceptor())
+            .build()
+
+        client.newCall(Request.Builder().url(server.url("/episode.mp3")).build()).execute().use { response ->
+            assertEquals("hello world", response.body.string())
+        }
+    }
+
     @Test
     fun `complete body passes through`() {
-        val body = readWholeBody(declaredLength = MB, deliveredBytes = MB.toInt())
-
-        assertEquals(MB.toInt(), body.size)
+        assertEquals(MB, readBody(declaredLength = MB, deliveredBytes = MB))
     }
 
     @Test
     fun `grossly truncated body throws`() {
         assertThrows(ProtocolException::class.java) {
-            readWholeBody(declaredLength = 2 * MB, deliveredBytes = MB.toInt())
+            readBody(declaredLength = 2 * MB, deliveredBytes = MB)
         }
     }
 
     @Test
-    fun `shortfall within absolute tolerance passes through`() {
-        val body = readWholeBody(declaredLength = MB, deliveredBytes = 600_000)
-
-        assertEquals(600_000, body.size)
-    }
-
-    @Test
-    fun `shortfall equal to the absolute threshold passes through`() {
-        val body = readWholeBody(declaredLength = MB, deliveredBytes = (MB - 512 * KB).toInt())
-
-        assertEquals((MB - 512 * KB).toInt(), body.size)
-    }
-
-    @Test
-    fun `grossly truncated partial content throws`() {
+    fun `large truncation beyond the capped tolerance throws`() {
         assertThrows(ProtocolException::class.java) {
-            readWholeBody(declaredLength = 2 * MB, deliveredBytes = MB.toInt(), code = 206)
+            readBody(declaredLength = 200 * MB, deliveredBytes = 200 * MB - 3 * MB)
         }
     }
 
     @Test
-    fun `shortfall above ninety percent delivered passes through`() {
-        val deliveredBytes = (6 * MB - 600 * KB).toInt()
+    fun `shortfall within the capped tolerance passes through`() {
+        val deliveredBytes = 200 * MB - MB
 
-        val body = readWholeBody(declaredLength = 6 * MB, deliveredBytes = deliveredBytes)
+        assertEquals(deliveredBytes, readBody(declaredLength = 200 * MB, deliveredBytes = deliveredBytes))
+    }
 
-        assertEquals(deliveredBytes, body.size)
+    @Test
+    fun `shortfall within the absolute floor passes through`() {
+        val deliveredBytes = MB - 400 * KB
+
+        assertEquals(deliveredBytes, readBody(declaredLength = MB, deliveredBytes = deliveredBytes))
+    }
+
+    @Test
+    fun `shortfall equal to the tolerance passes through`() {
+        val deliveredBytes = MB - 512 * KB
+
+        assertEquals(deliveredBytes, readBody(declaredLength = MB, deliveredBytes = deliveredBytes))
     }
 
     @Test
     fun `unknown content length is not validated`() {
-        val body = readWholeBody(declaredLength = -1L, deliveredBytes = 1_000)
-
-        assertEquals(1_000, body.size)
+        assertEquals(1_000L, readBody(declaredLength = -1L, deliveredBytes = 1_000L))
     }
 
     @Test
     fun `head request is not validated`() {
-        val body = readWholeBody(declaredLength = 2 * MB, deliveredBytes = 1_000, method = "HEAD")
-
-        assertEquals(1_000, body.size)
+        assertEquals(1_000L, readBody(declaredLength = 2 * MB, deliveredBytes = 1_000L, method = "HEAD"))
     }
 
     @Test
     fun `non success response is not validated`() {
-        val body = readWholeBody(declaredLength = 2 * MB, deliveredBytes = 1_000, code = 302)
+        assertEquals(1_000L, readBody(declaredLength = 2 * MB, deliveredBytes = 1_000L, code = 302))
+    }
 
-        assertEquals(1_000, body.size)
+    @Test
+    fun `truncated partial content throws`() {
+        assertThrows(ProtocolException::class.java) {
+            readBody(declaredLength = 2 * MB, deliveredBytes = MB, code = 206)
+        }
     }
 
     @Test
     fun `disabled flag skips validation`() {
         FeatureFlag.setEnabled(Feature.VALIDATE_CONTENT_LENGTH, false)
 
-        val body = readWholeBody(declaredLength = 2 * MB, deliveredBytes = 1_000)
-
-        assertEquals(1_000, body.size)
+        assertEquals(1_000L, readBody(declaredLength = 2 * MB, deliveredBytes = 1_000L))
     }
 
     @Test
     fun `closing before end of stream does not throw`() {
-        execute(declaredLength = 2 * MB, deliveredBytes = MB.toInt()).use { response ->
-            val read = response.body.source().read(Buffer(), 1_024)
-            assertTrue(read > 0)
+        execute(declaredLength = 2 * MB, deliveredBytes = MB).use { response ->
+            response.body.source().read(Buffer(), 1_024)
         }
     }
 
-    private fun readWholeBody(
+    private fun readBody(
         declaredLength: Long,
-        deliveredBytes: Int,
+        deliveredBytes: Long,
         method: String = "GET",
         code: Int = 200,
-    ): ByteArray {
+    ): Long {
         return execute(declaredLength, deliveredBytes, method, code).use { response ->
-            response.body.source().readByteArray()
+            response.body.source().readAll(blackholeSink())
         }
     }
 
     private fun execute(
         declaredLength: Long,
-        deliveredBytes: Int,
+        deliveredBytes: Long,
         method: String = "GET",
         code: Int = 200,
     ): Response {
         val responder = Interceptor { chain ->
-            val payload = Buffer().write(ByteArray(deliveredBytes))
             Response.Builder()
                 .request(chain.request())
                 .protocol(Protocol.HTTP_2)
                 .code(code)
                 .message("")
-                .body(payload.asResponseBody("audio/mpeg".toMediaType(), declaredLength))
+                .body(ZeroSource(deliveredBytes).buffer().asResponseBody("audio/mpeg".toMediaType(), declaredLength))
                 .build()
         }
         val client = OkHttpClient.Builder()
@@ -142,8 +155,25 @@ class ContentLengthValidatorInterceptorTest {
         return client.newCall(request).execute()
     }
 
+    private class ZeroSource(private var remaining: Long) : Source {
+        override fun read(sink: Buffer, byteCount: Long): Long {
+            if (remaining <= 0L) {
+                return -1L
+            }
+            val count = minOf(byteCount, remaining, CHUNK.size.toLong())
+            sink.write(CHUNK, 0, count.toInt())
+            remaining -= count
+            return count
+        }
+
+        override fun timeout(): Timeout = Timeout.NONE
+
+        override fun close() = Unit
+    }
+
     private companion object {
         const val KB = 1024L
         const val MB = 1024L * 1024L
+        val CHUNK = ByteArray(8 * 1024)
     }
 }

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -378,6 +378,15 @@ enum class Feature(
         hasDevToggle = true,
         addedOn = LocalDate.parse("2026-09-04"),
     ),
+    VALIDATE_CONTENT_LENGTH(
+        key = "validate_content_length",
+        title = "Fail truncated media responses instead of treating them as end of stream",
+        defaultValue = true,
+        tier = FeatureTier.Free,
+        hasFirebaseRemoteFlag = true,
+        hasDevToggle = true,
+        addedOn = LocalDate.parse("2026-09-07"),
+    ),
 }
 
 sealed class FeatureTier {


### PR DESCRIPTION
## Description

Fixes PCDROID-714 https://linear.app/a8c/issue/PCDROID-714

Some hosts truncate an audio response mid-transfer and end it with a clean **HTTP/2 `END_STREAM`** while still advertising the full `Content-Length` (e.g. Rádio Câmara / *Feijoada Completa* sends `content-length: 231288061` over h2 then cuts the body at ~150 MB; Libsyn DAI-stitched *Lore*). Today the app treats that short body as a legitimate end of stream, so the episode is **marked played, its download is deleted, and Up Next advances — with no error shown**. The same episodes play fine on desktop/web and iOS.

### Root cause

The app never checks that the bytes it received match the server-declared `Content-Length`:

- **Media3 1.10.1** `OkHttpDataSource.readInternal` (and `DefaultHttpDataSource`) return `C.RESULT_END_OF_INPUT` the moment the underlying stream returns `-1`, with no `bytesRead == bytesToRead` check.
- **OkHttp 5.5.0** is asymmetric: `Http1ExchangeCodec.FixedLengthSource` throws `ProtocolException("unexpected end of stream")` on a short **HTTP/1.1** body, but `Http2Stream.FramingSource` returns `-1` on a clean `END_STREAM` short body with no length reconciliation — so truncation is loud on h1 (already handled) and **silent on h2**.

Downstream, a silent end-of-stream becomes `Player.STATE_ENDED` → `PlaybackManager.onCompletion` (mark played, remove from Up Next, auto-archive → delete download). The `EpisodeDownloader` path has the same gap: a single GET + `readAll`, guarded only against files < 150 KB.

### The fix

A new **network** interceptor (`ContentLengthValidatorInterceptor`) is added to the `@Player` and `@Downloads` OkHttp clients — the only two that transfer media bytes. It wraps the response body in an okio `ForwardingSource` and, when the stream reaches EOF (`read() == -1`) while the body is **grossly short** of the declared `Content-Length`, throws `ProtocolException`. This mirrors OkHttp's own HTTP/1.1 behavior and extends it to HTTP/2.

The thrown `IOException` flows through existing, tested error handling instead of a silent completion:
- **Streaming**: Media3 wraps it as `HttpDataSourceException`; ExoPlayer surfaces `onPlayerError` (retryable), never `STATE_ENDED`, so nothing is marked played.
- **Download**: `EpisodeDownloader` → `Result.ExceptionFailure` → retryable, capped at the existing max attempts.
- **Cache prefetch**: `CacheWorker` → `Result.failure()`; the "caching complete" buffer-to-end callback only runs on success, so no false completion.

**Why "grossly short" and not an exact match:** a functional server that *over-declares* its `Content-Length` but sends a complete, playable file would be indistinguishable from truncation on h2. To avoid ever breaking such a file (which would otherwise become permanently undownloadable), the body is only treated as truncated when it is short by **both** more than 512 KB **and** more than 10 % of the declared length. Real truncations here miss 34–95 %; benign length mismatches miss kilobytes.

Gating (decided once per response, never in the read hot path):
- feature flag on, `GET`, response `200`/`206`, and a positive `Content-Length`.
- excludes `HEAD` (used by `UpdateEpisodeDetailsTask` on the `@Downloads` client), `204`/`304`, redirects, and chunked/unknown-length responses.

It sits **below** `BridgeInterceptor`, so gzip'd responses are validated on the compressed stream (consistent length), and it only throws on real EOF — never on an early `close()` (seek / buffer-full / bounded Range reads), so seeking and partial reads are unaffected.

Behind a **`Feature.VALIDATE_CONTENT_LENGTH`** flag (default on, `hasFirebaseRemoteFlag = true`) as a remote kill switch.

### Scope / follow-ups (not in this PR)

- Covers **byte-truncation** (Rádio Câmara, confirmed via curl; the HTTP/2 short-body *Lore* variant with "no exception logged" in the reporter's log).
- A hypothetical "all declared bytes delivered but the MP3 decodes to ~82 s" variant would need an `onCompletion` low-completion guard — deferred, since a naive guard risks blocking legitimate completions on feeds with over-declared durations.
- Pinning the resolved DAI build URL across a session (same length, different content per request) is a separate, larger change — deferred.

**Please do not auto-close PCDROID-714** on merge; this covers the truncation cases above.

## Testing Instructions

This is a network-layer change with no UI. Behaviour is covered by unit tests:

1. `./gradlew :modules:services:servers:testDebugUnitTest --tests "*ContentLengthValidatorInterceptorTest"` — 11 cases: complete body passes; gross truncation throws (200 and 206); shortfall within the absolute (512 KB) or relative (≥ 90 % delivered) tolerance passes; unknown length / HEAD / non-2xx / disabled-flag not validated; early close before EOF does not throw.
2. Manual sanity (optional): stream and fully play a normal episode, and download one, on a real device — both complete normally (healthy servers deliver the full `Content-Length`, so nothing changes for them). A full device repro of the server-side truncation is impractical (geo/campaign-dependent), which is why the behaviour is unit-tested and verified against the Media3 / OkHttp sources.

## Screenshots or Screencast

## Checklist

- [ ] If a user-facing change, I added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply`)
- [x] I considered whether it makes sense to add tests for my changes
- [x] All strings are already localized (no new strings)
- [x] No jetpack compose components added or changed
- [x] No new or changed analytics (Event Horizon schema unchanged)
