### PR TITLE
Fix played/archived status not syncing to episodes missing from the local library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
         ([#5835](https://github.com/Automattic/pocket-casts-android/pull/5835))
     *   Stop "Cache entire playing episode" from silently downloading oversized or video enclosures in the background
         ([#5868](https://github.com/Automattic/pocket-casts-android/pull/5868))
+    *   Sync the played, archived and starred status set on other devices even for episodes not yet in your local library
+        ([#5879](https://github.com/Automattic/pocket-casts-android/pull/5879))
 
 8.20
 -----

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/data/DataSyncProcess.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/data/DataSyncProcess.kt
@@ -63,7 +63,7 @@ class DataSyncProcess(
     private val logger = DataSyncLogger()
     private val podcastSync = PodcastSync(podcastManager, missingPodcastsSemaphore = Semaphore(permits = 10))
     private val folderSync = FoldersSync(folderManager)
-    private val episodeSync = EpisodeSync(episodeManager, podcastManager, playbackManager, settings)
+    private val episodeSync = EpisodeSync(episodeManager, podcastManager, playbackManager, settings, syncManager)
     private val playlistSync = PlaylistSync(syncManager, appDatabase)
     private val bookmarkSync = BookmarkSync(syncManager, appDatabase)
     private val deviceSync = DeviceSync(statsManager, settings)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/data/EpisodeMappers.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/data/EpisodeMappers.kt
@@ -1,0 +1,35 @@
+package au.com.shiftyjelly.pocketcasts.repositories.sync.data
+
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
+import au.com.shiftyjelly.pocketcasts.servers.extensions.toDate
+import com.pocketcasts.service.api.EpisodeResponse
+import com.pocketcasts.service.api.publishedOrNull
+import java.util.Date
+
+internal fun EpisodeResponse.toPodcastEpisode() = PodcastEpisode(
+    uuid = uuid,
+    downloadUrl = url,
+    publishedDate = publishedOrNull?.toDate() ?: Date(0),
+    duration = duration.toDouble(),
+    fileType = fileType,
+    title = title,
+    sizeInBytes = size,
+    playingStatus = EpisodePlayingStatus.fromInt(playingStatus),
+    playedUpTo = playedUpTo.toDouble(),
+    isStarred = starred,
+    podcastUuid = podcastUuid,
+    type = episodeType,
+    season = episodeSeason.toLong(),
+    number = episodeNumber.toLong(),
+    isArchived = isDeleted,
+    slug = slug,
+)
+
+internal fun EpisodeResponse.toPodcast() = Podcast(
+    uuid = podcastUuid,
+    title = podcastTitle,
+    author = author,
+    slug = podcastSlug,
+)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/data/EpisodeSync.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/data/EpisodeSync.kt
@@ -7,6 +7,8 @@ import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import com.google.protobuf.boolValue
 import com.google.protobuf.int32Value
 import com.google.protobuf.int64Value
@@ -16,6 +18,7 @@ import com.pocketcasts.service.api.durationOrNull
 import com.pocketcasts.service.api.isDeletedOrNull
 import com.pocketcasts.service.api.playedUpToOrNull
 import com.pocketcasts.service.api.playingStatusOrNull
+import com.pocketcasts.service.api.podcastsEpisodesRequest
 import com.pocketcasts.service.api.record
 import com.pocketcasts.service.api.starredModifiedOrNull
 import com.pocketcasts.service.api.starredOrNull
@@ -28,6 +31,7 @@ internal class EpisodeSync(
     private val podcastManager: PodcastManager,
     private val playbackManager: PlaybackManager,
     private val settings: Settings,
+    private val syncManager: SyncManager,
 ) {
     suspend fun incrementalData(): List<Record> {
         val episodes = episodeManager.findEpisodesToSync()
@@ -69,7 +73,9 @@ internal class EpisodeSync(
 
     suspend fun processIncrementalResponse(serverEpisodes: List<SyncUserEpisode>) {
         val serverEpisodesMap = serverEpisodes.associateBy(SyncUserEpisode::getUuid)
-        val localEpisodes = episodeManager.findByUuids(serverEpisodesMap.keys)
+        val presentEpisodes = episodeManager.findByUuids(serverEpisodesMap.keys)
+        val presentUuids = presentEpisodes.mapTo(mutableSetOf(), PodcastEpisode::uuid)
+        val localEpisodes = presentEpisodes + fetchMissingEpisodes(serverEpisodesMap, presentUuids)
 
         val episodesToArchive = mutableListOf<PodcastEpisode>()
         val episodeToFinish = mutableListOf<PodcastEpisode>()
@@ -89,6 +95,46 @@ internal class EpisodeSync(
             episodeManager.markedAsPlayedExternally(episode, playbackManager, podcastManager)
         }
         episodeManager.updateAllSyncFields(localEpisodes)
+    }
+
+    private suspend fun fetchMissingEpisodes(
+        serverEpisodesMap: Map<String, SyncUserEpisode>,
+        presentUuids: Set<String>,
+    ): List<PodcastEpisode> {
+        val missingEpisodes = serverEpisodesMap.values.filter { it.uuid !in presentUuids }
+        if (missingEpisodes.isEmpty()) {
+            return emptyList()
+        }
+        val subscribedPodcastUuids = podcastManager.findSubscribedUuids().toSet()
+        val episodesToFetch = missingEpisodes.filter { it.podcastUuid in subscribedPodcastUuids }
+        if (episodesToFetch.isEmpty()) {
+            return emptyList()
+        }
+        return runCatching {
+            episodesToFetch.chunked(MISSING_EPISODES_BATCH_SIZE).flatMap { batch ->
+                val request = podcastsEpisodesRequest {
+                    batch.forEach { episode ->
+                        podcastUuids.add(episode.podcastUuid)
+                        episodeUuids.add(episode.uuid)
+                    }
+                }
+                syncManager.getEpisodesOrThrow(request).episodesList.map { serverEpisode ->
+                    serverEpisode.toPodcastEpisode().copy(
+                        playingStatus = EpisodePlayingStatus.NOT_PLAYED,
+                        playedUpTo = 0.0,
+                        isStarred = false,
+                        isArchived = false,
+                    )
+                }
+            }.also { shells ->
+                shells.groupBy(PodcastEpisode::podcastUuid).forEach { (podcastUuid, episodes) ->
+                    episodeManager.add(episodes, podcastUuid, downloadMetaData = false)
+                }
+            }
+        }.getOrElse { error ->
+            LogBuffer.e("DataSync", error, "Failed to fetch missing episodes during incremental sync")
+            emptyList()
+        }
     }
 
     private fun PodcastEpisode.applyServerEpisode(
@@ -150,5 +196,9 @@ internal class EpisodeSync(
                 playedUpTo = value
                 playbackManager.seekIfPlayingToTimeMs(uuid, playedUpToMs)
             }
+    }
+
+    companion object {
+        private const val MISSING_EPISODES_BATCH_SIZE = 100
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/data/EpisodeSync.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/data/EpisodeSync.kt
@@ -118,14 +118,7 @@ internal class EpisodeSync(
                         episodeUuids.add(episode.uuid)
                     }
                 }
-                syncManager.getEpisodesOrThrow(request).episodesList.map { serverEpisode ->
-                    serverEpisode.toPodcastEpisode().copy(
-                        playingStatus = EpisodePlayingStatus.NOT_PLAYED,
-                        playedUpTo = 0.0,
-                        isStarred = false,
-                        isArchived = false,
-                    )
-                }
+                syncManager.getEpisodesOrThrow(request).episodesList.map { it.toPodcastEpisode() }
             }.also { shells ->
                 shells.groupBy(PodcastEpisode::podcastUuid).forEach { (podcastUuid, episodes) ->
                     episodeManager.add(episodes, podcastUuid, downloadMetaData = false)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/data/MissingEpisodesSync.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/data/MissingEpisodesSync.kt
@@ -4,13 +4,8 @@ import androidx.room.withTransaction
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
-import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
-import au.com.shiftyjelly.pocketcasts.servers.extensions.toDate
-import com.pocketcasts.service.api.EpisodeResponse
 import com.pocketcasts.service.api.podcastsEpisodesRequest
-import com.pocketcasts.service.api.publishedOrNull
-import java.util.Date
 
 internal class MissingEpisodesSync(
     private val syncManager: SyncManager,
@@ -39,8 +34,8 @@ internal class MissingEpisodesSync(
         val localEpisodes = mutableListOf<PodcastEpisode>()
         val localPodcasts = mutableListOf<Podcast>()
         response.episodesList.forEach { serverEpisode ->
-            localEpisodes.add(toPodcastEpisode(serverEpisode))
-            localPodcasts.add(toPodcast(serverEpisode))
+            localEpisodes.add(serverEpisode.toPodcastEpisode())
+            localPodcasts.add(serverEpisode.toPodcast())
         }
         appDatabase.withTransaction {
             episodeDao.insertAllOrIgnore(localEpisodes)
@@ -48,29 +43,3 @@ internal class MissingEpisodesSync(
         }
     }
 }
-
-private fun toPodcastEpisode(serverEpisode: EpisodeResponse) = PodcastEpisode(
-    uuid = serverEpisode.uuid,
-    downloadUrl = serverEpisode.url,
-    publishedDate = serverEpisode.publishedOrNull?.toDate() ?: Date(0),
-    duration = serverEpisode.duration.toDouble(),
-    fileType = serverEpisode.fileType,
-    title = serverEpisode.title,
-    sizeInBytes = serverEpisode.size,
-    playingStatus = EpisodePlayingStatus.fromInt(serverEpisode.playingStatus),
-    playedUpTo = serverEpisode.playedUpTo.toDouble(),
-    isStarred = serverEpisode.starred,
-    podcastUuid = serverEpisode.podcastUuid,
-    type = serverEpisode.episodeType,
-    season = serverEpisode.episodeSeason.toLong(),
-    number = serverEpisode.episodeNumber.toLong(),
-    isArchived = serverEpisode.isDeleted,
-    slug = serverEpisode.slug,
-)
-
-private fun toPodcast(serverEpisode: EpisodeResponse) = Podcast(
-    uuid = serverEpisode.podcastUuid,
-    title = serverEpisode.podcastTitle,
-    author = serverEpisode.author,
-    slug = serverEpisode.podcastSlug,
-)

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/sync/data/EpisodeSyncTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/sync/data/EpisodeSyncTest.kt
@@ -1,0 +1,129 @@
+package au.com.shiftyjelly.pocketcasts.repositories.sync.data
+
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
+import com.google.protobuf.int32Value
+import com.google.protobuf.int64Value
+import com.pocketcasts.service.api.EpisodeResponse
+import com.pocketcasts.service.api.EpisodesResponse
+import com.pocketcasts.service.api.SyncUserEpisode
+import com.pocketcasts.service.api.syncUserEpisode
+import java.util.Date
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class EpisodeSyncTest {
+
+    @Mock
+    private lateinit var episodeManager: EpisodeManager
+
+    @Mock
+    private lateinit var podcastManager: PodcastManager
+
+    @Mock
+    private lateinit var playbackManager: PlaybackManager
+
+    @Mock
+    private lateinit var settings: Settings
+
+    @Mock
+    private lateinit var syncManager: SyncManager
+
+    private lateinit var episodeSync: EpisodeSync
+
+    @Before
+    fun setup() {
+        MockitoAnnotations.openMocks(this)
+        whenever(playbackManager.isPlaying()).thenReturn(false)
+        whenever(playbackManager.getCurrentEpisode()).thenReturn(null)
+        whenever(settings.getPlaybackEpisodePositionChangedOnSyncThresholdSecs()).thenReturn(0L)
+        episodeSync = EpisodeSync(episodeManager, podcastManager, playbackManager, settings, syncManager)
+    }
+
+    @Test
+    fun `fetch and mark played a missing episode from a subscribed podcast`() = runTest {
+        val serverEpisode = completedServerEpisode(uuid = "episode1", podcastUuid = "podcast1")
+
+        whenever(episodeManager.findByUuids(any())).thenReturn(emptyList())
+        whenever(podcastManager.findSubscribedUuids()).thenReturn(listOf("podcast1"))
+        whenever(syncManager.getEpisodesOrThrow(any())).thenReturn(episodesResponse("episode1", "podcast1"))
+
+        episodeSync.processIncrementalResponse(listOf(serverEpisode))
+
+        verify(syncManager).getEpisodesOrThrow(any())
+        verify(episodeManager).add(argThat { size == 1 && first().uuid == "episode1" }, eq("podcast1"), eq(false))
+        verify(episodeManager).markedAsPlayedExternally(argThat { uuid == "episode1" }, eq(playbackManager), eq(podcastManager))
+        verify(episodeManager).updateAllSyncFields(argThat { any { it.uuid == "episode1" && it.playingStatus == EpisodePlayingStatus.COMPLETED } })
+    }
+
+    @Test
+    fun `do not fetch a missing episode from an unsubscribed podcast`() = runTest {
+        val serverEpisode = completedServerEpisode(uuid = "episode1", podcastUuid = "podcast1")
+
+        whenever(episodeManager.findByUuids(any())).thenReturn(emptyList())
+        whenever(podcastManager.findSubscribedUuids()).thenReturn(emptyList())
+
+        episodeSync.processIncrementalResponse(listOf(serverEpisode))
+
+        verify(syncManager, never()).getEpisodesOrThrow(any())
+        verify(episodeManager, never()).add(any(), any(), any())
+        verify(episodeManager, never()).markedAsPlayedExternally(any(), any(), any())
+    }
+
+    @Test
+    fun `apply the server change to an already present episode without fetching`() = runTest {
+        val serverEpisode = completedServerEpisode(uuid = "episode1", podcastUuid = "podcast1")
+        val localEpisode = PodcastEpisode(
+            uuid = "episode1",
+            podcastUuid = "podcast1",
+            publishedDate = Date(),
+            playingStatus = EpisodePlayingStatus.NOT_PLAYED,
+        )
+
+        whenever(episodeManager.findByUuids(any())).thenReturn(listOf(localEpisode))
+
+        episodeSync.processIncrementalResponse(listOf(serverEpisode))
+
+        verify(podcastManager, never()).findSubscribedUuids()
+        verify(syncManager, never()).getEpisodesOrThrow(any())
+        verify(episodeManager, never()).add(any(), any(), any())
+        verify(episodeManager).markedAsPlayedExternally(eq(localEpisode), eq(playbackManager), eq(podcastManager))
+    }
+
+    private fun completedServerEpisode(uuid: String, podcastUuid: String): SyncUserEpisode {
+        val modified = System.currentTimeMillis()
+        return syncUserEpisode {
+            this.uuid = uuid
+            this.podcastUuid = podcastUuid
+            playingStatus = int32Value { value = EpisodePlayingStatus.COMPLETED.toInt() }
+            playingStatusModified = int64Value { value = modified }
+        }
+    }
+
+    private fun episodesResponse(uuid: String, podcastUuid: String): EpisodesResponse {
+        return EpisodesResponse.newBuilder()
+            .addEpisodes(
+                EpisodeResponse.newBuilder()
+                    .setUuid(uuid)
+                    .setPodcastUuid(podcastUuid)
+                    .setTitle("Title $uuid")
+                    .setUrl("https://example.com/$uuid")
+                    .build(),
+            )
+            .build()
+    }
+}

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/sync/data/EpisodeSyncTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/sync/data/EpisodeSyncTest.kt
@@ -55,7 +55,7 @@ class EpisodeSyncTest {
     }
 
     @Test
-    fun `fetch and mark played a missing episode from a subscribed podcast`() = runTest {
+    fun `fetch and store the authoritative state of a missing episode from a subscribed podcast`() = runTest {
         val serverEpisode = completedServerEpisode(uuid = "episode1", podcastUuid = "podcast1")
 
         whenever(episodeManager.findByUuids(any())).thenReturn(emptyList())
@@ -66,8 +66,9 @@ class EpisodeSyncTest {
 
         verify(syncManager).getEpisodesOrThrow(any())
         verify(episodeManager).add(argThat { size == 1 && first().uuid == "episode1" }, eq("podcast1"), eq(false))
-        verify(episodeManager).markedAsPlayedExternally(argThat { uuid == "episode1" }, eq(playbackManager), eq(podcastManager))
-        verify(episodeManager).updateAllSyncFields(argThat { any { it.uuid == "episode1" && it.playingStatus == EpisodePlayingStatus.COMPLETED } })
+        verify(episodeManager).updateAllSyncFields(
+            argThat { any { it.uuid == "episode1" && it.playingStatus == EpisodePlayingStatus.COMPLETED && it.isStarred } },
+        )
     }
 
     @Test
@@ -122,6 +123,8 @@ class EpisodeSyncTest {
                     .setPodcastUuid(podcastUuid)
                     .setTitle("Title $uuid")
                     .setUrl("https://example.com/$uuid")
+                    .setPlayingStatus(EpisodePlayingStatus.COMPLETED.toInt())
+                    .setStarred(true)
                     .build(),
             )
             .build()


### PR DESCRIPTION
## Description

Incremental sync silently dropped server-side episode changes — played status, play position, archived, and starred — for any episode that was **not already in the local database**, and then never received them again. The sync server sends each change only once (an incremental delta by `modified_at`), so once a device's `lastModified` advanced past the change it was gone. The result: episodes stayed unplayed / stuck in **New Releases** on one device even after being completed on another, and only a full re-sync (log out / log back in) recovered them.

`EpisodeSync.processIncrementalResponse` applied server episode records only to episodes returned by `episodeManager.findByUuids(...)` and dropped the rest. This change makes it fetch the missing ones — for episodes whose podcast is subscribed locally — via the existing `/user/podcast/episodes` endpoint (the same call the manual-playlist `MissingEpisodesSync` uses, which returns the authoritative per-user state), insert them, and include them in the normal apply pass.

This mirrors iOS, whose `SyncTask+ServerChanges.importEpisode` already fetches missing episodes (`addMissingEpisode`) before applying sync changes — which is why the bug was Android-only. The behaviour has existed since the original JSON sync (the Protobuf rewrite preserved it), so this is a long-standing fix rather than a regression.

Fixes PCDROID-521 https://linear.app/a8c/issue/PCDROID-521/android-last-played-episode-doesnt-sync-completed-status-to-android

## Testing Instructions

The end-to-end path needs two synced clients, so the core logic is covered by new unit tests (`EpisodeSyncTest`). To verify manually:

1. On device A (or iOS / web), complete an episode of a subscribed podcast that device B does **not** yet have in its local library.
2. On device B (Android, this build), refresh / reopen the app to trigger an incremental sync.
3. The episode now appears as **played** (and archived, if it was archived on device A) instead of remaining unplayed in New Releases — without needing to log out and back in.


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

