### PR TITLE
[TV] Center the blurred player artwork behind the cover

### DIFF
--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvNowPlayingScreen.kt
@@ -411,7 +411,6 @@ private fun EpisodeArtwork(
             model = episode.artworkModel(),
             modifier = Modifier
                 .requiredSize(ArtworkSize * BlurredArtworkScale)
-                .offset(x = BlurredArtworkOffset, y = BlurredArtworkOffset)
                 .blur(BlurredArtworkRadius, BlurredEdgeTreatment.Unbounded)
                 .alpha(0.7f),
         )
@@ -525,7 +524,6 @@ private fun InfoButton(
 private val ArtworkSize = 210.dp
 private val ArtworkTopLift = 18.dp
 private val BlurredArtworkScale = 1.25f
-private val BlurredArtworkOffset = -ArtworkSize * 0.2f
 private val BlurredArtworkRadius = 49.5.dp
 
 private val CHROME_HIDE_DELAY = 5.seconds


### PR DESCRIPTION
## Description

The blurred artwork behind the Now Playing cover was shifted up and to the left. The artwork `Box` already centers its children (`contentAlignment = Alignment.Center`), so the enlarged blur was centered until an extra `offset(x = -0.2 * ArtworkSize, y = -0.2 * ArtworkSize)` pushed it off. Remove that offset (and the now-unused constant) so the blur sits exactly behind the cover.

POC-896 https://linear.app/a8c/issue/POC-896/center-cover-blur-in-the-player

## Testing Instructions

1. Play any episode and open Now Playing.
2. The blurred artwork glow is now centered symmetrically behind the cover instead of leaning to the top-left.

## Screenshots or Screencast

<img width="1920" height="1080" alt="poc896_nowplaying" src="https://github.com/user-attachments/assets/4e47c620-2a07-46ee-9a07-5c1170efe49b" />

## Checklist

- [ ] If this is a user-facing change, I added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply`)
- [x] I considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I updated the Event Horizon schema to reflect any new or changed analytics

#### I tested any UI changes...

- [ ] different themes
- [ ] landscape orientation
- [ ] device set to large display font size
- [ ] accessibility with TalkBack
