### PR TITLE
[TV] Scroll the search field away with results and stop clipping the last row

### DIFF
--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
@@ -314,6 +315,7 @@ private fun TvSearchContent(
 ) {
     val searchFieldFocusRequester = remember { FocusRequester() }
     val dropdownFocusRequester = remember { FocusRequester() }
+    val filtersFocusRequester = remember { FocusRequester() }
     var isEditing by remember { mutableStateOf(false) }
     var searchFieldFocused by remember { mutableStateOf(false) }
     var suggestionsFocused by remember { mutableStateOf(false) }
@@ -387,21 +389,34 @@ private fun TvSearchContent(
         val effectiveFilter = if (filter in filters) filter else TvSearchFilter.TopResults
 
         if (searchState !is TvSearchState.Idle) {
-            TvSearchFilters(
-                selected = effectiveFilter,
-                onFilterSelect = onFilterSelect,
-                filters = filters,
-                modifier = Modifier.padding(ContentPadding),
-                upFocusRequester = searchFieldFocusRequester,
-            )
-            Spacer(modifier = Modifier.height(18.dp))
+            Column(modifier = Modifier.collapseWithTopBar()) {
+                TvSearchFilters(
+                    selected = effectiveFilter,
+                    onFilterSelect = onFilterSelect,
+                    filters = filters,
+                    modifier = Modifier
+                        .padding(ContentPadding)
+                        .focusRequester(filtersFocusRequester)
+                        .focusGroup(),
+                    upFocusRequester = searchFieldFocusRequester,
+                )
+                Spacer(modifier = Modifier.height(18.dp))
+            }
         }
 
         Box(
             modifier = Modifier
                 .fillMaxWidth()
                 .weight(1f)
-                .onFocusChanged { resultsFocused = it.hasFocus },
+                .onFocusChanged { resultsFocused = it.hasFocus }
+                .focusProperties {
+                    onExit = {
+                        if (requestedFocusDirection == FocusDirection.Up) {
+                            filtersFocusRequester.requestFocus()
+                        }
+                    }
+                }
+                .focusGroup(),
         ) {
             when (searchState) {
                 is TvSearchState.Idle -> TvSearchIdle(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.search
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -35,6 +36,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -42,6 +44,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
@@ -52,6 +55,7 @@ import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.component.LocalOpenNowPlaying
+import au.com.shiftyjelly.pocketcasts.component.LocalTopBarScrollState
 import au.com.shiftyjelly.pocketcasts.component.LocalTvToastHostState
 import au.com.shiftyjelly.pocketcasts.component.ScrollToTopEffect
 import au.com.shiftyjelly.pocketcasts.component.TopBarScrollReporter
@@ -316,8 +320,23 @@ private fun TvSearchContent(
     var historyFocused by remember { mutableStateOf(false) }
     val showSuggestions = (isEditing || suggestionsFocused) && suggestions.isNotEmpty()
     val showHistory = (searchFieldFocused || historyFocused || isEditing) && !showSuggestions && query.isBlank() && history.isNotEmpty()
+
+    val topBarScroll = LocalTopBarScrollState.current
+    val barHeightPx = with(LocalDensity.current) { TvTopBarHeight.toPx() }
+    var resultsFocused by remember { mutableStateOf(false) }
+    val headerCollapse by animateFloatAsState(
+        targetValue = if (resultsFocused) barHeightPx else 0f,
+        label = "searchHeaderCollapse",
+    )
+    val isSearchActive = searchState !is TvSearchState.Idle
+    LaunchedEffect(isSearchActive) {
+        if (isSearchActive) {
+            snapshotFlow { headerCollapse }.collect { topBarScroll.offsetPx = it }
+        }
+    }
+
     Column(modifier = modifier.fillMaxSize().scrollAwayTopBar()) {
-        Column(modifier = Modifier.collapseWithTopBar(enabled = searchState is TvSearchState.Idle).padding(ContentPadding)) {
+        Column(modifier = Modifier.collapseWithTopBar().padding(ContentPadding)) {
             Spacer(modifier = Modifier.height(30.dp))
             TvSearchField(
                 query = query,
@@ -381,7 +400,8 @@ private fun TvSearchContent(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .weight(1f),
+                .weight(1f)
+                .onFocusChanged { resultsFocused = it.hasFocus },
         ) {
             when (searchState) {
                 is TvSearchState.Idle -> TvSearchIdle(
@@ -658,7 +678,6 @@ private fun TvSearchTopResults(
     val restoreFocusRequester = remember { FocusRequester() }
     val listState = rememberLazyListState()
     ScrollToTopEffect { listState.scrollToItem(0) }
-    TopBarScrollReporter(listState)
     var isInitialComposition by remember { mutableStateOf(true) }
     LaunchedEffect(restoreFocusTrigger) {
         if (isInitialComposition) {
@@ -778,7 +797,6 @@ private fun TvSearchEpisodeGrid(
 ) {
     val gridState = rememberLazyGridState()
     ScrollToTopEffect { gridState.scrollToItem(0) }
-    TopBarScrollReporter(gridState)
     val focusRequesters = remember(episodes.size) { List(episodes.size) { FocusRequester() } }
     val gridFocusRequester = remember { FocusRequester() }
     var lastFocusedKey by rememberSaveable { mutableStateOf<String?>(null) }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -325,16 +326,19 @@ private fun TvSearchContent(
 
     val topBarScroll = LocalTopBarScrollState.current
     val barHeightPx = with(LocalDensity.current) { TvTopBarHeight.toPx() }
+    val isSearchActive = searchState !is TvSearchState.Idle
     var resultsFocused by remember { mutableStateOf(false) }
     val headerCollapse by animateFloatAsState(
-        targetValue = if (resultsFocused) barHeightPx else 0f,
+        targetValue = if (resultsFocused && isSearchActive) barHeightPx else 0f,
         label = "searchHeaderCollapse",
     )
-    val isSearchActive = searchState !is TvSearchState.Idle
     LaunchedEffect(isSearchActive) {
         if (isSearchActive) {
             snapshotFlow { headerCollapse }.collect { topBarScroll.offsetPx = it }
         }
+    }
+    DisposableEffect(topBarScroll) {
+        onDispose { topBarScroll.offsetPx = 0f }
     }
 
     Column(modifier = modifier.fillMaxSize().scrollAwayTopBar()) {
@@ -411,8 +415,8 @@ private fun TvSearchContent(
                 .onFocusChanged { resultsFocused = it.hasFocus }
                 .focusProperties {
                     onExit = {
-                        if (requestedFocusDirection == FocusDirection.Up) {
-                            filtersFocusRequester.requestFocus()
+                        if (requestedFocusDirection == FocusDirection.Up && isSearchActive) {
+                            runCatching { filtersFocusRequester.requestFocus() }
                         }
                     }
                 }


### PR DESCRIPTION
## Description

On the TV Search screen, once you typed a query the search field and filter tabs stayed pinned while you scrolled down through the results, and the bottom row of each tab got cut off. With an empty query the header slid away fine, so the two cases were inconsistent.

Now the whole search header — the field, recent searches, and filter tabs — slides away as you move down into the results, so they fill the screen and nothing is clipped. Pressing up brings the filter tabs and the field back.

The header now collapses based on whether the results have focus, rather than on each list's scroll position (which never triggered for the podcast/folder grids or for short result sets).

Fixes POC-902 https://linear.app/a8c/issue/POC-902/search-screen-scroll-enhancements

## Testing Instructions

1. Open Search and type a query, e.g. "news".
2. Move down into the results — the field and filter tabs slide away and the last row is fully visible.
3. Press up from the first result — focus goes back to the filter tabs, then to the search field.
4. Press back — the list scrolls to the top and the header returns.

## Screenshots or Screencast
[search-focus.webm](https://github.com/user-attachments/assets/d954150e-51d5-47a9-9790-960353c8dcfb)


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md <!-- N/A: TV app is not tracked in CHANGELOG.md -->
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes <!-- Behaviour is focus/animation driven; covered by manual emulator testing -->
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml` <!-- No new strings -->
- [x] Any jetpack compose components I added or changed are covered by compose previews <!-- Existing TvSearchContent previews retained -->
- [x] I have updated (or requested that someone edit) the Event Horizon schema to reflect any new or changed analytics. <!-- No analytics change -->

#### I have tested any UI changes...
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
