### PR TITLE
Fix the Playback Effects icon disappearing when a podcast has no colours yet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
         ([#5835](https://github.com/Automattic/pocket-casts-android/pull/5835))
     *   Stop "Cache entire playing episode" from silently downloading oversized or video enclosures in the background
         ([#5868](https://github.com/Automattic/pocket-casts-android/pull/5868))
+    *   Keep the Playback Effects icon visible on the Now Playing screen when a podcast's colours haven't loaded yet
+        ([#5877](https://github.com/Automattic/pocket-casts-android/pull/5877))
 
 8.20
 -----

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/PodcastColors.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/PodcastColors.kt
@@ -17,7 +17,7 @@ data class PodcastColors(
 ) : Parcelable {
     constructor(podcast: Podcast) : this(
         background = Color(podcast.backgroundColor),
-        playerTint = Color(podcast.getPlayerTintColor(isDarkTheme = true)),
+        playerTint = Color(podcast.getTintColor(isDarkTheme = true)),
     )
 
     companion object {

--- a/modules/services/compose/src/test/java/au/com/shiftyjelly/pocketcasts/compose/PodcastColorsTest.kt
+++ b/modules/services/compose/src/test/java/au/com/shiftyjelly/pocketcasts/compose/PodcastColorsTest.kt
@@ -1,0 +1,30 @@
+package au.com.shiftyjelly.pocketcasts.compose
+
+import androidx.compose.ui.graphics.Color
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@Config(manifest = Config.NONE)
+@RunWith(RobolectricTestRunner::class)
+class PodcastColorsTest {
+    @Test
+    fun `player tint stays opaque when the podcast has no extracted colors`() {
+        val podcastColors = PodcastColors(Podcast(uuid = "uuid"))
+
+        assertEquals(1f, podcastColors.playerTint.alpha, 0f)
+        assertEquals(Color.White, podcastColors.playerTint)
+    }
+
+    @Test
+    fun `player tint uses the podcast dark tint when it is set`() {
+        val tint = 0xFF3366FF.toInt()
+
+        val podcastColors = PodcastColors(Podcast(uuid = "uuid", tintColorForDarkBg = tint))
+
+        assertEquals(Color(tint), podcastColors.playerTint)
+    }
+}

--- a/modules/services/compose/src/test/java/au/com/shiftyjelly/pocketcasts/compose/PodcastColorsTest.kt
+++ b/modules/services/compose/src/test/java/au/com/shiftyjelly/pocketcasts/compose/PodcastColorsTest.kt
@@ -20,6 +20,15 @@ class PodcastColorsTest {
     }
 
     @Test
+    fun `player tint falls back to white when the podcast uses the server default dark tint`() {
+        val serverDefaultDarkTint = 0xFFC62828.toInt()
+
+        val podcastColors = PodcastColors(Podcast(uuid = "uuid", tintColorForDarkBg = serverDefaultDarkTint))
+
+        assertEquals(Color.White, podcastColors.playerTint)
+    }
+
+    @Test
     fun `player tint uses the podcast dark tint when it is set`() {
         val tint = 0xFF3366FF.toInt()
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/Podcast.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/Podcast.kt
@@ -267,10 +267,6 @@ data class Podcast(
         return if (isDarkTheme) darkThemeTint() else lightThemeTint()
     }
 
-    fun getPlayerTintColor(isDarkTheme: Boolean): Int {
-        return if (isDarkTheme) tintColorForDarkBg else tintColorForLightBg
-    }
-
     fun displayableFrequency(resources: Resources): String? {
         val frequency = episodeFrequency ?: return null
         val stringId = when (frequency.lowercase()) {


### PR DESCRIPTION
## Description

On the Now Playing screen, the Playback Effects icon was sometimes missing from the actions shelf. Its slot was still there — it just showed nothing, while all the other icons were fine.

The effects icon is drawn using the podcast's accent colour (the same colour the player uses for its highlights). When playback effects are turned on, the icon is tinted with that colour. The catch is that a podcast's colours are filled in later — after they're fetched from the server or worked out from the artwork. Until then the colour value is `0`, which is fully transparent, so the icon was being painted with an invisible colour and vanished. Every other shelf icon uses a fixed theme colour, so they stayed visible. This is also why it came and went on its own: once the podcast's colours were populated, the icon reappeared.

The rest of the app already handles this. `getTintColor()` falls back to a visible default colour when a podcast has no colours yet, but the player was using `getPlayerTintColor()`, which returned the raw value with no fallback.

The fix is to build the player tint from the same guarded `getTintColor()`. For podcasts that already have colours nothing changes; for podcasts without colours yet the accent now falls back to a visible colour instead of being transparent. The now-unused `getPlayerTintColor()` is removed.

Fixes #5529
Fixes PCDROID-652 https://linear.app/a8c/issue/PCDROID-652/playback-effects-icon-missing-beta-815-rc-2-9437

## Testing Instructions

This is hard to trigger by hand because it only happens in the short window before a podcast's colours have been fetched, with playback effects enabled. The behaviour is covered by a unit test:

1. `./gradlew :modules:services:compose:testDebugUnitTest`
2. `PodcastColorsTest` checks that a podcast with no extracted colours produces a visible (opaque) player tint, and that a podcast with a real colour keeps it.


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

#### I have tested any UI changes...
<!-- Logic-only fix in a shared colour helper; behaviour verified by unit test. -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
