### PR TITLE
Preserve and report a corrupt local database instead of silently recreating it empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
     *   Browse podcast networks from Discover, search and the podcast page
         ([#5865](https://github.com/Automattic/pocket-casts-android/pull/5865))
 *   Bug Fixes
+    *   Preserve and report a corrupt local database instead of silently recreating it empty and losing the library
+        ([#5878](https://github.com/Automattic/pocket-casts-android/pull/5878))
     *   Keep the multi-select episode selection when rotating the device on the podcast screen
         ([#5836](https://github.com/Automattic/pocket-casts-android/pull/5836))
     *   Prevent the app from being killed in the background on low-memory devices by pausing player UI updates while playing

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/PcDroid687DatabaseLossReproTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/PcDroid687DatabaseLossReproTest.kt
@@ -64,18 +64,16 @@ class PcDroid687DatabaseLossReproTest {
         db.execSQL(insertUpNext)
     }
 
-    private fun countRows(db: SupportSQLiteDatabase, table: String): Int =
-        db.query("SELECT count(*) FROM $table").use { cursor ->
-            cursor.moveToFirst()
-            cursor.getInt(0)
-        }
+    private fun countRows(db: SupportSQLiteDatabase, table: String): Int = db.query("SELECT count(*) FROM $table").use { cursor ->
+        cursor.moveToFirst()
+        cursor.getInt(0)
+    }
 
-    private fun productionRoom(dbName: String, reporter: DatabaseCorruptionReporter): AppDatabase =
-        Room.databaseBuilder(context, AppDatabase::class.java, dbName)
-            .openHelperFactory(CorruptionHandlingOpenHelperFactory(FrameworkSQLiteOpenHelperFactory()) { reporter })
-            .also { builder -> AppDatabase.addMigrations(builder, context) }
-            .addTypeConverters(ModelModule.provideRoomConverters(Moshi.Builder().build()))
-            .build()
+    private fun productionRoom(dbName: String, reporter: DatabaseCorruptionReporter): AppDatabase = Room.databaseBuilder(context, AppDatabase::class.java, dbName)
+        .openHelperFactory(CorruptionHandlingOpenHelperFactory(FrameworkSQLiteOpenHelperFactory()) { reporter })
+        .also { builder -> AppDatabase.addMigrations(builder, context) }
+        .addTypeConverters(ModelModule.provideRoomConverters(Moshi.Builder().build()))
+        .build()
 
     @Test
     fun migration133ToCurrentPreservesPopulatedLibrary() {

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/PcDroid687DatabaseLossReproTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/PcDroid687DatabaseLossReproTest.kt
@@ -1,0 +1,136 @@
+package au.com.shiftyjelly.pocketcasts.models.db
+
+import android.content.Context
+import androidx.room.Room
+import androidx.room.testing.MigrationTestHelper
+import androidx.sqlite.db.SupportSQLiteDatabase
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import au.com.shiftyjelly.pocketcasts.models.di.ModelModule
+import au.com.shiftyjelly.pocketcasts.models.di.addTypeConverters
+import com.squareup.moshi.Moshi
+import java.io.File
+import java.io.RandomAccessFile
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class PcDroid687DatabaseLossReproTest {
+
+    private val context: Context get() = InstrumentationRegistry.getInstrumentation().targetContext
+
+    @Rule
+    @JvmField
+    val migrationTestHelper: MigrationTestHelper = MigrationTestHelper(
+        InstrumentationRegistry.getInstrumentation(),
+        AppDatabase::class.java,
+    )
+
+    private class RecordingReporter : DatabaseCorruptionReporter {
+        var calls = 0
+        var databaseName: String? = null
+        var backupPath: String? = null
+        var databaseSizeBytes: Long = -1
+
+        override fun onDatabaseCorrupted(databaseName: String, backupPath: String?, databaseSizeBytes: Long) {
+            calls++
+            this.databaseName = databaseName
+            this.backupPath = backupPath
+            this.databaseSizeBytes = databaseSizeBytes
+        }
+    }
+
+    private val insertPodcast =
+        "INSERT INTO podcasts (uuid, title, podcast_description, podcast_html_description, podcast_category, podcast_language, author, sort_order, episodes_sort_order, episodes_to_keep, override_global_settings, override_global_effects, start_from, playback_speed, volume_boosted, is_folder, subscribed, show_notifications, auto_download_status, auto_add_to_up_next, most_popular_color, primary_color, secondary_color, light_overlay_color, fab_for_light_bg, link_for_dark_bg, link_for_light_bg, color_version, color_last_downloaded, sync_status, exclude_from_auto_archive, override_global_archive, auto_archive_played_after, auto_archive_inactive_after, auto_archive_episode_limit, grouping, skip_last, show_archived, trim_silence_level, refresh_available, licensing, isPaid, is_private, is_header_expanded, slug, web_feed, clean_title) VALUES ('podcast-1', 'Test Show', '', '', '', '', '', 0, 0, 0, 0, 0, 0, 0.0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, '', 0, '')"
+    private val insertEpisode =
+        "INSERT INTO podcast_episodes (uuid, episode_description, published_date, title, size_in_bytes, episode_status, duration, played_up_to, playing_status, podcast_id, added_date, auto_download_status, starred, thumbnail_status, archived, last_playback_interaction_sync_status, exclude_from_episode_limit, deselected_chapters, slug, has_generated_transcript) VALUES ('episode-1', '', 0, 'Test Ep', 0, 0, 0.0, 0.0, 0, 'podcast-1', 0, 0, 0, 0, 0, 0, 0, '', '', 0)"
+    private val insertFolder =
+        "INSERT INTO folders (uuid, name, color, added_date, sort_position, podcasts_sort_type, deleted, sync_modified, clean_name) VALUES ('folder-1', 'Test Folder', 0, 0, 0, 0, 0, 0, '')"
+    private val insertPlaylist =
+        "INSERT INTO playlists (uuid, title, iconId, sortId, manual, deleted, syncStatus, autoDownload, autoDownloadLimit, unplayed, partiallyPlayed, finished, downloaded, notDownloaded, audioVideo, filterHours, starred, allPodcasts, filterDuration, longerThan, shorterThan, showArchivedEpisodes, clean_title) VALUES ('playlist-1', 'Test Filter', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, '')"
+    private val insertUpNext =
+        "INSERT INTO up_next_episodes (episodeUuid, position, title) VALUES ('episode-1', 0, 'Test Ep')"
+
+    private fun populate(db: SupportSQLiteDatabase) {
+        db.execSQL(insertPodcast)
+        db.execSQL(insertEpisode)
+        db.execSQL(insertFolder)
+        db.execSQL(insertPlaylist)
+        db.execSQL(insertUpNext)
+    }
+
+    private fun countRows(db: SupportSQLiteDatabase, table: String): Int =
+        db.query("SELECT count(*) FROM $table").use { cursor ->
+            cursor.moveToFirst()
+            cursor.getInt(0)
+        }
+
+    private fun productionRoom(dbName: String, reporter: DatabaseCorruptionReporter): AppDatabase =
+        Room.databaseBuilder(context, AppDatabase::class.java, dbName)
+            .openHelperFactory(CorruptionHandlingOpenHelperFactory(FrameworkSQLiteOpenHelperFactory()) { reporter })
+            .also { builder -> AppDatabase.addMigrations(builder, context) }
+            .addTypeConverters(ModelModule.provideRoomConverters(Moshi.Builder().build()))
+            .build()
+
+    @Test
+    fun migration133ToCurrentPreservesPopulatedLibrary() {
+        val dbName = "pcdroid687-migration"
+        migrationTestHelper.createDatabase(dbName, 133).use { populate(it) }
+
+        val db = migrationTestHelper.runMigrationsAndValidate(
+            dbName,
+            137,
+            true,
+            AppDatabase.MIGRATION_133_134,
+            AppDatabase.MIGRATION_134_135,
+            AppDatabase.MIGRATION_135_136,
+            AppDatabase.MIGRATION_136_137,
+        )
+
+        assertEquals("podcasts should survive the migration", 1, countRows(db, "podcasts"))
+        assertEquals("podcast_episodes should survive the migration", 1, countRows(db, "podcast_episodes"))
+        assertEquals("folders should survive the migration", 1, countRows(db, "folders"))
+        assertEquals("playlists should survive the migration", 1, countRows(db, "playlists"))
+        assertEquals("up_next_episodes should survive the migration", 1, countRows(db, "up_next_episodes"))
+    }
+
+    @Test
+    fun corruptDatabaseIsBackedUpAndReportedBeforeRecreation() {
+        val dbName = "pcdroid687-corrupt"
+
+        migrationTestHelper.createDatabase(dbName, 133).use { populate(it) }
+
+        val dbFile = context.getDatabasePath(dbName)
+        context.getDatabasePath("$dbName-wal").delete()
+        context.getDatabasePath("$dbName-shm").delete()
+        RandomAccessFile(dbFile, "rw").use { raf ->
+            val length = raf.length().coerceAtMost(8192L).toInt()
+            raf.seek(0)
+            raf.write(ByteArray(length) { 0xFF.toByte() })
+        }
+
+        val reporter = RecordingReporter()
+        var podcasts = -1
+        repeat(2) {
+            if (podcasts >= 0) return@repeat
+            val room = productionRoom(dbName, reporter)
+            try {
+                podcasts = countRows(room.openHelper.writableDatabase, "podcasts")
+            } catch (_: Throwable) {
+            } finally {
+                room.close()
+            }
+        }
+
+        assertEquals("corruption should be reported exactly once", 1, reporter.calls)
+        assertNotNull("the corrupt database should be preserved", reporter.backupPath)
+        assertTrue("the backup file should exist on disk", File(reporter.backupPath!!).exists())
+        assertTrue("the corrupt database size should be captured", reporter.databaseSizeBytes > 0)
+        assertEquals("Room still recovers by recreating an empty database", 0, podcasts)
+    }
+}

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/CorruptionHandlingOpenHelperFactory.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/CorruptionHandlingOpenHelperFactory.kt
@@ -58,8 +58,8 @@ class CorruptionHandlingOpenHelperFactory(
                 return null
             }
             val directory = databaseFile.parentFile ?: return null
-            val prefix = "${databaseFile.name}.$BACKUP_MARKER-"
-            directory.listFiles { file -> file.name.startsWith(prefix) }?.forEach { it.delete() }
+            val marker = ".$BACKUP_MARKER-"
+            directory.listFiles { file -> file.name.startsWith(databaseFile.name) && file.name.contains(marker) }?.forEach { it.delete() }
 
             val suffix = "$BACKUP_MARKER-${System.currentTimeMillis()}"
             val backup = File(directory, "${databaseFile.name}.$suffix")

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/CorruptionHandlingOpenHelperFactory.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/CorruptionHandlingOpenHelperFactory.kt
@@ -58,8 +58,6 @@ class CorruptionHandlingOpenHelperFactory(
                 return null
             }
             val directory = databaseFile.parentFile ?: return null
-            val marker = ".$BACKUP_MARKER-"
-            directory.listFiles { file -> file.name.startsWith(databaseFile.name) && file.name.contains(marker) }?.forEach { it.delete() }
 
             val suffix = "$BACKUP_MARKER-${System.currentTimeMillis()}"
             val backup = File(directory, "${databaseFile.name}.$suffix")
@@ -70,7 +68,17 @@ class CorruptionHandlingOpenHelperFactory(
                     auxiliary.copyTo(File(directory, "${databaseFile.name}$extension.$suffix"), overwrite = true)
                 }
             }
+
+            pruneOlderBackups(directory, databaseFile, keepSuffix = suffix)
             return backup
+        }
+
+        private fun pruneOlderBackups(directory: File, databaseFile: File, keepSuffix: String) {
+            val backupBaseNames = listOf(databaseFile.name) + AUXILIARY_EXTENSIONS.map { "${databaseFile.name}$it" }
+            directory.listFiles { file ->
+                !file.name.endsWith(".$keepSuffix") &&
+                    backupBaseNames.any { baseName -> file.name.startsWith("$baseName.$BACKUP_MARKER-") }
+            }?.forEach { it.delete() }
         }
     }
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/CorruptionHandlingOpenHelperFactory.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/CorruptionHandlingOpenHelperFactory.kt
@@ -1,0 +1,81 @@
+package au.com.shiftyjelly.pocketcasts.models.db
+
+import androidx.sqlite.db.SupportSQLiteDatabase
+import androidx.sqlite.db.SupportSQLiteOpenHelper
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
+import java.io.File
+
+class CorruptionHandlingOpenHelperFactory(
+    private val delegate: SupportSQLiteOpenHelper.Factory,
+    private val reporter: () -> DatabaseCorruptionReporter,
+) : SupportSQLiteOpenHelper.Factory {
+
+    override fun create(configuration: SupportSQLiteOpenHelper.Configuration): SupportSQLiteOpenHelper {
+        val wrapped = SupportSQLiteOpenHelper.Configuration.builder(configuration.context)
+            .name(configuration.name)
+            .noBackupDirectory(configuration.useNoBackupDirectory)
+            .allowDataLossOnRecovery(configuration.allowDataLossOnRecovery)
+            .callback(BackupOnCorruptionCallback(configuration, reporter))
+            .build()
+        return delegate.create(wrapped)
+    }
+
+    private class BackupOnCorruptionCallback(
+        private val configuration: SupportSQLiteOpenHelper.Configuration,
+        private val reporter: () -> DatabaseCorruptionReporter,
+    ) : SupportSQLiteOpenHelper.Callback(configuration.callback.version) {
+
+        private val delegate = configuration.callback
+
+        override fun onConfigure(db: SupportSQLiteDatabase) = delegate.onConfigure(db)
+
+        override fun onCreate(db: SupportSQLiteDatabase) = delegate.onCreate(db)
+
+        override fun onUpgrade(db: SupportSQLiteDatabase, oldVersion: Int, newVersion: Int) = delegate.onUpgrade(db, oldVersion, newVersion)
+
+        override fun onDowngrade(db: SupportSQLiteDatabase, oldVersion: Int, newVersion: Int) = delegate.onDowngrade(db, oldVersion, newVersion)
+
+        override fun onOpen(db: SupportSQLiteDatabase) = delegate.onOpen(db)
+
+        override fun onCorruption(db: SupportSQLiteDatabase) {
+            val name = configuration.name
+            if (name != null) {
+                runCatching { preserveAndReport(name) }
+                    .onFailure { LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, it, "Failed to preserve corrupt database $name") }
+            }
+            delegate.onCorruption(db)
+        }
+
+        private fun preserveAndReport(name: String) {
+            val databaseFile = configuration.context.getDatabasePath(name)
+            val sizeBytes = if (databaseFile.exists()) databaseFile.length() else 0L
+            val backup = backUp(databaseFile)
+            reporter().onDatabaseCorrupted(name, backup?.absolutePath, sizeBytes)
+        }
+
+        private fun backUp(databaseFile: File): File? {
+            if (!databaseFile.exists()) {
+                return null
+            }
+            val directory = databaseFile.parentFile ?: return null
+            val prefix = "${databaseFile.name}.$BACKUP_MARKER-"
+            directory.listFiles { file -> file.name.startsWith(prefix) }?.forEach { it.delete() }
+
+            val suffix = "$BACKUP_MARKER-${System.currentTimeMillis()}"
+            val backup = File(directory, "${databaseFile.name}.$suffix")
+            databaseFile.copyTo(backup, overwrite = true)
+            for (extension in AUXILIARY_EXTENSIONS) {
+                val auxiliary = File(directory, "${databaseFile.name}$extension")
+                if (auxiliary.exists()) {
+                    auxiliary.copyTo(File(directory, "${databaseFile.name}$extension.$suffix"), overwrite = true)
+                }
+            }
+            return backup
+        }
+    }
+
+    companion object {
+        private const val BACKUP_MARKER = "corrupt"
+        private val AUXILIARY_EXTENSIONS = listOf("-wal", "-shm")
+    }
+}

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/DatabaseCorruptionReporter.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/DatabaseCorruptionReporter.kt
@@ -2,10 +2,4 @@ package au.com.shiftyjelly.pocketcasts.models.db
 
 interface DatabaseCorruptionReporter {
     fun onDatabaseCorrupted(databaseName: String, backupPath: String?, databaseSizeBytes: Long)
-
-    companion object {
-        val NONE = object : DatabaseCorruptionReporter {
-            override fun onDatabaseCorrupted(databaseName: String, backupPath: String?, databaseSizeBytes: Long) = Unit
-        }
-    }
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/DatabaseCorruptionReporter.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/DatabaseCorruptionReporter.kt
@@ -1,0 +1,11 @@
+package au.com.shiftyjelly.pocketcasts.models.db
+
+interface DatabaseCorruptionReporter {
+    fun onDatabaseCorrupted(databaseName: String, backupPath: String?, databaseSizeBytes: Long)
+
+    companion object {
+        val NONE = object : DatabaseCorruptionReporter {
+            override fun onDatabaseCorrupted(databaseName: String, backupPath: String?, databaseSizeBytes: Long) = Unit
+        }
+    }
+}

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/di/ModelModule.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/di/ModelModule.kt
@@ -3,8 +3,11 @@ package au.com.shiftyjelly.pocketcasts.models.di
 import android.app.Application
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
 import au.com.shiftyjelly.pocketcasts.models.converter.AlternateEnclosureSourcesConverter
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
+import au.com.shiftyjelly.pocketcasts.models.db.CorruptionHandlingOpenHelperFactory
+import au.com.shiftyjelly.pocketcasts.models.db.DatabaseCorruptionReporter
 import au.com.shiftyjelly.pocketcasts.models.db.dao.AlternateEnclosureDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.ChapterDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.EndOfYearDao
@@ -21,6 +24,7 @@ import au.com.shiftyjelly.pocketcasts.models.db.dao.UserCategoryVisitsDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.UserNotificationsDao
 import au.com.shiftyjelly.pocketcasts.models.entity.AnonymousBumpStat
 import com.squareup.moshi.Moshi
+import dagger.Lazy
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -45,8 +49,12 @@ object ModelModule {
     fun providesAppDatabase(
         application: Application,
         @RoomConverters converters: List<@JvmSuppressWildcards Any>,
+        databaseCorruptionReporter: Lazy<DatabaseCorruptionReporter>,
     ): AppDatabase {
         return Room.databaseBuilder(application, AppDatabase::class.java, "pocketcasts")
+            .openHelperFactory(
+                CorruptionHandlingOpenHelperFactory(FrameworkSQLiteOpenHelperFactory()) { databaseCorruptionReporter.get() },
+            )
             .also { builder -> AppDatabase.addMigrations(builder, application) }
             .addTypeConverters(converters)
             .build()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/database/DatabaseCorruptionReporterImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/database/DatabaseCorruptionReporterImpl.kt
@@ -1,0 +1,37 @@
+package au.com.shiftyjelly.pocketcasts.repositories.database
+
+import au.com.shiftyjelly.pocketcasts.models.db.DatabaseCorruptionReporter
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
+import com.automattic.android.tracks.crashlogging.CrashLogging
+import javax.inject.Inject
+
+class DatabaseCorruptionReporterImpl @Inject constructor(
+    private val settings: Settings,
+    private val syncManager: SyncManager,
+    private val crashLogging: CrashLogging,
+) : DatabaseCorruptionReporter {
+
+    override fun onDatabaseCorrupted(databaseName: String, backupPath: String?, databaseSizeBytes: Long) {
+        val loggedIn = runCatching { syncManager.isLoggedIn() }.getOrDefault(false)
+        val message = "Database $databaseName was corrupt and recreated empty (sizeBytes=$databaseSizeBytes, backedUp=${backupPath != null}, loggedIn=$loggedIn)"
+        LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, message)
+        crashLogging.sendReport(
+            exception = DatabaseCorruptionException(databaseName),
+            tags = mapOf(
+                "database_name" to databaseName,
+                "database_size_bytes" to databaseSizeBytes.toString(),
+                "database_backed_up" to (backupPath != null).toString(),
+                "logged_in" to loggedIn.toString(),
+                "processed_sign_out" to settings.getFullySignedOut().toString(),
+                "app_version" to settings.getVersion(),
+                "app_version_code" to settings.getVersionCode().toString(),
+                "migrated_version_code" to settings.getMigratedVersionCode().toString(),
+            ),
+            message = message,
+        )
+    }
+
+    private class DatabaseCorruptionException(databaseName: String) : Exception("Room database corrupted: $databaseName")
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/RepositoryModule.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/RepositoryModule.kt
@@ -6,6 +6,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.AccountStatusInfo
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsListener
 import au.com.shiftyjelly.pocketcasts.crashlogging.CrashReportPermissionCheck
 import au.com.shiftyjelly.pocketcasts.crashlogging.ObserveUser
+import au.com.shiftyjelly.pocketcasts.models.db.DatabaseCorruptionReporter
 import au.com.shiftyjelly.pocketcasts.models.to.TranscriptType
 import au.com.shiftyjelly.pocketcasts.payment.PurchaseApprover
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -22,6 +23,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.chat.ChatManager
 import au.com.shiftyjelly.pocketcasts.repositories.chat.ChatManagerImpl
 import au.com.shiftyjelly.pocketcasts.repositories.chromecast.CastManager
 import au.com.shiftyjelly.pocketcasts.repositories.chromecast.CastManagerImpl
+import au.com.shiftyjelly.pocketcasts.repositories.database.DatabaseCorruptionReporterImpl
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadQueue
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadStatusObserver
@@ -114,6 +116,10 @@ abstract class RepositoryModule {
     @Binds
     @Singleton
     abstract fun provideWorkerFactory(castsWorkerFactory: CastsWorkerFactory): WorkerFactory
+
+    @Binds
+    @Singleton
+    abstract fun bindDatabaseCorruptionReporter(impl: DatabaseCorruptionReporterImpl): DatabaseCorruptionReporter
 
     @Binds
     @Singleton

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/database/DatabaseCorruptionReporterImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/database/DatabaseCorruptionReporterImplTest.kt
@@ -1,0 +1,54 @@
+package au.com.shiftyjelly.pocketcasts.repositories.database
+
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
+import com.automattic.android.tracks.crashlogging.CrashLogging
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+class DatabaseCorruptionReporterImplTest {
+
+    private val settings = mock<Settings> {
+        on { getVersion() } doReturn "8.16"
+        on { getVersionCode() } doReturn 9441
+        on { getMigratedVersionCode() } doReturn 9441
+        on { getFullySignedOut() } doReturn true
+    }
+    private val syncManager = mock<SyncManager> {
+        on { isLoggedIn() } doReturn false
+    }
+    private val crashLogging = mock<CrashLogging>()
+
+    private val reporter = DatabaseCorruptionReporterImpl(settings, syncManager, crashLogging)
+
+    @Test
+    fun `reports corruption with context tags`() {
+        reporter.onDatabaseCorrupted("pocketcasts", "/databases/pocketcasts.corrupt-123", databaseSizeBytes = 4096L)
+
+        val tags = argumentCaptor<Map<String, String>>()
+        verify(crashLogging).sendReport(any(), tags.capture(), any())
+
+        val captured = tags.firstValue
+        assertEquals("pocketcasts", captured["database_name"])
+        assertEquals("4096", captured["database_size_bytes"])
+        assertEquals("true", captured["database_backed_up"])
+        assertEquals("false", captured["logged_in"])
+        assertEquals("true", captured["processed_sign_out"])
+        assertEquals("9441", captured["migrated_version_code"])
+    }
+
+    @Test
+    fun `marks the report when no backup was taken`() {
+        reporter.onDatabaseCorrupted("pocketcasts", backupPath = null, databaseSizeBytes = 0L)
+
+        val tags = argumentCaptor<Map<String, String>>()
+        verify(crashLogging).sendReport(any(), tags.capture(), any())
+
+        assertEquals("false", tags.firstValue["database_backed_up"])
+    }
+}


### PR DESCRIPTION
## Description

Fixes PCDROID-687 https://linear.app/a8c/issue/PCDROID-687/android-involuntary-sign-out-no-account-manager-account-found-wipes

Root-cause analysis plus an on-device reproduction established that the trigger was **not** the involuntary "no account manager account found" sign-out named in the ticket — that path is non-destructive (it never deletes the library, in any version), and the logs show the library alive and playing downloaded episodes through ~21 of those sign-outs. The library disappeared across the 8.15 → 8.16 upgrade, and the reproduction pins the mechanism: **Room silently discards an unreadable database.** When the database file is corrupt (or missing), Room's default corruption handler deletes it and recreates an empty database at the current schema version — no crash, no warning, no backup. For a user whose library isn't backed up server-side, that is permanent, invisible, total loss.

This PR stops the silent data loss and makes the failure observable:

- `CorruptionHandlingOpenHelperFactory` wraps Room's framework open-helper and, on `onCorruption`, **copies the corrupt database (plus its `-wal`/`-shm`) aside** (`pocketcasts.corrupt-<timestamp>`, a single rotated backup) **before** letting Room delete/recreate it — so the data is recoverable instead of gone.
- `DatabaseCorruptionReporter` emits a `LogBuffer` line and a non-fatal crash-logging report tagged with recovery context (app + migrated version code, logged-in, processed-sign-out, size, whether a backup was taken) — the fleet-wide visibility we currently lack into how often this actually happens.

Design notes:
- Dependency-inverted so `model` stays at the bottom: the interface is in `model`; the crash-logging/settings/sync-backed implementation is in `repositories`.
- The reporter is injected as `dagger.Lazy` to avoid any DB-open construction cycle, and `onCorruption` always proceeds to Room's recovery even if backup/reporting throws.
- `LogBuffer` is the guaranteed signal (it is the exact artifact a user exports in a debug log); the crash-logging report is best-effort and may be skipped for corruption that occurs before crash logging initializes on a cold start.

Out of scope (deferred, pending the telemetry this PR produces): an auto-restore flow and a startup "library unexpectedly empty" tripwire for the file-missing case.

## Testing Instructions

Reproduction/regression harness, verified on a Pixel 9 (API 34) emulator:

1. `./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=au.com.shiftyjelly.pocketcasts.models.db.PcDroid687DatabaseLossReproTest`
   - `migration133ToCurrentPreservesPopulatedLibrary` — a populated schema-133 library survives the real 133→137 migrations (rules the migration out).
   - `corruptDatabaseIsBackedUpAndReportedBeforeRecreation` — a populated DB is corrupted, opened with the production Room config, and the corrupt file is backed up, the reporter fires once, and Room still recovers (empty DB, no crash).
2. `./gradlew :modules:services:repositories:testDebugUnitTest --tests "au.com.shiftyjelly.pocketcasts.repositories.database.*"` — the reporter emits the expected context tags.

## Screenshots or Screencast

N/A — no UI changes (database-open path + telemetry only).

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply`)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in localization — N/A (no new strings)
- [ ] Any jetpack compose components I added or changed are covered by compose previews — N/A (no Compose)
- [ ] I have updated the Event Horizon schema — N/A (uses crash logging, not a new analytics event)
