### PR TITLE
Network discovery tweaks: link the podcast info panel, hide blank website row, soften artwork shadow

### DIFF
--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/compose/NetworkCard.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/compose/NetworkCard.kt
@@ -15,13 +15,17 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.dropShadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.shadow.Shadow
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
@@ -87,12 +91,18 @@ private fun NetworkImage(
         modifier = modifier
             .fillMaxWidth()
             .aspectRatio(1f)
-            // the shadow keeps light artwork from blending into the background
-            .shadow(NetworkImageElevation, CircleShape),
+            .dropShadow(CircleShape, NetworkImageShadow)
+            .clip(CircleShape),
     )
 }
 
-private val NetworkImageElevation: Dp = 4.dp
+private val NetworkImageShadow = Shadow(
+    radius = 8.dp,
+    color = Color.Black,
+    spread = 0.dp,
+    offset = DpOffset(x = 0.dp, y = 2.dp),
+    alpha = 0.15f,
+)
 private val TitleSpacing: Dp = 10.dp
 private val DescriptionSpacing: Dp = 2.dp
 private val DescriptionHeight: Dp = 40.dp

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/PodcastGridListFragment.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/PodcastGridListFragment.kt
@@ -290,7 +290,7 @@ open class PodcastGridListFragment :
         // website
         val linkTitle = listFeed.webLinkTitle
         val linkUrl = listFeed.webLinkUrl
-        if (linkTitle != null && linkUrl != null) {
+        if (!linkTitle.isNullOrBlank() && !linkUrl.isNullOrBlank()) {
             linkView.visibility = View.VISIBLE
             linkTextView.text = linkTitle
             linkView.setOnClickListener {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -831,6 +831,7 @@ class PodcastAdapter(
                         description = podcastDescription,
                         podcastInfoState = PodcastInfoState(
                             author = podcast.author,
+                            networkListId = podcast.networkListId,
                             link = podcast.getShortUrl(),
                             schedule = podcast.displayableFrequency(context.resources),
                             next = podcast.displayableNextEpisodeDate(context),

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastHeader.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastHeader.kt
@@ -236,6 +236,7 @@ internal fun PodcastHeader(
                     isDescriptionExpanded = isDescriptionExpanded,
                     onClickShowNotes = onToggleDescription,
                     onClickWebsiteLink = onClickWebsiteLink,
+                    onClickNetwork = onClickNetwork,
                 )
             }
         }
@@ -766,6 +767,7 @@ private fun PodcastDetails(
     isDescriptionExpanded: Boolean,
     onClickShowNotes: () -> Unit,
     onClickWebsiteLink: () -> Unit,
+    onClickNetwork: () -> Unit,
 ) {
     val context = LocalContext.current
     Column {
@@ -798,6 +800,7 @@ private fun PodcastDetails(
         PodcastInfoView(
             state = podcastInfoState,
             onWebsiteLinkClick = onClickWebsiteLink,
+            onNetworkClick = onClickNetwork,
             linkColor = linkColor,
         )
     }
@@ -1019,6 +1022,7 @@ private fun PodcastHeaderPreview(
                 ),
                 podcastInfoState = PodcastInfoState(
                     author = "Pocket Casts",
+                    networkListId = "list-id",
                     link = "pocketcasts.com",
                     schedule = "Every two weeks",
                     next = "Meaning of life",

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastInfoView.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastInfoView.kt
@@ -13,6 +13,7 @@ import androidx.compose.material.Card
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -22,20 +23,26 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.podcasts.R as IR
 
 @Composable
 fun PodcastInfoView(
     state: PodcastInfoState,
     onWebsiteLinkClick: () -> Unit,
+    onNetworkClick: () -> Unit,
     modifier: Modifier = Modifier,
     linkColor: Color = MaterialTheme.theme.colors.primaryIcon01,
 ) {
+    val isNetworkDiscoveryEnabled by FeatureFlag.isEnabledFlow(Feature.NETWORK_DISCOVERY).collectAsStateWithLifecycle()
+    val isAuthorLinked = isNetworkDiscoveryEnabled && state.networkListId != null
     Card(
         shape = RoundedCornerShape(8.dp),
         elevation = 0.dp,
@@ -54,8 +61,11 @@ fun PodcastInfoView(
         ) {
             if (state.author.isNotEmpty()) {
                 PodcastInfoItem(
-                    state.author,
-                    IR.drawable.ic_author,
+                    text = state.author,
+                    icon = IR.drawable.ic_author,
+                    isLink = isAuthorLinked,
+                    linkColor = linkColor,
+                    onClick = onNetworkClick,
                 )
             }
 
@@ -65,7 +75,7 @@ fun PodcastInfoView(
                     icon = IR.drawable.ic_link,
                     isLink = true,
                     linkColor = linkColor,
-                    onWebsiteLinkClick = onWebsiteLinkClick,
+                    onClick = onWebsiteLinkClick,
                 )
             }
 
@@ -93,7 +103,7 @@ private fun PodcastInfoItem(
     modifier: Modifier = Modifier,
     isLink: Boolean = false,
     linkColor: Color = MaterialTheme.theme.colors.primaryIcon01,
-    onWebsiteLinkClick: () -> Unit = {},
+    onClick: () -> Unit = {},
 ) {
     Row(
         modifier = modifier
@@ -115,9 +125,7 @@ private fun PodcastInfoItem(
                 maxLines = 3,
                 color = linkColor,
                 fontWeight = FontWeight.W400,
-                modifier = Modifier.clickable {
-                    onWebsiteLinkClick.invoke()
-                },
+                modifier = Modifier.clickable(onClick = onClick),
             )
         } else {
             TextP40(
@@ -138,12 +146,14 @@ private fun PreviewPodcastInfoView(
     AppTheme(themeType) {
         PodcastInfoView(
             state = PodcastInfoState(
-                "John",
-                "www.google.com",
-                "Every two weeks",
-                "Episode 2",
+                author = "John",
+                networkListId = "list-id",
+                link = "www.google.com",
+                schedule = "Every two weeks",
+                next = "Episode 2",
             ),
             onWebsiteLinkClick = {},
+            onNetworkClick = {},
             modifier = Modifier.fillMaxWidth(),
         )
     }
@@ -151,6 +161,7 @@ private fun PreviewPodcastInfoView(
 
 data class PodcastInfoState(
     val author: String,
+    val networkListId: String?,
     val link: String?,
     val schedule: String?,
     val next: String?,


### PR DESCRIPTION
## Description

Three small follow-up tweaks to Network Discovery feature. The podcast's network is now tappable from the info panel further down the podcast page, an empty website row no longer appears on a network's podcast list, and the round network artwork has a softer shadow.

## Testing Instructions

1. Open the Discover tab and scroll to the Networks row. The circular network artwork should have a soft shadow beneath it rather than a hard dark edge. Check it in both light and dark themes, and against a network whose artwork is close to white.
2. Tap a network to open its page. If the network has no website, no empty link row should appear below the description (previously an empty row was tappable there).
3. Open a podcast that belongs to a network (any podcast reachable from a network page).
4. Scroll past the description to the info card showing author, website, release schedule and next episode. The author name should be coloured as a link.
5. Tap the author name. It should open that network's page, the same as tapping the network name in the byline under the podcast title.
6. Open a podcast that is not part of a network. The author name in the info card should be plain text and not tappable.
7. Disable the `NETWORK_DISCOVERY` feature flag in developer settings and repeat step 4. The author name should be plain text.

## Screenshots or Screencast

| Before | After |
| --- | --- |
| <img width="1080" height="2400" alt="Screenshot_20260909_102326" src="https://github.com/user-attachments/assets/6cb86d44-ed83-40e0-a364-c28e6000ec7e" /> | <img width="1080" height="2400" alt="Screenshot_20260909_102245" src="https://github.com/user-attachments/assets/e9823043-e6ae-449d-bfec-773f2646011a" /> | 
| <img width="1080" height="2400" alt="Screenshot_20260909_102332" src="https://github.com/user-attachments/assets/bb9ac82f-6eb1-49de-b85f-8f50e38b6371" /> | <img width="1080" height="2400" alt="Screenshot_20260909_102218" src="https://github.com/user-attachments/assets/25435999-a668-4788-a701-6b825cad1fba" /> | 
| <img width="1080" height="2400" alt="Screenshot_20260909_092911" src="https://github.com/user-attachments/assets/538bd431-9ce6-4328-95af-46f7bcec8436" /> | <img width="1080" height="2400" alt="Screenshot_20260909_093538" src="https://github.com/user-attachments/assets/488c1159-4e06-4c51-b752-193e9ba326c4" /> | 

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
