### PR TITLE
Keep PiP video alive across config changes and restore the inline video on PiP close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
     *   Fix video freezing when rotating into landscape fullscreen and stuttering when resuming from the background
         ([#5844](https://github.com/Automattic/pocket-casts-android/pull/5844))
     *   Keep Picture-in-Picture video playing across rotation and config changes, and restore the inline video after closing PiP
-        ([#PENDING](https://github.com/Automattic/pocket-casts-android/pull/PENDING))
+        ([#5912](https://github.com/Automattic/pocket-casts-android/pull/5912))
     *   Keep the multi-select episode selection when rotating the device on the podcast screen
         ([#5836](https://github.com/Automattic/pocket-casts-android/pull/5836))
     *   Prevent the app from being killed in the background on low-memory devices by pausing player UI updates while playing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 *   Bug Fixes
     *   Fix video freezing when rotating into landscape fullscreen and stuttering when resuming from the background
         ([#5844](https://github.com/Automattic/pocket-casts-android/pull/5844))
+    *   Keep Picture-in-Picture video playing across rotation and config changes, and restore the inline video after closing PiP
+        ([#PENDING](https://github.com/Automattic/pocket-casts-android/pull/PENDING))
     *   Keep the multi-select episode selection when rotating the device on the podcast screen
         ([#5836](https://github.com/Automattic/pocket-casts-android/pull/5836))
     *   Prevent the app from being killed in the background on low-memory devices by pausing player UI updates while playing

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -169,6 +169,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackNoticeType
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
 import au.com.shiftyjelly.pocketcasts.repositories.playback.StreamVideoState
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextSource
+import au.com.shiftyjelly.pocketcasts.repositories.playback.VideoSurfaceState
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.Playlist
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
@@ -779,6 +780,10 @@ class MainActivity :
     }
 
     private fun openFullscreenViewPlayer() {
+        // A live fullscreen or PiP VideoActivity already owns the surface; don't launch another over it.
+        if (playbackManager.videoSurfaceState.value != VideoSurfaceState.NONE) {
+            return
+        }
         videoPlayerShown = true
         startActivity(VideoActivity.buildIntent(context = this))
     }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -961,6 +961,7 @@ class PlayerHeaderFragment :
                 ArtworkOrVideo(
                     state = artworkOrVideoState,
                     onChapterUrlClick = {},
+                    videoSurfaceState = playbackManager.videoSurfaceState,
                     configureVideoView = { videoView ->
                         videoView.setOnClickListener { onFullScreenVideoClick() }
                     },
@@ -1110,6 +1111,7 @@ class PlayerHeaderFragment :
                         state = artworkOrVideoState,
                         artworkCornerRadius = if (availableHeightDp > 120.dp) 16.dp else 8.dp,
                         onChapterUrlClick = viewModel::onChapterUrlClick,
+                        videoSurfaceState = playbackManager.videoSurfaceState,
                         configureVideoView = { videoView ->
                             videoView.setOnClickListener { onFullScreenVideoClick() }
                         },
@@ -1167,6 +1169,7 @@ class PlayerHeaderFragment :
                 ) {
                     VideoBox(
                         player = artworkOrVideoState.player,
+                        videoSurfaceState = playbackManager.videoSurfaceState,
                         configureVideoView = { videoView ->
                             videoView.setOnClickListener { onFullScreenVideoClick() }
                         },

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/nowplaying/ArtworkOrVideo.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/nowplaying/ArtworkOrVideo.kt
@@ -9,12 +9,15 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.player.view.video.VideoView
 import au.com.shiftyjelly.pocketcasts.repositories.playback.Player
+import au.com.shiftyjelly.pocketcasts.repositories.playback.VideoSurfaceState
+import kotlinx.coroutines.flow.StateFlow
 import okhttp3.HttpUrl
 
 @Composable
 internal fun ArtworkOrVideo(
     state: ArtworkOrVideoState,
     onChapterUrlClick: (HttpUrl) -> Unit,
+    videoSurfaceState: StateFlow<VideoSurfaceState>,
     configureVideoView: (VideoView) -> Unit,
     modifier: Modifier = Modifier,
     artworkCornerRadius: Dp = 16.dp,
@@ -33,6 +36,7 @@ internal fun ArtworkOrVideo(
             is ArtworkOrVideoState.Video -> {
                 VideoBox(
                     player = state.player,
+                    videoSurfaceState = videoSurfaceState,
                     configureVideoView = configureVideoView,
                 )
             }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/nowplaying/VideoBox.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/nowplaying/VideoBox.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
@@ -13,15 +14,19 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import au.com.shiftyjelly.pocketcasts.player.view.video.VideoView
 import au.com.shiftyjelly.pocketcasts.repositories.playback.Player
+import au.com.shiftyjelly.pocketcasts.repositories.playback.VideoSurfaceState
+import kotlinx.coroutines.flow.StateFlow
 
 @Composable
 internal fun VideoBox(
     player: Player?,
+    videoSurfaceState: StateFlow<VideoSurfaceState>,
     configureVideoView: (VideoView) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -38,23 +43,38 @@ internal fun VideoBox(
             )
         }
     } else {
+        val context = LocalContext.current
         var aspectRatio by remember { mutableFloatStateOf(1.78f) }
+        val videoView = remember {
+            VideoView(context).apply {
+                videoSurfaceStateProvider = { videoSurfaceState.value }
+            }
+        }
+
+        // When the fullscreen or PiP player hands the surface back, reclaim it for the inline view.
+        LaunchedEffect(videoView) {
+            videoSurfaceState.collect { state ->
+                if (state == VideoSurfaceState.NONE) {
+                    videoView.reconnect()
+                }
+            }
+        }
 
         AndroidView(
-            factory = { context ->
-                VideoView(context).apply {
+            factory = {
+                videoView.apply {
                     configureVideoView(this)
                     addOnAspectRatioListener { ratio -> aspectRatio = ratio }
                 }
             },
-            update = { videoView ->
-                videoView.player = player
-                videoView.connectWithDelay()
+            update = { view ->
+                view.player = player
+                view.connectWithDelay()
             },
-            onRelease = { videoView ->
+            onRelease = { view ->
                 // Switching to a non-video stream removes this composable; detach the surface so the
                 // last video frame doesn't linger over the artwork.
-                videoView.releaseSurface()
+                view.releaseSurface()
             },
             modifier = modifier.aspectRatio(aspectRatio),
         )

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/video/VideoActivity.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/video/VideoActivity.kt
@@ -24,6 +24,7 @@ import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.SimplePlayer
 import au.com.shiftyjelly.pocketcasts.repositories.playback.StreamVideoState
+import au.com.shiftyjelly.pocketcasts.repositories.playback.VideoSurfaceState
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -42,7 +43,7 @@ class VideoActivity : AppCompatActivity() {
 
     private var pipActionsPlaying: List<RemoteAction>? = null
     private var pipActionsPaused: List<RemoteAction>? = null
-    private var wasInPiP: Boolean = false
+    private var lastPipAspectRatio: Rational? = null
 
     companion object {
         const val EXTRA_PIP = "EXTRA_PIP"
@@ -83,6 +84,9 @@ class VideoActivity : AppCompatActivity() {
         setTheme(Theme.ThemeType.EXTRA_DARK.resourceId)
         setContentView(R.layout.activity_video)
 
+        // Seed the surface owner even on recreation (uiMode/font-scale changes) so a live PiP keeps its state.
+        playbackManager.setVideoSurfaceState(if (isInPictureInPictureMode) VideoSurfaceState.PIP else VideoSurfaceState.FULLSCREEN)
+
         if (savedInstanceState == null) {
             supportFragmentManager.beginTransaction()
                 .replace(R.id.container, VideoFragment())
@@ -91,14 +95,13 @@ class VideoActivity : AppCompatActivity() {
             // Enter Picture-in-Picture
             if (intent.getBooleanExtra(EXTRA_PIP, false)) {
                 enterPictureInPicture()
-            } else {
-                playbackManager.player?.isPip = false
             }
         }
 
         playbackManager.playbackStateLive.observe(this) { playbackState ->
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 updatePictureInPictureActions(playbackState.isPlaying)
+                updatePictureInPictureAspectRatio()
             }
             finishIfNotVideo()
         }
@@ -123,6 +126,14 @@ class VideoActivity : AppCompatActivity() {
         }
     }
 
+    override fun onStop() {
+        super.onStop()
+        // Close-X (mode-changed(false) precedes onStop) and fullscreen finish both land here without PiP.
+        if (!isInPictureInPictureMode) {
+            playbackManager.setVideoSurfaceState(VideoSurfaceState.NONE)
+        }
+    }
+
     override fun onDestroy() {
         super.onDestroy()
         unregisterReceiver(pipReceiver)
@@ -131,7 +142,7 @@ class VideoActivity : AppCompatActivity() {
     override fun onPictureInPictureModeChanged(isInPictureInPictureMode: Boolean, newConfig: Configuration) {
         super.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig)
 
-        playbackManager.player?.isPip = isInPictureInPictureMode
+        playbackManager.setVideoSurfaceState(if (isInPictureInPictureMode) VideoSurfaceState.PIP else VideoSurfaceState.FULLSCREEN)
     }
 
     override fun onNewIntent(intent: Intent) {
@@ -140,15 +151,13 @@ class VideoActivity : AppCompatActivity() {
         // Enter Picture-in-Picture
         if (intent.getBooleanExtra(EXTRA_PIP, false)) {
             enterPictureInPicture()
-        } else {
-            playbackManager.player?.isPip = false
         }
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
 
-        if (newConfig.orientation != Configuration.ORIENTATION_LANDSCAPE && !wasInPiP) {
+        if (newConfig.orientation != Configuration.ORIENTATION_LANDSCAPE && !isInPictureInPictureMode) {
             finish()
         }
     }
@@ -157,9 +166,6 @@ class VideoActivity : AppCompatActivity() {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
             return
         }
-
-        wasInPiP = true
-        playbackManager.player?.isPip = true
 
         // create PiP actions
         if (pipActionsPlaying == null) {
@@ -177,8 +183,12 @@ class VideoActivity : AppCompatActivity() {
         val height = player.videoHeight
         val aspectRatio = if (width == 0 || height == 0) Rational(16, 9) else Rational(width, height)
         val params = PictureInPictureParams.Builder().setAspectRatio(aspectRatio)
-        enterPictureInPictureMode(params.build())
-        updatePictureInPictureActions(isPlaying = playbackManager.isPlaying())
+        // Only claim PiP when the system actually entered it; the permission can be revoked.
+        if (enterPictureInPictureMode(params.build())) {
+            lastPipAspectRatio = null
+            playbackManager.setVideoSurfaceState(VideoSurfaceState.PIP)
+            updatePictureInPictureActions(isPlaying = playbackManager.isPlaying())
+        }
     }
 
     @RequiresApi(Build.VERSION_CODES.O)
@@ -186,6 +196,25 @@ class VideoActivity : AppCompatActivity() {
         val actions = if (isPlaying) pipActionsPlaying else pipActionsPaused
         val params = PictureInPictureParams.Builder().setActions(actions)
         setPictureInPictureParams(params.build())
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    private fun updatePictureInPictureAspectRatio() {
+        if (!isInPictureInPictureMode) {
+            return
+        }
+        val player = playbackManager.player as? SimplePlayer ?: return
+        val width = player.videoWidth
+        val height = player.videoHeight
+        if (width == 0 || height == 0) {
+            return
+        }
+        val aspectRatio = Rational(width, height)
+        if (aspectRatio == lastPipAspectRatio) {
+            return
+        }
+        lastPipAspectRatio = aspectRatio
+        setPictureInPictureParams(PictureInPictureParams.Builder().setAspectRatio(aspectRatio).build())
     }
 
     @RequiresApi(Build.VERSION_CODES.O)

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/video/VideoActivity.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/video/VideoActivity.kt
@@ -128,21 +128,31 @@ class VideoActivity : AppCompatActivity() {
 
     override fun onStop() {
         super.onStop()
-        // Close-X (mode-changed(false) precedes onStop) and fullscreen finish both land here without PiP.
-        if (!isInPictureInPictureMode) {
+        // Backgrounding from fullscreen (not PiP, not a config change) hands the surface back to the inline player.
+        if (!isInPictureInPictureMode && !isChangingConfigurations) {
             playbackManager.setVideoSurfaceState(VideoSurfaceState.NONE)
         }
     }
 
     override fun onDestroy() {
         super.onDestroy()
+        // Closing the PiP delivers onPictureInPictureModeChanged(false) before the finish is visible, so
+        // hand the surface back here where isFinishing is reliably set.
+        if (isFinishing) {
+            playbackManager.setVideoSurfaceState(VideoSurfaceState.NONE)
+        }
         unregisterReceiver(pipReceiver)
     }
 
     override fun onPictureInPictureModeChanged(isInPictureInPictureMode: Boolean, newConfig: Configuration) {
         super.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig)
 
-        playbackManager.setVideoSurfaceState(if (isInPictureInPictureMode) VideoSurfaceState.PIP else VideoSurfaceState.FULLSCREEN)
+        val state = when {
+            isInPictureInPictureMode -> VideoSurfaceState.PIP
+            isFinishing -> VideoSurfaceState.NONE
+            else -> VideoSurfaceState.FULLSCREEN
+        }
+        playbackManager.setVideoSurfaceState(state)
     }
 
     override fun onNewIntent(intent: Intent) {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/video/VideoFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/video/VideoFragment.kt
@@ -11,6 +11,9 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.player.binding.setPlaybackState
 import au.com.shiftyjelly.pocketcasts.player.databinding.FragmentVideoBinding
@@ -26,6 +29,10 @@ import com.airbnb.lottie.LottieAnimationView
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import kotlin.time.Duration
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
 @AndroidEntryPoint
@@ -107,7 +114,41 @@ class VideoFragment :
             }
         }
 
+        observeVideoSurfaceHandback()
+
         return binding.root
+    }
+
+    override fun onResume() {
+        super.onResume()
+        // Fires on fullscreen entry and on PiP-expand (a pause→resume with no onStart), covering
+        // wrong-owner residuals the surface-loss observer can't detect.
+        reclaimVideoSurface()
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private fun observeVideoSurfaceHandback() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                playbackManager.playerFlow
+                    .flatMapLatest { (it as? SimplePlayer)?.hasVideoSurfaceFlow ?: flowOf(false) }
+                    .collect { hasSurface ->
+                        if (!hasSurface) {
+                            reclaimVideoSurface()
+                        }
+                    }
+            }
+        }
+    }
+
+    private fun reclaimVideoSurface() {
+        if (activity?.isFinishing == true) {
+            return
+        }
+        val exoPlayer = (playbackManager.player as? SimplePlayer)?.exoPlayer ?: return
+        val videoView = binding?.videoView ?: return
+        videoView.player = null
+        videoView.player = exoPlayer
     }
 
     override fun onDetach() {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/video/VideoView.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/video/VideoView.kt
@@ -94,6 +94,11 @@ class VideoView @JvmOverloads constructor(
         }, SURFACE_CONNECT_DELAY_MS)
     }
 
+    fun reconnect() {
+        isSurfaceConnected = false
+        connectWithDelay()
+    }
+
     private fun connect() {
         if (!isSurfaceCreated || isSurfaceConnected || !isSurfaceConnectionPending) {
             return

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/video/VideoView.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/video/VideoView.kt
@@ -44,7 +44,7 @@ class VideoView @JvmOverloads constructor(
         super.setVisibility(visibility)
         if (visibility == GONE) {
             isSurfaceConnected = false
-            (player as? SimplePlayer)?.setDisplay(null)
+            (player as? SimplePlayer)?.clearDisplay(binding.surfaceView)
         }
     }
 
@@ -66,7 +66,7 @@ class VideoView @JvmOverloads constructor(
 
     /** Detach the surface from the player so no frozen frame lingers once video is no longer shown. */
     fun releaseSurface() {
-        (player as? SimplePlayer)?.setDisplay(null)
+        (player as? SimplePlayer)?.clearDisplay(binding.surfaceView)
         isSurfaceConnected = false
         isSurfaceConnectionPending = false
     }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/video/VideoView.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/video/VideoView.kt
@@ -14,6 +14,7 @@ import androidx.media3.common.util.UnstableApi
 import au.com.shiftyjelly.pocketcasts.player.databinding.VideoViewBinding
 import au.com.shiftyjelly.pocketcasts.repositories.playback.Player
 import au.com.shiftyjelly.pocketcasts.repositories.playback.SimplePlayer
+import au.com.shiftyjelly.pocketcasts.repositories.playback.VideoSurfaceState
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 
 @OptIn(UnstableApi::class)
@@ -25,6 +26,7 @@ class VideoView @JvmOverloads constructor(
     SurfaceHolder.Callback,
     SimplePlayer.VideoChangedListener {
     var player: Player? = null
+    var videoSurfaceStateProvider: (() -> VideoSurfaceState)? = null
     private var isSurfaceCreated = false
     private var isSurfaceConnectionPending = false
     private var isSurfaceConnected = false
@@ -99,12 +101,17 @@ class VideoView @JvmOverloads constructor(
 
         // A backgrounded host must not steal the video output from the fullscreen player.
         val lifecycleState = findViewTreeLifecycleOwner()?.lifecycle?.currentState
-        if (lifecycleState != null && !lifecycleState.isAtLeast(Lifecycle.State.RESUMED)) {
+        if (lifecycleState != null && !lifecycleState.isAtLeast(Lifecycle.State.STARTED)) {
+            return
+        }
+
+        // The fullscreen or PiP player owns the surface while it lives, so don't claim it here.
+        if ((videoSurfaceStateProvider?.invoke() ?: VideoSurfaceState.NONE) != VideoSurfaceState.NONE) {
             return
         }
 
         val player = this.player as? SimplePlayer
-        if (player == null || !player.supportsVideo() || player.isRemote || player.isPip) {
+        if (player == null || !player.supportsVideo() || player.isRemote) {
             return
         }
 

--- a/modules/features/player/src/main/res/layout/fragment_video.xml
+++ b/modules/features/player/src/main/res/layout/fragment_video.xml
@@ -11,6 +11,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:use_controller="false"
+        app:keep_content_on_player_reset="true"
         app:repeat_toggle_modes="none"/>
 
     <View

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CastPlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CastPlayer.kt
@@ -49,8 +49,6 @@ class CastPlayer(
     private val remoteMediaClientListener = RemoteMediaClientListener()
     private val playPauseCallback = PlayPauseCallback(playbackStatsCollector, currentClient = { remoteMediaClient })
 
-    override var isPip: Boolean = false
-
     private val sessionManager: SessionManager?
         get() = CastContext.getSharedInstance()?.sessionManager
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -268,6 +268,13 @@ open class PlaybackManager @Inject constructor(
     private val _playerFlow = MutableStateFlow<Player?>(null)
     val playerFlow = _playerFlow.asStateFlow()
 
+    private val _videoSurfaceState = MutableStateFlow(VideoSurfaceState.NONE)
+    val videoSurfaceState = _videoSurfaceState.asStateFlow()
+
+    fun setVideoSurfaceState(state: VideoSurfaceState) {
+        _videoSurfaceState.value = state
+    }
+
     // HLS starts Unknown until the player's tracks resolve it to HasVideo or AudioOnly; the video
     // surface is shown only once HasVideo is known.
     private val _streamVideoState = MutableStateFlow(StreamVideoState.NotVideo)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Player.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Player.kt
@@ -52,7 +52,6 @@ enum class StreamVideoState {
 }
 
 interface Player {
-    var isPip: Boolean
     val isRemote: Boolean
     val isStreaming: Boolean
     val filePath: String?

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -68,8 +68,6 @@ class SimplePlayer(
     var videoWidth: Int = 0
     var videoHeight: Int = 0
 
-    override var isPip: Boolean = false
-
     override val currentAudioLevel: Float get() = renderersFactory?.currentAudioLevel ?: 0f
 
     private var videoChangedListener: VideoChangedListener? = null

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -418,7 +418,7 @@ class SimplePlayer(
         )
     }
 
-    fun setDisplay(surfaceView: SurfaceView?): Boolean {
+    fun setDisplay(surfaceView: SurfaceView): Boolean {
         val player = player
         if (player == null) {
             pendingSurface = surfaceView
@@ -427,11 +427,27 @@ class SimplePlayer(
         pendingSurface = null
 
         return try {
-            player.setVideoSurfaceHolder(surfaceView?.holder)
+            player.setVideoSurfaceHolder(surfaceView.holder)
             true
         } catch (e: Exception) {
             Timber.e(e)
             false
+        }
+    }
+
+    fun clearDisplay(surfaceView: SurfaceView) {
+        val player = player
+        if (player == null) {
+            if (pendingSurface == surfaceView) {
+                pendingSurface = null
+            }
+            return
+        }
+
+        try {
+            player.clearVideoSurfaceHolder(surfaceView.holder)
+        } catch (e: Exception) {
+            Timber.e(e)
         }
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -34,6 +34,8 @@ import au.com.shiftyjelly.pocketcasts.utils.fingerprint.FingerprintPolicy
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 
@@ -73,7 +75,13 @@ class SimplePlayer(
     private var videoChangedListener: VideoChangedListener? = null
     private val mainHandler = Handler(Looper.getMainLooper())
 
-    private var hasVideoSurface = false
+    private val _hasVideoSurfaceFlow = MutableStateFlow(false)
+    val hasVideoSurfaceFlow = _hasVideoSurfaceFlow.asStateFlow()
+    private var hasVideoSurface: Boolean
+        get() = _hasVideoSurfaceFlow.value
+        set(value) {
+            _hasVideoSurfaceFlow.value = value
+        }
     private var videoTrackDisableRunnable: Runnable? = null
 
     private var pendingSurface: SurfaceView? = null

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/VideoSurfaceState.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/VideoSurfaceState.kt
@@ -1,0 +1,7 @@
+package au.com.shiftyjelly.pocketcasts.repositories.playback
+
+enum class VideoSurfaceState {
+    NONE,
+    FULLSCREEN,
+    PIP,
+}

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvVideoSurface.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvVideoSurface.kt
@@ -99,7 +99,7 @@ private class TvVideoView(
         }
 
         val player = this.player as? SimplePlayer
-        if (player == null || !player.supportsVideo() || player.isRemote || player.isPip) {
+        if (player == null || !player.supportsVideo() || player.isRemote) {
             return
         }
 

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvVideoSurface.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/nowplaying/TvVideoSurface.kt
@@ -68,7 +68,7 @@ private class TvVideoView(
     }
 
     fun releaseSurface() {
-        (player as? SimplePlayer)?.setDisplay(null)
+        (player as? SimplePlayer)?.clearDisplay(surfaceView)
         isSurfaceConnected = false
         isSurfaceConnectionPending = false
     }


### PR DESCRIPTION
## Description

Picture-in-Picture video broke in two ways, both tied to which surface owns the single shared ExoPlayer output:

- Rotating (or any config change) while in PiP froze the PiP video to a black frame.
- Closing the PiP left the inline now playing video black until the app was backgrounded and resumed.

The shared player renders into whichever surface claimed it last (inline `VideoView`, or the fullscreen/PiP `PlayerView`), and there was no reliable source of truth for the current owner. `Player.isPip` silently reset across `resetPlayer` swaps, and the inline view could clear a surface it no longer owned.

This adds a single owner state and makes release/claim ownership-safe:

- `SimplePlayer.clearDisplay(surfaceView)` releases via `clearVideoSurfaceHolder`, which no-ops unless that holder is the current output — so a dying inline view can no longer clear the PiP surface. The nullable `setDisplay(null)` form is removed.
- `PlaybackManager.videoSurfaceState: StateFlow<NONE|FULLSCREEN|PIP>` replaces `Player.isPip`, written only by `VideoActivity` across its lifecycle. Closing the PiP delivers `onPictureInPictureModeChanged(false)` before the finish is observable, so the hand-back to `NONE` happens in `onDestroy` where `isFinishing` is reliable.
- The inline `VideoView` refuses to claim the surface unless the state is `NONE` (lifecycle gate relaxed to `STARTED`), and reconnects when the fullscreen/PiP owner hands it back.
- `VideoFragment` reclaims its `PlayerView` surface after player swaps and PiP expand via a new `SimplePlayer.hasVideoSurfaceFlow`, with `keep_content_on_player_reset` so re-claims don't flash the shutter.
- `VideoActivity` uses `isInPictureInPictureMode` for rotation handling and refreshes the PiP aspect ratio mid-session.

Fixes #3807

## Testing Instructions

Verified on a physical Pixel 6. Use a video podcast — add the RSS feed `https://feeds.twit.tv/twit_video_hd.xml` ("This Week in Tech (Video)") and play an episode.

1. Portrait: video plays inline on the now playing screen.
2. Rotate to landscape → fullscreen video opens and plays.
3. Enter PiP (top-right button) → video plays in the PiP window.
4. Rotate the device while in PiP → the PiP video keeps playing (previously froze to black).
5. Close the PiP → the inline now playing video is restored within ~1s (previously stayed black until background/resume).
6. Expand the PiP back to fullscreen a few times → video renders each time.
7. Plain rotate to fullscreen without PiP still works (no regression from #5844).

## Screenshots



https://github.com/user-attachments/assets/1d8a9e27-efc1-40da-8608-9e531463d493




## Checklist

- [x] If this is a user-facing change, I added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply`)
- [x] I considered whether it makes sense to add tests (no player unit/Robolectric tests per team guidance; behaviour verified end-to-end on device)
- [ ] All strings that need to be localized are in `strings.xml` (n/a — no strings)
- [ ] Any jetpack compose components I added or changed are covered by compose previews (n/a — no new visual components)
- [ ] I updated the Event Horizon schema (n/a — no analytics changes)

#### I tested any UI changes...

- [ ] different themes
- [x] landscape orientation
- [ ] device set to a large display font size
- [ ] accessibility with TalkBack
