### PR TITLE
[TV] Use a vertical background gradient for better pill contrast

### DIFF
--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvScreenBackgroundBrush.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvScreenBackgroundBrush.kt
@@ -1,17 +1,12 @@
 package au.com.shiftyjelly.pocketcasts.theme
 
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.graphics.Brush
-import androidx.tv.material3.MaterialTheme
+import androidx.compose.ui.graphics.Color
 
 // Shared screen background so detail overlays fully occlude the content fading underneath them.
-val TvScreenBackgroundBrush: Brush
-    @Composable
-    @ReadOnlyComposable
-    get() = Brush.horizontalGradient(
-        colors = listOf(
-            MaterialTheme.tvColors.backgroundBase,
-            MaterialTheme.tvColors.backgroundSunken,
-        ),
-    )
+val TvScreenBackgroundBrush: Brush = Brush.verticalGradient(
+    colors = listOf(
+        Color(0xFF3D4045),
+        Color(0xFF22252A),
+    ),
+)


### PR DESCRIPTION
## Description

The TV screen background used a horizontal gradient between the base/sunken theme tokens, which left too little contrast behind the light pills. Replace it with a vertical gradient from `#3D4045` (top) to `#22252A` (bottom) so pills stand out more clearly.

The `backgroundBase`/`backgroundSunken` tokens are reused as solid fills elsewhere, so only `TvScreenBackgroundBrush` changes.

Fixes POC-895 https://linear.app/a8c/issue/POC-895/update-background-gradient

## Testing Instructions

1. Launch the TV app.
2. On any screen with pills (e.g. Discover category pills, sort pills), observe the background now runs top-to-bottom from a lighter grey to a darker one, with better contrast behind the pills.

## Screenshots or Screencast
<img width="1920" height="1080" alt="Screenshot_1789052623" src="https://github.com/user-attachments/assets/bed03076-0f81-4ed1-9eed-59cee0b049a2" />



## Checklist

- [ ] If this is a user-facing change, I added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply`)
- [x] I considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I updated the Event Horizon schema to reflect any new or changed analytics

#### I tested any UI changes...

- [ ] different themes
- [ ] landscape orientation
- [ ] device set to large display font size
- [ ] accessibility with TalkBack
