### PR TITLE
[Smart Bookmarks] Redesign the bookmarks paywall sample animation

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/contextual/Bookmarks.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/contextual/Bookmarks.kt
@@ -28,9 +28,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
@@ -70,20 +70,24 @@ fun BookmarksAnimation(modifier: Modifier = Modifier) {
         StackedCard(gradient = backGradient, inset = 34.dp, revealedOffset = (-22).dp, revealed = revealed, delayMillis = 100)
         StackedCard(gradient = middleGradient, inset = 17.dp, revealedOffset = (-11).dp, revealed = revealed, delayMillis = 300)
 
-        val offset by animateDpAsState(
+        val frontOffset by animateDpAsState(
             targetValue = if (revealed) 0.dp else 24.dp,
             animationSpec = tween(REVEAL_DURATION, delayMillis = 500, easing = LinearOutSlowInEasing),
             label = "frontOffset",
         )
-        val alpha by animateFloatAsState(
+        val frontAlpha by animateFloatAsState(
             targetValue = if (revealed) 1f else 0f,
             animationSpec = tween(REVEAL_DURATION, delayMillis = 500, easing = LinearOutSlowInEasing),
             label = "frontAlpha",
         )
         BookmarkUpgradeCard(
-            modifier = Modifier
-                .offset(y = offset)
-                .alpha(alpha),
+            modifier = Modifier.graphicsLayer {
+                translationY = frontOffset.toPx()
+                alpha = frontAlpha
+                shadowElevation = 8.dp.toPx()
+                shape = RoundedCornerShape(CARD_CORNER.dp)
+                clip = false
+            },
         )
     }
 }
@@ -122,7 +126,6 @@ private fun BookmarkUpgradeCard(modifier: Modifier = Modifier) {
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .shadow(elevation = 8.dp, shape = RoundedCornerShape(CARD_CORNER.dp))
             .clip(RoundedCornerShape(CARD_CORNER.dp))
             .background(Brush.linearGradient(frontGradient))
             .padding(12.dp),

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/contextual/Bookmarks.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/contextual/Bookmarks.kt
@@ -1,296 +1,197 @@
 package au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.contextual
 
-import androidx.annotation.DrawableRes
-import androidx.compose.animation.core.FastOutLinearInEasing
-import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.LinearOutSlowInEasing
-import androidx.compose.animation.core.animateFloat
-import androidx.compose.animation.core.animateInt
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
-import androidx.compose.animation.core.updateTransition
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.TransformOrigin
-import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.layout.Layout
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
-import androidx.compose.ui.unit.Constraints
-import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
-import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
-import kotlin.math.abs
-import kotlin.random.Random
-import kotlinx.coroutines.delay
 import au.com.shiftyjelly.pocketcasts.images.R as IR
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
-private data class AnimationParams(
-    val shouldStart: Boolean,
-    val centerOffset: IntOffset,
-    val rotationOffset: Int,
-)
+private val frontGradient = listOf(Color(0xFF0202FE), Color(0xFF27D9E9))
+private val middleGradient = listOf(Color(0xFFEC4034), Color(0xFFFF9D00))
+private val backGradient = listOf(Color(0xFFE8A92C), Color(0xFFE4D820))
 
-private const val WIDTH_DP = 202
+private const val REVEAL_DURATION = 500
+private const val CARD_CORNER = 12
 
 @Composable
-fun BookmarksAnimation(
-    modifier: Modifier = Modifier,
-    bookmarks: List<BookmarkConfig> = predefinedBookmarks,
-) {
-    val centerYOffsetPx = LocalDensity.current.run {
-        8.dp.toPx().toInt()
-    }
-    val animationTriggers = remember {
-        List(bookmarks.size) {
-            val totalOffset = (bookmarks.size - 1) * centerYOffsetPx
-            mutableStateOf(
-                AnimationParams(
-                    shouldStart = false,
-                    centerOffset = IntOffset(x = 0, y = totalOffset - (it * centerYOffsetPx)),
-                    rotationOffset = Random.nextInt(10),
-                ),
-            )
-        }
-    }
+fun BookmarksAnimation(modifier: Modifier = Modifier) {
+    var revealed by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) { revealed = true }
 
-    LaunchedEffect("animations") {
-        for (i in bookmarks.indices) {
-            animationTriggers[i].value = animationTriggers[i].value.copy(shouldStart = true)
-            delay(800)
-        }
-    }
-
-    Layout(
+    Box(
         modifier = modifier
-            .semantics(mergeDescendants = true) { role = Role.Image }
-            .focusable(false),
-        content = {
-            bookmarks.forEachIndexed { index, item ->
-                val animParams = animationTriggers[index].value
-                val rotationDirection = if (index % 2 == 0) {
-                    1
-                } else {
-                    -1
-                }
-                val startRotation = (30 + abs(item.endRotationDegree)).toInt() * rotationDirection
-                val endRotation = item.endRotationDegree.toInt()
-                Bookmark(
-                    modifier = Modifier
-                        .aspectRatio(WIDTH_DP / 219f),
-                    bookmarkConfig = item,
-                    startAnimation = animationTriggers[index].value.shouldStart,
-                    centerOffset = animParams.centerOffset,
-                    startRotation = startRotation,
-                    endRotation = endRotation,
-                )
-            }
-        },
-    ) { measurables, constraints ->
-        val placeables = measurables.map {
-            it.measure(
-                Constraints.fixedWidth(WIDTH_DP.dp.roundToPx()),
-            )
-        }
-        val maxHeight = placeables.maxOf { it.height }
-        layout(constraints.maxWidth, maxHeight) {
-            placeables.forEachIndexed { index, item ->
-                item.placeRelative(
-                    x = (constraints.maxWidth - item.width) / 2,
-                    y = 0,
-                )
-            }
-        }
+            .padding(horizontal = 16.dp)
+            .semantics(mergeDescendants = true) { role = Role.Image },
+        contentAlignment = Alignment.TopCenter,
+    ) {
+        StackedCard(gradient = backGradient, inset = 34.dp, revealedOffset = (-22).dp, revealed = revealed, delayMillis = 100)
+        StackedCard(gradient = middleGradient, inset = 17.dp, revealedOffset = (-11).dp, revealed = revealed, delayMillis = 300)
+
+        val offset by animateDpAsState(
+            targetValue = if (revealed) 0.dp else 24.dp,
+            animationSpec = tween(REVEAL_DURATION, delayMillis = 500, easing = LinearOutSlowInEasing),
+            label = "frontOffset",
+        )
+        val alpha by animateFloatAsState(
+            targetValue = if (revealed) 1f else 0f,
+            animationSpec = tween(REVEAL_DURATION, delayMillis = 500, easing = LinearOutSlowInEasing),
+            label = "frontAlpha",
+        )
+        BookmarkUpgradeCard(
+            modifier = Modifier
+                .offset(y = offset)
+                .alpha(alpha),
+        )
     }
 }
 
-private val predefinedBookmarks = listOf(
-    BookmarkConfig(
-        backgroundStartColor = Color(0xffE4D820),
-        backgroundEndColor = Color(0xffE8A92C),
-        artworkResId = IR.drawable.artwork_12,
-        text = "Amazing quote!",
-        timestamp = "19:05",
-        endRotationDegree = 9.6f,
-    ),
-    BookmarkConfig(
-        backgroundStartColor = Color(0xffFF9D00),
-        backgroundEndColor = Color(0xffEC4034),
-        artworkResId = IR.drawable.artwork_10,
-        text = "This bit cracks me up",
-        timestamp = "6:45",
-        endRotationDegree = -7.48f,
-    ),
-    BookmarkConfig(
-        backgroundStartColor = Color(0xff27D9E9),
-        backgroundEndColor = Color(0xff0202FE),
-        artworkResId = IR.drawable.artwork_11,
-        text = "Love this part!",
-        timestamp = "6:45",
-        endRotationDegree = 5.72f,
-    ),
-)
-
-data class BookmarkConfig(
-    val backgroundStartColor: Color,
-    val backgroundEndColor: Color,
-    @DrawableRes val artworkResId: Int,
-    val text: String,
-    val timestamp: String,
-    val endRotationDegree: Float,
-)
+@Composable
+private fun BoxScope.StackedCard(
+    gradient: List<Color>,
+    inset: Dp,
+    revealedOffset: Dp,
+    revealed: Boolean,
+    delayMillis: Int,
+) {
+    val offset by animateDpAsState(
+        targetValue = if (revealed) revealedOffset else 0.dp,
+        animationSpec = tween(REVEAL_DURATION, delayMillis = delayMillis, easing = LinearOutSlowInEasing),
+        label = "stackedOffset",
+    )
+    val alpha by animateFloatAsState(
+        targetValue = if (revealed) 1f else 0f,
+        animationSpec = tween(REVEAL_DURATION, delayMillis = delayMillis, easing = LinearOutSlowInEasing),
+        label = "stackedAlpha",
+    )
+    Box(
+        modifier = Modifier
+            .matchParentSize()
+            .padding(horizontal = inset)
+            .offset(y = offset)
+            .alpha(alpha)
+            .clip(RoundedCornerShape(CARD_CORNER.dp))
+            .background(Brush.linearGradient(gradient)),
+    )
+}
 
 @Composable
-private fun Bookmark(
-    bookmarkConfig: BookmarkConfig,
-    modifier: Modifier = Modifier,
-    startAnimation: Boolean = true,
-    startRotation: Int = 0,
-    endRotation: Int = 0,
-    centerOffset: IntOffset = IntOffset(0, 0),
-    startScale: Float = 1.5f,
-) {
-    val transition = updateTransition(startAnimation, "bookmarkAnimation")
-    val rotationAnim by transition.animateInt(
-        transitionSpec = { tween(durationMillis = 600, easing = LinearEasing) },
-    ) { visible ->
-        if (visible) {
-            endRotation
-        } else {
-            startRotation
-        }
-    }
-    val alphaAnim by transition.animateFloat(
-        transitionSpec = { tween(durationMillis = 600, easing = LinearOutSlowInEasing) },
-    ) { visible ->
-        if (visible) {
-            1f
-        } else {
-            0f
-        }
-    }
-    val scaleAnim by transition.animateFloat(
-        transitionSpec = { tween(durationMillis = 600, easing = FastOutLinearInEasing) },
-    ) { visible ->
-        if (visible) {
-            1f
-        } else {
-            startScale
-        }
-    }
-
-    val gradientStartPx = LocalDensity.current.run {
-        24.dp.toPx()
-    }
-
-    Column(
+private fun BookmarkUpgradeCard(modifier: Modifier = Modifier) {
+    Row(
         modifier = modifier
-            .offset {
-                IntOffset(centerOffset.x, centerOffset.y)
-            }
-            .graphicsLayer {
-                rotationZ = rotationAnim.toFloat()
-                alpha = alphaAnim
-                scaleX = scaleAnim
-                scaleY = scaleAnim
-                transformOrigin = TransformOrigin.Center
-            }
-            .clip(RoundedCornerShape(13.dp))
-            .background(
-                brush = Brush.linearGradient(
-                    colors = listOf(bookmarkConfig.backgroundStartColor, bookmarkConfig.backgroundEndColor),
-                    start = Offset(x = gradientStartPx, y = gradientStartPx),
-                ),
-                shape = RoundedCornerShape(13.dp),
-            )
-            .padding(vertical = 25.dp, horizontal = 12.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.SpaceBetween,
+            .fillMaxWidth()
+            .shadow(elevation = 8.dp, shape = RoundedCornerShape(CARD_CORNER.dp))
+            .clip(RoundedCornerShape(CARD_CORNER.dp))
+            .background(Brush.linearGradient(frontGradient))
+            .padding(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         Image(
+            painter = painterResource(IR.drawable.artwork_10),
+            contentDescription = null,
             modifier = Modifier
-                .size(78.dp)
-                .clip(RoundedCornerShape(8.dp)),
-            painter = painterResource(bookmarkConfig.artworkResId),
-            contentDescription = "",
+                .size(44.dp)
+                .clip(RoundedCornerShape(6.dp)),
         )
-        TextP40(
-            text = bookmarkConfig.text,
-            color = Color.White,
-            disableAutoScale = true,
-            fontWeight = FontWeight.W500,
-            lineHeight = 20.sp,
-        )
-        Row(
-            modifier = Modifier
-                .height(36.dp)
-                .wrapContentWidth()
-                .clip(RoundedCornerShape(18.dp))
-                .background(color = Color.White, shape = RoundedCornerShape(18.dp))
-                .padding(horizontal = 17.dp, vertical = 8.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(11.dp),
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(2.dp),
         ) {
-            TextP40(
-                text = bookmarkConfig.timestamp,
-                color = Color.Black,
-                disableAutoScale = true,
+            Text(
+                text = stringResource(LR.string.bookmarks_upgrade_example_title),
+                color = Color.White,
+                fontSize = 15.sp,
+                fontWeight = FontWeight.W600,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
             )
-            Icon(
-                painter = painterResource(IR.drawable.ic_play),
-                contentDescription = "",
-                tint = Color.Black,
+            Text(
+                text = stringResource(LR.string.bookmarks_upgrade_example_passage),
+                color = Color.White.copy(alpha = 0.8f),
+                fontSize = 12.sp,
+                lineHeight = 16.sp,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
             )
         }
+        TimestampPill()
+    }
+}
+
+@Composable
+private fun TimestampPill() {
+    Row(
+        modifier = Modifier
+            .clip(RoundedCornerShape(percent = 50))
+            .background(Color.White)
+            .padding(horizontal = 12.dp, vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Text(
+            text = "6:45",
+            color = Color.Black,
+            fontSize = 13.sp,
+            fontWeight = FontWeight.W500,
+        )
+        Icon(
+            painter = painterResource(IR.drawable.ic_play),
+            contentDescription = null,
+            tint = Color.Black,
+            modifier = Modifier.size(12.dp),
+        )
     }
 }
 
 @Preview
 @Composable
-private fun PreviewBookmark(
+private fun BookmarksAnimationPreview(
     @PreviewParameter(ThemePreviewParameterProvider::class) theme: Theme.ThemeType,
 ) = AppTheme(theme) {
-    Column {
-        predefinedBookmarks.forEach {
-            Bookmark(
-                bookmarkConfig = it,
-                modifier = Modifier
-                    .widthIn(max = 230.dp)
-                    .aspectRatio(1f),
-            )
-        }
+    Box(modifier = Modifier.padding(vertical = 40.dp)) {
+        BookmarkUpgradeCard()
     }
 }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2475,6 +2475,8 @@
     <string name="bookmark_notification_content_tap_to_view">Tap to view</string>
     <string name="bookmark_notification_action_change_title">Change title</string>
     <string name="bookmark_notification_action_delete_title" translatable="false">@string/delete</string>
+    <string name="bookmarks_upgrade_example_title">The audition room</string>
+    <string name="bookmarks_upgrade_example_passage">You\'re casting the person, not the résumé.</string>
     <string name="bookmarks_upsell_instructions">Save timestamps of your favorite episodes and unlock many more features with Pocket&#160;Casts Plus.</string>
     <string name="bookmarks_upsell_instructions_early_access">Get early access to this feature with Pocket&#160;Casts Patron and save timestamps of your favorite episodes. Available for Plus subscribers soon.</string>
     <string name="bookmarks_search_results_not_found">We couldn\'t find any bookmark matching your search criteria. Try another keyword.</string>


### PR DESCRIPTION
## Description

Redesigns the sample-card animation on the Bookmarks upgrade paywall. The single sample now reads as a smart bookmark — podcast artwork, a generated title ("The audition room"), the transcript passage, and a timestamp play pill — sitting over two gradient cards that fan up behind it as it reveals.

The reveal is staggered: the back (yellow) and middle (red) cards slide up from behind first, then the front (blue) card fades and slides in.

## Testing Instructions

1. As a non-Plus user, play an episode and tap **Add Bookmark** on the player (or open any Bookmarks upsell).
2. On the paywall's **Bookmarks** page, the sample animates in: the two colored cards fan upward, then the front smart-bookmark card fades/slides into place.

Fixes PCDROID-770 https://linear.app/a8c/issue/PCDROID-770/bookmarks-upgrade-path-update
Figma EZYjDdD3AxXH2cXLMHfiHF-fi-322_4847

## Screenshots or Screencast


https://github.com/user-attachments/assets/fca7695a-0d47-4e17-b557-b37065b4b643



## Checklist

- [ ] If this is a user-facing change, I added an entry in CHANGELOG.md — _flag-gated feature, not yet shipped_
- [x] Ensure the linter passes (`./gradlew spotlessApply`)
- [x] I considered whether it makes sense to add tests — _pure animation composable, covered by a Compose preview_
- [x] All strings needing localization are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Jetpack Compose components I changed are covered by previews
- [ ] EventHorizon schema — _no analytics change_

#### I tested any UI changes...

- [ ] different themes
- [ ] landscape orientation
- [ ] device set to a large display font size
- [ ] accessibility with TalkBack