### PR TITLE
[TV] Rework the player effects popup with Volume Boost On/Off options

### DIFF
--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvPlayerEffectsControls.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvPlayerEffectsControls.kt
@@ -118,19 +118,31 @@ internal fun TvPlayerEffectsButton(
             val trimChangedTemplate = stringResource(LR.string.tv_trim_silence_changed)
             val trimOffToast = stringResource(LR.string.tv_trim_silence_off)
             TvDropdownMenu(
-                title = stringResource(LR.string.player_effects),
+                title = stringResource(LR.string.player_effects_volume_boost),
                 onDismissRequest = { onMenuVisibleChange(false) },
                 alignment = Alignment.BottomCenter,
                 offset = DpOffset(x = 0.dp, y = (-64).dp),
             ) {
                 TvDropdownMenuItem(
-                    label = stringResource(LR.string.player_effects_volume_boost),
-                    isSelected = isVolumeBoosted,
-                    requestInitialFocus = true,
+                    label = stringResource(LR.string.off),
+                    isSelected = !isVolumeBoosted,
                     onClick = {
-                        val isBoosted = !isVolumeBoosted
-                        onSetVolumeBoost(isBoosted)
-                        toastHostState.show(if (isBoosted) boostOnToast else boostOffToast)
+                        onMenuVisibleChange(false)
+                        if (isVolumeBoosted) {
+                            onSetVolumeBoost(false)
+                            toastHostState.show(boostOffToast)
+                        }
+                    },
+                )
+                TvDropdownMenuItem(
+                    label = stringResource(LR.string.on),
+                    isSelected = isVolumeBoosted,
+                    onClick = {
+                        onMenuVisibleChange(false)
+                        if (!isVolumeBoosted) {
+                            onSetVolumeBoost(true)
+                            toastHostState.show(boostOnToast)
+                        }
                     },
                 )
                 TvDropdownMenuSectionTitle(text = stringResource(LR.string.player_effects_trim_silence))


### PR DESCRIPTION
## Description

Reworks the player effects popup to match the design:

- Replaces the "Player effects" title with a "Volume Boost" section title.
- Volume Boost is now two explicit options — **Off** and **On** — with a checkmark on the current state, instead of a single toggle row.
- The menu now closes on **every** selection. Previously toggling Volume Boost kept the menu open while a Trim Silence change closed it.

POC-898 https://linear.app/a8c/issue/POC-898/changes-in-playback-effects-popup

## Testing Instructions

1. Play an episode and open Now Playing.
2. Open the player effects menu (the effects icon in the control bar).
3. The menu shows "Volume Boost" with Off/On, then "Trim Silence" with Off/Mild/Medium/Mad Max.
4. Selecting any Volume Boost or Trim Silence option applies it and closes the menu.

## Screenshots or Screencast
[untitled.webm](https://github.com/user-attachments/assets/ad9a7adb-a6af-475f-bea5-2dfbe779f97f)



## Checklist

- [ ] If this is a user-facing change, I added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply`)
- [x] I considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I updated the Event Horizon schema to reflect any new or changed analytics

#### I tested any UI changes...

- [ ] different themes
- [ ] landscape orientation
- [ ] device set to large display font size
- [ ] accessibility with TalkBack
