### PR TITLE
Migrate auto add to Up Next podcasts from RxJava to Flow

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoAddSettingsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoAddSettingsViewModel.kt
@@ -1,7 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.settings.viewmodel
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.toLiveData
+import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -13,11 +13,9 @@ import com.automattic.eventhorizon.SettingsAutoAddUpNextLimitReachedChangedEvent
 import com.automattic.eventhorizon.SettingsAutoAddUpNextPodcastPositionOptionChangedEvent
 import com.automattic.eventhorizon.SettingsAutoAddUpNextShownEvent
 import dagger.hilt.android.lifecycle.HiltViewModel
-import io.reactivex.BackpressureStrategy
-import io.reactivex.rxkotlin.combineLatest
 import javax.inject.Inject
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.rx2.asObservable
 import timber.log.Timber
 
 data class AutoAddSettingsState(val autoAddPodcasts: List<Podcast>, val limit: Int, val behaviour: AutoAddUpNextLimitBehaviour)
@@ -41,18 +39,13 @@ class AutoAddSettingsViewModel @Inject constructor(
         isFragmentChangingConfigurations = isChangingConfigurations ?: false
     }
 
-    val autoAddPodcasts =
-        podcastManager.autoAddToUpNextPodcastsRxFlowable()
-            .combineLatest(
-                settings.autoAddUpNextLimit.flow
-                    .asObservable(viewModelScope.coroutineContext)
-                    .toFlowable(BackpressureStrategy.LATEST),
-                settings.autoAddUpNextLimitBehaviour.flow
-                    .asObservable(viewModelScope.coroutineContext)
-                    .toFlowable(BackpressureStrategy.LATEST),
-            )
-            .map { AutoAddSettingsState(it.first, it.second, it.third) }
-            .toLiveData()
+    val autoAddPodcasts = combine(
+        podcastManager.autoAddToUpNextPodcastsFlow(),
+        settings.autoAddUpNextLimit.flow,
+        settings.autoAddUpNextLimitBehaviour.flow,
+    ) { podcasts, limit, behaviour ->
+        AutoAddSettingsState(podcasts, limit, behaviour)
+    }.asLiveData()
 
     fun updatePodcast(podcast: Podcast, autoAddOption: Podcast.AutoAddUpNext) {
         viewModelScope.launch {

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
@@ -116,7 +116,7 @@ abstract class PodcastDao {
 
     @Transaction
     @Query("SELECT * FROM podcasts WHERE subscribed = 1 AND auto_add_to_up_next > 0 ORDER BY LOWER(title) ASC")
-    abstract fun findAutoAddToUpNextPodcastsRxFlowable(): Flowable<List<Podcast>>
+    abstract fun findAutoAddToUpNextPodcastsFlow(): Flow<List<Podcast>>
 
     @Transaction
     @Query("SELECT * FROM podcasts WHERE auto_add_to_up_next > 0")

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
@@ -129,7 +129,7 @@ interface PodcastManager {
     fun updateGroupingForAllBlocking(grouping: PodcastGrouping)
 
     fun buildUserEpisodePodcast(episode: UserEpisode): Podcast
-    fun autoAddToUpNextPodcastsRxFlowable(): Flowable<List<Podcast>>
+    fun autoAddToUpNextPodcastsFlow(): Flow<List<Podcast>>
     suspend fun findAutoAddToUpNextPodcasts(): List<Podcast>
 
     suspend fun refreshPodcastFeed(podcast: Podcast): Boolean

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -632,8 +632,8 @@ class PodcastManagerImpl @Inject constructor(
         return Podcast.userPodcast.copy(thumbnailUrl = episode.getUrlForArtwork())
     }
 
-    override fun autoAddToUpNextPodcastsRxFlowable(): Flowable<List<Podcast>> {
-        return podcastDao.findAutoAddToUpNextPodcastsRxFlowable()
+    override fun autoAddToUpNextPodcastsFlow(): Flow<List<Podcast>> {
+        return podcastDao.findAutoAddToUpNextPodcastsFlow()
     }
 
     override suspend fun findAutoAddToUpNextPodcasts(): List<Podcast> {


### PR DESCRIPTION
## Description

No behaviour change: the Auto Add to Up Next settings screen now gets its data through Kotlin Flow instead of RxJava.

One step in the incremental RxJava removal. The screen was the only consumer of a Room query that was declared as a `Flowable`, exported as a `Flowable` on `PodcastManager`, and then combined in the ViewModel with two settings values that were *already* Flows but had to be pushed back through `asObservable().toFlowable(LATEST)` to join the Rx chain. Dropping the Rx end lets the whole pipeline stay in Flow and deletes that round-trip.

- `PodcastDao.findAutoAddToUpNextPodcastsRxFlowable()` becomes `findAutoAddToUpNextPodcastsFlow()`, same `@Transaction` and SQL.
- `PodcastManager.autoAddToUpNextPodcastsRxFlowable()` becomes `autoAddToUpNextPodcastsFlow()`. One caller, no test stubs, and `PodcastManagerImpl` is the only implementation.
- `AutoAddSettingsViewModel` swaps `combineLatest` for `combine` and `toLiveData()` for `asLiveData()`, and is now Rx-free. `autoAddPodcasts` stays a `LiveData`, so the XML fragment is untouched.

One difference worth a reviewer's eye: `asLiveData()` keeps collecting for its default 5s timeout after going inactive and publishes via `setValue` rather than `postValue`, so bursty emissions are no longer coalesced. The observer just does `submitList` behind a `DiffUtil` callback, so extra invocations are invisible.

## Testing Instructions

With a few podcasts subscribed, go to **Profile → Settings → Auto add to Up Next**.

1. Tap **Choose podcasts**, select two, go back. The list should update without leaving the screen, and the count on the **Choose podcasts** row should match.
2. Change a podcast's position, the **Auto add limit**, and **When auto add limit reached**. Each subtitle should update immediately.
3. Rotate the device. The list and all three subtitles should survive.
4. Deselect everything. The list should empty out.


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

