### PR TITLE
Fix stale media-notification artwork on episode auto-advance (Media3 session)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
         ([#5868](https://github.com/Automattic/pocket-casts-android/pull/5868))
     *   Keep the Playback Effects icon visible on the Now Playing screen when a podcast's colours haven't loaded yet
         ([#5877](https://github.com/Automattic/pocket-casts-android/pull/5877))
+    *   Show the correct episode artwork on the media notification and lock screen when the next queued episode starts
+        ([#5911](https://github.com/Automattic/pocket-casts-android/pull/5911))
 
 8.20
 -----

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -518,6 +518,7 @@ class MediaSessionManager(
             it.previousMediaId = currentPlayer.previousMediaId
             it.isTransientLoss = currentPlayer.isTransientLoss
         }
+        applyCurrentEpisodeMetadata(swapped)
         forwardingPlayer = swapped
         media3Session?.player = swapped
         placeholderPlayer?.release()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -431,12 +431,23 @@ class MediaSessionManager(
         pendingPlayer = null
         castStatePlayer = null
         val swapped = currentPlayer.swapPlayer(exoPlayer)
+        applyCurrentEpisodeMetadata(swapped)
         forwardingPlayer = swapped
         media3Session?.player = swapped
         placeholderPlayer?.release()
         placeholderPlayer = null
         replayMetadataToPlayer(swapped)
         Timber.i("Media3 session player swapped")
+    }
+
+    @OptIn(UnstableApi::class)
+    @MainThread
+    private fun applyCurrentEpisodeMetadata(player: PocketCastsForwardingPlayer) {
+        val episode = playbackManager.getCurrentEpisode() ?: return
+        val showArtwork = settings.showArtworkOnLockScreen.value
+        val useEpisodeArtwork = settings.artworkConfiguration.value.useEpisodeArtwork
+        val artworkUri = if (showArtwork) resolveAndWrapArtworkUri(episode, podcast = null, useEpisodeArtwork) else null
+        player.updateMetadata(episode, podcast = null, showArtwork = showArtwork, useEpisodeArtwork = useEpisodeArtwork, artworkData = null, artworkUri = artworkUri, showRating = !isAutomotive)
     }
 
     @OptIn(UnstableApi::class)
@@ -698,6 +709,7 @@ class MediaSessionManager(
                     player.updateMetadata(data.episode, data.podcast, data.showArtwork, data.useEpisodeArtwork, data.artworkData, artworkUri = wrappedUri, showRating = !isAutomotive)
                     player.isTransientLoss = data.state.transientLoss
                     updateMedia3CustomLayout()
+                    media3Service?.triggerNotificationUpdate()
                 },
                 onError = { Timber.e(it, "Error observing Media3 updates") },
             )


### PR DESCRIPTION
## Description

When the current episode finishes and the app auto-advances to the next queued episode, the Android media notification (pull-down) and the lock screen kept showing the **previous** episode's artwork. This only happens on the Media3 `MediaSession` path (`media3_session` flag), which is why it surfaced for beta testers; the home-screen widget was unaffected because it reloads its own artwork keyed on the episode.

On an episode change, `PlaybackManager` builds a fresh player and calls `MediaSessionManager.installPlayer()`. `PocketCastsForwardingPlayer.swapPlayer()` copies the previous episode's `currentMediaItem`/`previousMediaId` into the new session player, and `installPlayer` assigns it to the session (`media3Session.player = swapped`) **before** the asynchronous `replayMetadataToPlayer()` applies the correct episode. So Media3's first snapshot after the swap is the previous episode's metadata, and the correct episode only lands later (async). On a cold start the carried item is `MediaItem.EMPTY`, so the stale snapshot is only visible on auto-advance.

The fix applies the current episode's metadata to the swapped player **synchronously, before** it becomes the session player, so the session's first snapshot is always the current episode. `replayMetadataToPlayer()` still runs afterwards to enrich it with the artwork bitmap and podcast details. The same pre-population is applied to the cast player path (which had the identical bug on cast auto-advance), and the steady-state metadata observer now also forces a notification refresh, matching the existing replay path.

Fixes #5897
Fixes PCDROID-777 https://linear.app/a8c/issue/PCDROID-777/beta-820-rc-2-9451-wrong-artwork-shown-in-android-media-player

## Testing Instructions

1. Enable the `media3_session` feature flag (dev toggle, or use a debug build where it defaults on).
2. Queue two or more episodes with different artwork.
3. Play the first episode and let it finish so the next one auto-starts (seeking near the end speeds this up).
4. Open the pull-down media controls / lock screen and confirm the artwork and title match the now-playing episode, not the previous one.
5. Repeat across further auto-advances, and repeat again while casting.

Verified: `./gradlew spotlessApply`, `:app`/`:automotive`/`:wear` `compileDebugKotlin`, and `:modules:services:repositories:testDebugUnitTest` all pass. Also verified on-device (Pixel 6, Android 16, debugProd with the Media3 flag on): queued two episodes from different podcasts, played the first to completion and confirmed that on auto-advance the pull-down media notification switched to the **second** episode's artwork, title, and correct playing state (rather than keeping the previous episode's artwork).

## Screenshots or Screencast

https://github.com/user-attachments/assets/a922ac17-ddc6-4ca6-8cba-14a17e5c73b0


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) the Event Horizon schema to reflect any new or changed analytics.

