### PR TITLE
[TV] Widen featured carousel spacing so less of the next item peeks

### DIFF
--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvRow.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvRow.kt
@@ -73,7 +73,7 @@ fun <T> TvRow(
     itemSpacing: Dp = TvTileSpacing,
     key: ((T) -> Any)? = null,
     focusRequester: FocusRequester? = null,
-    centerFocusedItem: Boolean = false,
+    leftAlignFocusedItem: Boolean = false,
     content: @Composable (T) -> Unit,
 ) {
     var hasFocus by remember { mutableStateOf(false) }
@@ -99,12 +99,9 @@ fun <T> TvRow(
         val focusRequesters = remember(items) { List(items.size) { FocusRequester() } }
         val listState = rememberLazyListState()
 
-        if (centerFocusedItem) {
+        if (leftAlignFocusedItem) {
             LaunchedEffect(lastFocusedIndex) {
-                val item = listState.layoutInfo.visibleItemsInfo.firstOrNull { it.index == lastFocusedIndex }
-                val viewport = listState.layoutInfo.viewportSize.width
-                val centerOffset = item?.let { -(viewport - it.size) / 2 } ?: 0
-                listState.animateScrollToItem(lastFocusedIndex, centerOffset)
+                listState.animateScrollToItem(lastFocusedIndex)
             }
         }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/discover/TvDiscoverRows.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/discover/TvDiscoverRows.kt
@@ -61,7 +61,7 @@ fun LazyListScope.tvDiscoverRow(
                 contentPadding = contentPadding,
                 key = TvDiscoverPodcast::uuid,
                 focusRequester = focusRequester,
-                centerFocusedItem = true,
+                leftAlignFocusedItem = true,
                 modifier = modifier,
             ) { podcast ->
                 TvFeaturedTile(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/discover/TvDiscoverRows.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/discover/TvDiscoverRows.kt
@@ -57,7 +57,7 @@ fun LazyListScope.tvDiscoverRow(
             TvRow(
                 title = row.title,
                 items = row.podcasts,
-                itemSpacing = 12.dp,
+                itemSpacing = 40.dp,
                 contentPadding = contentPadding,
                 key = TvDiscoverPodcast::uuid,
                 focusRequester = focusRequester,


### PR DESCRIPTION
## Description

Follow-up polish for the featured (Discover) carousel. Most of POC-888 already landed on `main` — solid buttons (no outline), no button-expand jump when a tile becomes active, network/author shown above the title, and a focused scale + drop-shadow glow, plus `centerFocusedItem` so the active tile is centered.

This change widens the featured row's item spacing (12dp → 40dp) so that when the active tile is centered, only a small sliver of the next tile peeks in — matching the ticket's request to show "only a bit of the next position."

POC-888 https://linear.app/a8c/issue/POC-888/featured-carrousel-changes

## Testing Instructions

1. Open Home / Discover and focus the "Featured Podcasts" carousel.
2. Move across items — the active tile is snaps to the left edge of the screen.

## Screenshots or Screencast
[untitled.webm](https://github.com/user-attachments/assets/46a88eca-4b74-4a87-9771-13fbc60d5fdb)


## Checklist

- [ ] If this is a user-facing change, I added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply`)
- [x] I considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I updated the Event Horizon schema to reflect any new or changed analytics

#### I tested any UI changes...

- [ ] different themes
- [ ] landscape orientation
- [ ] device set to large display font size
- [ ] accessibility with TalkBack
