### PR TITLE
[DO NOT MERGE] Validate empty-array guard on mac-metal for #5831

### DIFF
--- a/.buildkite/commands/validate-empty-array.sh
+++ b/.buildkite/commands/validate-empty-array.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Throwaway: refutes the claim that `${#arr[@]}` on an empty array trips `set -u`
+# on bash < 4.4. Delete with the rest of this branch.
+
+failures=0
+
+fail() {
+  echo "FAIL  $1"
+  failures=$((failures + 1))
+}
+
+echo "--- :shell: The shell this step runs under"
+echo "BASH_VERSION       = $BASH_VERSION"
+echo "BASH               = $BASH"
+echo "command -v bash    = $(command -v bash)"
+echo "/bin/bash          = $(/bin/bash --version | head -1)"
+
+echo "--- :mag: Negative control -- which array semantics is this shell on?"
+# The actual bash 4.4 change: expanding an EMPTY array under `set -u`.
+if ( set -euo pipefail; a=(); for _ in "${a[@]}"; do :; done ) 2>/dev/null; then
+  old_bash=0
+  echo "\"\${a[@]}\" on an empty array is allowed -> bash >= 4.4 semantics"
+else
+  old_bash=1
+  echo "\"\${a[@]}\" on an empty array is an error -> bash < 4.4 semantics"
+fi
+
+echo "--- :mag: The disputed line: \${#arr[@]} on an empty array"
+# If this tripped `set -u`, the script would die here rather than print anything.
+empty=()
+if [[ ${#empty[@]} -gt 0 ]]; then
+  fail "an empty array reported ${#empty[@]} elements"
+else
+  echo "PASS  \${#empty[@]} = ${#empty[@]}, guard skipped, shell still running"
+fi
+
+if [ "$old_bash" -eq 1 ]; then
+  echo "      ...and this shell errors on \"\${a[@]}\", so the pre-4.4 regime is the one just exercised"
+fi
+
+echo "--- :rocket: The real update-rollouts.sh, both paths"
+script_under_test="$(dirname "${BASH_SOURCE[0]}")/update-rollouts.sh"
+stubs="$(mktemp -d)"
+for cmd in install_gems bundle; do
+  printf '#!/bin/sh\necho "[stub] %s $*"\n' "$cmd" > "$stubs/$cmd"
+  chmod +x "$stubs/$cmd"
+done
+
+echo "happy path -- all required vars set:"
+if out=$(PATH="$stubs:$PATH" TRACK=beta ROLLOUT_PERCENT=0.10 RELEASE_VERSION=8.20 \
+  "$script_under_test" 2>&1); then
+  sed 's/^/    /' <<<"$out"
+  echo "PASS  exited 0 -- the guard let the happy path through"
+else
+  sed 's/^/    /' <<<"$out"
+  fail "the happy path exited non-zero"
+fi
+
+echo "happy path, forced through /bin/bash regardless of what env bash resolves to:"
+if out=$(PATH="$stubs:$PATH" TRACK=beta ROLLOUT_PERCENT=0.10 RELEASE_VERSION=8.20 \
+  /bin/bash "$script_under_test" 2>&1); then
+  sed 's/^/    /' <<<"$out"
+  echo "PASS  exited 0 under $(/bin/bash --version | head -1)"
+else
+  sed 's/^/    /' <<<"$out"
+  fail "the happy path exited non-zero under /bin/bash"
+fi
+
+echo "guard path -- RELEASE_VERSION unset:"
+if out=$(PATH="$stubs:$PATH" TRACK=beta ROLLOUT_PERCENT=0.10 \
+  "$script_under_test" 2>&1); then
+  sed 's/^/    /' <<<"$out"
+  fail "a missing RELEASE_VERSION did not stop the script"
+elif ! grep -q 'RELEASE_VERSION' <<<"$out"; then
+  sed 's/^/    /' <<<"$out"
+  fail "the script stopped, but not through the guard"
+else
+  sed 's/^/    /' <<<"$out"
+  echo "PASS  stopped through the guard, naming RELEASE_VERSION"
+fi
+
+echo "--- :white_check_mark: Result"
+if [ "$failures" -ne 0 ]; then
+  echo "$failures assertion(s) failed"
+  exit 1
+fi
+echo "all assertions held"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,118 +1,13 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 ---
 
-agents:
-  queue: "android"
+# [DO NOT MERGE] Every other step is deliberately stripped so this branch answers one
+# question in seconds instead of running a full Android build.
 
 steps:
-  - label: Gradle Wrapper Validation
-    command: validate_gradle_wrapper
+  # `mac-metal` is the queue the Update Rollouts step runs on, so it is the shell
+  # the claim under test is about.
+  - label: ":test_tube: Validate empty-array guard on mac-metal"
+    command: .buildkite/commands/validate-empty-array.sh
     agents:
-      queue: linter
-
-  # Wait for Gradle Wrapper to be validated before running any other jobs
-  - wait
-
-  - group: "Linters"
-    steps:
-      - label: ":danger: Danger - PR Check"
-        command: danger
-        key: danger
-        if: "build.pull_request.id != null"
-        retry:
-          manual:
-            permit_on_passed: true
-        agents:
-          queue: "linter"
-
-      - label: 'Lint'
-        command: ".buildkite/commands/lint.sh"
-        plugins: [ $CI_TOOLKIT ]
-        artifact_paths:
-          - "**/build/reports/lint-results*.*"
-
-  - label: ":fastlane: fastlane Helper Tests"
-    command: ruby fastlane/test/helpers_test.rb
-    plugins: [ $CI_TOOLKIT ]
-
-  - label: 'Unit tests'
-    command: ".buildkite/commands/run-unit-tests.sh"
-    plugins: [ $CI_TOOLKIT ]
-
-  - group: "Diff Reports"
-    steps:
-      - label: 'Dependency diff'
-        if: build.pull_request.id != null
-        command: comment_with_dependency_diff 'app' 'releaseRuntimeClasspath'
-        plugins: [ $CI_TOOLKIT ]
-        artifact_paths:
-          - "**/build/reports/diff/*"
-
-      - label: "Merged Manifest Diff"
-        command: ".buildkite/commands/diff-merged-manifest.sh release"
-        if: build.pull_request.id != null
-        plugins: [ $CI_TOOLKIT ]
-        artifact_paths:
-          - "**/build/reports/diff_manifest/**/**/*"
-
-  - label: 'Spotless formatting check'
-    command: |
-      if .buildkite/commands/should-skip-job.sh --job-type validation; then
-        exit 0
-      fi
-
-      echo "--- 🔎 Checking formatting with Spotless"
-      ./gradlew spotlessCheck
-    plugins: [ $CI_TOOLKIT ]
-
-  - label: "Instrumented tests"
-    command: ".buildkite/commands/run-instrumented-tests.sh"
-    plugins: [ $CI_TOOLKIT ]
-    artifact_paths:
-      - "**/build/instrumented-tests/**/*"
-
-  - group: "Assemble release APKs"
-    steps:
-      - label: "Assemble app release APK"
-        command: ".buildkite/commands/assemble-release-apk.sh app"
-        plugins: [ $CI_TOOLKIT ]
-        artifact_paths:
-          - "**/build/outputs/apk/**/*"
-
-      - label: "Assemble automotive release APK"
-        command: ".buildkite/commands/assemble-release-apk.sh automotive"
-        plugins: [ $CI_TOOLKIT ]
-        artifact_paths:
-          - "**/build/outputs/apk/**/*"
-
-      - label: "Assemble wear release APK"
-        command: ".buildkite/commands/assemble-release-apk.sh wear"
-        plugins: [ $CI_TOOLKIT ]
-        artifact_paths:
-          - "**/build/outputs/apk/**/*"
-
-      - label: "Assemble tv release APK"
-        command: ".buildkite/commands/assemble-release-apk.sh tv"
-        plugins: [ $CI_TOOLKIT ]
-        artifact_paths:
-          - "**/build/outputs/apk/**/*"
-
-    ##########
-    # Optional Prototype Builds
-    #
-    # Builds all modules, uploads app to FAD and Wear, Automotive and TV to S3
-    ##########
-  - group: Prototype Builds
-    if: "build.pull_request.id != null || build.branch == 'main'"
-    steps:
-      - input: "🚀 Generate Prototype Builds?"
-        prompt: Generate Prototype Builds?
-        key: prototype_builds_triggered
-      - label: ":rocket: Prototype Builds"
-        depends_on: prototype_builds_triggered
-        command: .buildkite/commands/prototype-build.sh
-        plugins: [ $CI_TOOLKIT ]
-        artifact_paths:
-          - "**/build/outputs/apk/**/*"
-        # No notify node to avoid GitHub checks status being stuck on yellow.
-        # This step being optional, chances are it will never be triggered.
+      queue: "mac-metal"


### PR DESCRIPTION
**Validation only — do not merge.** Stacked on `ainfra-3066-pocket-casts-android-post-rollout-slack-announcements-from` (#5831). Closed once CI has answered.

### The question

[#5831 (comment)](https://github.com/Automattic/pocket-casts-android/pull/5831#discussion_r3954976716) says `${#missing[@]}` on an empty array is an "unbound variable" error under `set -u` in bash < 4.4, so `update-rollouts.sh` would exit 1 on the **happy path** if `env bash` resolves to macOS `/bin/bash` 3.2.57 on the `mac-metal` agents. The comment notes it couldn't run bash to check.

The bash 4.4 change is real, but it applies to *expanding* an empty array — `"${a[@]}"`, `"${a[*]}"` — not to the `${#…}` length operator. This branch settles it on the agent in question.

### Why nothing else answers it

`update-rollouts.yml` runs only when ReleasesV2 triggers the pipeline with `PIPELINE` and the rollout env vars set, so no PR build ever executes `update-rollouts.sh` or reaches a `mac-metal` shell with it.

### What to read

One job, **expected to pass**: `:test_tube: Validate empty-array guard on mac-metal`, on the `mac-metal` queue. Every other step is stripped from `pipeline.yml` so it takes seconds.

| Assertion | Proves |
|---|---|
| Prints `BASH_VERSION`, `$BASH`, `command -v bash`, `/bin/bash --version` | which shell the claim is actually about on these agents |
| `"${a[@]}"` on an empty array under `set -u` | negative control: which side of the 4.4 change this shell is on |
| `${#empty[@]} -gt 0` on an empty array | the disputed line — a trip would kill the script here, so reaching the next line *is* the assertion |
| Real `update-rollouts.sh`, all vars set, `install_gems`/`bundle` stubbed on `PATH` | the happy path exits 0 |
| Same, forced through `/bin/bash` | the happy path exits 0 under 3.2 specifically, whatever `env bash` resolves to |
| Same, `RELEASE_VERSION` unset | the guard still fires, and names the variable |

It can go red: relaxing the disputed comparison to `-ge 0` locally turns the first assertion into `FAIL` and the script exits 1.

### What this cannot answer

Nothing outstanding — the whole claim is decidable on the agent.

---

## Answer — [build 18912](https://buildkite.com/automattic/pocket-casts-android/builds/18912#01a07ff6-a959-4825-899c-e6ac3618fb25), passed in 8s on `mac-metal` (`MV-MKE-ARM64-023`)

The comment's precondition holds — and its conclusion still does not follow.

```
--- :shell: The shell this step runs under
BASH_VERSION       = 3.2.57(1)-release
BASH               = /bin/bash
command -v bash    = /bin/bash
/bin/bash          = GNU bash, version 3.2.57(1)-release (arm64-apple-darwin24)
--- :mag: Negative control -- which array semantics is this shell on?
"${a[@]}" on an empty array is an error -> bash < 4.4 semantics
--- :mag: The disputed line: ${#arr[@]} on an empty array
PASS  ${#empty[@]} = 0, guard skipped, shell still running
      ...and this shell errors on "${a[@]}", so the pre-4.4 regime is the one just exercised
--- :rocket: The real update-rollouts.sh, both paths
happy path -- all required vars set:
    [stub] bundle exec fastlane update_rollouts track:beta percent:0.10 version:8.20 milestone:
PASS  exited 0 -- the guard let the happy path through
happy path, forced through /bin/bash regardless of what env bash resolves to:
PASS  exited 0 under GNU bash, version 3.2.57(1)-release (arm64-apple-darwin24)
guard path -- RELEASE_VERSION unset:
    Error: missing or empty environment variables: RELEASE_VERSION
PASS  stopped through the guard, naming RELEASE_VERSION
```

Point by point:

- **`command -v bash` is `/bin/bash`** on these agents — no Homebrew bash ahead of it on `PATH`. So `#!/usr/bin/env bash` really does get 3.2.57, exactly the case the comment was worried about.
- **The negative control errors**, so this shell is genuinely on the pre-4.4 side. That is what makes the next line evidence rather than a lucky pass on a modern bash.
- **`${#empty[@]}` returns 0 and the script keeps running.** The bash 4.4 change covers *expanding* an empty array (`"${a[@]}"`, `"${a[*]}"`), not the `${#…}` length operator, which has always been safe.
- **The real `update-rollouts.sh` exits 0 on the happy path**, both through its own shebang and forced through `/bin/bash`, so no rollout would have failed.
- **The guard still fires** on a missing `RELEASE_VERSION`.

Worth keeping regardless of this thread: `mac-metal` has no Homebrew bash on `PATH`, so anything under `.buildkite/commands/` that needs bash 4+ syntax will break there.
