### PR TITLE
Send the user file playback token in a header instead of the URL

### DIFF
--- a/automotive/src/main/AndroidManifest.xml
+++ b/automotive/src/main/AndroidManifest.xml
@@ -20,11 +20,9 @@
 
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"/>
-    <!-- Merged in by Firebase Analytics; the car app has no ad SDK and never reads an advertising ID. -->
     <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove"/>
     <uses-permission android:name="android.permission.ACCESS_ADSERVICES_AD_ID" tools:node="remove"/>
     <uses-permission android:name="android.permission.ACCESS_ADSERVICES_ATTRIBUTION" tools:node="remove"/>
-    <!-- Merged in by Firebase Analytics; nothing here reads the Play install referrer. -->
     <uses-permission android:name="com.google.android.finsky.permission.BIND_GET_INSTALL_REFERRER_SERVICE" tools:node="remove"/>
     <uses-permission android:name="android.permission.DETECT_SCREEN_CAPTURE" tools:node="remove"/>
     <uses-permission android:name="android.permission.USE_BIOMETRIC" tools:node="remove"/>

--- a/automotive/src/main/AndroidManifest.xml
+++ b/automotive/src/main/AndroidManifest.xml
@@ -20,7 +20,12 @@
 
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"/>
+    <!-- Merged in by Firebase Analytics; the car app has no ad SDK and never reads an advertising ID. -->
     <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove"/>
+    <uses-permission android:name="android.permission.ACCESS_ADSERVICES_AD_ID" tools:node="remove"/>
+    <uses-permission android:name="android.permission.ACCESS_ADSERVICES_ATTRIBUTION" tools:node="remove"/>
+    <!-- Merged in by Firebase Analytics; nothing here reads the Play install referrer. -->
+    <uses-permission android:name="com.google.android.finsky.permission.BIND_GET_INSTALL_REFERRER_SERVICE" tools:node="remove"/>
     <uses-permission android:name="android.permission.DETECT_SCREEN_CAPTURE" tools:node="remove"/>
     <uses-permission android:name="android.permission.USE_BIOMETRIC" tools:node="remove"/>
     <uses-permission android:name="android.permission.USE_FINGERPRINT" tools:node="remove"/>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadEpisodeWorker.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadEpisodeWorker.kt
@@ -45,7 +45,6 @@ import java.util.UUID
 import javax.net.ssl.SSLException
 import kotlin.time.measureTimedValue
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.rx2.await
 import okhttp3.Call
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.repositories.download.EpisodeDownloader.Result as DownloadResult
@@ -207,8 +206,7 @@ class DownloadEpisodeWorker @AssistedInject constructor(
             }
 
             is UserEpisode -> {
-                val freshDownloadUrl = userEpisodeManager.getPlaybackUrlRxSingle(episode).await()
-                episode.copy(downloadUrl = freshDownloadUrl)
+                episode.copy(downloadUrl = userEpisodeManager.getPlaybackUrl(episode))
             }
         }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CastPlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CastPlayer.kt
@@ -12,6 +12,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.PlaybackEffects
 import au.com.shiftyjelly.pocketcasts.models.type.UserEpisodeServerStatus
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.getArtworkUrl
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.stats.PlaybackStatsCollector
 import com.google.android.gms.cast.MediaInfo
 import com.google.android.gms.cast.MediaLoadOptions
@@ -23,6 +24,7 @@ import com.google.android.gms.cast.framework.CastSession
 import com.google.android.gms.cast.framework.SessionManager
 import com.google.android.gms.cast.framework.media.RemoteMediaClient
 import com.google.android.gms.common.images.WebImage
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.json.JSONException
@@ -31,6 +33,7 @@ import timber.log.Timber
 
 class CastPlayer(
     private val playbackStatsCollector: PlaybackStatsCollector,
+    private val userEpisodeManager: UserEpisodeManager,
     override val onPlayerEvent: (Player, PlayerEvent) -> Unit,
 ) : Player {
 
@@ -252,7 +255,7 @@ class CastPlayer(
         remoteMediaClient?.registerCallback(playPauseCallback)
     }
 
-    private fun loadEpisode(episodeUuid: String, currentPositionMs: Int, autoPlay: Boolean) {
+    private suspend fun loadEpisode(episodeUuid: String, currentPositionMs: Int, autoPlay: Boolean) {
         if (episodeUuid == remoteEpisodeUuid && autoPlay) {
             remoteMediaClient?.play()
             return
@@ -268,7 +271,20 @@ class CastPlayer(
             onPlayerEvent(this, PlayerEvent.PlayerError("Unable to cast local file"))
             return
         }
-        val mediaInfo = buildMediaInfo(url, episode, podcast)
+        // A cast device fetches the file itself and cannot send our auth header, so it needs a signed URL.
+        val castUrl = if (episode is UserEpisode) {
+            try {
+                withContext(Dispatchers.IO) { userEpisodeManager.getSignedPlaybackUrl(episode) }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                onPlayerEvent(this, PlayerEvent.PlayerError("Could not load cloud file ${e.message}"))
+                return
+            }
+        } else {
+            url
+        }
+        val mediaInfo = buildMediaInfo(castUrl, episode, podcast)
         val loadOptions = MediaLoadOptions.Builder()
             .setAutoplay(autoPlay)
             .setPlaybackRate(calcPlaybackSpeed())

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -138,7 +138,6 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.rx2.asFlow
 import kotlinx.coroutines.rx2.asFlowable
-import kotlinx.coroutines.rx2.await
 import kotlinx.coroutines.rx2.awaitSingleOrNull
 import kotlinx.coroutines.rx2.rxCompletable
 import kotlinx.coroutines.sync.Mutex
@@ -2145,14 +2144,7 @@ open class PlaybackManager @Inject constructor(
 
             is UserEpisode -> {
                 if (episode.serverStatus == UserEpisodeServerStatus.UPLOADED) {
-                    try {
-                        val newDownloadUrl = userEpisodeManager.getPlaybackUrlRxSingle(episode).await()
-                        episode.downloadUrl = newDownloadUrl
-                    } catch (e: Exception) {
-                        onPlayerError(PlayerEvent.PlayerError("Could not load cloud file ${e.message}"))
-                        removeEpisode(episode, source = sourceView)
-                        return
-                    }
+                    episode.downloadUrl = userEpisodeManager.getPlaybackUrl(episode)
                 }
             }
         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayerFactoryImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayerFactoryImpl.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.repositories.playback
 import android.content.Context
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.fingerprint.FingerprintPcmTap
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.stats.PlaybackStatsCollector
 import au.com.shiftyjelly.pocketcasts.repositories.user.StatsManager
 import au.com.shiftyjelly.pocketcasts.utils.fingerprint.FingerprintDecodePolicy
@@ -15,6 +16,7 @@ class PlayerFactoryImpl @Inject constructor(
     private val playbackStatsCollector: PlaybackStatsCollector,
     private val dataSourceFactory: ExoPlayerDataSourceFactory,
     private val fingerprintPcmTap: FingerprintPcmTap,
+    private val userEpisodeManager: UserEpisodeManager,
     private val fingerprintDecodePolicy: FingerprintDecodePolicy,
     @ApplicationContext private val context: Context,
 ) : PlayerFactory {
@@ -22,6 +24,7 @@ class PlayerFactoryImpl @Inject constructor(
     override fun createCastPlayer(onPlayerEvent: (Player, PlayerEvent) -> Unit): Player {
         return CastPlayer(
             playbackStatsCollector = playbackStatsCollector,
+            userEpisodeManager = userEpisodeManager,
             onPlayerEvent = onPlayerEvent,
         )
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/UserEpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/UserEpisodeManager.kt
@@ -77,7 +77,8 @@ interface UserEpisodeManager {
     fun removeFromCloud(userEpisode: UserEpisode)
     fun cancelUpload(userEpisode: UserEpisode)
     suspend fun syncFiles(playbackManager: PlaybackManager)
-    fun getPlaybackUrlRxSingle(userEpisode: UserEpisode): Single<String>
+    fun getPlaybackUrl(userEpisode: UserEpisode): String
+    suspend fun getSignedPlaybackUrl(userEpisode: UserEpisode): String
     fun downloadUserEpisodesRxFlowable(): Flowable<List<UserEpisode>>
     suspend fun updateDownloadedFilePath(episode: UserEpisode, filePath: String)
     suspend fun updateFileType(episode: UserEpisode, fileType: String)
@@ -518,9 +519,9 @@ class UserEpisodeManagerImpl @Inject constructor(
         update(userEpisode)
     }
 
-    override fun getPlaybackUrlRxSingle(userEpisode: UserEpisode): Single<String> {
-        return syncManager.getPlaybackUrlRxSingle(userEpisode)
-    }
+    override fun getPlaybackUrl(userEpisode: UserEpisode) = syncManager.getPlaybackUrl(userEpisode)
+
+    override suspend fun getSignedPlaybackUrl(userEpisode: UserEpisode) = syncManager.getSignedPlaybackUrl(userEpisode)
 
     override suspend fun updateEpisodeStatus(episode: UserEpisode, status: EpisodeDownloadStatus) {
         userEpisodeDao.updateEpisodeStatusBlocking(episode.uuid, status)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManager.kt
@@ -96,7 +96,8 @@ interface SyncManager : NamedSettingsCaller {
     fun getFileUsageRxSingle(): Single<FileAccount>
     fun deleteImageFromServerRxSingle(episode: UserEpisode): Single<Response<Void>>
     fun deleteFromServerRxSingle(episode: UserEpisode): Single<Response<Void>>
-    fun getPlaybackUrlRxSingle(episode: UserEpisode): Single<String>
+    fun getPlaybackUrl(episode: UserEpisode): String
+    suspend fun getSignedPlaybackUrl(episode: UserEpisode): String
 
     // History
     fun historySyncRxSingle(request: HistorySyncRequest): Single<HistorySyncResponse>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
@@ -371,8 +371,10 @@ class SyncManagerImpl @Inject constructor(
         syncServiceManager.deleteFromServer(episode, token)
     }
 
-    override fun getPlaybackUrlRxSingle(episode: UserEpisode): Single<String> = getCacheTokenOrLoginRxSingle { token ->
-        syncServiceManager.getPlaybackUrl(episode, token)
+    override fun getPlaybackUrl(episode: UserEpisode): String = syncServiceManager.getPlaybackUrl(episode)
+
+    override suspend fun getSignedPlaybackUrl(episode: UserEpisode): String = getCacheTokenOrLogin { token ->
+        syncServiceManager.getSignedPlaybackUrl(episode, token)
     }
 
     override fun getUserEpisodeRxMaybe(uuid: String): Maybe<ServerFile> = if (settings.cachedMembership.value.subscription != null) {

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImplTest.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.repositories.sync
 import android.content.Context
 import android.content.res.Resources
 import au.com.shiftyjelly.pocketcasts.analytics.testing.TestEventSink
+import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.AccessToken
 import au.com.shiftyjelly.pocketcasts.preferences.RefreshToken
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -20,7 +21,9 @@ import com.automattic.eventhorizon.UserAccountCreationFailedEvent
 import com.automattic.eventhorizon.UserSignedInEvent
 import com.automattic.eventhorizon.UserSigninFailedEvent
 import com.squareup.moshi.Moshi
+import java.util.Date
 import kotlinx.coroutines.test.runTest
+import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -34,6 +37,8 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import retrofit2.HttpException
+import retrofit2.Response
 
 @RunWith(MockitoJUnitRunner::class)
 class SyncManagerImplTest {
@@ -145,6 +150,31 @@ class SyncManagerImplTest {
         whenever(syncServiceManager.deviceToken(any(), any())).thenThrow(RuntimeException("boom"))
         syncManager.loginWithDeviceAuth("device-code", SignInSource.UserInitiated.Onboarding, isNewAccount = false)
         assertTrue(eventSink.pollEvent() is UserSigninFailedEvent)
+    }
+
+    @Test
+    fun `signed playback url is fetched with the cached token`() = runTest {
+        val episode = UserEpisode(uuid = "episode-uuid", publishedDate = Date())
+        whenever(syncAccountManager.isLoggedIn()).thenReturn(true)
+        whenever(syncAccountManager.getAccessToken()).thenReturn(AccessToken("access-token"))
+        whenever(syncServiceManager.getSignedPlaybackUrl(episode, AccessToken("access-token"))).thenReturn("https://files.example.com/signed")
+
+        assertEquals("https://files.example.com/signed", syncManager.getSignedPlaybackUrl(episode))
+    }
+
+    @Test
+    fun `signed playback url is retried with a refreshed token when unauthorized`() = runTest {
+        val episode = UserEpisode(uuid = "episode-uuid", publishedDate = Date())
+        val expiredToken = AccessToken("expired-access-token")
+        val freshToken = AccessToken("fresh-access-token")
+        whenever(syncAccountManager.isLoggedIn()).thenReturn(true)
+        whenever(syncAccountManager.getAccessToken()).thenReturn(expiredToken, freshToken)
+        whenever(syncServiceManager.getSignedPlaybackUrl(episode, expiredToken))
+            .thenThrow(HttpException(Response.error<String>(401, "".toResponseBody())))
+        whenever(syncServiceManager.getSignedPlaybackUrl(episode, freshToken)).thenReturn("https://files.example.com/signed")
+
+        assertEquals("https://files.example.com/signed", syncManager.getSignedPlaybackUrl(episode))
+        verify(syncAccountManager).invalidateAccessToken()
     }
 
     private fun stubResources() {

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/di/InterceptorModule.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/di/InterceptorModule.kt
@@ -230,7 +230,6 @@ object InterceptorModule {
             add(crashLoggingInterceptor.toClientInterceptor())
             add(basicAuthInterceptor)
             add(cleanAndRetryInterceptor)
-            // Must be after cleanAndRetry, which re-issues any 401 before this can refresh the token.
             add(userFileAuthInterceptor.toClientInterceptor())
 
             if (BuildConfig.DEBUG) {
@@ -276,7 +275,6 @@ object InterceptorModule {
             add(crashLoggingInterceptor.toClientInterceptor())
             add(basicAuthInterceptor)
             add(cleanAndRetryInterceptor)
-            // Must be after cleanAndRetry, which re-issues any 401 before this can refresh the token.
             add(userFileAuthInterceptor.toClientInterceptor())
 
             if (BuildConfig.DEBUG) {

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/di/InterceptorModule.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/di/InterceptorModule.kt
@@ -8,12 +8,11 @@ import au.com.shiftyjelly.pocketcasts.servers.CleanAndRetryInterceptor
 import au.com.shiftyjelly.pocketcasts.servers.OkHttpInterceptor
 import au.com.shiftyjelly.pocketcasts.servers.interceptors.BasicAuthInterceptor
 import au.com.shiftyjelly.pocketcasts.servers.interceptors.InternationalizationInterceptor
+import au.com.shiftyjelly.pocketcasts.servers.interceptors.UserFileAuthInterceptor
 import au.com.shiftyjelly.pocketcasts.servers.sync.TokenHandler
-import au.com.shiftyjelly.pocketcasts.servers.sync.exception.RefreshTokenExpiredException
+import au.com.shiftyjelly.pocketcasts.servers.sync.getAccessTokenBlocking
 import au.com.shiftyjelly.pocketcasts.servers.toClientInterceptor
 import au.com.shiftyjelly.pocketcasts.servers.toNetworkInterceptor
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import com.automattic.android.tracks.crashlogging.CrashLoggingOkHttpInterceptorProvider
 import com.automattic.android.tracks.crashlogging.FormattedUrl
 import com.automattic.android.tracks.crashlogging.RequestFormatter
@@ -24,7 +23,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import java.net.HttpURLConnection
 import kotlin.time.Duration.Companion.minutes
-import kotlinx.coroutines.runBlocking
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Interceptor
 import okhttp3.Request
 import okhttp3.logging.HttpLoggingInterceptor
@@ -112,30 +111,18 @@ object InterceptorModule {
             return builder.build()
         }
 
-        fun getAccessToken(): AccessToken? {
-            return if (FeatureFlag.isEnabled(Feature.INTERCEPTOR_REFRESH_TOKEN_FALLBACK)) {
-                try {
-                    runBlocking { tokenHandler.getAccessToken() }
-                } catch (_: RefreshTokenExpiredException) {
-                    null
-                }
-            } else {
-                runBlocking { tokenHandler.getAccessToken() }
-            }
-        }
-
         return Interceptor { chain ->
             val original = chain.request()
             if (unauthenticatedEndpoints.contains(original.url.encodedPathSegments.firstOrNull())) {
                 chain.proceed(original)
             } else {
-                val token = getAccessToken()
+                val token = tokenHandler.getAccessTokenBlocking()
                 return@Interceptor if (token != null) {
                     val response = chain.proceed(buildRequestWithToken(original, token))
                     if (response.code == HttpURLConnection.HTTP_UNAUTHORIZED) {
                         tokenHandler.invalidateAccessToken()
                         response.close()
-                        val newToken = getAccessToken()
+                        val newToken = tokenHandler.getAccessTokenBlocking()
                         chain.proceed(buildRequestWithToken(original, newToken))
                     } else {
                         response
@@ -145,6 +132,17 @@ object InterceptorModule {
                 }
             }
         }
+    }
+
+    @Provides
+    @UserFileInterceptor
+    fun provideUserFileAuthInterceptor(
+        tokenHandler: TokenHandler,
+    ): Interceptor {
+        return UserFileAuthInterceptor(
+            apiUrl = Settings.SERVER_API_URL.toHttpUrl(),
+            tokenHandler = tokenHandler,
+        )
     }
 
     @Provides
@@ -224,6 +222,7 @@ object InterceptorModule {
     @Downloads
     fun provideDownloadsInterceptors(
         @I18nInterceptor i18nInterceptor: Interceptor,
+        @UserFileInterceptor userFileAuthInterceptor: Interceptor,
     ): List<OkHttpInterceptor> {
         return buildList {
             add(publicUserAgentInterceptor.toClientInterceptor())
@@ -231,6 +230,8 @@ object InterceptorModule {
             add(crashLoggingInterceptor.toClientInterceptor())
             add(basicAuthInterceptor)
             add(cleanAndRetryInterceptor)
+            // Must be after cleanAndRetry, which re-issues any 401 before this can refresh the token.
+            add(userFileAuthInterceptor.toClientInterceptor())
 
             if (BuildConfig.DEBUG) {
                 val loggingInterceptor = HttpLoggingInterceptor().apply {
@@ -267,6 +268,7 @@ object InterceptorModule {
     @Player
     fun providePlayerInterceptors(
         @I18nInterceptor i18nInterceptor: Interceptor,
+        @UserFileInterceptor userFileAuthInterceptor: Interceptor,
     ): List<OkHttpInterceptor> {
         return buildList {
             add(publicUserAgentInterceptor.toClientInterceptor())
@@ -274,6 +276,8 @@ object InterceptorModule {
             add(crashLoggingInterceptor.toClientInterceptor())
             add(basicAuthInterceptor)
             add(cleanAndRetryInterceptor)
+            // Must be after cleanAndRetry, which re-issues any 401 before this can refresh the token.
+            add(userFileAuthInterceptor.toClientInterceptor())
 
             if (BuildConfig.DEBUG) {
                 val loggingInterceptor = HttpLoggingInterceptor().apply {

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/di/NetworkModule.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/di/NetworkModule.kt
@@ -468,6 +468,10 @@ annotation class TokenInterceptor
 
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
+annotation class UserFileInterceptor
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
 annotation class I18nInterceptor
 
 @Qualifier

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/interceptors/UserFileAuthInterceptor.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/interceptors/UserFileAuthInterceptor.kt
@@ -11,8 +11,7 @@ import okhttp3.Interceptor
 import okhttp3.Request
 import okhttp3.Response
 
-// Must be a client interceptor: the endpoint redirects to signed storage, and a network interceptor
-// would run again on that hop and send the token to a third party host.
+// Must be a client interceptor: a network interceptor would run on the redirect to signed storage and leak the token.
 internal class UserFileAuthInterceptor(
     private val apiUrl: HttpUrl,
     private val tokenHandler: TokenHandler,
@@ -25,7 +24,7 @@ internal class UserFileAuthInterceptor(
 
         val token = accessToken() ?: return chain.proceed(request)
         val response = chain.proceed(request.withBearer(token))
-        // chain.proceed already followed the redirect, so a 401 here can come from signed storage, not the API.
+        // chain.proceed follows redirects, so a 401 here can come from signed storage rather than the API.
         if (response.code != HttpURLConnection.HTTP_UNAUTHORIZED || !response.request.isUserFileRequest()) {
             return response
         }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/interceptors/UserFileAuthInterceptor.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/interceptors/UserFileAuthInterceptor.kt
@@ -1,0 +1,56 @@
+package au.com.shiftyjelly.pocketcasts.servers.interceptors
+
+import au.com.shiftyjelly.pocketcasts.preferences.AccessToken
+import au.com.shiftyjelly.pocketcasts.servers.sync.SyncServiceManager.Companion.USER_FILE_PLAYBACK_PATH
+import au.com.shiftyjelly.pocketcasts.servers.sync.TokenHandler
+import au.com.shiftyjelly.pocketcasts.servers.sync.getAccessTokenBlocking
+import java.io.IOException
+import java.net.HttpURLConnection
+import okhttp3.HttpUrl
+import okhttp3.Interceptor
+import okhttp3.Request
+import okhttp3.Response
+
+// Must be a client interceptor: the endpoint redirects to signed storage, and a network interceptor
+// would run again on that hop and send the token to a third party host.
+internal class UserFileAuthInterceptor(
+    private val apiUrl: HttpUrl,
+    private val tokenHandler: TokenHandler,
+) : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+        if (!request.isUserFileRequest()) {
+            return chain.proceed(request)
+        }
+
+        val token = accessToken() ?: return chain.proceed(request)
+        val response = chain.proceed(request.withBearer(token))
+        // chain.proceed already followed the redirect, so a 401 here can come from signed storage, not the API.
+        if (response.code != HttpURLConnection.HTTP_UNAUTHORIZED || !response.request.isUserFileRequest()) {
+            return response
+        }
+
+        tokenHandler.invalidateAccessToken()
+        response.close()
+        val refreshedToken = accessToken() ?: return chain.proceed(request)
+        return chain.proceed(request.withBearer(refreshedToken))
+    }
+
+    // AccountManager signals network failure with NetworkErrorException, which the player treats as fatal, not retryable.
+    private fun accessToken() = try {
+        tokenHandler.getAccessTokenBlocking()
+    } catch (e: IOException) {
+        throw e
+    } catch (e: Exception) {
+        throw IOException("Could not read an access token for a user file request", e)
+    }
+
+    private fun Request.isUserFileRequest() = url.scheme == apiUrl.scheme &&
+        url.host == apiUrl.host &&
+        url.port == apiUrl.port &&
+        url.encodedPath.startsWith(USER_FILE_PLAYBACK_PATH)
+
+    private fun Request.withBearer(token: AccessToken) = newBuilder()
+        .header("Authorization", "Bearer ${token.value}")
+        .build()
+}

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncService.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncService.kt
@@ -178,7 +178,6 @@ interface SyncService {
     @GET("/files/{uuid}")
     fun getFile(@Header("Authorization") authorization: String, @Path("uuid") uuid: String): Single<Response<ServerFile>>
 
-    @GET("/files/play/{uuid}")
     @Headers("Cache-Control: no-store")
     @GET("/files/play/{uuid}")
     suspend fun getFilePlaybackUrl(@Header("Authorization") authorization: String, @Path("uuid") uuid: String): FileUrlResponse

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncService.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncService.kt
@@ -179,6 +179,8 @@ interface SyncService {
     fun getFile(@Header("Authorization") authorization: String, @Path("uuid") uuid: String): Single<Response<ServerFile>>
 
     @GET("/files/play/{uuid}")
+    @Headers("Cache-Control: no-store")
+    @GET("/files/play/{uuid}")
     suspend fun getFilePlaybackUrl(@Header("Authorization") authorization: String, @Path("uuid") uuid: String): FileUrlResponse
 
     @POST("/user/stats/summary")

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncService.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncService.kt
@@ -178,6 +178,9 @@ interface SyncService {
     @GET("/files/{uuid}")
     fun getFile(@Header("Authorization") authorization: String, @Path("uuid") uuid: String): Single<Response<ServerFile>>
 
+    @GET("/files/play/{uuid}")
+    suspend fun getFilePlaybackUrl(@Header("Authorization") authorization: String, @Path("uuid") uuid: String): FileUrlResponse
+
     @POST("/user/stats/summary")
     suspend fun loadStats(@Header("Authorization") authorization: String, @Body request: StatsSummaryRequest): Map<String, Any>
 

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServiceManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServiceManager.kt
@@ -82,6 +82,9 @@ open class SyncServiceManager @Inject constructor(
         const val SCOPE_MOBILE = "mobile"
         const val SCOPE_TV = "tv"
 
+        // Credentials come from UserFileAuthInterceptor, not from the URL.
+        internal const val USER_FILE_PLAYBACK_PATH = "/files/url/token/"
+
         private val userPodcastListRequest = userPodcastListRequest {
             v = Settings.SYNC_API_VERSION.toString()
             m = Settings.SYNC_API_MODEL
@@ -269,7 +272,9 @@ open class SyncServiceManager @Inject constructor(
 
     fun deleteFromServer(episode: UserEpisode, token: AccessToken): Single<Response<Void>> = service.deleteFile(addBearer(token), episode.uuid)
 
-    fun getPlaybackUrl(episode: UserEpisode, token: AccessToken): Single<String> = Single.just("${Settings.SERVER_API_URL}/files/url/${episode.uuid}?token=${token.value}")
+    fun getPlaybackUrl(episode: UserEpisode): String = "${Settings.SERVER_API_URL}$USER_FILE_PLAYBACK_PATH${episode.uuid}"
+
+    suspend fun getSignedPlaybackUrl(episode: UserEpisode, token: AccessToken): String = service.getFilePlaybackUrl(addBearer(token), episode.uuid).url
 
     fun getUserEpisode(uuid: String, token: AccessToken): Single<Response<ServerFile>> = service.getFile(addBearer(token), uuid)
 

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/TokenHandler.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/TokenHandler.kt
@@ -1,8 +1,24 @@
 package au.com.shiftyjelly.pocketcasts.servers.sync
 
 import au.com.shiftyjelly.pocketcasts.preferences.AccessToken
+import au.com.shiftyjelly.pocketcasts.servers.sync.exception.RefreshTokenExpiredException
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
+import kotlinx.coroutines.runBlocking
 
 interface TokenHandler {
     suspend fun getAccessToken(): AccessToken?
     fun invalidateAccessToken()
+}
+
+// OkHttp interceptors are synchronous, so they cannot use the suspending accessor.
+internal fun TokenHandler.getAccessTokenBlocking(): AccessToken? {
+    if (!FeatureFlag.isEnabled(Feature.INTERCEPTOR_REFRESH_TOKEN_FALLBACK)) {
+        return runBlocking { getAccessToken() }
+    }
+    return try {
+        runBlocking { getAccessToken() }
+    } catch (_: RefreshTokenExpiredException) {
+        null
+    }
 }

--- a/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/interceptors/UserFileAuthInterceptorTest.kt
+++ b/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/interceptors/UserFileAuthInterceptorTest.kt
@@ -1,0 +1,167 @@
+package au.com.shiftyjelly.pocketcasts.servers.interceptors
+
+import au.com.shiftyjelly.pocketcasts.preferences.AccessToken
+import au.com.shiftyjelly.pocketcasts.servers.sync.TokenHandler
+import au.com.shiftyjelly.pocketcasts.sharedtest.InMemoryFeatureFlagRule
+import java.net.HttpURLConnection
+import java.util.ArrayDeque
+import java.util.concurrent.TimeUnit
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+class UserFileAuthInterceptorTest {
+    @get:Rule
+    val apiServer = MockWebServer()
+
+    @get:Rule
+    val otherServer = MockWebServer()
+
+    @get:Rule
+    val featureFlagRule = InMemoryFeatureFlagRule()
+
+    @Test
+    fun `adds authorization header to user file requests`() {
+        val tokenHandler = FakeTokenHandler(AccessToken("access-token"))
+        val client = newClient(tokenHandler)
+        apiServer.enqueue(MockResponse())
+
+        client.newCall(userFileRequest()).execute().use { response ->
+            assertEquals(HttpURLConnection.HTTP_OK, response.code)
+        }
+
+        val request = apiServer.takeRequest(5, TimeUnit.SECONDS)
+        assertEquals("Bearer access-token", request?.getHeader("Authorization"))
+    }
+
+    @Test
+    fun `does not add authorization header for other hosts`() {
+        val tokenHandler = FakeTokenHandler(AccessToken("access-token"))
+        val client = newClient(tokenHandler)
+        otherServer.enqueue(MockResponse())
+
+        val url = otherServer.url("/files/url/token/episode-uuid")
+        client.newCall(Request.Builder().url(url).build()).execute().use { response ->
+            assertEquals(HttpURLConnection.HTTP_OK, response.code)
+        }
+
+        val request = requireNotNull(otherServer.takeRequest(5, TimeUnit.SECONDS))
+        assertNull(request.getHeader("Authorization"))
+        assertEquals(0, tokenHandler.getAccessTokenCalls)
+    }
+
+    @Test
+    fun `does not add authorization header for other paths on the api host`() {
+        val tokenHandler = FakeTokenHandler(AccessToken("access-token"))
+        val client = newClient(tokenHandler)
+        apiServer.enqueue(MockResponse())
+
+        val url = apiServer.url("/files/url/episode-uuid")
+        client.newCall(Request.Builder().url(url).build()).execute().use { response ->
+            assertEquals(HttpURLConnection.HTTP_OK, response.code)
+        }
+
+        val request = requireNotNull(apiServer.takeRequest(5, TimeUnit.SECONDS))
+        assertNull(request.getHeader("Authorization"))
+        assertEquals(0, tokenHandler.getAccessTokenCalls)
+    }
+
+    @Test
+    fun `does not forward authorization header when redirected to another host`() {
+        val tokenHandler = FakeTokenHandler(AccessToken("access-token"))
+        val client = newClient(tokenHandler)
+        val redirect = MockResponse()
+            .setResponseCode(HTTP_TEMPORARY_REDIRECT)
+            .setHeader("Location", otherServer.url("/signed-file.mp3"))
+        apiServer.enqueue(redirect)
+        otherServer.enqueue(MockResponse())
+
+        client.newCall(userFileRequest()).execute().use { response ->
+            assertEquals(HttpURLConnection.HTTP_OK, response.code)
+        }
+
+        val apiRequest = requireNotNull(apiServer.takeRequest(5, TimeUnit.SECONDS))
+        val storageRequest = requireNotNull(otherServer.takeRequest(5, TimeUnit.SECONDS))
+        assertEquals("Bearer access-token", apiRequest.getHeader("Authorization"))
+        assertNull(storageRequest.getHeader("Authorization"))
+    }
+
+    @Test
+    fun `retries with a refreshed token when unauthorized`() {
+        val tokenHandler = FakeTokenHandler(AccessToken("expired-access-token"), AccessToken("fresh-access-token"))
+        val client = newClient(tokenHandler)
+        apiServer.enqueue(MockResponse().setResponseCode(HttpURLConnection.HTTP_UNAUTHORIZED))
+        apiServer.enqueue(MockResponse())
+
+        client.newCall(userFileRequest()).execute().use { response ->
+            assertEquals(HttpURLConnection.HTTP_OK, response.code)
+        }
+
+        val firstRequest = requireNotNull(apiServer.takeRequest(5, TimeUnit.SECONDS))
+        val secondRequest = requireNotNull(apiServer.takeRequest(5, TimeUnit.SECONDS))
+        assertEquals("Bearer expired-access-token", firstRequest.getHeader("Authorization"))
+        assertEquals("Bearer fresh-access-token", secondRequest.getHeader("Authorization"))
+        assertTrue(tokenHandler.invalidatedAccessToken)
+    }
+
+    @Test
+    fun `does not refresh the token when the redirected storage host is unauthorized`() {
+        val tokenHandler = FakeTokenHandler(AccessToken("access-token"), AccessToken("fresh-access-token"))
+        val client = newClient(tokenHandler)
+        val redirect = MockResponse()
+            .setResponseCode(HTTP_TEMPORARY_REDIRECT)
+            .setHeader("Location", otherServer.url("/signed-file.mp3"))
+        apiServer.enqueue(redirect)
+        otherServer.enqueue(MockResponse().setResponseCode(HttpURLConnection.HTTP_UNAUTHORIZED))
+
+        client.newCall(userFileRequest()).execute().use { response ->
+            assertEquals(HttpURLConnection.HTTP_UNAUTHORIZED, response.code)
+        }
+
+        assertEquals(1, tokenHandler.getAccessTokenCalls)
+        assertFalse(tokenHandler.invalidatedAccessToken)
+    }
+
+    private companion object {
+        const val HTTP_TEMPORARY_REDIRECT = 307
+    }
+
+    private fun userFileRequest() = Request.Builder()
+        .url(apiServer.url("/files/url/token/episode-uuid"))
+        .build()
+
+    private fun newClient(tokenHandler: TokenHandler): OkHttpClient {
+        val interceptor = UserFileAuthInterceptor(apiUrl = apiServer.url("/"), tokenHandler = tokenHandler)
+        return OkHttpClient.Builder()
+            .addInterceptor(interceptor)
+            .build()
+    }
+
+    private class FakeTokenHandler(
+        vararg tokens: AccessToken,
+    ) : TokenHandler {
+        private val tokens = ArrayDeque(tokens.toList())
+
+        var getAccessTokenCalls = 0
+            private set
+
+        var invalidatedAccessToken = false
+            private set
+
+        override suspend fun getAccessToken(): AccessToken? {
+            getAccessTokenCalls++
+            return tokens.pollFirst()
+        }
+
+        override fun invalidateAccessToken() {
+            invalidatedAccessToken = true
+        }
+    }
+}


### PR DESCRIPTION
## Description

Playing or downloading an uploaded file no longer puts the account's login token as a query parameter. The credential is now sent as a request header, so it can no longer end up in logs, caches or a third party's server records.

Previously `getPlaybackUrl` built `${SERVER_API_URL}/files/url/${uuid}?token=${accessToken}` and stored that whole string in `episode.downloadUrl`. Because it is a plain `String` consumed by the generic download and playback pipelines, the live bearer token travelled anywhere that URL did: `LogBuffer`/logcat download logs, the OkHttp cache, `Referer` headers, and any 3xx redirect to a third party storage host.

The fix keeps `downloadUrl` a plain string, but a tokenless one: `${SERVER_API_URL}/files/url/token/${uuid}`. A new client interceptor, `UserFileAuthInterceptor`, attaches `Authorization: Bearer …` to requests for that path, and only for that path on our own API host. Some detail worth calling out:

- It has to be a **client** interceptor, not a network one. The endpoint redirects to signed storage, and a network interceptor would run again on that hop and hand the token to a third party host.
- It is registered *after* `cleanAndRetryInterceptor` in both the `@Downloads` and `@Player` interceptor lists, because `cleanAndRetry` re-issues a 401 before the auth interceptor would get a chance to refresh the token.
- On a 401 it invalidates the cached token, refreshes and retries once, but only when the 401 came from our API. `chain.proceed` has already followed the redirect by then, so a 401 from the signed storage host must not trigger a token refresh.
- Token reads throw `IOException` rather than propagating `AccountManager`'s `NetworkErrorException`, which the player treats as fatal rather than retryable.

Chromecast cannot use any of this: the cast device fetches the file itself and cannot send our header. `CastPlayer` now calls a new `getSignedPlaybackUrl`, backed by a new `GET /files/play/{uuid}` endpoint that returns a short-lived server-signed URL, and reports a player error if that call fails.

Along the way, `getPlaybackUrlRxSingle` became the suspending/plain `getPlaybackUrl` (the callers in `PlaybackManager` and `DownloadEpisodeWorker` no longer need RxJava), and the `INTERCEPTOR_REFRESH_TOKEN_FALLBACK` handling that used to live inline in `InterceptorModule` moved into a shared `TokenHandler.getAccessTokenBlocking()` extension so both interceptors behave the same way.

As part of these improvements for Automotive the manifest now also removes the `ACCESS_ADSERVICES_*` and `BIND_GET_INSTALL_REFERRER_SERVICE` permissions that Firebase Analytics merges in, alongside the `AD_ID` removal that was already there. The car app has no ad SDK and reads neither an advertising ID nor the install referrer.

Fixes https://linear.app/a8c/issue/PCDROID-662/servers-01-access-token-embedded-in-the-playback-url-as-a-query

## Testing Instructions

Requires a Plus/Patron account with at least one uploaded file.

1. Sign in and go to **Files**. 
1. Add a file, tap the row and pick "Upload to cloud".
1. Tap the row again, tap "Delete", tap "Delete from device only"
1. Tap play on the episode
1. ✅ Verify the episode plays from a stream
1. Download the file again and tap play
1. ✅ Verify the download plays
1. Chromecast the episode
1. ✅ Verify it plays on your TV

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
