### PR TITLE
Add missing Network Discovery analytics

### DIFF
--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
@@ -143,6 +143,13 @@ class DiscoverFragment :
     }
 
     override fun onNetworkClicked(network: DiscoverListSummary) {
+        eventHorizon.track(
+            DiscoverListShowAllTappedEvent(
+                listId = network.uuid,
+                // No date passed as it's not available until the list is loaded
+                listDatetime = "",
+            ),
+        )
         (activity as FragmentHostListener).openNetworkPage(
             listId = network.uuid,
             title = network.title,

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/NetworksGridFragment.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/NetworksGridFragment.kt
@@ -16,6 +16,8 @@ import au.com.shiftyjelly.pocketcasts.discover.viewmodel.NetworksGridViewModel
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
+import com.automattic.eventhorizon.DiscoverListShowAllTappedEvent
+import com.automattic.eventhorizon.EventHorizon
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -37,6 +39,8 @@ class NetworksGridFragment : BaseFragment() {
 
     @Inject lateinit var settings: Settings
 
+    @Inject lateinit var eventHorizon: EventHorizon
+
     private val viewModel: NetworksGridViewModel by viewModels()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?) = contentWithoutConsumedInsets {
@@ -50,6 +54,13 @@ class NetworksGridFragment : BaseFragment() {
                 state = state,
                 onClickBack = { requireActivity().onBackPressedDispatcher.onBackPressed() },
                 onClickNetwork = { network ->
+                    eventHorizon.track(
+                        DiscoverListShowAllTappedEvent(
+                            listId = network.uuid,
+                            // No date passed as it's not available until the list is loaded
+                            listDatetime = "",
+                        ),
+                    )
                     (requireActivity() as FragmentHostListener).openNetworkPage(
                         listId = network.uuid,
                         title = network.title,


### PR DESCRIPTION
## Description

Tapping an individual podcast network in the Discover tab is now recorded in analytics, in both the Networks row and the full grid of every network. This matches the behaviour on iOS.

Follow-up to the Network Discovery work. When the Networks row landed we only tracked the "Show all" tap and the network taps in search results, so the two most common ways of opening a network page, tapping a network in the Discover row and tapping one in the networks grid, were invisible in the data.

Both call sites now send the existing `discover_list_show_all` event (`DiscoverListShowAllTappedEvent`) with the network's list uuid, matching how the rest of the Discover tab reports a list being opened. `listDatetime` is sent empty because at the point of the tap only the network summary is in hand; the list's date is not known until the list itself loads.

## Testing Instructions

1. Build a debug variant with analytics logging visible (`adb logcat -s AnalyticsTracker` or the Tracks debug output).
2. Open the **Discover** tab and scroll to the **Networks** row.
3. Tap one of the network logos in the row. Confirm a `discover_list_show_all` event is logged with `list_id` set to that network's uuid, and that the network page opens.
4. Go back, tap **Show all** on the Networks row to open the full networks grid. Confirm the existing `discover_list_show_all` event for the row itself still fires.
5. Tap a network in the grid. Confirm another `discover_list_show_all` event is logged with that network's uuid, and that the network page opens.
6. Check that no duplicate events are sent for a single tap.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
