### PR TITLE
Switch to version 2 of the combined search endpoint

### DIFF
--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheService.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheService.kt
@@ -125,7 +125,7 @@ interface PodcastCacheService {
     @POST("/podcast/suggest_folders")
     suspend fun suggestedFolders(@Body request: SuggestedFoldersRequest): SuggestedFoldersResponse
 
-    @POST("/search/combined")
+    @POST("/v2/search/combined")
     suspend fun combinedSearch(
         @Body request: CombinedSearchRequest,
     ): CombinedSearchResponse


### PR DESCRIPTION
## Description

Search now requests the newer version of the combined search results from the server, so that podcast networks keep showing up alongside podcasts and episodes.

Older app versions do not understand the `network` result type and crash when the server returns one, so the server has stopped sending network results from the original combined search route and serves them from a new versioned route instead ([PCSERVE-828](https://linear.app/a8c/issue/PCSERVE-828/add-new-combined-search-endpoint-to-avoid-client-crashes), [pocket-casts-podcast-api#381](https://github.com/Automattic/pocket-casts-podcast-api/pull/381)). This app already handles network results (behind the Network Discovery feature flag), so it needs to call the new route to keep receiving them.

The change is a single endpoint path in `PodcastCacheService`: `/search/combined` becomes `/v2/search/combined`. The request and response models are unchanged, because v2 returns the same payload shape and only differs in whether network entries are included.

## Testing Instructions

1. Open the Search tab and search for a term that matches a network, for example `relay`.
2. Confirm the results still include podcasts and episodes, and that network rows appear.
3. Tap a network row and confirm it opens the network page as before.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
