### PR TITLE
Increase SURFACE_CONNECT_DELAY_MS to fix timing issue when rotating

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/video/VideoView.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/video/VideoView.kt
@@ -123,7 +123,7 @@ class VideoView @JvmOverloads constructor(
     override fun surfaceChanged(holder: SurfaceHolder, format: Int, width: Int, height: Int) = Unit
 
     companion object {
-        private const val SURFACE_CONNECT_DELAY_MS = 300L
+        private const val SURFACE_CONNECT_DELAY_MS = 400L
         private const val TAG = "VideoView"
     }
 }


### PR DESCRIPTION
## Description

Increase SURFACE_CONNECT_DELAY_MS to fix timing issue when rotating the screen while video is playing.

The previous value of 300L would cause the video player to go black instead of rotate.

Fixes #3807

## Testing Instructions
1. Play a podcast that's video
2. Rotate screen
3. Video should rotate and continue to play instead of turning to a black screen.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
