### PR TITLE
[Smart Bookmarks] Play from a bookmark via its reference time

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarkDetailFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarkDetailFragment.kt
@@ -5,6 +5,8 @@ import android.os.Parcelable
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.lifecycleScope
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
@@ -19,6 +21,7 @@ import com.automattic.eventhorizon.BookmarkPlayTappedEvent
 import com.automattic.eventhorizon.EventHorizon
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -95,6 +98,8 @@ class BookmarkDetailFragment : BaseDialogFragment() {
     @Inject
     internal lateinit var bookmarkPlaybackTimeResolver: BookmarkPlaybackTimeResolver
 
+    private val isResolving = MutableStateFlow(false)
+
     private val args get() = requireArguments().requireParcelable<Args>(NEW_INSTANCE_ARG)
 
     override fun onCreateView(
@@ -103,6 +108,7 @@ class BookmarkDetailFragment : BaseDialogFragment() {
         savedInstanceState: Bundle?,
     ) = contentWithoutConsumedInsets {
         DialogBox(fillMaxHeight = false) {
+            val resolving by isResolving.collectAsState()
             BookmarkDetailPage(
                 title = args.title,
                 episodeTitle = args.episodeTitle,
@@ -110,6 +116,7 @@ class BookmarkDetailFragment : BaseDialogFragment() {
                 podcastTitle = args.podcastTitle,
                 timeSecs = args.timeSecs,
                 createdAtText = args.createdAtText,
+                isResolving = resolving,
                 onPlayClick = ::onPlayClick,
                 onClose = { dismiss() },
             )
@@ -128,11 +135,25 @@ class BookmarkDetailFragment : BaseDialogFragment() {
                 dismiss()
                 return@launch
             }
-            val seekToMs = bookmarkPlaybackTimeResolver.playbackTimeMs(
-                episode = episode,
-                referenceTimeSecs = args.referenceTime,
-                fallbackTimeSecs = args.timeSecs,
-            )
+            val hasReferenceTime = args.referenceTime != null
+            if (hasReferenceTime &&
+                playbackManager.isPlaying() &&
+                playbackManager.getCurrentEpisode()?.uuid == args.episodeUuid
+            ) {
+                playbackManager.pauseSuspend()
+            }
+            if (hasReferenceTime) {
+                isResolving.value = true
+            }
+            val seekToMs = try {
+                bookmarkPlaybackTimeResolver.playbackTimeMs(
+                    episode = episode,
+                    referenceTimeSecs = args.referenceTime,
+                    fallbackTimeSecs = args.timeSecs,
+                )
+            } finally {
+                isResolving.value = false
+            }
             playbackManager.playNowSuspend(episode, sourceView = args.sourceView)
             playbackManager.seekToTimeMs(positionMs = seekToMs)
             eventHorizon.track(

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarkDetailFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarkDetailFragment.kt
@@ -56,6 +56,7 @@ class BookmarkDetailFragment : BaseDialogFragment() {
                     NEW_INSTANCE_ARG,
                     Args(
                         title = bookmark.title,
+                        referenceTime = bookmark.referenceTime,
                         episodeTitle = episodeTitle,
                         episodeUuid = bookmark.episodeUuid,
                         podcastUuid = podcastUuid,
@@ -72,6 +73,7 @@ class BookmarkDetailFragment : BaseDialogFragment() {
     @Parcelize
     private data class Args(
         val title: String,
+        val referenceTime: Int?,
         val episodeTitle: String,
         val episodeUuid: String,
         val podcastUuid: String,
@@ -89,6 +91,9 @@ class BookmarkDetailFragment : BaseDialogFragment() {
 
     @Inject
     internal lateinit var eventHorizon: EventHorizon
+
+    @Inject
+    internal lateinit var bookmarkPlaybackTimeResolver: BookmarkPlaybackTimeResolver
 
     private val args get() = requireArguments().requireParcelable<Args>(NEW_INSTANCE_ARG)
 
@@ -123,8 +128,13 @@ class BookmarkDetailFragment : BaseDialogFragment() {
                 dismiss()
                 return@launch
             }
+            val seekToMs = bookmarkPlaybackTimeResolver.playbackTimeMs(
+                episode = episode,
+                referenceTimeSecs = args.referenceTime,
+                fallbackTimeSecs = args.timeSecs,
+            )
             playbackManager.playNowSuspend(episode, sourceView = args.sourceView)
-            playbackManager.seekToTimeMs(positionMs = args.timeSecs * 1000)
+            playbackManager.seekToTimeMs(positionMs = seekToMs)
             eventHorizon.track(
                 BookmarkPlayTappedEvent(
                     source = args.sourceView.analyticsValue,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarkDetailPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarkDetailPage.kt
@@ -8,11 +8,13 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
@@ -49,6 +51,7 @@ internal fun BookmarkDetailPage(
     podcastTitle: String,
     timeSecs: Int,
     createdAtText: String,
+    isResolving: Boolean,
     onPlayClick: () -> Unit,
     onClose: () -> Unit,
     modifier: Modifier = Modifier,
@@ -145,16 +148,31 @@ internal fun BookmarkDetailPage(
             )
 
             Spacer(modifier = Modifier.height(20.dp))
-            RowButton(
-                text = stringResource(LR.string.bookmark_play_from, formattedTime),
-                onClick = onPlayClick,
-                includePadding = false,
-                textIcon = IR.drawable.ic_play,
-                colors = ButtonDefaults.buttonColors(
-                    backgroundColor = playButtonBackground,
-                ),
-                textColor = playButtonText,
-            )
+            if (isResolving) {
+                Box(
+                    contentAlignment = Alignment.Center,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(48.dp),
+                ) {
+                    CircularProgressIndicator(
+                        color = playButtonBackground,
+                        strokeWidth = 2.dp,
+                        modifier = Modifier.size(24.dp),
+                    )
+                }
+            } else {
+                RowButton(
+                    text = stringResource(LR.string.bookmark_play_from, formattedTime),
+                    onClick = onPlayClick,
+                    includePadding = false,
+                    textIcon = IR.drawable.ic_play,
+                    colors = ButtonDefaults.buttonColors(
+                        backgroundColor = playButtonBackground,
+                    ),
+                    textColor = playButtonText,
+                )
+            }
         }
     }
 }
@@ -206,6 +224,7 @@ private fun BookmarkDetailPagePreview(
             podcastTitle = "Hard Fork",
             timeSecs = 340,
             createdAtText = "May 7, 2024 - 6:40 PM",
+            isResolving = false,
             onPlayClick = {},
             onClose = {},
         )

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarkPlaybackTimeResolver.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarkPlaybackTimeResolver.kt
@@ -1,0 +1,28 @@
+package au.com.shiftyjelly.pocketcasts.player.view.bookmark
+
+import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
+import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.ChapterSeekResult
+import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.FingerprintTimingManager
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
+import javax.inject.Inject
+import kotlin.time.Duration.Companion.seconds
+
+class BookmarkPlaybackTimeResolver @Inject constructor(
+    private val fingerprintTimingManager: FingerprintTimingManager,
+) {
+    suspend fun playbackTimeMs(
+        episode: BaseEpisode,
+        referenceTimeSecs: Int?,
+        fallbackTimeSecs: Int,
+    ): Int {
+        val fallbackMs = fallbackTimeSecs * 1000
+        if (referenceTimeSecs == null || !FeatureFlag.isEnabled(Feature.SYNCED_TRANSCRIPTS)) {
+            return fallbackMs
+        }
+        return when (val result = fingerprintTimingManager.resolvePlaybackTime(episode, referenceTimeSecs.seconds)) {
+            is ChapterSeekResult.Resolved -> result.playbackTime.inWholeMilliseconds.toInt()
+            is ChapterSeekResult.Unresolved -> fallbackMs
+        }
+    }
+}

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksPage.kt
@@ -79,10 +79,12 @@ fun BookmarksPage(
 ) {
     val context = LocalContext.current
     val state by bookmarksViewModel.uiState.collectAsStateWithLifecycle()
+    val resolvingBookmarkUuid by bookmarksViewModel.resolvingBookmarkUuid.collectAsStateWithLifecycle()
     val bookmarkColors = rememberBookmarkColors()
 
     Content(
         state = state,
+        resolvingBookmarkUuid = resolvingBookmarkUuid,
         colors = bookmarkColors,
         bottomInset = bottomInset,
         onRowLongClick = onRowLongClick,
@@ -141,6 +143,7 @@ fun BookmarksPage(
 @Composable
 private fun Content(
     state: UiState,
+    resolvingBookmarkUuid: String?,
     colors: BookmarkColors,
     bottomInset: Dp,
     onRowLongClick: (Bookmark) -> Unit,
@@ -165,6 +168,7 @@ private fun Content(
 
             is UiState.Loaded -> BookmarksView(
                 state = state,
+                resolvingBookmarkUuid = resolvingBookmarkUuid,
                 colors = colors,
                 bottomInset = bottomInset,
                 onRowLongClick = onRowLongClick,
@@ -209,6 +213,7 @@ private fun Content(
 @Composable
 private fun BookmarksView(
     state: UiState.Loaded,
+    resolvingBookmarkUuid: String?,
     bottomInset: Dp,
     colors: BookmarkColors,
     onRowLongClick: (Bookmark) -> Unit,
@@ -276,6 +281,7 @@ private fun BookmarksView(
                 showIcon = state.showIcon,
                 useEpisodeArtwork = state.useEpisodeArtwork,
                 showEpisodeTitle = state.showEpisodeTitle,
+                isLoading = bookmark.uuid == resolvingBookmarkUuid,
                 colors = colors,
                 onPlayClick = { onPlayClick(bookmark) },
                 modifier = Modifier.pointerInput(bookmark.adapterId) {
@@ -321,6 +327,7 @@ private fun BookmarksPreview(
                 onRowClick = {},
                 sourceView = SourceView.PLAYER,
             ),
+            resolvingBookmarkUuid = null,
             bottomInset = 0.dp,
             colors = rememberBookmarkColors(),
             onPlayClick = {},

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
@@ -44,6 +44,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -84,6 +85,8 @@ class BookmarksViewModel
     val showBookmarkDetail = _showBookmarkDetail.asSharedFlow()
 
     private var isFragmentActive: Boolean = true
+
+    private var playJob: Job? = null
 
     private var sourceView: SourceView = SourceView.UNKNOWN
         set(value) {
@@ -318,7 +321,8 @@ class BookmarksViewModel
     }
 
     fun play(bookmark: Bookmark) {
-        viewModelScope.launch {
+        playJob?.cancel()
+        playJob = viewModelScope.launch {
             val bookmarkEpisode = episodeManager.findEpisodeByUuid(bookmark.episodeUuid) ?: run {
                 _message.emit(BookmarkMessage.BookmarkEpisodeNotFound)
                 return@launch

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
@@ -15,6 +15,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.player.view.bookmark.BookmarkArguments
+import au.com.shiftyjelly.pocketcasts.player.view.bookmark.BookmarkPlaybackTimeResolver
 import au.com.shiftyjelly.pocketcasts.player.view.bookmark.search.BookmarkSearchHandler
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
@@ -67,6 +68,7 @@ class BookmarksViewModel
     private val playbackManager: PlaybackManager,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
     private val bookmarkSearchHandler: BookmarkSearchHandler,
+    private val bookmarkPlaybackTimeResolver: BookmarkPlaybackTimeResolver,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<UiState>(UiState.Loading)
@@ -317,19 +319,22 @@ class BookmarksViewModel
 
     fun play(bookmark: Bookmark) {
         viewModelScope.launch {
-            val bookmarkEpisode = episodeManager.findEpisodeByUuid(bookmark.episodeUuid)
-            bookmarkEpisode?.let {
-                val shouldLoadOrSwitchEpisode = !playbackManager.isPlaying() ||
-                    playbackManager.getCurrentEpisode()?.uuid != bookmarkEpisode.uuid
-                if (shouldLoadOrSwitchEpisode) {
-                    playbackManager.playNowSync(it, sourceView = sourceView)
-                }
-            } ?: run {
+            val bookmarkEpisode = episodeManager.findEpisodeByUuid(bookmark.episodeUuid) ?: run {
                 _message.emit(BookmarkMessage.BookmarkEpisodeNotFound)
                 return@launch
             }
+            val seekToMs = bookmarkPlaybackTimeResolver.playbackTimeMs(
+                episode = bookmarkEpisode,
+                referenceTimeSecs = bookmark.referenceTime,
+                fallbackTimeSecs = bookmark.timeSecs,
+            )
+            val shouldLoadOrSwitchEpisode = !playbackManager.isPlaying() ||
+                playbackManager.getCurrentEpisode()?.uuid != bookmarkEpisode.uuid
+            if (shouldLoadOrSwitchEpisode) {
+                playbackManager.playNowSync(bookmarkEpisode, sourceView = sourceView)
+            }
             _message.emit(BookmarkMessage.PlayingBookmark(bookmark.title))
-            playbackManager.seekToTimeMs(positionMs = bookmark.timeSecs * 1000)
+            playbackManager.seekToTimeMs(positionMs = seekToMs)
             eventHorizon.track(
                 BookmarkPlayTappedEvent(
                     source = sourceView.analyticsValue,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
@@ -84,6 +84,9 @@ class BookmarksViewModel
     private val _showBookmarkDetail = MutableSharedFlow<BookmarkDetailData>(extraBufferCapacity = 1)
     val showBookmarkDetail = _showBookmarkDetail.asSharedFlow()
 
+    private val _resolvingBookmarkUuid = MutableStateFlow<String?>(null)
+    val resolvingBookmarkUuid: StateFlow<String?> = _resolvingBookmarkUuid
+
     private var isFragmentActive: Boolean = true
 
     private var playJob: Job? = null
@@ -327,14 +330,27 @@ class BookmarksViewModel
                 _message.emit(BookmarkMessage.BookmarkEpisodeNotFound)
                 return@launch
             }
-            val seekToMs = bookmarkPlaybackTimeResolver.playbackTimeMs(
-                episode = bookmarkEpisode,
-                referenceTimeSecs = bookmark.referenceTime,
-                fallbackTimeSecs = bookmark.timeSecs,
-            )
-            val shouldLoadOrSwitchEpisode = !playbackManager.isPlaying() ||
-                playbackManager.getCurrentEpisode()?.uuid != bookmarkEpisode.uuid
-            if (shouldLoadOrSwitchEpisode) {
+            val hasReferenceTime = bookmark.referenceTime != null
+            val isPlayingBookmarkEpisode = playbackManager.isPlaying() &&
+                playbackManager.getCurrentEpisode()?.uuid == bookmarkEpisode.uuid
+            if (hasReferenceTime && isPlayingBookmarkEpisode) {
+                playbackManager.pauseSuspend()
+            }
+            if (hasReferenceTime) {
+                _resolvingBookmarkUuid.value = bookmark.uuid
+            }
+            val seekToMs = try {
+                bookmarkPlaybackTimeResolver.playbackTimeMs(
+                    episode = bookmarkEpisode,
+                    referenceTimeSecs = bookmark.referenceTime,
+                    fallbackTimeSecs = bookmark.timeSecs,
+                )
+            } finally {
+                if (_resolvingBookmarkUuid.value == bookmark.uuid) {
+                    _resolvingBookmarkUuid.value = null
+                }
+            }
+            if (hasReferenceTime || !isPlayingBookmarkEpisode) {
                 playbackManager.playNowSync(bookmarkEpisode, sourceView = sourceView)
             }
             _message.emit(BookmarkMessage.PlayingBookmark(bookmark.title))

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarkPlaybackTimeResolverTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarkPlaybackTimeResolverTest.kt
@@ -1,0 +1,71 @@
+package au.com.shiftyjelly.pocketcasts.player.view.bookmark
+
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.ChapterSeekResult
+import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.FingerprintTimingManager
+import au.com.shiftyjelly.pocketcasts.sharedtest.InMemoryFeatureFlagRule
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
+import java.util.Date
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verifyBlocking
+import org.mockito.kotlin.whenever
+
+class BookmarkPlaybackTimeResolverTest {
+
+    @get:Rule
+    val featureFlagRule = InMemoryFeatureFlagRule()
+
+    private val fingerprintTimingManager = mock<FingerprintTimingManager>()
+    private val episode = PodcastEpisode(uuid = "episode", publishedDate = Date())
+    private val resolver = BookmarkPlaybackTimeResolver(fingerprintTimingManager)
+
+    @Test
+    fun `resolves the reference time to a playback position`() = runTest {
+        FeatureFlag.setEnabled(Feature.SYNCED_TRANSCRIPTS, true)
+        whenever(fingerprintTimingManager.resolvePlaybackTime(any(), any()))
+            .thenReturn(ChapterSeekResult.Resolved(42.seconds, usedPrior = false))
+
+        val result = resolver.playbackTimeMs(episode, referenceTimeSecs = 25, fallbackTimeSecs = 10)
+
+        assertEquals(42_000, result)
+    }
+
+    @Test
+    fun `falls back to the stored time when the reference time cannot be resolved`() = runTest {
+        FeatureFlag.setEnabled(Feature.SYNCED_TRANSCRIPTS, true)
+        whenever(fingerprintTimingManager.resolvePlaybackTime(any(), any()))
+            .thenReturn(ChapterSeekResult.Unresolved(ChapterSeekResult.REASON_NO_MATCH))
+
+        val result = resolver.playbackTimeMs(episode, referenceTimeSecs = 25, fallbackTimeSecs = 10)
+
+        assertEquals(10_000, result)
+    }
+
+    @Test
+    fun `falls back to the stored time when there is no reference time`() = runTest {
+        FeatureFlag.setEnabled(Feature.SYNCED_TRANSCRIPTS, true)
+
+        val result = resolver.playbackTimeMs(episode, referenceTimeSecs = null, fallbackTimeSecs = 10)
+
+        assertEquals(10_000, result)
+        verifyBlocking(fingerprintTimingManager, never()) { resolvePlaybackTime(any(), any()) }
+    }
+
+    @Test
+    fun `falls back to the stored time when synced transcripts are disabled`() = runTest {
+        FeatureFlag.setEnabled(Feature.SYNCED_TRANSCRIPTS, false)
+
+        val result = resolver.playbackTimeMs(episode, referenceTimeSecs = 25, fallbackTimeSecs = 10)
+
+        assertEquals(10_000, result)
+        verifyBlocking(fingerprintTimingManager, never()) { resolvePlaybackTime(any(), any()) }
+    }
+}

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModelTest.kt
@@ -50,7 +50,9 @@ import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyBlocking
 import org.mockito.kotlin.whenever
 
 @ExperimentalCoroutinesApi
@@ -231,5 +233,31 @@ class BookmarksViewModelTest {
         bookmarksViewModel.play(bookmark)
 
         verify(playbackManager).seekToTimeMs(eq(42_000), anyOrNull())
+    }
+
+    @Test
+    fun `play pauses the current episode for a reference-timed bookmark`() = runTest {
+        whenever(playbackManager.isPlaying()).thenReturn(true)
+        whenever(playbackManager.getCurrentEpisode()).thenReturn(episode)
+        whenever(bookmarkPlaybackTimeResolver.playbackTimeMs(any(), anyOrNull(), any())).thenReturn(42_000)
+        val bookmark = Bookmark("uuid1", episodeUuid = episodeUuid, timeSecs = 10, referenceTime = 25)
+
+        bookmarksViewModel.play(bookmark)
+
+        verifyBlocking(playbackManager) { pauseSuspend(any(), any()) }
+        verify(playbackManager).seekToTimeMs(eq(42_000), anyOrNull())
+    }
+
+    @Test
+    fun `play does not pause the current episode for a bookmark without a reference time`() = runTest {
+        whenever(playbackManager.isPlaying()).thenReturn(true)
+        whenever(playbackManager.getCurrentEpisode()).thenReturn(episode)
+        whenever(bookmarkPlaybackTimeResolver.playbackTimeMs(any(), anyOrNull(), any())).thenReturn(10_000)
+        val bookmark = Bookmark("uuid1", episodeUuid = episodeUuid, timeSecs = 10)
+
+        bookmarksViewModel.play(bookmark)
+
+        verifyBlocking(playbackManager, never()) { pauseSuspend(any(), any()) }
+        verify(playbackManager).seekToTimeMs(eq(10_000), anyOrNull())
     }
 }

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModelTest.kt
@@ -11,6 +11,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPlatform
 import au.com.shiftyjelly.pocketcasts.payment.BillingCycle
 import au.com.shiftyjelly.pocketcasts.payment.SubscriptionTier
+import au.com.shiftyjelly.pocketcasts.player.view.bookmark.BookmarkPlaybackTimeResolver
 import au.com.shiftyjelly.pocketcasts.player.view.bookmark.search.BookmarkSearchHandler
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
@@ -45,7 +46,9 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -80,6 +83,9 @@ class BookmarksViewModelTest {
 
     @Mock
     private lateinit var playbackManager: PlaybackManager
+
+    @Mock
+    private lateinit var bookmarkPlaybackTimeResolver: BookmarkPlaybackTimeResolver
 
     private lateinit var bookmarkSearchHandler: BookmarkSearchHandler
 
@@ -133,6 +139,7 @@ class BookmarksViewModelTest {
             playbackManager = playbackManager,
             ioDispatcher = UnconfinedTestDispatcher(),
             bookmarkSearchHandler = bookmarkSearchHandler,
+            bookmarkPlaybackTimeResolver = bookmarkPlaybackTimeResolver,
         )
     }
 
@@ -214,5 +221,15 @@ class BookmarksViewModelTest {
             expectNoEvents()
         }
         verify(multiSelectHelper).select(bookmark)
+    }
+
+    @Test
+    fun `play seeks to the resolved reference time`() = runTest {
+        val bookmark = Bookmark("uuid1", episodeUuid = episodeUuid, timeSecs = 10)
+        whenever(bookmarkPlaybackTimeResolver.playbackTimeMs(any(), anyOrNull(), any())).thenReturn(42_000)
+
+        bookmarksViewModel.play(bookmark)
+
+        verify(playbackManager).seekToTimeMs(eq(42_000), anyOrNull())
     }
 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/bookmark/BookmarkRow.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/bookmark/BookmarkRow.kt
@@ -78,8 +78,8 @@ fun BookmarkRow(
     showEpisodeTitle: Boolean,
     useEpisodeArtwork: Boolean,
     onPlayClick: () -> Unit,
-    isLoading: Boolean = false,
     modifier: Modifier = Modifier,
+    isLoading: Boolean = false,
     colors: BookmarkColors = rememberBookmarkColors(),
 ) {
     Column(

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/bookmark/BookmarkRow.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/bookmark/BookmarkRow.kt
@@ -78,6 +78,7 @@ fun BookmarkRow(
     showEpisodeTitle: Boolean,
     useEpisodeArtwork: Boolean,
     onPlayClick: () -> Unit,
+    isLoading: Boolean = false,
     modifier: Modifier = Modifier,
     colors: BookmarkColors = rememberBookmarkColors(),
 ) {
@@ -174,6 +175,7 @@ fun BookmarkRow(
                     timeSecs = bookmark.timeSecs,
                     contentDescriptionId = LR.string.bookmark_play,
                     onClick = { onPlayClick() },
+                    isLoading = isLoading,
                     colors = colors.playButton,
                 )
             }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/TimePlayButton.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/TimePlayButton.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedButton
@@ -54,13 +55,14 @@ fun TimePlayButton(
     @StringRes contentDescriptionId: Int,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    isLoading: Boolean = false,
     colors: TimePlayButtonColors = TimePlayButtonColors.default(MaterialTheme.theme.colors),
 ) {
     val timeText = TimeHelper.formattedSeconds(timeSecs.toDouble())
     val description = stringResource(contentDescriptionId, timeText)
 
     OutlinedButton(
-        onClick = onClick,
+        onClick = { if (!isLoading) onClick() },
         border = BorderStroke(2.dp, colors.border),
         colors = ButtonDefaults.outlinedButtonColors(
             backgroundColor = Color.Transparent,
@@ -68,19 +70,27 @@ fun TimePlayButton(
         shape = CircleShape,
         modifier = modifier.semantics { contentDescription = description },
     ) {
-        TextH40(
-            text = timeText,
-            color = colors.text,
-            maxLines = 1,
-            modifier = Modifier.clearAndSetSemantics { },
-        )
-        Spacer(Modifier.size(ButtonDefaults.IconSpacing))
-        Icon(
-            painter = painterResource(IR.drawable.ic_play),
-            contentDescription = null,
-            tint = colors.text,
-            modifier = Modifier.size(10.dp, 13.dp),
-        )
+        if (isLoading) {
+            CircularProgressIndicator(
+                color = colors.text,
+                strokeWidth = 2.dp,
+                modifier = Modifier.size(16.dp),
+            )
+        } else {
+            TextH40(
+                text = timeText,
+                color = colors.text,
+                maxLines = 1,
+                modifier = Modifier.clearAndSetSemantics { },
+            )
+            Spacer(Modifier.size(ButtonDefaults.IconSpacing))
+            Icon(
+                painter = painterResource(IR.drawable.ic_play),
+                contentDescription = null,
+                tint = colors.text,
+                modifier = Modifier.size(10.dp, 13.dp),
+            )
+        }
     }
 }
 


### PR DESCRIPTION
## Description

Fast-follow to #5880. A bookmark now persists a `reference_time` (its position on the transcript's fingerprint/reference timeline); this makes "play from bookmark" resolve that reference time back onto the current device's playback timeline **before** seeking, so playback lands on the right content on dynamic-ad episodes.

**Stacked on #5880** (`feat/smart-bookmarks-data-foundation`) — review/merge that first; this PR targets that branch.

**What changed**
- `BookmarkPlaybackTimeResolver` (new): resolves a bookmark's `reference_time` → playback ms via the existing `FingerprintTimingManager.resolvePlaybackTime` (the same resolver the synced-transcript tap and chapter seek use), gated on `FeatureFlag.SYNCED_TRANSCRIPTS`, falling back to the stored `time`.
- `BookmarksViewModel.play` and `BookmarkDetailFragment` resolve the reference time before starting playback — Android's resolve fingerprints the episode audio itself, so resolving first means the bookmark never lands on wrong-content audio. Last-tap-wins: a new play cancels an in-flight resolve.
- iOS-parity UX while resolving: the currently-playing episode is **paused**, and the bookmark's play control shows a **loading spinner** (list-row `TimePlayButton` and the detail "Play from" button). Normal (non-reference) bookmarks are unaffected.

Behind `SYNCED_TRANSCRIPTS`; `reference_time` is only set when a confident mapping existed at capture, and the resolve falls back to the stored time when it can't map.

## Testing Instructions
1. `./gradlew :app:compileDebugKotlin :modules:features:player:testDebugUnitTest` — green.
2. With `SYNCED_TRANSCRIPTS` on and a bookmark that has a `reference_time` (created on a fingerprinted episode): tapping play briefly shows a spinner (pausing the current episode), resolves, and lands on the correct content on a dynamic-ad episode. On an episode with no confident mapping it falls back to the stored time. Normal bookmarks play instantly as before.


## Checklist
- [ ] If this is a user-facing change, I added an entry in CHANGELOG.md <!-- behind a dev-only flag, not user-facing yet -->
- [x] Ensure the linter passes (`./gradlew spotlessApply`)
- [x] I considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in strings.xml <!-- none added -->
- [x] Any Jetpack Compose components I added or changed are covered by compose previews
- [ ] I updated the Event Horizon schema <!-- no analytics changes in this PR -->

