### PR TITLE
[Smart Bookmarks] Promo: New badge, player tip & What's New

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/shelf/MenuShelfItems.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/shelf/MenuShelfItems.kt
@@ -64,6 +64,7 @@ fun MenuShelfItems(
                                     isEditable = state.isEditable,
                                     isTranscriptAvailable = state.isTranscriptAvailable,
                                     isVideoEnabled = isVideoEnabled,
+                                    showNewBadge = !state.isEditable && state.showBookmarkNewBadge && listItem == ShelfItem.Bookmark,
                                     onClick = onClick,
                                     modifier = rowDraggableModifier,
                                 )

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/shelf/PlayerShelf.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/shelf/PlayerShelf.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.player.view.shelf
 import android.view.View
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -21,6 +22,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -28,6 +30,8 @@ import androidx.lifecycle.map
 import androidx.mediarouter.app.MediaRouteButton
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.PlayerColors
+import au.com.shiftyjelly.pocketcasts.compose.components.TipPosition
+import au.com.shiftyjelly.pocketcasts.compose.components.TooltipPopup
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
@@ -152,6 +156,8 @@ fun PlayerShelf(
                 source = ShelfItemSource.Shelf,
             )
         },
+        showBookmarkTooltip = shelfItemsState.showBookmarkTooltip,
+        onBookmarkTooltipDismiss = { shelfSharedViewModel.dismissBookmarkTooltip() },
         modifier = modifier,
     )
 }
@@ -177,6 +183,8 @@ private fun PlayerShelfContent(
     onAddToPlaylistClick: () -> Unit,
     onMoreClick: () -> Unit,
     modifier: Modifier = Modifier,
+    showBookmarkTooltip: Boolean = false,
+    onBookmarkTooltipDismiss: () -> Unit = {},
     playerColors: PlayerColors = MaterialTheme.theme.rememberPlayerColorsOrDefault(),
 ) {
     Row(
@@ -243,10 +251,22 @@ private fun PlayerShelfContent(
                     onClick = onPlayedClick,
                 )
 
-                ShelfItem.Bookmark -> BookmarkButton(
-                    playerColors = playerColors,
-                    onClick = onAddBookmarkClick,
-                )
+                ShelfItem.Bookmark -> Box {
+                    BookmarkButton(
+                        playerColors = playerColors,
+                        onClick = onAddBookmarkClick,
+                    )
+                    if (showBookmarkTooltip) {
+                        TooltipPopup(
+                            title = stringResource(LR.string.bookmark_player_tip_title),
+                            body = stringResource(LR.string.bookmark_player_tip_message),
+                            tipPosition = TipPosition.BottomCenter,
+                            anchorOffset = DpOffset(0.dp, (-4).dp),
+                            clickableElevationPadding = true,
+                            onClick = onBookmarkTooltipDismiss,
+                        )
+                    }
+                }
 
                 ShelfItem.Archive -> ArchiveButton(
                     isUserEpisode = playerShelfData.isUserEpisode,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/shelf/ShelfItemRow.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/shelf/ShelfItemRow.kt
@@ -1,18 +1,23 @@
 package au.com.shiftyjelly.pocketcasts.player.view.shelf
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Icon
 import androidx.compose.material.LocalRippleConfiguration
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.RippleConfiguration
 import androidx.compose.material.RippleDefaults
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
@@ -21,9 +26,11 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH50
@@ -47,6 +54,7 @@ fun ShelfItemRow(
     isEditable: Boolean = true,
     isTranscriptAvailable: Boolean = false,
     isVideoEnabled: Boolean = true,
+    showNewBadge: Boolean = false,
     onClick: ((ShelfItem, Boolean) -> Unit)? = null,
 ) {
     val subtitleResId = item.subtitleId(episode)
@@ -93,10 +101,16 @@ fun ShelfItemRow(
                     .weight(1f)
                     .padding(horizontal = 24.dp, vertical = 8.dp),
             ) {
-                TextH40(
-                    text = stringResource(titleResId),
-                    color = MaterialTheme.theme.colors.playerContrast01,
-                )
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    TextH40(
+                        text = stringResource(titleResId),
+                        color = MaterialTheme.theme.colors.playerContrast01,
+                    )
+                    if (showNewBadge) {
+                        Spacer(modifier = Modifier.width(8.dp))
+                        NewBadge()
+                    }
+                }
                 if (isEditable && subtitleResId != null) {
                     TextH50(
                         text = stringResource(subtitleResId),
@@ -116,6 +130,22 @@ fun ShelfItemRow(
             }
         }
     }
+}
+
+@Composable
+private fun NewBadge() {
+    Text(
+        text = stringResource(LR.string.bookmark_new_badge),
+        color = MaterialTheme.theme.colors.playerContrast01,
+        fontSize = 12.sp,
+        fontWeight = FontWeight.Medium,
+        modifier = Modifier
+            .background(
+                color = MaterialTheme.theme.colors.playerContrast05,
+                shape = RoundedCornerShape(8.dp),
+            )
+            .padding(horizontal = 8.dp, vertical = 2.dp),
+    )
 }
 
 @Preview

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ShelfSharedViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ShelfSharedViewModel.kt
@@ -107,6 +107,7 @@ class ShelfSharedViewModel @Inject constructor(
             .mapNotNull { state -> (state as? UpNextQueue.State.Loaded)?.episode?.uuid }
             .flatMapLatest { episodeUuid -> transcriptManager.observeIsTranscriptAvailable(episodeUuid) },
         videoStateFlow,
+        settings.showSmartBookmarksTooltip.flow,
         ::createUiState,
     ).stateIn(
         viewModelScope,
@@ -119,6 +120,7 @@ class ShelfSharedViewModel @Inject constructor(
         shelfUpNext: UpNextQueue.State,
         isTranscriptAvailable: Boolean,
         videoState: VideoState,
+        showSmartBookmarksTooltip: Boolean,
     ): UiState {
         val episode = (shelfUpNext as? UpNextQueue.State.Loaded)?.episode
         val streamHasVideo = videoState.streamVideoState == StreamVideoState.HasVideo || videoState.streamVideoState == StreamVideoState.Unknown
@@ -131,6 +133,7 @@ class ShelfSharedViewModel @Inject constructor(
             episode = episode,
             isTranscriptAvailable = isTranscriptAvailable,
             isVideoRenderingEnabled = videoState.renderingEnabled && streamHasVideo,
+            isSmartBookmarksPromoActive = showSmartBookmarksTooltip && FeatureFlag.isEnabled(Feature.SMART_BOOKMARKS),
         )
     }
 
@@ -262,10 +265,15 @@ class ShelfSharedViewModel @Inject constructor(
         }
     }
 
+    fun dismissBookmarkTooltip() {
+        settings.showSmartBookmarksTooltip.set(false, updateModifiedAt = false)
+    }
+
     fun onAddBookmarkClick(
         onboardingUpgradeSource: OnboardingUpgradeSource,
         source: ShelfItemSource,
     ) {
+        dismissBookmarkTooltip()
         trackShelfAction(ShelfItem.Bookmark, source)
         viewModelScope.launch {
             val isPaidUser = settings.cachedSubscription.value != null
@@ -361,11 +369,14 @@ class ShelfSharedViewModel @Inject constructor(
         val episode: BaseEpisode? = null,
         val isTranscriptAvailable: Boolean = false,
         val isVideoRenderingEnabled: Boolean = true,
+        val isSmartBookmarksPromoActive: Boolean = false,
     ) {
         val playerShelfItems: List<ShelfItem>
             get() = shelfItems.take(MIN_SHELF_ITEMS_SIZE)
         val playerBottomSheetShelfItems: List<ShelfItem>
             get() = shelfItems.drop(MIN_SHELF_ITEMS_SIZE)
+        val showBookmarkTooltip: Boolean
+            get() = isSmartBookmarksPromoActive && ShelfItem.Bookmark in playerShelfItems
     }
 
     data class PlayerShelfData(

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ShelfViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ShelfViewModel.kt
@@ -9,6 +9,8 @@ import au.com.shiftyjelly.pocketcasts.preferences.model.ShelfItem
 import au.com.shiftyjelly.pocketcasts.preferences.model.ShelfRowItem
 import au.com.shiftyjelly.pocketcasts.preferences.model.ShelfTitle
 import au.com.shiftyjelly.pocketcasts.repositories.transcript.TranscriptManager
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import com.automattic.eventhorizon.EventHorizon
 import com.automattic.eventhorizon.PlayerShelfOverflowMenuRearrangeActionMovedEvent
 import com.automattic.eventhorizon.PlayerShelfOverflowMenuRearrangeFinishedEvent
@@ -46,6 +48,13 @@ class ShelfViewModel @AssistedInject constructor(
                 .collectLatest { isAvailable ->
                     _uiState.update { it.copy(isTranscriptAvailable = isAvailable) }
                 }
+        }
+        viewModelScope.launch {
+            settings.showSmartBookmarksTooltip.flow.collectLatest { showTooltip ->
+                _uiState.update {
+                    it.copy(showBookmarkNewBadge = showTooltip && FeatureFlag.isEnabled(Feature.SMART_BOOKMARKS))
+                }
+            }
         }
     }
 
@@ -158,6 +167,7 @@ class ShelfViewModel @AssistedInject constructor(
         val shelfRowItems: List<ShelfRowItem> = emptyList(),
         val episode: BaseEpisode? = null,
         val isTranscriptAvailable: Boolean = false,
+        val showBookmarkNewBadge: Boolean = false,
     )
 
     enum class ShelfActionSource(

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ShelfSharedViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ShelfSharedViewModelTest.kt
@@ -447,6 +447,10 @@ class ShelfSharedViewModelTest {
         whenever(userSetting.flow).thenReturn(MutableStateFlow(ShelfItem.entries))
         whenever(settings.shelfItems).thenReturn(userSetting)
 
+        val smartBookmarksTooltipSetting = mock<UserSetting<Boolean>>()
+        whenever(smartBookmarksTooltipSetting.flow).thenReturn(MutableStateFlow(false))
+        whenever(settings.showSmartBookmarksTooltip).thenReturn(smartBookmarksTooltipSetting)
+
         val userSubscriptionSetting = mock<UserSetting<Subscription?>>()
         whenever(userSubscriptionSetting.value).thenReturn(subscription)
         whenever(settings.cachedSubscription).thenReturn(userSubscriptionSetting)

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ShelfViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ShelfViewModelTest.kt
@@ -16,6 +16,7 @@ import com.automattic.eventhorizon.EventHorizon
 import com.automattic.eventhorizon.PlayerShelfOverflowMenuRearrangeActionMovedEvent
 import com.automattic.eventhorizon.ShelfActionSourceType
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -215,6 +216,9 @@ class ShelfViewModelTest {
         whenever(transcriptManager.observeIsTranscriptAvailable(episodeId)).thenReturn(flowOf(true))
         val userSetting = mock<UserSetting<List<ShelfItem>>>()
         whenever(settings.shelfItems).thenReturn(userSetting)
+        val smartBookmarksTooltipSetting = mock<UserSetting<Boolean>>()
+        whenever(smartBookmarksTooltipSetting.flow).thenReturn(MutableStateFlow(false))
+        whenever(settings.showSmartBookmarksTooltip).thenReturn(smartBookmarksTooltipSetting)
 
         shelfViewModel = ShelfViewModel(
             episodeId = episodeId,

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/SmartBookmarksHeader.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/SmartBookmarksHeader.kt
@@ -1,0 +1,21 @@
+package au.com.shiftyjelly.pocketcasts.settings.whatsnew
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+
+@Composable
+fun SmartBookmarksHeader(modifier: Modifier = Modifier) {
+    Image(
+        painter = painterResource(id = IR.drawable.ic_plus_feature_bookmark),
+        contentDescription = null,
+        modifier = modifier
+            .padding(bottom = 16.dp)
+            .size(96.dp),
+    )
+}

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewPage.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewPage.kt
@@ -68,6 +68,7 @@ fun WhatsNewPage(
                 header = {
                     when (uiState.feature) {
                         is WhatsNewFeature.SyncedTranscripts -> SyncedTranscriptsHeader()
+                        is WhatsNewFeature.SmartBookmarks -> SmartBookmarksHeader()
                     }
                 },
                 onConfirm = { viewModel.onConfirm() },

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewViewModel.kt
@@ -6,6 +6,8 @@ import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.payment.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -23,8 +25,13 @@ class WhatsNewViewModel @Inject constructor(
 ) : ViewModel() {
     val state: StateFlow<UiState> = settings.cachedSubscription.flow
         .map { subscription ->
+            val isUserEntitled = subscription != null
             UiState.Loaded(
-                feature = WhatsNewFeature.SyncedTranscripts(isUserEntitled = subscription != null),
+                feature = if (FeatureFlag.isEnabled(Feature.SMART_BOOKMARKS)) {
+                    WhatsNewFeature.SmartBookmarks(isUserEntitled = isUserEntitled)
+                } else {
+                    WhatsNewFeature.SyncedTranscripts(isUserEntitled = isUserEntitled)
+                },
             )
         }
         .stateIn(
@@ -42,7 +49,7 @@ class WhatsNewViewModel @Inject constructor(
             val target = if (feature.isUserEntitled) {
                 NavigationState.ForceClose
             } else {
-                NavigationState.StartUpsellFlow(source = OnboardingUpgradeSource.SYNCED_TRANSCRIPTS)
+                NavigationState.StartUpsellFlow(source = feature.upgradeSource)
             }
             _navigationState.emit(target)
         }
@@ -68,6 +75,7 @@ class WhatsNewViewModel @Inject constructor(
         @get:StringRes val confirmButtonNote: Int? get() = null
         val isUserEntitled: Boolean
         val subscriptionTier: SubscriptionTier? get() = null
+        val upgradeSource: OnboardingUpgradeSource
 
         data class SyncedTranscripts(
             override val isUserEntitled: Boolean,
@@ -78,6 +86,18 @@ class WhatsNewViewModel @Inject constructor(
                 get() = if (isUserEntitled) LR.string.got_it else LR.string.profile_start_free_trial
             override val confirmButtonNote = LR.string.synced_transcripts_whats_new_button_note
             override val subscriptionTier get() = SubscriptionTier.Plus
+            override val upgradeSource = OnboardingUpgradeSource.SYNCED_TRANSCRIPTS
+        }
+
+        data class SmartBookmarks(
+            override val isUserEntitled: Boolean,
+        ) : WhatsNewFeature {
+            override val title = LR.string.smart_bookmarks_whats_new_title
+            override val message = LR.string.smart_bookmarks_whats_new_message
+            override val confirmButtonTitle
+                get() = if (isUserEntitled) LR.string.got_it else LR.string.smart_bookmarks_whats_new_button
+            override val subscriptionTier get() = SubscriptionTier.Plus
+            override val upgradeSource = OnboardingUpgradeSource.BOOKMARKS
         }
     }
 

--- a/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewViewModelTest.kt
+++ b/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewViewModelTest.kt
@@ -5,7 +5,10 @@ import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.preferences.ReadSetting
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
+import au.com.shiftyjelly.pocketcasts.sharedtest.InMemoryFeatureFlagRule
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -26,6 +29,9 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 class WhatsNewViewModelTest {
     @get:Rule
     val coroutineRule = MainCoroutineRule()
+
+    @get:Rule
+    val featureFlagRule = InMemoryFeatureFlagRule()
 
     @Mock
     private lateinit var settings: Settings
@@ -59,6 +65,7 @@ class WhatsNewViewModelTest {
 
     @Test
     fun `free user sees Start Free Trial button`() = runTest {
+        FeatureFlag.setEnabled(Feature.SMART_BOOKMARKS, false)
         val viewModel = createViewModel(subscription = null)
 
         val state = viewModel.state.value as WhatsNewViewModel.UiState.Loaded
@@ -68,12 +75,34 @@ class WhatsNewViewModelTest {
 
     @Test
     fun `free user confirm starts upsell flow`() = runTest {
+        FeatureFlag.setEnabled(Feature.SMART_BOOKMARKS, false)
         val viewModel = createViewModel(subscription = null)
 
         viewModel.navigationState.test {
             viewModel.onConfirm()
             val target = awaitItem() as WhatsNewViewModel.NavigationState.StartUpsellFlow
             assertEquals(OnboardingUpgradeSource.SYNCED_TRANSCRIPTS, target.source)
+        }
+    }
+
+    @Test
+    fun `free user sees Get Bookmarks button when smart bookmarks enabled`() = runTest {
+        FeatureFlag.setEnabled(Feature.SMART_BOOKMARKS, true)
+        val viewModel = createViewModel(subscription = null)
+
+        val state = viewModel.state.value as WhatsNewViewModel.UiState.Loaded
+        assertEquals(LR.string.smart_bookmarks_whats_new_button, state.feature.confirmButtonTitle)
+    }
+
+    @Test
+    fun `free user confirm starts bookmarks upsell when smart bookmarks enabled`() = runTest {
+        FeatureFlag.setEnabled(Feature.SMART_BOOKMARKS, true)
+        val viewModel = createViewModel(subscription = null)
+
+        viewModel.navigationState.test {
+            viewModel.onConfirm()
+            val target = awaitItem() as WhatsNewViewModel.NavigationState.StartUpsellFlow
+            assertEquals(OnboardingUpgradeSource.BOOKMARKS, target.source)
         }
     }
 }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2659,6 +2659,9 @@
     <string name="synced_transcripts_whats_new_title">Read along. Even at&#160;2x.</string>
     <string name="synced_transcripts_whats_new_message">Read fast, miss nothing. The name you blew past, the book they recommended, the stat you wanted — tap the word, jump&#160;back.</string>
     <string name="synced_transcripts_whats_new_button_note">Synced transcripts available for recent episodes only.</string>
+    <string name="smart_bookmarks_whats_new_title">Save the parts worth keeping</string>
+    <string name="smart_bookmarks_whats_new_message">One tap. It\'s named, and the words come with it.</string>
+    <string name="smart_bookmarks_whats_new_button">Get Bookmarks</string>
 
     <!-- Pocket Casts Champion -->
     <string name="pocket_casts_champion_dialog_title">You’re a true champion of Pocket Casts!</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -13,6 +13,9 @@
     <string name="add_bookmark">Add bookmark</string>
     <string name="add_bookmark_title">Add Bookmark</string>
     <string name="bookmark_added">Bookmark \"%s\" added</string>
+    <string name="bookmark_new_badge">New</string>
+    <string name="bookmark_player_tip_title">Add bookmark</string>
+    <string name="bookmark_player_tip_message">Keep the part you wanted</string>
     <string name="bookmark_updated">Bookmark \"%s\" updated</string>
     <string name="change_title">Change title</string>
     <string name="add_bookmark_title_hint">Add an optional title to identify this bookmark</string>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -131,6 +131,8 @@ interface Settings {
         const val SHOW_REFERRALS_TOOLTIP = "show_referrals_tooltip"
 
         const val SHOW_UP_NEXT_SORT_DURATION_TOOLTIP = "show_up_next_sort_duration_tooltip"
+
+        const val SHOW_SMART_BOOKMARKS_TOOLTIP = "show_smart_bookmarks_tooltip"
     }
 
     enum class NotificationChannel(val id: String) {
@@ -597,6 +599,8 @@ interface Settings {
     fun setAutomotiveConnectedToMediaSession(isLoaded: Boolean)
 
     val showReferralsTooltip: UserSetting<Boolean>
+
+    val showSmartBookmarksTooltip: UserSetting<Boolean>
 
     val showUpNextSortDurationTooltip: UserSetting<Boolean>
 

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -1609,6 +1609,12 @@ class SettingsImpl @Inject constructor(
         sharedPrefs = sharedPreferences,
     )
 
+    override val showSmartBookmarksTooltip: UserSetting<Boolean> = UserSetting.BoolPref(
+        sharedPrefKey = Settings.SHOW_SMART_BOOKMARKS_TOOLTIP,
+        defaultValue = true,
+        sharedPrefs = sharedPreferences,
+    )
+
     override val showUpNextSortDurationTooltip: UserSetting<Boolean> = UserSetting.BoolPref(
         sharedPrefKey = Settings.SHOW_UP_NEXT_SORT_DURATION_TOOLTIP,
         // Defaults to false so fresh installs never see the tooltip, VersionMigrationsWorker enables it for upgrading users.


### PR DESCRIPTION
## Description

Adds the Smart Bookmarks discoverability affordances, gated on the `SMART_BOOKMARKS` feature flag and shown once via a new `showSmartBookmarksTooltip` preference:

- A **"New" badge** on the Add Bookmark row in the player's More Actions menu.
- A **tip** on the shelf bookmark button ("Add bookmark / Keep the part you wanted").
- A **What's New announcement** ("Save the parts worth keeping") that upsells non-subscribers.

The tip and the badge appear depending on where the Add Bookmark action lives (player shelf vs. the More Actions overflow), so only one shows at a time. Both are cleared once the tip is tapped or a bookmark is added. The What's New screen shows the Smart Bookmarks entry while the flag is enabled, and falls back to the previous announcement otherwise.

There is no separate promo flag — enabling `SMART_BOOKMARKS` (e.g. via remote config) lights up the promo too.

Note: the What's New header currently reuses the bookmark feature icon; it can be swapped for a hero illustration when design provides one.

Fixes PCDROID-780 https://linear.app/a8c/issue/PCDROID-780/new-tooltip-and-badge
Figma: EZYjDdD3AxXH2cXLMHfiHF-fi-322_4847

## Testing Instructions

1. Enable the **Smart Bookmarks** feature flag (on by default in debug/prototype builds).
2. Play an episode and open the full-screen player. A tip points at the Add Bookmark (**+**) shelf action.
   - If Add Bookmark sits in the More Actions overflow instead, open **More Actions** and the row shows a **New** badge.
3. Tap the tip (or add a bookmark) — it dismisses and does not come back.
4. Trigger the What's New screen — it shows "Save the parts worth keeping". A free user sees a **Get Bookmarks** button (starts the upsell); a Plus user sees **Got it**.

## Screenshots or Screencast

| Tooltip | New badge | Whats new |
| --- | --- | --- |
| <img width="1080" height="2400" alt="Screenshot_20260914_124834" src="https://github.com/user-attachments/assets/6061265e-0d57-4512-90d7-77f159e95ed3" /> | <img width="1080" height="2400" alt="Screenshot_20260914_115027" src="https://github.com/user-attachments/assets/cdc6cf03-e624-453e-a638-af9fe59b9fb6" /> | <img width="1080" height="2400" alt="Screenshot_20260914_124936" src="https://github.com/user-attachments/assets/5ea88ec3-8131-4596-ac70-5ef0c0b50487" /> |

## Checklist

- [ ] If this is a user-facing change, I added an entry in CHANGELOG.md — _feature is flag-gated and not yet shipped_
- [x] Ensure the linter passes (`./gradlew spotlessApply`)
- [x] I considered whether it makes sense to add tests (added What's New + shelf coverage)
- [x] All strings needing localization are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Jetpack Compose components I changed are covered by previews (`ShelfItemRow`, `WhatsNewPage`)
- [ ] EventHorizon schema — _no analytics in this change; tracked separately_

#### I tested any UI changes...

- [ ] different themes
- [ ] landscape orientation
- [ ] device set to a large display font size
- [ ] accessibility with TalkBack