### PR TITLE
[TV] Align the "Your Podcasts" title with its grid tiles

### DIFF
--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastGridScaffold.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastGridScaffold.kt
@@ -113,7 +113,7 @@ internal fun TvPodcastGridScaffold(
                         text = title,
                         style = MaterialTheme.tvTypography.title2,
                         color = MaterialTheme.tvColors.textPrimary,
-                        modifier = Modifier.padding(start = horizontalContentPadding, top = 40.dp, bottom = 0.dp),
+                        modifier = Modifier.padding(top = 40.dp),
                     )
                 }
             }


### PR DESCRIPTION
## Description

The "Your Podcasts" title was misaligned to the right relative to its podcast tiles. When `TvPodcastGridScaffold` scrolls the top bar, the title is a full-span grid header item, so it already inherits the grid's `contentPadding` start inset — the extra `start = horizontalContentPadding` on the title added a second inset and pushed it further right than the tiles. Drop the redundant start padding so the title lines up with the grid content.

POC-899 https://linear.app/a8c/issue/POC-899/your-podcasts-title-misaligned

## Testing Instructions

1. Sign in and open the "Your Podcasts" tab (with at least one podcast/folder so the grid renders).
2. The "Your Podcasts" title now starts at the same left edge as the podcast tiles below it.

## Screenshots or Screencast
<img width="1920" height="1080" alt="poc899_yp" src="https://github.com/user-attachments/assets/8cd543d0-79a6-4477-9d23-3d02fc44697a" />


## Checklist

- [ ] If this is a user-facing change, I added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply`)
- [x] I considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I updated the Event Horizon schema to reflect any new or changed analytics

#### I tested any UI changes...

- [ ] different themes
- [ ] landscape orientation
- [ ] device set to large display font size
- [ ] accessibility with TalkBack
