### PR TITLE
Make Wear OS login failures diagnosable (PCDROID-763)

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/watchsync/WatchSync.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/watchsync/WatchSync.kt
@@ -90,7 +90,10 @@ constructor(
                     loginIdentity = data.loginIdentity,
                     signInSource = SignInSource.WatchPhoneSync,
                 )
-                LogBuffer.i(TAG, "Login result: ${result::class.simpleName}")
+                when (result) {
+                    is LoginResult.Success -> LogBuffer.i(TAG, "Login from phone succeeded")
+                    is LoginResult.Failed -> LogBuffer.e(TAG, "Login from phone failed: ${result.message} (id: ${result.messageId})")
+                }
                 onResult(result)
             } else {
                 LogBuffer.i(TAG, "Already logged in, skipping login")

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/watchsync/WatchSync.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/watchsync/WatchSync.kt
@@ -51,7 +51,7 @@ constructor(
                 if (watchSyncAuthData == null) {
                     LogBuffer.i(TAG, "Removing auth token from Wear: Phone not logged in to Pocket Casts")
                 } else {
-                    LogBuffer.i(TAG, "Sending auth token to Wear Data Layer (identity: ${watchSyncAuthData.loginIdentity})")
+                    LogBuffer.i(TAG, "Sending auth token to Wear Data Layer (identity: ${watchSyncAuthData.loginIdentity.key})")
                 }
 
                 tokenBundleRepository.update(watchSyncAuthData)
@@ -81,7 +81,7 @@ constructor(
             return
         }
         try {
-            LogBuffer.i(TAG, "Received WatchSyncAuthData change from phone (identity: ${data.loginIdentity})")
+            LogBuffer.i(TAG, "Received WatchSyncAuthData change from phone (identity: ${data.loginIdentity.key})")
 
             if (!syncManager.isLoggedIn()) {
                 LogBuffer.i(TAG, "Not logged in - attempting login with token")

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2314,6 +2314,7 @@
     <string name="onboarding_sign_up">Sign up</string>
     <string name="onboarding_continue_with_google">Continue with Google</string>
     <string name="onboarding_continue_with_google_error">Unable to launch Google sign in.</string>
+    <string name="onboarding_continue_with_google_server_error">Couldn\'t sign in with Google. Please try again.</string>
     <string name="log_in_no_network" translatable="false">@string/error_no_network</string>
     <string name="log_in_with_google">Log in with Google</string>
     <string name="log_in_on_phone">Log in on phone</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2314,7 +2314,8 @@
     <string name="onboarding_sign_up">Sign up</string>
     <string name="onboarding_continue_with_google">Continue with Google</string>
     <string name="onboarding_continue_with_google_error">Unable to launch Google sign in.</string>
-    <string name="onboarding_continue_with_google_server_error">Couldn\'t sign in with Google. Please try again.</string>
+    <string name="onboarding_continue_with_google_no_credential">No Google account available to sign in.</string>
+    <string name="onboarding_continue_with_google_failed">Couldn\'t sign in with Google. Please try again.</string>
     <string name="log_in_no_network" translatable="false">@string/error_no_network</string>
     <string name="log_in_with_google">Log in with Google</string>
     <string name="log_in_on_phone">Log in on phone</string>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
@@ -285,7 +285,7 @@ class SyncManagerImpl @Inject constructor(
             val result = handleTokenResponse(loginIdentity = loginIdentity, response = response)
             LoginResult.Success(result)
         } catch (ex: Exception) {
-            Timber.e(ex, "Failed to sign in with Pocket Casts")
+            LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, ex, "Failed to sign in (identity: ${loginIdentity.key})")
             exceptionToAuthResult(exception = ex, fallbackMessage = LR.string.error_login_failed)
         }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
@@ -284,6 +284,8 @@ class SyncManagerImpl @Inject constructor(
             val response = loginFunction()
             val result = handleTokenResponse(loginIdentity = loginIdentity, response = response)
             LoginResult.Success(result)
+        } catch (ex: CancellationException) {
+            throw ex
         } catch (ex: Exception) {
             LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, ex, "Failed to sign in (identity: ${loginIdentity.key})")
             exceptionToAuthResult(exception = ex, fallbackMessage = LR.string.error_login_failed)

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/AuthenticationNavGraph.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/AuthenticationNavGraph.kt
@@ -102,6 +102,7 @@ fun NavGraphBuilder.authenticationNavGraph(
                 }
             }
             val defaultErrorMessage = stringResource(LR.string.onboarding_continue_with_google_error)
+            val serverErrorMessage = stringResource(LR.string.onboarding_continue_with_google_server_error)
 
             LoginWithGoogleScreen(
                 successContent = {
@@ -112,6 +113,9 @@ fun NavGraphBuilder.authenticationNavGraph(
                 },
                 onGoogleNotAvailable = {
                     showErrorToastMessage = defaultErrorMessage
+                },
+                onServerError = {
+                    showErrorToastMessage = serverErrorMessage
                 },
                 onCancel = {
                     navController.popBackStack()

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/AuthenticationNavGraph.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/AuthenticationNavGraph.kt
@@ -102,7 +102,8 @@ fun NavGraphBuilder.authenticationNavGraph(
                 }
             }
             val defaultErrorMessage = stringResource(LR.string.onboarding_continue_with_google_error)
-            val serverErrorMessage = stringResource(LR.string.onboarding_continue_with_google_server_error)
+            val noCredentialMessage = stringResource(LR.string.onboarding_continue_with_google_no_credential)
+            val otherErrorMessage = stringResource(LR.string.onboarding_continue_with_google_failed)
 
             LoginWithGoogleScreen(
                 successContent = {
@@ -114,8 +115,11 @@ fun NavGraphBuilder.authenticationNavGraph(
                 onGoogleNotAvailable = {
                     showErrorToastMessage = defaultErrorMessage
                 },
-                onServerError = {
-                    showErrorToastMessage = serverErrorMessage
+                onNoCredential = {
+                    showErrorToastMessage = noCredentialMessage
+                },
+                onOtherFailure = {
+                    showErrorToastMessage = otherErrorMessage
                 },
                 onCancel = {
                     navController.popBackStack()

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginWithGoogleScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginWithGoogleScreen.kt
@@ -10,7 +10,8 @@ import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 fun LoginWithGoogleScreen(
     onError: (t: Throwable?) -> Unit,
     onGoogleNotAvailable: () -> Unit,
-    onServerError: () -> Unit,
+    onNoCredential: () -> Unit,
+    onOtherFailure: () -> Unit,
     onCancel: () -> Unit,
     viewModel: LoginWithGoogleViewModel = hiltViewModel(),
     successContent: @Composable (LoginWithGoogleViewModel.State.SignedInWithGoogle) -> Unit,
@@ -27,9 +28,11 @@ fun LoginWithGoogleScreen(
     when (state) {
         is LoginWithGoogleViewModel.State.Failed.GoogleLoginUnavailable -> onGoogleNotAvailable()
 
+        is LoginWithGoogleViewModel.State.Failed.NoGoogleCredential -> onNoCredential()
+
         is LoginWithGoogleViewModel.State.Failed.CredentialError -> onError(state.exception)
 
-        is LoginWithGoogleViewModel.State.Failed.Other -> onServerError()
+        is LoginWithGoogleViewModel.State.Failed.Other -> onOtherFailure()
 
         is LoginWithGoogleViewModel.State.Failed.Cancelled -> onCancel()
 

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginWithGoogleScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginWithGoogleScreen.kt
@@ -10,6 +10,7 @@ import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 fun LoginWithGoogleScreen(
     onError: (t: Throwable?) -> Unit,
     onGoogleNotAvailable: () -> Unit,
+    onServerError: () -> Unit,
     onCancel: () -> Unit,
     viewModel: LoginWithGoogleViewModel = hiltViewModel(),
     successContent: @Composable (LoginWithGoogleViewModel.State.SignedInWithGoogle) -> Unit,
@@ -28,7 +29,7 @@ fun LoginWithGoogleScreen(
 
         is LoginWithGoogleViewModel.State.Failed.CredentialError -> onError(state.exception)
 
-        is LoginWithGoogleViewModel.State.Failed.Other -> onError(null)
+        is LoginWithGoogleViewModel.State.Failed.Other -> onServerError()
 
         is LoginWithGoogleViewModel.State.Failed.Cancelled -> onCancel()
 

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginWithGoogleViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginWithGoogleViewModel.kt
@@ -45,6 +45,7 @@ class LoginWithGoogleViewModel @Inject constructor(
 
         sealed interface Failed : State {
             data object GoogleLoginUnavailable : Failed
+            data object NoGoogleCredential : Failed
             data class CredentialError(val exception: Throwable) : Failed
             data object Cancelled : Failed
             data object Other : Failed
@@ -105,7 +106,7 @@ class LoginWithGoogleViewModel @Inject constructor(
                 }.onFailure {
                     LogBuffer.e(LogBuffer.TAG_CRASH, it, "${WearLogging.PREFIX} Unable to sign in with Google One Tap")
                     _state.value = when (it) {
-                        is NoCredentialException -> State.Failed.GoogleLoginUnavailable
+                        is NoCredentialException -> State.Failed.NoGoogleCredential
 
                         is GetCredentialCancellationException,
                         is GetCredentialInterruptedException,


### PR DESCRIPTION
## Description

Fixes PCDROID-763 https://linear.app/a8c/issue/PCDROID-763/wear-os-instant-loginfailed-on-both-login-routes-galaxy-watch-ultra-2

**This is a diagnostics-only change. It does not — and cannot yet — fix the reported failure.** The root cause is unconfirmable from the outside because the failure reason is swallowed at every layer, and this reporter can't send us watch logs (in-app export is gated behind the signed-in state they can't reach, PCDROID-476). So instead of shipping a blind behavioral change to a login path every Wear user depends on, this PR makes the *next* occurrence legible — via readable logs and a disambiguated on-screen error — so we can actually pin the cause.

What was invisible before this PR:

1. **The identity in phone→watch logs was R8-obscured.** `LoginIdentity` is a `sealed class` of `object`s with no `toString`, so `WatchSync` logged `identity: tq6@6084f14` in release. Now it logs `loginIdentity.key` (`Google` / `PocketCasts` / `QrCode`).
2. **The actual login exception was dropped on the floor.** `SyncManagerImpl.handleLogin` caught the exception, sent it to `Timber.e(…)`, then replaced it with a generic string. But on a **release watch Timber is never planted** (and `TimberDebugTree` doesn't forward to `LogBuffer` anyway) — so the real exception (HTTP status, `IOException`, `SecurityException`, TLS, …) was lost even from the exportable log. It now goes to `LogBuffer.e(…, ex, …)`, recovering the signal across all release platforms.
3. **The phone-sync failure reason was unlogged.** `WatchSync.processAuthDataChange` logged only `"Login result: Failed"` (itself R8-degraded). It now logs the server `message` + `messageId`.
4. **The Google-route toast was ambiguous.** `State.Failed.GoogleLoginUnavailable` (pre-picker: Play services / no credential) and `State.Failed.Other` (post-picker: server rejected the token) both showed the same "Unable to launch Google sign in." A distinct toast now covers the server-side case, so the reporter's screenshot alone tells us client-side vs server-side.

No login success/failure behavior changes. The only user-visible delta is a more accurate toast on the post-picker Google case; the dominant pre-picker path keeps its exact current string.

## Testing Instructions

This is not reproducible in-house (no Galaxy Watch Ultra 2). Verification is of the diagnostics themselves:

1. Unit tests (green): `:modules:features:account` (36), `:modules:services:repositories` (963), `:wear` (61) — 1060 total, 0 failures. `WatchSyncTest` still asserts the `Failed` result reaches the callback (the `onResult` invariant is preserved).
2. Manual (optional, closest to a real repro): boot a **Wear OS API 36 emulator** (> the API-34 gate) and tap **Log in with Google** with no usable Google credential — this exercises the modern Credential Manager path the Ultra 2 takes. Observe which toast appears: the unchanged "Unable to launch Google sign in." (`GoogleLoginUnavailable`, pre-picker) vs. the new "Couldn't sign in with Google. Please try again." (`Other`, server-side).
3. To confirm the R8 log fix survives obfuscation, build a `prototype` wear APK, trigger a phone→watch sync, and grep the on-device log for `identity: Google` (not `identity: tq6@…`).

## Screenshots or Screencast

N/A — no on-device UI layout changes (a toast string differs on one Google error path). No repro hardware available.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md <!-- internal/diagnostics change; only a minor Wear error-toast wording differs — no CHANGELOG entry -->
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes <!-- existing WatchSyncTest covers the onResult invariant; no logic branch added -->
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews <!-- LoginWithGoogleScreen only dispatches state to callbacks; nothing renders to preview -->
- [x] I have updated (or requested that someone edit) the Event Horizon schema to reflect any new or changed analytics. <!-- no analytics changes -->
