### PR TITLE
Refresh a podcast's private flag on refresh so sharing follows the server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
         ([#5835](https://github.com/Automattic/pocket-casts-android/pull/5835))
     *   Stop "Cache entire playing episode" from silently downloading oversized or video enclosures in the background
         ([#5868](https://github.com/Automattic/pocket-casts-android/pull/5868))
+    *   Refresh a podcast's private flag so sharing becomes available again once a podcast is made public
+        ([#5875](https://github.com/Automattic/pocket-casts-android/pull/5875))
 
 8.20
 -----

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/PodcastDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/PodcastDaoTest.kt
@@ -230,5 +230,6 @@ class PodcastDaoTest {
         explicit = null,
         webFeed = false,
         networkListId = networkListId,
+        isPrivate = false,
     )
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
@@ -292,8 +292,8 @@ abstract class PodcastDao {
     @Update
     abstract suspend fun updateSuspend(podcast: Podcast)
 
-    @Query("UPDATE podcasts SET title = :title, author = :author, podcast_category = :podcastCategory, podcast_description = :podcastDescription, estimated_next_episode = :estimatedNextEpisode, episode_frequency = :episodeFrequency, refresh_available = :refreshAvailable, funding_url = :fundingUrl, explicit = :explicit, web_feed = :webFeed, network_list_id = :networkListId WHERE uuid = :uuid")
-    abstract suspend fun updateRefresh(uuid: String, title: String, author: String, podcastCategory: String, podcastDescription: String, estimatedNextEpisode: Date?, episodeFrequency: String?, refreshAvailable: Boolean, fundingUrl: String?, explicit: Boolean?, webFeed: Boolean, networkListId: String?)
+    @Query("UPDATE podcasts SET title = :title, author = :author, podcast_category = :podcastCategory, podcast_description = :podcastDescription, estimated_next_episode = :estimatedNextEpisode, episode_frequency = :episodeFrequency, refresh_available = :refreshAvailable, funding_url = :fundingUrl, explicit = :explicit, web_feed = :webFeed, network_list_id = :networkListId, is_private = :isPrivate WHERE uuid = :uuid")
+    abstract suspend fun updateRefresh(uuid: String, title: String, author: String, podcastCategory: String, podcastDescription: String, estimatedNextEpisode: Date?, episodeFrequency: String?, refreshAvailable: Boolean, fundingUrl: String?, explicit: Boolean?, webFeed: Boolean, networkListId: String?, isPrivate: Boolean)
 
     @Query("DELETE FROM podcasts WHERE uuid = :uuid")
     abstract fun deleteByUuidBlocking(uuid: String)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastRefresherImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastRefresherImpl.kt
@@ -147,7 +147,8 @@ class PodcastRefresherImpl @Inject constructor(
             existingPodcast.fundingUrl != updatedPodcast.fundingUrl ||
             existingPodcast.explicit != updatedPodcast.explicit ||
             existingPodcast.webFeed != updatedPodcast.webFeed ||
-            existingPodcast.networkListId != updatedPodcast.networkListId
+            existingPodcast.networkListId != updatedPodcast.networkListId ||
+            existingPodcast.isPrivate != updatedPodcast.isPrivate
         ) {
             LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Refresh required update for podcast ${existingPodcast.uuid}")
             appDatabase.podcastDao().updateRefresh(
@@ -163,6 +164,7 @@ class PodcastRefresherImpl @Inject constructor(
                 explicit = updatedPodcast.explicit,
                 webFeed = updatedPodcast.webFeed,
                 networkListId = updatedPodcast.networkListId,
+                isPrivate = updatedPodcast.isPrivate,
             )
         }
     }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastRefresherImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastRefresherImplTest.kt
@@ -75,6 +75,7 @@ class PodcastRefresherImplTest {
             explicit = podcast.explicit,
             webFeed = podcast.webFeed,
             networkListId = podcast.networkListId,
+            isPrivate = podcast.isPrivate,
         )
     }
 
@@ -98,6 +99,7 @@ class PodcastRefresherImplTest {
             explicit = existingPodcast.explicit,
             webFeed = existingPodcast.webFeed,
             networkListId = existingPodcast.networkListId,
+            isPrivate = existingPodcast.isPrivate,
         )
     }
 
@@ -121,6 +123,7 @@ class PodcastRefresherImplTest {
             explicit = existingPodcast.explicit,
             webFeed = existingPodcast.webFeed,
             networkListId = existingPodcast.networkListId,
+            isPrivate = existingPodcast.isPrivate,
         )
     }
 
@@ -144,6 +147,7 @@ class PodcastRefresherImplTest {
             explicit = existingPodcast.explicit,
             webFeed = existingPodcast.webFeed,
             networkListId = existingPodcast.networkListId,
+            isPrivate = existingPodcast.isPrivate,
         )
     }
 
@@ -167,6 +171,7 @@ class PodcastRefresherImplTest {
             explicit = existingPodcast.explicit,
             webFeed = existingPodcast.webFeed,
             networkListId = existingPodcast.networkListId,
+            isPrivate = existingPodcast.isPrivate,
         )
     }
 
@@ -192,6 +197,7 @@ class PodcastRefresherImplTest {
             explicit = existingPodcast.explicit,
             webFeed = existingPodcast.webFeed,
             networkListId = existingPodcast.networkListId,
+            isPrivate = existingPodcast.isPrivate,
         )
     }
 
@@ -215,6 +221,7 @@ class PodcastRefresherImplTest {
             explicit = existingPodcast.explicit,
             webFeed = existingPodcast.webFeed,
             networkListId = existingPodcast.networkListId,
+            isPrivate = existingPodcast.isPrivate,
         )
     }
 
@@ -238,6 +245,7 @@ class PodcastRefresherImplTest {
             explicit = existingPodcast.explicit,
             webFeed = existingPodcast.webFeed,
             networkListId = existingPodcast.networkListId,
+            isPrivate = existingPodcast.isPrivate,
         )
     }
 
@@ -261,6 +269,7 @@ class PodcastRefresherImplTest {
             explicit = existingPodcast.explicit,
             webFeed = existingPodcast.webFeed,
             networkListId = existingPodcast.networkListId,
+            isPrivate = existingPodcast.isPrivate,
         )
     }
 
@@ -284,6 +293,7 @@ class PodcastRefresherImplTest {
             explicit = true,
             webFeed = existingPodcast.webFeed,
             networkListId = existingPodcast.networkListId,
+            isPrivate = existingPodcast.isPrivate,
         )
     }
 
@@ -307,6 +317,7 @@ class PodcastRefresherImplTest {
             explicit = true,
             webFeed = existingPodcast.webFeed,
             networkListId = existingPodcast.networkListId,
+            isPrivate = existingPodcast.isPrivate,
         )
     }
 
@@ -330,6 +341,7 @@ class PodcastRefresherImplTest {
             explicit = existingPodcast.explicit,
             webFeed = true,
             networkListId = existingPodcast.networkListId,
+            isPrivate = existingPodcast.isPrivate,
         )
     }
 
@@ -363,6 +375,7 @@ class PodcastRefresherImplTest {
             explicit = existingPodcast.explicit,
             webFeed = existingPodcast.webFeed,
             networkListId = existingPodcast.networkListId,
+            isPrivate = existingPodcast.isPrivate,
         )
     }
 
@@ -390,6 +403,7 @@ class PodcastRefresherImplTest {
             explicit = existingPodcast.explicit,
             webFeed = existingPodcast.webFeed,
             networkListId = existingPodcast.networkListId,
+            isPrivate = existingPodcast.isPrivate,
         )
     }
 
@@ -413,6 +427,7 @@ class PodcastRefresherImplTest {
             explicit = existingPodcast.explicit,
             webFeed = existingPodcast.webFeed,
             networkListId = "cdb75bc0-9f5a-4217-b1ca-f573821a7913",
+            isPrivate = existingPodcast.isPrivate,
         )
     }
 
@@ -436,6 +451,55 @@ class PodcastRefresherImplTest {
             explicit = existingPodcast.explicit,
             webFeed = existingPodcast.webFeed,
             networkListId = "cdb75bc0-9f5a-4217-b1ca-f573821a7913",
+            isPrivate = existingPodcast.isPrivate,
+        )
+    }
+
+    @Test
+    fun `updatePodcastIfRequired updates when the podcast becomes public`() = runTest {
+        val existingPodcast = createPodcast(isPrivate = true)
+        val updatedPodcast = existingPodcast.copy(isPrivate = false)
+
+        podcastRefresher.updatePodcastIfRequired(existingPodcast, updatedPodcast)
+
+        verify(podcastDao).updateRefresh(
+            uuid = existingPodcast.uuid,
+            title = existingPodcast.title,
+            author = existingPodcast.author,
+            podcastCategory = existingPodcast.podcastCategory,
+            podcastDescription = existingPodcast.podcastDescription,
+            estimatedNextEpisode = existingPodcast.estimatedNextEpisode,
+            episodeFrequency = existingPodcast.episodeFrequency,
+            refreshAvailable = existingPodcast.refreshAvailable,
+            fundingUrl = existingPodcast.fundingUrl,
+            explicit = existingPodcast.explicit,
+            webFeed = existingPodcast.webFeed,
+            networkListId = existingPodcast.networkListId,
+            isPrivate = false,
+        )
+    }
+
+    @Test
+    fun `updatePodcastIfRequired updates when the podcast becomes private`() = runTest {
+        val existingPodcast = createPodcast(isPrivate = false)
+        val updatedPodcast = existingPodcast.copy(isPrivate = true)
+
+        podcastRefresher.updatePodcastIfRequired(existingPodcast, updatedPodcast)
+
+        verify(podcastDao).updateRefresh(
+            uuid = existingPodcast.uuid,
+            title = existingPodcast.title,
+            author = existingPodcast.author,
+            podcastCategory = existingPodcast.podcastCategory,
+            podcastDescription = existingPodcast.podcastDescription,
+            estimatedNextEpisode = existingPodcast.estimatedNextEpisode,
+            episodeFrequency = existingPodcast.episodeFrequency,
+            refreshAvailable = existingPodcast.refreshAvailable,
+            fundingUrl = existingPodcast.fundingUrl,
+            explicit = existingPodcast.explicit,
+            webFeed = existingPodcast.webFeed,
+            networkListId = existingPodcast.networkListId,
+            isPrivate = true,
         )
     }
 
@@ -452,6 +516,7 @@ class PodcastRefresherImplTest {
         explicit: Boolean? = null,
         webFeed: Boolean = false,
         networkListId: String? = null,
+        isPrivate: Boolean = false,
     ) = Podcast(
         uuid = uuid,
         title = title,
@@ -465,5 +530,6 @@ class PodcastRefresherImplTest {
         explicit = explicit,
         webFeed = webFeed,
         networkListId = networkListId,
+        isPrivate = isPrivate,
     )
 }


### PR DESCRIPTION
## Description

`Podcast.isPrivate` was only written when a podcast row is first created from the server
(`PodcastInfo.toPodcast()` in `PodcastResponse.kt`, i.e. at follow time). The refresh path
`PodcastRefresherImpl.updatePodcastIfRequired()` compared and rewrote title, author, category,
description, next-episode estimate, frequency, refresh-availability, funding URL, explicit, web-feed
and network-list id — but never `isPrivate`. Because `Podcast.canShare = !isPrivate`, a podcast that
was private when the user followed it kept blocking sharing on that device forever, even after the
listing had been public server-side for months. The only workaround was to unfollow and re-follow
(a fresh `toPodcast()`), which loses per-episode progress. iOS already writes `podcast.isPrivate`
from `is_private` on every update (`ServerPodcastManager+Update.swift`).

This adds `isPrivate` to both the change-detection comparison and `PodcastDao.updateRefresh`, so the
flag tracks the server value in both directions (private → public and public → private), matching iOS.

No database migration is needed: the `is_private` column already exists (`MIGRATION_105_106`);
`updateRefresh` is a plain `@Query` UPDATE, so adding a column to its SET clause does not change the
schema.

**On null handling (deliberate):** `is_private` is deserialized as `Boolean?` and coerced to `false`
in `toPodcast()`, and the entity column is non-null, so "unknown" cannot be represented. I chose the
iOS-parity unconditional write rather than an "only overwrite when present" guard. The risk of a
null/absent `is_private` wrongly clearing a genuinely-private flag is bounded: follow and refresh hit
the same podcast-cache endpoint through the same `null → false` mapper, a non-2xx response yields a
null body so `toPodcast()` never runs, and `canShare` only gates the client share affordance — real
privacy is enforced server-side.

Fixes PCDROID-766 https://linear.app/a8c/issue/PCDROID-766/android-is-private-is-only-written-at-follow-time-and-never-refreshed

## Testing Instructions

1. Follow a podcast whose nodeweb listing is a private feed type (or set one to "manual private").
2. In nodeweb, set the listing back to public and Update Cache / force upload to S3.
3. On the device, open the podcast, use the three-dot menu → Refresh Episode List (and/or let a
   background refresh run).
4. Tap the share icon on the podcast page.

Expected: after the refresh the app picks up `is_private: false` and the share sheet opens (previously
it showed the toast "Sharing is not available for private podcasts" until unfollow/re-follow).

Automated coverage: `PodcastRefresherImplTest` gains a private → public case (the exact ticket repro)
and a public → private case. Run:
`./gradlew :modules:services:repositories:testDebugUnitTest --tests "*PodcastRefresherImplTest"`.

## Screenshots


## Checklist

- [x] If user-facing change, I added entry in CHANGELOG.md
- [x] Ensure linter passes (`./gradlew spotlessApply` was run)
- [x] I considered whether it makes sense to add tests to my changes
- [ ] All strings that need to be localized are in `modules/services/localization/.../strings.xml` — no new strings
- [ ] Any jetpack compose components I added or changed are covered by compose previews — no Compose changes
- [ ] I updated the Event Horizon schema — no analytics changes
