### PR TITLE
[TV] Polish the podcast view (title, follow buttons, scrolling header, episode actions)

### DIFF
--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeListFocus.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeListFocus.kt
@@ -30,13 +30,16 @@ internal fun rememberTvEpisodeListFocus(
     episodes: List<PodcastEpisode>,
     listState: LazyListState,
     requestInitialFocus: Boolean,
+    leadingItemCount: Int = 0,
 ): TvEpisodeListFocus {
     val focus = remember { TvEpisodeListFocus() }
 
     if (requestInitialFocus) {
         LaunchedEffect(episodes.isNotEmpty()) {
             if (episodes.isNotEmpty() && !focus.hasRequestedInitialFocus) {
-                val index = Snapshot.withoutReadObservation { listState.firstVisibleItemIndex }
+                // The list may lead with non-episode items (e.g. a scrolling header), so shift the
+                // first-visible list index back into episode space before indexing.
+                val index = (Snapshot.withoutReadObservation { listState.firstVisibleItemIndex } - leadingItemCount)
                     .coerceIn(0, episodes.lastIndex)
                 focus.focusRow(listState, targetUuid = episodes[index].uuid, removedUuid = null)
                 focus.hasRequestedInitialFocus = true

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeListItem.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeListItem.kt
@@ -41,11 +41,12 @@ fun TvEpisodeListItem(
     TvEpisodeListItemContainer(
         onOpenActions = onOpenActions,
         modifier = modifier,
-    ) { rowModifier ->
+    ) { rowModifier, isRowFocused ->
         TvEpisodeRow(
             episode = episode,
             onClick = onClick,
             dateFormatter = dateFormatter,
+            isRowFocused = isRowFocused,
             modifier = rowModifier
                 .then(if (leftFocusRequester != null) Modifier.focusProperties { left = leftFocusRequester } else Modifier)
                 .then(if (episodeFocusRequester != null) Modifier.focusRequester(episodeFocusRequester) else Modifier),
@@ -57,7 +58,7 @@ fun TvEpisodeListItem(
 fun TvEpisodeListItemContainer(
     onOpenActions: () -> Unit,
     modifier: Modifier = Modifier,
-    content: @Composable (Modifier) -> Unit,
+    content: @Composable (rowModifier: Modifier, isRowFocused: Boolean) -> Unit,
 ) {
     var isItemFocused by remember { mutableStateOf(false) }
     Row(
@@ -66,7 +67,7 @@ fun TvEpisodeListItemContainer(
             .fillMaxWidth()
             .onFocusChanged { isItemFocused = it.hasFocus },
     ) {
-        content(Modifier.weight(1f))
+        content(Modifier.weight(1f), isItemFocused)
         MoreButtonSlot(
             visible = isItemFocused,
             onClick = onOpenActions,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeListItem.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeListItem.kt
@@ -4,6 +4,8 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -19,9 +21,14 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
+import androidx.tv.material3.MaterialTheme
 import au.com.shiftyjelly.pocketcasts.localization.helper.RelativeDateFormatter
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
+import au.com.shiftyjelly.pocketcasts.theme.tvColors
 
 @Composable
 fun TvEpisodeListItem(
@@ -33,22 +40,22 @@ fun TvEpisodeListItem(
     episodeFocusRequester: FocusRequester? = null,
     leftFocusRequester: FocusRequester? = null,
 ) {
-    var isItemFocused by remember { mutableStateOf(false) }
+    val rowInteractionSource = remember { MutableInteractionSource() }
+    val isRowFocused by rowInteractionSource.collectIsFocusedAsState()
+    var isMoreButtonFocused by remember { mutableStateOf(false) }
     val moreButtonFocusRequester = remember { FocusRequester() }
-    Box(
-        modifier = modifier
-            .fillMaxWidth()
-            .onFocusChanged { isItemFocused = it.hasFocus },
-    ) {
+    val showMoreButton = isRowFocused || isMoreButtonFocused
+    Box(modifier = modifier.fillMaxWidth()) {
         TvEpisodeRow(
             episode = episode,
             onClick = onClick,
             dateFormatter = dateFormatter,
             contentEndPadding = MoreButtonReservedWidth,
+            interactionSource = rowInteractionSource,
             modifier = Modifier
                 .fillMaxWidth()
                 .focusProperties {
-                    if (isItemFocused) {
+                    if (showMoreButton) {
                         right = moreButtonFocusRequester
                     }
                     if (leftFocusRequester != null) {
@@ -58,11 +65,13 @@ fun TvEpisodeListItem(
                 .then(if (episodeFocusRequester != null) Modifier.focusRequester(episodeFocusRequester) else Modifier),
         )
         MoreButtonSlot(
-            visible = isItemFocused,
+            visible = showMoreButton,
             onClick = onOpenActions,
             modifier = Modifier
                 .align(Alignment.CenterEnd)
+                .zIndex(1f)
                 .padding(end = MoreButtonEndInset)
+                .onFocusChanged { isMoreButtonFocused = it.hasFocus }
                 .then(if (episodeFocusRequester != null) Modifier.focusProperties { left = episodeFocusRequester } else Modifier)
                 .focusRequester(moreButtonFocusRequester),
         )
@@ -84,7 +93,13 @@ private fun MoreButtonSlot(
             enter = fadeIn(tween(MORE_BUTTON_ANIMATION_DURATION_MS)),
             exit = fadeOut(tween(MORE_BUTTON_ANIMATION_DURATION_MS)),
         ) {
-            TvMoreButton(onClick = onClick)
+            TvMoreButton(
+                onClick = onClick,
+                colors = TvButtonDefaults.iconButtonColors(
+                    containerColor = Color.Transparent,
+                    contentColor = MaterialTheme.tvColors.textPrimaryActive,
+                ),
+            )
         }
     }
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeListItem.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeListItem.kt
@@ -5,7 +5,6 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -34,38 +33,38 @@ fun TvEpisodeListItem(
     episodeFocusRequester: FocusRequester? = null,
     leftFocusRequester: FocusRequester? = null,
 ) {
-    TvEpisodeListItemContainer(
-        onOpenActions = onOpenActions,
-        modifier = modifier,
-    ) { rowModifier ->
-        TvEpisodeRow(
-            episode = episode,
-            onClick = onClick,
-            dateFormatter = dateFormatter,
-            modifier = rowModifier
-                .then(if (leftFocusRequester != null) Modifier.focusProperties { left = leftFocusRequester } else Modifier)
-                .then(if (episodeFocusRequester != null) Modifier.focusRequester(episodeFocusRequester) else Modifier),
-        )
-    }
-}
-
-@Composable
-fun TvEpisodeListItemContainer(
-    onOpenActions: () -> Unit,
-    modifier: Modifier = Modifier,
-    content: @Composable (Modifier) -> Unit,
-) {
     var isItemFocused by remember { mutableStateOf(false) }
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
+    val moreButtonFocusRequester = remember { FocusRequester() }
+    Box(
         modifier = modifier
             .fillMaxWidth()
             .onFocusChanged { isItemFocused = it.hasFocus },
     ) {
-        content(Modifier.weight(1f))
+        TvEpisodeRow(
+            episode = episode,
+            onClick = onClick,
+            dateFormatter = dateFormatter,
+            contentEndPadding = MoreButtonReservedWidth,
+            modifier = Modifier
+                .fillMaxWidth()
+                .focusProperties {
+                    if (isItemFocused) {
+                        right = moreButtonFocusRequester
+                    }
+                    if (leftFocusRequester != null) {
+                        left = leftFocusRequester
+                    }
+                }
+                .then(if (episodeFocusRequester != null) Modifier.focusRequester(episodeFocusRequester) else Modifier),
+        )
         MoreButtonSlot(
             visible = isItemFocused,
             onClick = onOpenActions,
+            modifier = Modifier
+                .align(Alignment.CenterEnd)
+                .padding(end = MoreButtonEndInset)
+                .then(if (episodeFocusRequester != null) Modifier.focusProperties { left = episodeFocusRequester } else Modifier)
+                .focusRequester(moreButtonFocusRequester),
         )
     }
 }
@@ -74,12 +73,11 @@ fun TvEpisodeListItemContainer(
 private fun MoreButtonSlot(
     visible: Boolean,
     onClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     Box(
         contentAlignment = Alignment.Center,
-        modifier = Modifier
-            .padding(start = 12.dp)
-            .size(TvMoreButtonSize),
+        modifier = modifier.size(TvMoreButtonSize),
     ) {
         AnimatedVisibility(
             visible = visible,
@@ -92,3 +90,5 @@ private fun MoreButtonSlot(
 }
 
 private const val MORE_BUTTON_ANIMATION_DURATION_MS = 200
+private val MoreButtonEndInset = 16.dp
+private val MoreButtonReservedWidth = TvMoreButtonSize + 16.dp

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeListItem.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeListItem.kt
@@ -4,11 +4,13 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -16,13 +18,26 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.tv.material3.Icon
+import androidx.tv.material3.MaterialTheme
 import au.com.shiftyjelly.pocketcasts.localization.helper.RelativeDateFormatter
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.theme.tvColors
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 fun TvEpisodeListItem(
@@ -35,7 +50,6 @@ fun TvEpisodeListItem(
     leftFocusRequester: FocusRequester? = null,
 ) {
     TvEpisodeListItemContainer(
-        onOpenActions = onOpenActions,
         modifier = modifier,
     ) { rowModifier ->
         TvEpisodeRow(
@@ -44,14 +58,21 @@ fun TvEpisodeListItem(
             dateFormatter = dateFormatter,
             modifier = rowModifier
                 .then(if (leftFocusRequester != null) Modifier.focusProperties { left = leftFocusRequester } else Modifier)
-                .then(if (episodeFocusRequester != null) Modifier.focusRequester(episodeFocusRequester) else Modifier),
+                .then(if (episodeFocusRequester != null) Modifier.focusRequester(episodeFocusRequester) else Modifier)
+                .onPreviewKeyEvent { event ->
+                    if (event.type == KeyEventType.KeyDown && event.key == Key.DirectionRight) {
+                        onOpenActions()
+                        true
+                    } else {
+                        false
+                    }
+                },
         )
     }
 }
 
 @Composable
 fun TvEpisodeListItemContainer(
-    onOpenActions: () -> Unit,
     modifier: Modifier = Modifier,
     content: @Composable (Modifier) -> Unit,
 ) {
@@ -63,18 +84,12 @@ fun TvEpisodeListItemContainer(
             .onFocusChanged { isItemFocused = it.hasFocus },
     ) {
         content(Modifier.weight(1f))
-        MoreButtonSlot(
-            visible = isItemFocused,
-            onClick = onOpenActions,
-        )
+        MoreButtonHint(visible = isItemFocused)
     }
 }
 
 @Composable
-private fun MoreButtonSlot(
-    visible: Boolean,
-    onClick: () -> Unit,
-) {
+private fun MoreButtonHint(visible: Boolean) {
     Box(
         contentAlignment = Alignment.Center,
         modifier = Modifier
@@ -86,7 +101,20 @@ private fun MoreButtonSlot(
             enter = fadeIn(tween(MORE_BUTTON_ANIMATION_DURATION_MS)),
             exit = fadeOut(tween(MORE_BUTTON_ANIMATION_DURATION_MS)),
         ) {
-            TvMoreButton(onClick = onClick)
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier
+                    .size(TvMoreButtonSize)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.tvColors.backgroundActive20),
+            ) {
+                Icon(
+                    painter = painterResource(IR.drawable.ic_ellipsis_horizontal),
+                    contentDescription = stringResource(LR.string.more_options),
+                    tint = MaterialTheme.tvColors.textPrimary,
+                    modifier = Modifier.size(15.dp),
+                )
+            }
         }
     }
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeListItem.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeListItem.kt
@@ -4,9 +4,8 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -21,14 +20,9 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.zIndex
-import androidx.tv.material3.MaterialTheme
 import au.com.shiftyjelly.pocketcasts.localization.helper.RelativeDateFormatter
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
-import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
-import au.com.shiftyjelly.pocketcasts.theme.tvColors
 
 @Composable
 fun TvEpisodeListItem(
@@ -40,40 +34,38 @@ fun TvEpisodeListItem(
     episodeFocusRequester: FocusRequester? = null,
     leftFocusRequester: FocusRequester? = null,
 ) {
-    val rowInteractionSource = remember { MutableInteractionSource() }
-    val isRowFocused by rowInteractionSource.collectIsFocusedAsState()
-    var isMoreButtonFocused by remember { mutableStateOf(false) }
-    val moreButtonFocusRequester = remember { FocusRequester() }
-    val showMoreButton = isRowFocused || isMoreButtonFocused
-    Box(modifier = modifier.fillMaxWidth()) {
+    TvEpisodeListItemContainer(
+        onOpenActions = onOpenActions,
+        modifier = modifier,
+    ) { rowModifier ->
         TvEpisodeRow(
             episode = episode,
             onClick = onClick,
             dateFormatter = dateFormatter,
-            contentEndPadding = MoreButtonReservedWidth,
-            interactionSource = rowInteractionSource,
-            modifier = Modifier
-                .fillMaxWidth()
-                .focusProperties {
-                    if (showMoreButton) {
-                        right = moreButtonFocusRequester
-                    }
-                    if (leftFocusRequester != null) {
-                        left = leftFocusRequester
-                    }
-                }
+            modifier = rowModifier
+                .then(if (leftFocusRequester != null) Modifier.focusProperties { left = leftFocusRequester } else Modifier)
                 .then(if (episodeFocusRequester != null) Modifier.focusRequester(episodeFocusRequester) else Modifier),
         )
+    }
+}
+
+@Composable
+fun TvEpisodeListItemContainer(
+    onOpenActions: () -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable (Modifier) -> Unit,
+) {
+    var isItemFocused by remember { mutableStateOf(false) }
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier
+            .fillMaxWidth()
+            .onFocusChanged { isItemFocused = it.hasFocus },
+    ) {
+        content(Modifier.weight(1f))
         MoreButtonSlot(
-            visible = showMoreButton,
+            visible = isItemFocused,
             onClick = onOpenActions,
-            modifier = Modifier
-                .align(Alignment.CenterEnd)
-                .zIndex(1f)
-                .padding(end = MoreButtonEndInset)
-                .onFocusChanged { isMoreButtonFocused = it.hasFocus }
-                .then(if (episodeFocusRequester != null) Modifier.focusProperties { left = episodeFocusRequester } else Modifier)
-                .focusRequester(moreButtonFocusRequester),
         )
     }
 }
@@ -82,28 +74,21 @@ fun TvEpisodeListItem(
 private fun MoreButtonSlot(
     visible: Boolean,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier,
 ) {
     Box(
         contentAlignment = Alignment.Center,
-        modifier = modifier.size(TvMoreButtonSize),
+        modifier = Modifier
+            .padding(start = 12.dp)
+            .size(TvMoreButtonSize),
     ) {
         AnimatedVisibility(
             visible = visible,
             enter = fadeIn(tween(MORE_BUTTON_ANIMATION_DURATION_MS)),
             exit = fadeOut(tween(MORE_BUTTON_ANIMATION_DURATION_MS)),
         ) {
-            TvMoreButton(
-                onClick = onClick,
-                colors = TvButtonDefaults.iconButtonColors(
-                    containerColor = Color.Transparent,
-                    contentColor = MaterialTheme.tvColors.textPrimaryActive,
-                ),
-            )
+            TvMoreButton(onClick = onClick)
         }
     }
 }
 
 private const val MORE_BUTTON_ANIMATION_DURATION_MS = 200
-private val MoreButtonEndInset = 16.dp
-private val MoreButtonReservedWidth = TvMoreButtonSize + 16.dp

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeListItem.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeListItem.kt
@@ -4,13 +4,11 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -18,26 +16,17 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
-import androidx.compose.ui.input.key.Key
-import androidx.compose.ui.input.key.KeyEventType
-import androidx.compose.ui.input.key.key
-import androidx.compose.ui.input.key.onPreviewKeyEvent
-import androidx.compose.ui.input.key.type
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.relocation.BringIntoViewModifierNode
 import androidx.compose.ui.unit.dp
-import androidx.tv.material3.Icon
-import androidx.tv.material3.MaterialTheme
 import au.com.shiftyjelly.pocketcasts.localization.helper.RelativeDateFormatter
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
-import au.com.shiftyjelly.pocketcasts.theme.tvColors
-import au.com.shiftyjelly.pocketcasts.images.R as IR
-import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 fun TvEpisodeListItem(
@@ -50,6 +39,7 @@ fun TvEpisodeListItem(
     leftFocusRequester: FocusRequester? = null,
 ) {
     TvEpisodeListItemContainer(
+        onOpenActions = onOpenActions,
         modifier = modifier,
     ) { rowModifier ->
         TvEpisodeRow(
@@ -58,21 +48,14 @@ fun TvEpisodeListItem(
             dateFormatter = dateFormatter,
             modifier = rowModifier
                 .then(if (leftFocusRequester != null) Modifier.focusProperties { left = leftFocusRequester } else Modifier)
-                .then(if (episodeFocusRequester != null) Modifier.focusRequester(episodeFocusRequester) else Modifier)
-                .onPreviewKeyEvent { event ->
-                    if (event.type == KeyEventType.KeyDown && event.key == Key.DirectionRight) {
-                        onOpenActions()
-                        true
-                    } else {
-                        false
-                    }
-                },
+                .then(if (episodeFocusRequester != null) Modifier.focusRequester(episodeFocusRequester) else Modifier),
         )
     }
 }
 
 @Composable
 fun TvEpisodeListItemContainer(
+    onOpenActions: () -> Unit,
     modifier: Modifier = Modifier,
     content: @Composable (Modifier) -> Unit,
 ) {
@@ -84,39 +67,49 @@ fun TvEpisodeListItemContainer(
             .onFocusChanged { isItemFocused = it.hasFocus },
     ) {
         content(Modifier.weight(1f))
-        MoreButtonHint(visible = isItemFocused)
+        MoreButtonSlot(
+            visible = isItemFocused,
+            onClick = onOpenActions,
+        )
     }
 }
 
 @Composable
-private fun MoreButtonHint(visible: Boolean) {
+private fun MoreButtonSlot(
+    visible: Boolean,
+    onClick: () -> Unit,
+) {
     Box(
         contentAlignment = Alignment.Center,
         modifier = Modifier
             .padding(start = 12.dp)
-            .size(TvMoreButtonSize),
+            .size(TvMoreButtonSize)
+            .then(ConsumeBringIntoViewElement),
     ) {
         AnimatedVisibility(
             visible = visible,
             enter = fadeIn(tween(MORE_BUTTON_ANIMATION_DURATION_MS)),
             exit = fadeOut(tween(MORE_BUTTON_ANIMATION_DURATION_MS)),
         ) {
-            Box(
-                contentAlignment = Alignment.Center,
-                modifier = Modifier
-                    .size(TvMoreButtonSize)
-                    .clip(CircleShape)
-                    .background(MaterialTheme.tvColors.backgroundActive20),
-            ) {
-                Icon(
-                    painter = painterResource(IR.drawable.ic_ellipsis_horizontal),
-                    contentDescription = stringResource(LR.string.more_options),
-                    tint = MaterialTheme.tvColors.textPrimary,
-                    modifier = Modifier.size(15.dp),
-                )
-            }
+            TvMoreButton(onClick = onClick)
         }
     }
 }
 
 private const val MORE_BUTTON_ANIMATION_DURATION_MS = 200
+
+private object ConsumeBringIntoViewElement : ModifierNodeElement<ConsumeBringIntoViewNode>() {
+    override fun create() = ConsumeBringIntoViewNode()
+
+    override fun update(node: ConsumeBringIntoViewNode) = Unit
+
+    override fun hashCode() = 0
+
+    override fun equals(other: Any?) = other is ConsumeBringIntoViewElement
+}
+
+private class ConsumeBringIntoViewNode :
+    Modifier.Node(),
+    BringIntoViewModifierNode {
+    override suspend fun bringIntoView(childCoordinates: LayoutCoordinates, boundsProvider: () -> Rect?) = Unit
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeRow.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeRow.kt
@@ -54,14 +54,12 @@ val LocalUseEpisodeArtwork = staticCompositionLocalOf { false }
 fun TvEpisodeRow(
     episode: PodcastEpisode,
     onClick: () -> Unit,
+    onLongClick: (() -> Unit)? = null,
     dateFormatter: RelativeDateFormatter,
     modifier: Modifier = Modifier,
-    onLongClick: (() -> Unit)? = null,
-    contentEndPadding: Dp = 0.dp,
-    interactionSource: MutableInteractionSource? = null,
 ) {
-    val resolvedInteractionSource = interactionSource ?: remember { MutableInteractionSource() }
-    val isFocused by resolvedInteractionSource.collectIsFocusedAsState()
+    val interactionSource = remember { MutableInteractionSource() }
+    val isFocused by interactionSource.collectIsFocusedAsState()
     val titleColor = if (isFocused) MaterialTheme.tvColors.textPrimaryActive else MaterialTheme.tvColors.textPrimary
     val captionColor = if (isFocused) {
         MaterialTheme.tvColors.textSecondaryActive
@@ -78,7 +76,7 @@ fun TvEpisodeRow(
             containerColor = MaterialTheme.tvColors.backgroundBase,
             focusedContainerColor = MaterialTheme.tvColors.backgroundActive,
         ),
-        interactionSource = resolvedInteractionSource,
+        interactionSource = interactionSource,
         modifier = modifier.alpha(if (episode.isArchived && !isFocused) 0.3f else 1f),
     ) {
         Row(
@@ -86,7 +84,7 @@ fun TvEpisodeRow(
             horizontalArrangement = Arrangement.spacedBy(12.dp),
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(start = 16.dp, top = 16.dp, end = 16.dp + contentEndPadding, bottom = 16.dp),
+                .padding(16.dp),
         ) {
             EpisodeArtwork(episode = episode)
             Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeRow.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeRow.kt
@@ -54,9 +54,10 @@ val LocalUseEpisodeArtwork = staticCompositionLocalOf { false }
 fun TvEpisodeRow(
     episode: PodcastEpisode,
     onClick: () -> Unit,
-    onLongClick: (() -> Unit)? = null,
     dateFormatter: RelativeDateFormatter,
     modifier: Modifier = Modifier,
+    onLongClick: (() -> Unit)? = null,
+    contentEndPadding: Dp = 0.dp,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     val isFocused by interactionSource.collectIsFocusedAsState()
@@ -84,7 +85,7 @@ fun TvEpisodeRow(
             horizontalArrangement = Arrangement.spacedBy(12.dp),
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(16.dp),
+                .padding(start = 16.dp, top = 16.dp, end = 16.dp + contentEndPadding, bottom = 16.dp),
         ) {
             EpisodeArtwork(episode = episode)
             Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeRow.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeRow.kt
@@ -54,12 +54,16 @@ val LocalUseEpisodeArtwork = staticCompositionLocalOf { false }
 fun TvEpisodeRow(
     episode: PodcastEpisode,
     onClick: () -> Unit,
-    onLongClick: (() -> Unit)? = null,
     dateFormatter: RelativeDateFormatter,
     modifier: Modifier = Modifier,
+    onLongClick: (() -> Unit)? = null,
+    isRowFocused: Boolean = false,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
-    val isFocused by interactionSource.collectIsFocusedAsState()
+    val isTileFocused by interactionSource.collectIsFocusedAsState()
+    // Focus can sit on a sibling control (e.g. the "…" button) that logically belongs to this row,
+    // so keep the row lit for that too rather than fading it back to its resting appearance.
+    val isFocused = isTileFocused || isRowFocused
     val titleColor = if (isFocused) MaterialTheme.tvColors.textPrimaryActive else MaterialTheme.tvColors.textPrimary
     val captionColor = if (isFocused) {
         MaterialTheme.tvColors.textSecondaryActive
@@ -73,7 +77,11 @@ fun TvEpisodeRow(
         scale = CardDefaults.scale(focusedScale = TvFocusedWideCardScale),
         shape = CardDefaults.shape(RoundedCornerShape(8.dp)),
         colors = CardDefaults.colors(
-            containerColor = MaterialTheme.tvColors.backgroundBase,
+            containerColor = if (isRowFocused) {
+                MaterialTheme.tvColors.backgroundActive
+            } else {
+                MaterialTheme.tvColors.backgroundBase
+            },
             focusedContainerColor = MaterialTheme.tvColors.backgroundActive,
         ),
         interactionSource = interactionSource,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeRow.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeRow.kt
@@ -58,9 +58,10 @@ fun TvEpisodeRow(
     modifier: Modifier = Modifier,
     onLongClick: (() -> Unit)? = null,
     contentEndPadding: Dp = 0.dp,
+    interactionSource: MutableInteractionSource? = null,
 ) {
-    val interactionSource = remember { MutableInteractionSource() }
-    val isFocused by interactionSource.collectIsFocusedAsState()
+    val resolvedInteractionSource = interactionSource ?: remember { MutableInteractionSource() }
+    val isFocused by resolvedInteractionSource.collectIsFocusedAsState()
     val titleColor = if (isFocused) MaterialTheme.tvColors.textPrimaryActive else MaterialTheme.tvColors.textPrimary
     val captionColor = if (isFocused) {
         MaterialTheme.tvColors.textSecondaryActive
@@ -77,7 +78,7 @@ fun TvEpisodeRow(
             containerColor = MaterialTheme.tvColors.backgroundBase,
             focusedContainerColor = MaterialTheme.tvColors.backgroundActive,
         ),
-        interactionSource = interactionSource,
+        interactionSource = resolvedInteractionSource,
         modifier = modifier.alpha(if (episode.isArchived && !isFocused) 0.3f else 1f),
     ) {
         Row(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastGridScaffold.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastGridScaffold.kt
@@ -92,7 +92,9 @@ internal fun TvPodcastGridScaffold(
             verticalArrangement = Arrangement.spacedBy(TvTileSpacing),
             contentPadding = PaddingValues(
                 start = horizontalContentPadding,
-                top = 20.dp,
+                // A scrolling title sits inside the grid and carries its own top padding, so it
+                // aligns with the other screens; a fixed title needs a gap above the first row.
+                top = if (titleScrolls) 0.dp else 20.dp,
                 end = horizontalContentPadding,
                 bottom = 32.dp,
             ),

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastGridScaffold.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvPodcastGridScaffold.kt
@@ -42,13 +42,15 @@ internal fun TvPodcastGridScaffold(
     autoFocusFirstItem: Boolean = false,
     restoreFocusTrigger: Int = 0,
     scrollsTopBar: Boolean = false,
+    scrollsTitle: Boolean = false,
     itemContent: @Composable (index: Int, itemModifier: Modifier) -> Unit,
 ) {
-    val headerCount = if (scrollsTopBar && title != null) 1 else 0
+    val titleScrolls = scrollsTopBar || scrollsTitle
+    val headerCount = if (title != null && titleScrolls) 1 else 0
     val gridModifier = if (scrollsTopBar) Modifier.scrollAwayTopBar() else Modifier
 
     Column(modifier = modifier) {
-        if (title != null && !scrollsTopBar) {
+        if (title != null && !titleScrolls) {
             Text(
                 text = title,
                 style = MaterialTheme.tvTypography.title2,
@@ -107,7 +109,7 @@ internal fun TvPodcastGridScaffold(
                     }
                 },
         ) {
-            if (scrollsTopBar && title != null) {
+            if (titleScrolls && title != null) {
                 item(span = { GridItemSpan(maxLineSpan) }) {
                     Text(
                         text = title,

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsScreen.kt
@@ -52,7 +52,6 @@ import au.com.shiftyjelly.pocketcasts.component.TvDetailOverlay
 import au.com.shiftyjelly.pocketcasts.component.TvEmptyState
 import au.com.shiftyjelly.pocketcasts.component.TvPlaylistCard
 import au.com.shiftyjelly.pocketcasts.component.TvPlaylistCardColors
-import au.com.shiftyjelly.pocketcasts.component.scrollAwayTopBar
 import au.com.shiftyjelly.pocketcasts.component.tvFocusInactiveWhen
 import au.com.shiftyjelly.pocketcasts.compose.loading.LoadingView
 import au.com.shiftyjelly.pocketcasts.models.to.PlaylistIcon
@@ -239,7 +238,7 @@ private fun TvPlaylistsGrid(
             verticalArrangement = Arrangement.spacedBy(12.dp),
             contentPadding = PaddingValues(bottom = 32.dp),
             modifier = Modifier
-                .scrollAwayTopBar()
+                .padding(top = TvTopBarHeight)
                 .focusRequester(gridFocusRequester)
                 .focusGroup()
                 .focusProperties {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvPlaylistsScreen.kt
@@ -47,7 +47,6 @@ import androidx.tv.material3.Button
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.component.ScrollToTopEffect
-import au.com.shiftyjelly.pocketcasts.component.TopBarScrollReporter
 import au.com.shiftyjelly.pocketcasts.component.TvDetailOverlay
 import au.com.shiftyjelly.pocketcasts.component.TvEmptyState
 import au.com.shiftyjelly.pocketcasts.component.TvPlaylistCard
@@ -218,7 +217,6 @@ private fun TvPlaylistsGrid(
         val gridFocusRequester = remember { FocusRequester() }
         val gridState = rememberLazyGridState()
         ScrollToTopEffect { gridState.scrollToItem(0) }
-        TopBarScrollReporter(gridState)
 
         var isInitialComposition by remember { mutableStateOf(true) }
         LaunchedEffect(restoreFocusTrigger) {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
@@ -312,7 +312,7 @@ private fun EpisodeList(
 ) {
     val context = LocalContext.current
     val dateFormatter = remember(context) { RelativeDateFormatter(context) }
-    val focus = rememberTvEpisodeListFocus(episodes, listState, requestInitialFocus = true)
+    val focus = rememberTvEpisodeListFocus(episodes, listState, requestInitialFocus = true, leadingItemCount = 1)
     var actionsEpisode by remember { mutableStateOf<PodcastEpisode?>(null) }
     var detailsEpisode by remember { mutableStateOf<PodcastEpisode?>(null) }
     LazyColumn(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
@@ -237,32 +238,33 @@ private fun SortableEpisodeList(
     val isManual = uiState.playlist.type == Playlist.Type.Manual
     val leftFocusRequester = playAllFocusRequester.takeIf { uiState.episodes.isNotEmpty() }
     Column(modifier = modifier) {
-        Row(
-            horizontalArrangement = Arrangement.spacedBy(9.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier
-                .align(Alignment.End)
-                .padding(bottom = 9.dp),
-        ) {
-            if (isManual) {
-                TvArchivedFilterButton(
-                    isShowingArchived = uiState.isShowingArchivedOnDevice,
-                    onToggleArchiveFilter = onToggleArchiveFilter,
-                    leftFocusRequester = leftFocusRequester,
+        val header: @Composable (Modifier) -> Unit = { headerModifier ->
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(9.dp, Alignment.End),
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = headerModifier.fillMaxWidth(),
+            ) {
+                if (isManual) {
+                    TvArchivedFilterButton(
+                        isShowingArchived = uiState.isShowingArchivedOnDevice,
+                        onToggleArchiveFilter = onToggleArchiveFilter,
+                        leftFocusRequester = leftFocusRequester,
+                    )
+                }
+                TvSortButton(
+                    selected = sortType,
+                    options = uiState.playlist.availableSortTypes,
+                    label = { it.displayLabel() },
+                    onSelect = onChangeSortType,
+                    onExpand = onSortTap,
+                    leftFocusRequester = if (isManual) null else leftFocusRequester,
                 )
             }
-            TvSortButton(
-                selected = sortType,
-                options = uiState.playlist.availableSortTypes,
-                label = { it.displayLabel() },
-                onSelect = onChangeSortType,
-                onExpand = onSortTap,
-                leftFocusRequester = if (isManual) null else leftFocusRequester,
-            )
         }
         if (uiState.episodes.isNotEmpty()) {
             EpisodeList(
                 episodes = uiState.episodes,
+                header = header,
                 onOpenPodcast = onOpenPodcast,
                 onPlayEpisode = onPlayEpisode,
                 playAllFocusRequester = playAllFocusRequester,
@@ -270,6 +272,7 @@ private fun SortableEpisodeList(
                 modifier = Modifier.weight(1f),
             )
         } else {
+            header(Modifier.padding(bottom = 9.dp))
             AllEpisodesArchived(
                 episodeCount = uiState.availableEpisodeCount,
                 modifier = Modifier.weight(1f).fillMaxWidth(),
@@ -300,6 +303,7 @@ private fun AllEpisodesArchived(
 @Composable
 private fun EpisodeList(
     episodes: List<PodcastEpisode>,
+    header: @Composable (Modifier) -> Unit,
     onOpenPodcast: (String) -> Unit,
     onPlayEpisode: (PodcastEpisode) -> Unit,
     playAllFocusRequester: FocusRequester,
@@ -314,8 +318,12 @@ private fun EpisodeList(
     LazyColumn(
         state = listState,
         verticalArrangement = Arrangement.spacedBy(9.dp),
+        contentPadding = PaddingValues(top = 8.dp, end = 8.dp, bottom = 24.dp),
         modifier = modifier,
     ) {
+        item(key = "sort-filter-header") {
+            header(Modifier)
+        }
         itemsIndexed(
             items = episodes,
             key = { _, episode -> episode.uuid },

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvFolderDetailScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvFolderDetailScreen.kt
@@ -103,6 +103,7 @@ private fun TvFolderDetailContent(
                 itemKeys = state.podcasts.map(Podcast::uuid),
                 autoFocusFirstItem = true,
                 restoreFocusTrigger = restoreFocusTrigger,
+                scrollsTitle = true,
                 modifier = Modifier.fillMaxSize(),
             ) { index, itemModifier ->
                 val podcast = state.podcasts[index]

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
@@ -321,32 +321,14 @@ private fun EpisodeList(
     var actionsEpisode by remember { mutableStateOf<PodcastEpisode?>(null) }
     var detailsEpisode by remember { mutableStateOf<PodcastEpisode?>(null) }
     Column(modifier = modifier) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(bottom = 12.dp),
-        ) {
-            Text(
-                text = stringResource(LR.string.search_results_all_episodes),
-                style = MaterialTheme.tvTypography.title3,
-                color = MaterialTheme.tvColors.textPrimary,
-                modifier = Modifier.weight(1f),
-            )
-            TvArchivedFilterButton(
+        if (episodes.isEmpty()) {
+            EpisodeListHeader(
+                podcast = podcast,
                 isShowingArchived = isShowingArchived,
+                onChangeSortType = onChangeSortType,
                 onToggleArchiveFilter = onToggleArchiveFilter,
                 leftFocusRequester = leftFocusRequester,
             )
-            Spacer(Modifier.width(12.dp))
-            TvSortButton(
-                selected = podcast.episodesSortType,
-                options = PodcastSortOptions,
-                label = { it.displayLabel() },
-                onSelect = onChangeSortType,
-            )
-        }
-        if (episodes.isEmpty()) {
             AllEpisodesArchived(
                 episodeCount = archivedEpisodeCount,
                 modifier = Modifier.weight(1f).fillMaxWidth(),
@@ -357,6 +339,15 @@ private fun EpisodeList(
                 verticalArrangement = Arrangement.spacedBy(8.dp),
                 modifier = Modifier.weight(1f),
             ) {
+                item(key = "episode-list-header") {
+                    EpisodeListHeader(
+                        podcast = podcast,
+                        isShowingArchived = isShowingArchived,
+                        onChangeSortType = onChangeSortType,
+                        onToggleArchiveFilter = onToggleArchiveFilter,
+                        leftFocusRequester = leftFocusRequester,
+                    )
+                }
                 itemsIndexed(
                     items = episodes,
                     key = { _, episode -> episode.uuid },
@@ -392,6 +383,42 @@ private fun EpisodeList(
             episode = episode,
             actionContext = TvEpisodeActionContext.PodcastDetails,
             onDismissRequest = { detailsEpisode = null },
+        )
+    }
+}
+
+@Composable
+private fun EpisodeListHeader(
+    podcast: Podcast,
+    isShowingArchived: Boolean,
+    onChangeSortType: (EpisodesSortType) -> Unit,
+    onToggleArchiveFilter: () -> Unit,
+    leftFocusRequester: FocusRequester,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(bottom = 12.dp),
+    ) {
+        Text(
+            text = stringResource(LR.string.search_results_all_episodes),
+            style = MaterialTheme.tvTypography.title3,
+            color = MaterialTheme.tvColors.textPrimary,
+            modifier = Modifier.weight(1f),
+        )
+        TvArchivedFilterButton(
+            isShowingArchived = isShowingArchived,
+            onToggleArchiveFilter = onToggleArchiveFilter,
+            leftFocusRequester = leftFocusRequester,
+        )
+        Spacer(Modifier.width(12.dp))
+        TvSortButton(
+            selected = podcast.episodesSortType,
+            options = PodcastSortOptions,
+            label = { it.displayLabel() },
+            onSelect = onChangeSortType,
         )
     }
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -337,6 +338,7 @@ private fun EpisodeList(
             LazyColumn(
                 state = listState,
                 verticalArrangement = Arrangement.spacedBy(8.dp),
+                contentPadding = PaddingValues(top = 8.dp, end = 8.dp, bottom = 24.dp),
                 modifier = Modifier.weight(1f),
             ) {
                 item(key = "episode-list-header") {

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
@@ -445,7 +445,7 @@ private fun AllEpisodesArchived(
 }
 
 private const val INFO_PANE_WEIGHT = 0.35f
-private val DetailsTopPadding = 56.dp
+private val DetailsTopPadding = 12.dp
 private val CoverGlowSize = 460.dp
 private val CoverGlowOffset = (-140).dp
 private val CoverGlowBlurRadius = 80.dp

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
@@ -263,6 +263,8 @@ private fun PodcastInfo(
                 text = podcast.title,
                 style = MaterialTheme.tvTypography.title2,
                 color = MaterialTheme.tvColors.textPrimary,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
             )
             if (podcast.podcastDescription.isNotBlank()) {
                 Text(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.Button
+import androidx.tv.material3.ButtonDefaults
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
@@ -280,6 +281,7 @@ private fun PodcastInfo(
             Button(
                 onClick = onFollow,
                 colors = TvButtonDefaults.filledButtonColors(),
+                scale = ButtonDefaults.scale(focusedScale = 1f),
                 modifier = Modifier
                     .focusRequester(followFocusRequester)
                     .animateContentSize(),
@@ -289,6 +291,7 @@ private fun PodcastInfo(
             Button(
                 onClick = onMoreInfo,
                 colors = TvButtonDefaults.filledButtonColors(),
+                scale = ButtonDefaults.scale(focusedScale = 1f),
             ) {
                 Text(stringResource(LR.string.tv_podcast_more_info))
             }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsScreen.kt
@@ -48,7 +48,6 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.Button
-import androidx.tv.material3.ButtonDefaults
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
@@ -282,7 +281,7 @@ private fun PodcastInfo(
             Button(
                 onClick = onFollow,
                 colors = TvButtonDefaults.filledButtonColors(),
-                scale = ButtonDefaults.scale(focusedScale = 1f),
+                scale = TvButtonDefaults.noScale(),
                 modifier = Modifier
                     .focusRequester(followFocusRequester)
                     .animateContentSize(),
@@ -292,7 +291,7 @@ private fun PodcastInfo(
             Button(
                 onClick = onMoreInfo,
                 colors = TvButtonDefaults.filledButtonColors(),
-                scale = ButtonDefaults.scale(focusedScale = 1f),
+                scale = TvButtonDefaults.noScale(),
             ) {
                 Text(stringResource(LR.string.tv_podcast_more_info))
             }
@@ -315,7 +314,7 @@ private fun EpisodeList(
     val context = LocalContext.current
     val dateFormatter = remember(context) { RelativeDateFormatter(context) }
     val listState = rememberLazyListState()
-    val focus = rememberTvEpisodeListFocus(episodes, listState, requestInitialFocus = true)
+    val focus = rememberTvEpisodeListFocus(episodes, listState, requestInitialFocus = true, leadingItemCount = 1)
     LaunchedEffect(podcast.episodesSortType) {
         listState.scrollToItem(0)
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvButtonDefaults.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvButtonDefaults.kt
@@ -6,10 +6,14 @@ import androidx.tv.material3.Border
 import androidx.tv.material3.ButtonBorder
 import androidx.tv.material3.ButtonColors
 import androidx.tv.material3.ButtonDefaults
+import androidx.tv.material3.ButtonScale
 import androidx.tv.material3.IconButtonDefaults
 import androidx.tv.material3.MaterialTheme
 
 object TvButtonDefaults {
+
+    /** Keeps a button the same size on focus, so buttons near the safe-area edge don't grow into it. */
+    fun noScale(): ButtonScale = ButtonDefaults.scale(focusedScale = 1f)
 
     @Composable
     fun filledButtonColors(): ButtonColors = ButtonDefaults.colors(


### PR DESCRIPTION
## Description

Some small polish fixes across the TV podcast, playlist and folder screens:

- The podcast title now stays to two lines so it doesn't push the Follow / More info buttons down, and those buttons no longer grow past the screen edge when they're focused.
- The "All episodes" heading and the sort / filter controls scroll away with the list now instead of staying pinned at the top — on both the podcast and playlist screens. The folder name scrolls with its grid too.
- Moving focus onto an episode's "…" button no longer makes the list jump.
- The last row on the Playlists screen isn't cut off at the bottom anymore.
- Lined up the page titles ("Your Podcasts" sat a little lower than "Playlists" and "Up Next"), and gave the podcast screen the same top spacing as the playlist screen.

Fixes POC-894 https://linear.app/a8c/issue/POC-894/podcast-view-changes

## Testing Instructions

1. Open a podcast on a TV. The title wraps to two lines, and Follow / More info stay put and aren't clipped when focused.
2. Scroll the episode list — the "All episodes" heading and the sort / filter controls scroll away with it. Same on a playlist.
3. Focus an episode and move right onto its "…" — the list stays put, and selecting it opens the actions menu.
4. Open a folder and scroll — the folder name scrolls away with the grid.
5. Open Playlists and scroll to the bottom — the last row is fully visible.
6. Glance at the titles on Your Podcasts, Playlists and Up Next — they all sit at the same height.

## Screencast

https://github.com/user-attachments/assets/eb3380ce-fdb5-4ae2-a1f8-ea78f4345a07



## Checklist

- [ ] If this is a user-facing change, I added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply`)
- [x] I considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I updated the Event Horizon schema to reflect any new or changed analytics

#### I tested any UI changes...

- [ ] different themes
- [ ] landscape orientation
- [ ] device set to large display font size
- [ ] accessibility with TalkBack
