### PR TITLE
[TV] Blur the screen behind modals and fade the backdrop out with them

### DIFF
--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionsModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvEpisodeActionsModal.kt
@@ -44,7 +44,7 @@ fun TvEpisodeActionsModal(
             episode = episode,
             actionContext = actionContext,
             actions = actions,
-            onDismissRequest = onDismissRequest,
+            onDismissRequest = { dismiss() },
             onShowEpisodeDetails = onShowEpisodeDetails,
             onGoToPodcast = onGoToPodcast,
         )

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvModal.kt
@@ -99,7 +99,8 @@ fun TvModal(
 private class TvModalScopeImpl(
     columnScope: ColumnScope,
     private val onDismiss: () -> Unit,
-) : TvModalScope, ColumnScope by columnScope {
+) : TvModalScope,
+    ColumnScope by columnScope {
     override fun dismiss() = onDismiss()
 }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvModal.kt
@@ -58,10 +58,8 @@ fun TvModal(
     val currentOnDismissRequest by rememberUpdatedState(onDismissRequest)
     val backdrop = LocalTvModalBackdrop.current
     val backdropKey = remember { Any() }
-    LaunchedEffect(visible) {
+    DisposableEffect(visible) {
         backdrop.setActive(backdropKey, visible)
-    }
-    DisposableEffect(Unit) {
         onDispose { backdrop.setActive(backdropKey, false) }
     }
     Dialog(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvModal.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.component
 
+import android.os.Build
 import android.view.WindowManager
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.MutableTransitionState
@@ -62,6 +63,9 @@ fun TvModal(
         backdrop.setActive(backdropKey, visible)
         onDispose { backdrop.setActive(backdropKey, false) }
     }
+    DisposableEffect(Unit) {
+        onDispose { backdrop.removePanel(backdropKey) }
+    }
     Dialog(
         onDismissRequest = { visible = false },
         properties = DialogProperties(usePlatformDefaultWidth = false),
@@ -82,11 +86,11 @@ fun TvModal(
                 scaleOut(tween(TvModalAnimationDurationMillis), targetScale = 0.92f),
         ) {
             TvModalSurface(
-                isTranslucent = true,
+                isTranslucent = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S,
                 width = width,
                 contentPadding = contentPadding,
                 modifier = modifier
-                    .onGloballyPositioned { backdrop.dialogSize = it.size }
+                    .onGloballyPositioned { backdrop.setSize(backdropKey, it.size) }
                     .onPreviewKeyEvent { visible.not() },
             ) {
                 val scope = remember(this) { TvModalScopeImpl(this) { visible = false } }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvModal.kt
@@ -1,6 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.component
 
-import android.os.Build
 import android.view.WindowManager
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.MutableTransitionState
@@ -33,6 +32,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -82,10 +82,12 @@ fun TvModal(
                 scaleOut(tween(TvModalAnimationDurationMillis), targetScale = 0.92f),
         ) {
             TvModalSurface(
-                isTranslucent = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S,
+                isTranslucent = true,
                 width = width,
                 contentPadding = contentPadding,
-                modifier = modifier.onPreviewKeyEvent { visible.not() },
+                modifier = modifier
+                    .onGloballyPositioned { backdrop.dialogSize = it.size }
+                    .onPreviewKeyEvent { visible.not() },
             ) {
                 val scope = remember(this) { TvModalScopeImpl(this) { visible = false } }
                 scope.content()

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvModal.kt
@@ -4,7 +4,6 @@ import android.os.Build
 import android.view.WindowManager
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.MutableTransitionState
-import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -23,7 +22,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
-import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -35,7 +33,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.onPreviewKeyEvent
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -44,7 +41,10 @@ import androidx.compose.ui.window.DialogProperties
 import androidx.compose.ui.window.DialogWindowProvider
 import androidx.tv.material3.MaterialTheme
 import au.com.shiftyjelly.pocketcasts.theme.tvColors
-import java.util.function.Consumer
+
+interface TvModalScope : ColumnScope {
+    fun dismiss()
+}
 
 @Composable
 fun TvModal(
@@ -52,23 +52,25 @@ fun TvModal(
     modifier: Modifier = Modifier,
     width: Dp = DefaultModalWidth,
     contentPadding: PaddingValues = DefaultContentPadding,
-    content: @Composable ColumnScope.() -> Unit,
+    content: @Composable TvModalScope.() -> Unit,
 ) {
     var visible by remember { mutableStateOf(true) }
     val currentOnDismissRequest by rememberUpdatedState(onDismissRequest)
+    val backdrop = LocalTvModalBackdrop.current
+    val backdropKey = remember { Any() }
+    LaunchedEffect(visible) {
+        backdrop.setActive(backdropKey, visible)
+    }
+    DisposableEffect(Unit) {
+        onDispose { backdrop.setActive(backdropKey, false) }
+    }
     Dialog(
         onDismissRequest = { visible = false },
         properties = DialogProperties(usePlatformDefaultWidth = false),
     ) {
         val transitionState = remember { MutableTransitionState(false) }
         transitionState.targetState = visible
-        val isBlurBehindEnabled by rememberIsBlurBehindEnabled()
-        val dimAmount by animateFloatAsState(
-            targetValue = if (visible) ModalDimAmount else 0f,
-            animationSpec = tween(ModalAnimationDuration),
-            label = "TvModalDim",
-        )
-        TvModalWindowEffects(isBlurBehindEnabled = isBlurBehindEnabled, dimAmount = dimAmount)
+        TvModalDialogWindowEffects()
         LaunchedEffect(transitionState.isIdle) {
             if (!visible && transitionState.isIdle && !transitionState.currentState) {
                 currentOnDismissRequest()
@@ -76,18 +78,29 @@ fun TvModal(
         }
         AnimatedVisibility(
             visibleState = transitionState,
-            enter = fadeIn(tween(ModalAnimationDuration)) + scaleIn(tween(ModalAnimationDuration), initialScale = 0.92f),
-            exit = fadeOut(tween(ModalAnimationDuration)) + scaleOut(tween(ModalAnimationDuration), targetScale = 0.92f),
+            enter = fadeIn(tween(TvModalAnimationDurationMillis)) +
+                scaleIn(tween(TvModalAnimationDurationMillis), initialScale = 0.92f),
+            exit = fadeOut(tween(TvModalAnimationDurationMillis)) +
+                scaleOut(tween(TvModalAnimationDurationMillis), targetScale = 0.92f),
         ) {
             TvModalSurface(
-                isTranslucent = isBlurBehindEnabled,
+                isTranslucent = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S,
                 width = width,
                 contentPadding = contentPadding,
                 modifier = modifier.onPreviewKeyEvent { visible.not() },
-                content = content,
-            )
+            ) {
+                val scope = remember(this) { TvModalScopeImpl(this) { visible = false } }
+                scope.content()
+            }
         }
     }
+}
+
+private class TvModalScopeImpl(
+    columnScope: ColumnScope,
+    private val onDismiss: () -> Unit,
+) : TvModalScope, ColumnScope by columnScope {
+    override fun dismiss() = onDismiss()
 }
 
 @Composable
@@ -118,45 +131,14 @@ internal fun TvModalSurface(
 }
 
 @Composable
-private fun TvModalWindowEffects(isBlurBehindEnabled: Boolean, dimAmount: Float) {
+private fun TvModalDialogWindowEffects() {
     val window = (LocalView.current.parent as? DialogWindowProvider)?.window ?: return
-    val blurRadius = with(LocalDensity.current) { ModalBlurRadius.roundToPx() }
     SideEffect {
         window.setWindowAnimations(0)
-        window.setDimAmount(dimAmount)
-    }
-    LaunchedEffect(window, isBlurBehindEnabled, blurRadius) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            if (isBlurBehindEnabled) {
-                window.addFlags(WindowManager.LayoutParams.FLAG_BLUR_BEHIND)
-                window.attributes = window.attributes.apply { blurBehindRadius = blurRadius }
-            } else {
-                window.clearFlags(WindowManager.LayoutParams.FLAG_BLUR_BEHIND)
-            }
-        }
+        window.clearFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND)
     }
 }
 
-@Composable
-private fun rememberIsBlurBehindEnabled(): State<Boolean> {
-    val isBlurBehindEnabled = remember { mutableStateOf(false) }
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-        val view = LocalView.current
-        DisposableEffect(view) {
-            val windowManager = view.context.getSystemService(WindowManager::class.java)
-            val listener = Consumer<Boolean> { isEnabled -> isBlurBehindEnabled.value = isEnabled }
-            windowManager.addCrossWindowBlurEnabledListener(listener)
-            onDispose {
-                windowManager.removeCrossWindowBlurEnabledListener(listener)
-            }
-        }
-    }
-    return isBlurBehindEnabled
-}
-
-private val ModalAnimationDuration = 200
-private val ModalDimAmount = 0.4f
-private val ModalBlurRadius = 30.dp
 private val DefaultModalWidth = 300.dp
 private val DefaultContentPadding = PaddingValues(horizontal = 40.dp, vertical = 30.dp)
 private val ModalShape = RoundedCornerShape(21.dp)

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvModalBackdrop.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvModalBackdrop.kt
@@ -1,0 +1,64 @@
+package au.com.shiftyjelly.pocketcasts.component
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateSetOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.blur
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+@Stable
+class TvModalBackdropState {
+    private val activeKeys = mutableStateSetOf<Any>()
+
+    val isActive: Boolean get() = activeKeys.isNotEmpty()
+
+    fun setActive(key: Any, active: Boolean) {
+        if (active) {
+            activeKeys.add(key)
+        } else {
+            activeKeys.remove(key)
+        }
+    }
+}
+
+val LocalTvModalBackdrop = compositionLocalOf { TvModalBackdropState() }
+
+@Composable
+fun TvModalBackdrop(
+    state: TvModalBackdropState,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    val progress by animateFloatAsState(
+        targetValue = if (state.isActive) 1f else 0f,
+        animationSpec = tween(TvModalAnimationDurationMillis),
+        label = "TvModalBackdrop",
+    )
+    Box(modifier.fillMaxSize()) {
+        Box(
+            modifier = if (progress > 0f) Modifier.blur(ModalBlurRadius * progress) else Modifier,
+        ) {
+            content()
+        }
+        if (progress > 0f) {
+            Box(
+                modifier = Modifier
+                    .matchParentSize()
+                    .background(Color.Black.copy(alpha = ModalScrimAlpha * progress)),
+            )
+        }
+    }
+}
+
+internal const val TvModalAnimationDurationMillis = 200
+private val ModalBlurRadius = 30.dp
+private const val ModalScrimAlpha = 0.4f

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvModalBackdrop.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvModalBackdrop.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.component
 
+import android.os.Build
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Box
@@ -8,9 +9,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateSetOf
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.CornerRadius
@@ -29,10 +29,11 @@ import androidx.compose.ui.unit.dp
 @Stable
 class TvModalBackdropState {
     private val activeKeys = mutableStateSetOf<Any>()
+    private val panelSizes = mutableStateListOf<Pair<Any, IntSize>>()
 
     val isActive: Boolean get() = activeKeys.isNotEmpty()
 
-    var dialogSize: IntSize? by mutableStateOf(null)
+    val dialogSize: IntSize? get() = panelSizes.lastOrNull()?.second
 
     fun setActive(key: Any, active: Boolean) {
         if (active) {
@@ -40,6 +41,19 @@ class TvModalBackdropState {
         } else {
             activeKeys.remove(key)
         }
+    }
+
+    fun setSize(key: Any, size: IntSize) {
+        val index = panelSizes.indexOfFirst { it.first === key }
+        if (index >= 0) {
+            panelSizes[index] = key to size
+        } else {
+            panelSizes.add(key to size)
+        }
+    }
+
+    fun removePanel(key: Any) {
+        panelSizes.removeAll { it.first === key }
     }
 }
 
@@ -70,7 +84,9 @@ fun TvModalBackdrop(
                 drawContent()
                 drawRect(Color.Black, alpha = ModalScrimAlpha * progress)
                 val dialogSize = state.dialogSize
-                if (dialogSize != null && dialogSize.width > 0 && dialogSize.height > 0) {
+                if (dialogSize != null && dialogSize.width > 0 && dialogSize.height > 0 &&
+                    Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+                ) {
                     graphicsLayer.record { this@drawWithContent.drawContent() }
                     graphicsLayer.renderEffect = BlurEffect(blurRadiusPx, blurRadiusPx, TileMode.Clamp)
                     graphicsLayer.alpha = progress

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvModalBackdrop.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvModalBackdrop.kt
@@ -59,6 +59,6 @@ fun TvModalBackdrop(
     }
 }
 
-internal const val TvModalAnimationDurationMillis = 200
+internal val TvModalAnimationDurationMillis = 200
 private val ModalBlurRadius = 30.dp
-private const val ModalScrimAlpha = 0.4f
+private val ModalScrimAlpha = 0.4f

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvModalBackdrop.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvModalBackdrop.kt
@@ -1,6 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.component
 
-import android.os.Build
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Box
@@ -9,14 +8,22 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.mutableStateSetOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.RoundRect
 import androidx.compose.ui.graphics.BlurEffect
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.TileMode
-import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.drawscope.clipPath
+import androidx.compose.ui.graphics.layer.drawLayer
+import androidx.compose.ui.graphics.rememberGraphicsLayer
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 
 @Stable
@@ -24,6 +31,8 @@ class TvModalBackdropState {
     private val activeKeys = mutableStateSetOf<Any>()
 
     val isActive: Boolean get() = activeKeys.isNotEmpty()
+
+    var dialogSize: IntSize? by mutableStateOf(null)
 
     fun setActive(key: Any, active: Boolean) {
         if (active) {
@@ -47,22 +56,40 @@ fun TvModalBackdrop(
         animationSpec = tween(TvModalAnimationDurationMillis),
         label = "TvModalBackdrop",
     )
+    val graphicsLayer = rememberGraphicsLayer()
     val blurRadiusPx = with(LocalDensity.current) { ModalBlurRadius.toPx() }
+    val cornerPx = with(LocalDensity.current) { ModalCornerRadius.toPx() }
     Box(
         modifier
             .fillMaxSize()
             .drawWithContent {
-                drawContent()
-                if (progress > 0f) {
-                    drawRect(Color.Black, alpha = ModalScrimAlpha * progress)
+                if (progress <= 0f) {
+                    drawContent()
+                    return@drawWithContent
                 }
-            }
-            .graphicsLayer {
-                renderEffect = if (progress > 0f && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                    val radius = blurRadiusPx * progress
-                    BlurEffect(radius, radius, TileMode.Clamp)
-                } else {
-                    null
+                drawContent()
+                drawRect(Color.Black, alpha = ModalScrimAlpha * progress)
+                val dialogSize = state.dialogSize
+                if (dialogSize != null && dialogSize.width > 0 && dialogSize.height > 0) {
+                    graphicsLayer.record { this@drawWithContent.drawContent() }
+                    graphicsLayer.renderEffect = BlurEffect(blurRadiusPx, blurRadiusPx, TileMode.Clamp)
+                    graphicsLayer.alpha = progress
+                    val left = (size.width - dialogSize.width) / 2f
+                    val top = (size.height - dialogSize.height) / 2f
+                    val panel = Path().apply {
+                        addRoundRect(
+                            RoundRect(
+                                left = left,
+                                top = top,
+                                right = left + dialogSize.width,
+                                bottom = top + dialogSize.height,
+                                cornerRadius = CornerRadius(cornerPx, cornerPx),
+                            ),
+                        )
+                    }
+                    clipPath(panel) {
+                        drawLayer(graphicsLayer)
+                    }
                 }
             },
     ) {
@@ -71,5 +98,6 @@ fun TvModalBackdrop(
 }
 
 internal val TvModalAnimationDurationMillis = 200
+internal val ModalCornerRadius = 21.dp
 private val ModalBlurRadius = 30.dp
-private val ModalScrimAlpha = 0.4f
+private val ModalScrimAlpha = 0.65f

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvModalBackdrop.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvModalBackdrop.kt
@@ -1,8 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.component
 
+import android.os.Build
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
@@ -11,8 +11,12 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateSetOf
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.blur
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.BlurEffect
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.TileMode
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 
 @Stable
@@ -43,19 +47,26 @@ fun TvModalBackdrop(
         animationSpec = tween(TvModalAnimationDurationMillis),
         label = "TvModalBackdrop",
     )
-    Box(modifier.fillMaxSize()) {
-        Box(
-            modifier = if (progress > 0f) Modifier.blur(ModalBlurRadius * progress) else Modifier,
-        ) {
-            content()
-        }
-        if (progress > 0f) {
-            Box(
-                modifier = Modifier
-                    .matchParentSize()
-                    .background(Color.Black.copy(alpha = ModalScrimAlpha * progress)),
-            )
-        }
+    val blurRadiusPx = with(LocalDensity.current) { ModalBlurRadius.toPx() }
+    Box(
+        modifier
+            .fillMaxSize()
+            .drawWithContent {
+                drawContent()
+                if (progress > 0f) {
+                    drawRect(Color.Black, alpha = ModalScrimAlpha * progress)
+                }
+            }
+            .graphicsLayer {
+                renderEffect = if (progress > 0f && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                    val radius = blurRadiusPx * progress
+                    BlurEffect(radius, radius, TileMode.Clamp)
+                } else {
+                    null
+                }
+            },
+    ) {
+        content()
     }
 }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvModalButton.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/component/TvModalButton.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.tv.material3.Button
+import androidx.tv.material3.ButtonDefaults
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import au.com.shiftyjelly.pocketcasts.theme.TvButtonDefaults
@@ -19,6 +20,7 @@ fun TvModalButton(
     Button(
         onClick = onClick,
         colors = TvButtonDefaults.filledButtonColors(),
+        scale = ButtonDefaults.scale(focusedScale = 1f),
         modifier = modifier.fillMaxWidth(),
     ) {
         Text(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvProfileModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvProfileModal.kt
@@ -56,12 +56,30 @@ fun TvProfileModal(
     ) {
         TvProfileModalContent(
             profile = profile,
-            onLogIn = onLogIn,
-            onCreateAccount = onCreateAccount,
-            onStarredEpisodes = onStarredEpisodes,
-            onListeningHistory = onListeningHistory,
-            onSettings = onSettings,
-            onLogOut = onLogOut,
+            onLogIn = {
+                dismiss()
+                onLogIn()
+            },
+            onCreateAccount = {
+                dismiss()
+                onCreateAccount()
+            },
+            onStarredEpisodes = {
+                dismiss()
+                onStarredEpisodes()
+            },
+            onListeningHistory = {
+                dismiss()
+                onListeningHistory()
+            },
+            onSettings = {
+                dismiss()
+                onSettings()
+            },
+            onLogOut = {
+                dismiss()
+                onLogOut()
+            },
         )
     }
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffold.kt
@@ -172,33 +172,24 @@ fun TvScaffold(
             LaunchedEffect(Unit) {
                 viewModel.trackProfileShown()
             }
+            var pendingProfileAction by remember { mutableStateOf<(() -> Unit)?>(null) }
             TvProfileModal(
                 profile = uiState.profile,
-                onDismissRequest = { isProfileModalVisible = false },
-                onLogIn = {
+                onDismissRequest = {
                     isProfileModalVisible = false
-                    onLogIn()
+                    pendingProfileAction?.invoke()
+                    pendingProfileAction = null
                 },
-                onCreateAccount = {
-                    isProfileModalVisible = false
-                    onCreateAccount()
-                },
-                onStarredEpisodes = {
-                    isProfileModalVisible = false
-                    isStarredVisible = true
-                },
-                onListeningHistory = {
-                    isProfileModalVisible = false
-                    isListeningHistoryVisible = true
-                },
-                onSettings = {
-                    isProfileModalVisible = false
-                    isSettingsModalVisible = true
-                },
+                onLogIn = { pendingProfileAction = onLogIn },
+                onCreateAccount = { pendingProfileAction = onCreateAccount },
+                onStarredEpisodes = { isStarredVisible = true },
+                onListeningHistory = { isListeningHistoryVisible = true },
+                onSettings = { isSettingsModalVisible = true },
                 onLogOut = {
-                    isProfileModalVisible = false
-                    viewModel.signOut()
-                    onSignedOut()
+                    pendingProfileAction = {
+                        viewModel.signOut()
+                        onSignedOut()
+                    }
                 },
             )
         }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingNavHost.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/onboarding/TvOnboardingNavHost.kt
@@ -14,7 +14,10 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import au.com.shiftyjelly.pocketcasts.component.LocalTvModalBackdrop
 import au.com.shiftyjelly.pocketcasts.component.LocalTvToastHostState
+import au.com.shiftyjelly.pocketcasts.component.TvModalBackdrop
+import au.com.shiftyjelly.pocketcasts.component.TvModalBackdropState
 import au.com.shiftyjelly.pocketcasts.component.TvToastHost
 import au.com.shiftyjelly.pocketcasts.component.TvToastHostState
 import au.com.shiftyjelly.pocketcasts.home.TvScaffold
@@ -48,54 +51,63 @@ fun TvOnboardingNavHost(
         }
     }
     val toastHostState = remember { TvToastHostState() }
-    CompositionLocalProvider(LocalTvToastHostState provides toastHostState) {
+    val modalBackdropState = remember { TvModalBackdropState() }
+    CompositionLocalProvider(
+        LocalTvToastHostState provides toastHostState,
+        LocalTvModalBackdrop provides modalBackdropState,
+    ) {
         Box(modifier = modifier.fillMaxSize()) {
-            NavHost(
-                navController = navController,
-                startDestination = viewModel.startDestination,
+            TvModalBackdrop(
+                state = modalBackdropState,
                 modifier = Modifier.fillMaxSize(),
             ) {
-                composable(TvOnboardingRoutes.LANDING) {
-                    TvWelcomeScreen(
-                        onSignIn = { navController.navigate(TvOnboardingRoutes.SIGN_IN) },
-                        onCreateAccount = { navController.navigate(TvOnboardingRoutes.CREATE_ACCOUNT) },
-                        onContinueWithoutAccount = {
-                            navController.navigate(TvOnboardingRoutes.HOME) {
-                                popUpTo(TvOnboardingRoutes.LANDING) { inclusive = true }
-                            }
-                        },
-                    )
-                }
-                composable(TvOnboardingRoutes.CREATE_ACCOUNT) {
-                    TvCreateAccountScreen(
-                        onCreateAccountComplete = { navigateClearingBackStack(TvOnboardingRoutes.SYNCING) },
-                    )
-                }
-                composable(TvOnboardingRoutes.SIGN_IN) {
-                    TvSignInScreen(
-                        onSignInComplete = { navigateClearingBackStack(TvOnboardingRoutes.SYNCING) },
-                    )
-                }
-                composable(TvOnboardingRoutes.SYNCING) {
-                    TvSyncingScreen(
-                        onSyncComplete = {
-                            navController.navigate(TvOnboardingRoutes.HOME) {
-                                popUpTo(TvOnboardingRoutes.SYNCING) { inclusive = true }
-                            }
-                        },
-                    )
-                }
-                composable(TvOnboardingRoutes.SIGNED_OUT) {
-                    TvSignedOutScreen(
-                        onLogIn = { navigateClearingBackStack(TvOnboardingRoutes.LANDING) },
-                    )
-                }
-                composable(TvOnboardingRoutes.HOME) {
-                    TvScaffold(
-                        onLogIn = { navController.navigate(TvOnboardingRoutes.SIGN_IN) },
-                        onCreateAccount = { navController.navigate(TvOnboardingRoutes.CREATE_ACCOUNT) },
-                        onSignedOut = { navigateClearingBackStack(TvOnboardingRoutes.LANDING) },
-                    )
+                NavHost(
+                    navController = navController,
+                    startDestination = viewModel.startDestination,
+                    modifier = Modifier.fillMaxSize(),
+                ) {
+                    composable(TvOnboardingRoutes.LANDING) {
+                        TvWelcomeScreen(
+                            onSignIn = { navController.navigate(TvOnboardingRoutes.SIGN_IN) },
+                            onCreateAccount = { navController.navigate(TvOnboardingRoutes.CREATE_ACCOUNT) },
+                            onContinueWithoutAccount = {
+                                navController.navigate(TvOnboardingRoutes.HOME) {
+                                    popUpTo(TvOnboardingRoutes.LANDING) { inclusive = true }
+                                }
+                            },
+                        )
+                    }
+                    composable(TvOnboardingRoutes.CREATE_ACCOUNT) {
+                        TvCreateAccountScreen(
+                            onCreateAccountComplete = { navigateClearingBackStack(TvOnboardingRoutes.SYNCING) },
+                        )
+                    }
+                    composable(TvOnboardingRoutes.SIGN_IN) {
+                        TvSignInScreen(
+                            onSignInComplete = { navigateClearingBackStack(TvOnboardingRoutes.SYNCING) },
+                        )
+                    }
+                    composable(TvOnboardingRoutes.SYNCING) {
+                        TvSyncingScreen(
+                            onSyncComplete = {
+                                navController.navigate(TvOnboardingRoutes.HOME) {
+                                    popUpTo(TvOnboardingRoutes.SYNCING) { inclusive = true }
+                                }
+                            },
+                        )
+                    }
+                    composable(TvOnboardingRoutes.SIGNED_OUT) {
+                        TvSignedOutScreen(
+                            onLogIn = { navigateClearingBackStack(TvOnboardingRoutes.LANDING) },
+                        )
+                    }
+                    composable(TvOnboardingRoutes.HOME) {
+                        TvScaffold(
+                            onLogIn = { navController.navigate(TvOnboardingRoutes.SIGN_IN) },
+                            onCreateAccount = { navController.navigate(TvOnboardingRoutes.CREATE_ACCOUNT) },
+                            onSignedOut = { navigateClearingBackStack(TvOnboardingRoutes.LANDING) },
+                        )
+                    }
                 }
             }
             TvToastHost(

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvDownloadAppModal.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/TvDownloadAppModal.kt
@@ -39,7 +39,7 @@ fun TvDownloadAppModal(
         width = 450.dp,
         modifier = modifier,
     ) {
-        TvDownloadAppModalContent(onDone = onDismissRequest)
+        TvDownloadAppModalContent(onDone = { dismiss() })
     }
 }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/details/TvPlaylistDetailsScreen.kt
@@ -144,18 +144,10 @@ fun TvPlaylistDetailsScreen(
 
     if (isReplaceUpNextConfirmationVisible) {
         TvPlayAllReplaceUpNextModal(
-            onPlayWithoutSaving = {
-                isReplaceUpNextConfirmationVisible = false
-                viewModel.replaceUpNextAndPlay(saveUpNext = false, upNextName = upNextName)
-            },
-            onSaveAndPlay = {
-                isReplaceUpNextConfirmationVisible = false
-                viewModel.replaceUpNextAndPlay(saveUpNext = true, upNextName = upNextName)
-            },
-            onCancel = {
-                isReplaceUpNextConfirmationVisible = false
-                viewModel.trackPlayAllDismissed()
-            },
+            onPlayWithoutSaving = { viewModel.replaceUpNextAndPlay(saveUpNext = false, upNextName = upNextName) },
+            onSaveAndPlay = { viewModel.replaceUpNextAndPlay(saveUpNext = true, upNextName = upNextName) },
+            onCancel = { viewModel.trackPlayAllDismissed() },
+            onDismiss = { isReplaceUpNextConfirmationVisible = false },
         )
     }
 }
@@ -449,12 +441,29 @@ private fun TvPlayAllReplaceUpNextModal(
     onPlayWithoutSaving: () -> Unit,
     onSaveAndPlay: () -> Unit,
     onCancel: () -> Unit,
+    onDismiss: () -> Unit,
 ) {
-    TvModal(onDismissRequest = onCancel) {
+    var isActionTaken by remember { mutableStateOf(false) }
+    TvModal(
+        onDismissRequest = {
+            if (!isActionTaken) {
+                onCancel()
+            }
+            onDismiss()
+        },
+    ) {
         TvPlayAllReplaceUpNextContent(
-            onPlayWithoutSaving = onPlayWithoutSaving,
-            onSaveAndPlay = onSaveAndPlay,
-            onCancel = onCancel,
+            onPlayWithoutSaving = {
+                isActionTaken = true
+                onPlayWithoutSaving()
+                dismiss()
+            },
+            onSaveAndPlay = {
+                isActionTaken = true
+                onSaveAndPlay()
+                dismiss()
+            },
+            onCancel = { dismiss() },
         )
     }
 }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/search/TvSearchScreen.kt
@@ -269,7 +269,6 @@ fun TvSearchScreen(
                 },
                 onGoToPodcast = {
                     viewModel.trackEpisodeResultTapped(episode.uuid)
-                    viewModel.dismissEpisodeActions()
                     openedPodcastUuid = episode.podcastUuid
                 },
             )

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvColorScheme.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/theme/TvColorScheme.kt
@@ -22,6 +22,6 @@ data class TvColorScheme(
     val backgroundActive50: Color = backgroundActive.copy(alpha = 0.5f),
     val backgroundActive20: Color = backgroundActive.copy(alpha = 0.2f),
     val overlayContainer: Color = backgroundSunken.copy(alpha = 0.94f),
-    val translucentOverlayContainer: Color = backgroundSunken.copy(alpha = 0.6f),
+    val translucentOverlayContainer: Color = Color.Black.copy(alpha = 0.8f),
     val overlayBorder: Color = backgroundActive.copy(alpha = 0.12f),
 )


### PR DESCRIPTION
## Description

Fixes two problems with TV modals (profile, episode/podcast info, episode actions, settings, …) reported in POC-897:

1. **The blur behind the modal was intermittently lost**, and on real TV hardware it was never there at all.
2. **The semi-transparent layer snapped away on exit** instead of fading out with the modal.

Root cause: `TvModal` was a `Dialog` whose backdrop was the *window* — dim via `setDimAmount`, blur via `FLAG_BLUR_BEHIND`, gated on the async `addCrossWindowBlurEnabledListener`. Cross-window blur is a compositor feature that TV hardware doesn't enable (the Google TV Streamer reports `ro.surface_flinger.supports_background_blur` unset), so the modal was dimmed-but-sharp there; the async gate caused the "blur lost on quick reopen" race on devices where it does work; and the blur radius / window dim were never eased in step with the modal.

What changed:
- A new `TvModalBackdrop` hosts the app content at the root (`TvOnboardingNavHost`) and blurs it with `Modifier.blur` (a RenderEffect that renders on all hardware, including the Streamer) plus a scrim, driven by a shared state that every `TvModal` toggles from its visibility. The blur and scrim now animate in exact sync with the modal.
- `TvModal` stays a `Dialog` (so focus-trapping, Back handling and in-place composition are untouched) but becomes transparent — the window dim, `FLAG_BLUR_BEHIND` and the cross-window listener are gone, which also removes the "blur lost on quick reopen" race.
- Modal action buttons now dismiss through an animated `dismiss()` so tapping an action eases the modal + backdrop out, matching the Back gesture.

On API < 31 (Android TV 9–11) `Modifier.blur` is a no-op, so those devices fall back to scrim-only — still an improvement, since the scrim now fades.


Fixes POC-897 https://linear.app/a8c/issue/POC-897/modal-transparency-issues-and-fade-out-animation

## Testing Instructions

1. Open a modal on TV (e.g. the profile menu from the top-left avatar, or the "…" actions on any episode).
2. The screen behind blurs and darkens as the modal scales in.
3. Press Back, or pick an action (Play, Cancel, …) — the modal and the blurred/darkened backdrop fade out together, not abruptly.
4. Open and dismiss a modal repeatedly and quickly — the blur is present every time.
5. Verified on the Google TV Streamer (blur now renders where it previously couldn't) and the Android TV emulator (blur + fade, no reopen race).

## Screenshots or Screencast

<img width="1920" height="1080" alt="after-streamer-blurred-backdrop" src="https://github.com/user-attachments/assets/4124ff62-a826-4d2e-8eb0-e343a8d1d6cf" />

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml` (no new strings)
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) the Event Horizon schema to reflect any new or changed analytics (no analytics changes)

#### I have tested any UI changes...
- [ ] with different themes (TV is a single dark theme)
- [x] with a landscape orientation (TV is landscape-only)
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
