### PR TITLE
Remove SyncManager.emailFlowable() in favour of the existing emailFlow() twin

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncAccountManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncAccountManager.kt
@@ -6,8 +6,6 @@ import au.com.shiftyjelly.pocketcasts.preferences.AccountConstants
 import au.com.shiftyjelly.pocketcasts.preferences.RefreshToken
 import au.com.shiftyjelly.pocketcasts.servers.sync.LoginIdentity
 import au.com.shiftyjelly.pocketcasts.servers.sync.TokenHandler
-import au.com.shiftyjelly.pocketcasts.utils.Optional
-import io.reactivex.Flowable
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -20,7 +18,6 @@ interface SyncAccountManager : TokenHandler {
     fun getAccount(): Account?
     fun getEmail(): String?
     fun emailFlow(): Flow<String?>
-    fun emailFlowable(): Flowable<Optional<String>>
     fun getLoginIdentity(): LoginIdentity?
     fun getRefreshToken(account: Account? = null): RefreshToken?
     fun getSignInType(account: Account): AccountConstants.SignInType

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncAccountManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncAccountManagerImpl.kt
@@ -49,7 +49,13 @@ open class SyncAccountManagerImpl @Inject constructor(
             }
         }
         trySend(getEmail())
-        accountManager.addOnAccountsUpdatedListener(listener, null, true)
+        try {
+            accountManager.addOnAccountsUpdatedListener(listener, null, true)
+        } catch (e: Exception) {
+            // AccountManager stores the listener before the calls that can throw, so it stays registered unless we remove it here
+            accountManager.removeOnAccountsUpdatedListener(listener)
+            throw e
+        }
         awaitClose {
             accountManager.removeOnAccountsUpdatedListener(listener)
         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncAccountManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncAccountManagerImpl.kt
@@ -13,12 +13,9 @@ import au.com.shiftyjelly.pocketcasts.preferences.RefreshToken
 import au.com.shiftyjelly.pocketcasts.servers.sync.LoginIdentity
 import au.com.shiftyjelly.pocketcasts.servers.sync.TokenHandler
 import au.com.shiftyjelly.pocketcasts.servers.sync.exception.RefreshTokenExpiredException
-import au.com.shiftyjelly.pocketcasts.utils.Optional
 import au.com.shiftyjelly.pocketcasts.utils.extensions.findParcelable
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import com.automattic.eventhorizon.SignInSourceType
-import io.reactivex.BackpressureStrategy
-import io.reactivex.Flowable
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.Dispatchers
@@ -56,24 +53,6 @@ open class SyncAccountManagerImpl @Inject constructor(
         awaitClose {
             accountManager.removeOnAccountsUpdatedListener(listener)
         }
-    }
-
-    override fun emailFlowable(): Flowable<Optional<String>> {
-        return Flowable.create({ emitter ->
-            try {
-                val listener = OnAccountsUpdateListener { accounts ->
-                    val email = accounts?.find { it.type == AccountConstants.ACCOUNT_TYPE }?.name
-                    emitter.onNext(Optional.of(email))
-                }
-                emitter.onNext(Optional.of(getEmail()))
-                accountManager.addOnAccountsUpdatedListener(listener, null, true)
-                emitter.setCancellable {
-                    accountManager.removeOnAccountsUpdatedListener(listener)
-                }
-            } catch (e: Exception) {
-                emitter.tryOnError(e)
-            }
-        }, BackpressureStrategy.BUFFER)
     }
 
     override fun getUuid(): String? = getAccount()?.let { account ->

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManager.kt
@@ -26,7 +26,6 @@ import au.com.shiftyjelly.pocketcasts.servers.sync.UserChangeResponse
 import au.com.shiftyjelly.pocketcasts.servers.sync.history.HistoryYearResponse
 import au.com.shiftyjelly.pocketcasts.servers.sync.login.DeviceAuthorizeResponse
 import au.com.shiftyjelly.pocketcasts.servers.sync.login.ExchangeSonosResponse
-import au.com.shiftyjelly.pocketcasts.utils.Optional
 import com.jakewharton.rxrelay2.BehaviorRelay
 import com.pocketcasts.service.api.BookmarksResponse
 import com.pocketcasts.service.api.EpisodesResponse
@@ -45,7 +44,6 @@ import com.pocketcasts.service.api.UserPodcastListResponse
 import com.pocketcasts.service.api.WebFeedCreateResponse
 import com.pocketcasts.service.api.WinbackResponse
 import io.reactivex.Completable
-import io.reactivex.Flowable
 import io.reactivex.Maybe
 import io.reactivex.Single
 import java.io.File
@@ -62,7 +60,6 @@ interface SyncManager : NamedSettingsCaller {
     fun getLoginIdentity(): LoginIdentity?
     fun getEmail(): String?
     fun emailFlow(): Flow<String?>
-    fun emailFlowable(): Flowable<Optional<String>>
     suspend fun signOut(action: suspend () -> Unit = {})
     suspend fun loginWithGoogle(idToken: String, signInSource: SignInSource): LoginResult
     suspend fun loginWithEmailAndPassword(email: String, password: String, signInSource: SignInSource): LoginResult

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
@@ -44,7 +44,6 @@ import au.com.shiftyjelly.pocketcasts.servers.sync.login.ExchangeSonosResponse
 import au.com.shiftyjelly.pocketcasts.servers.sync.login.LoginTokenResponse
 import au.com.shiftyjelly.pocketcasts.servers.sync.parseErrorResponse
 import au.com.shiftyjelly.pocketcasts.servers.sync.parseTokenErrorResponse
-import au.com.shiftyjelly.pocketcasts.utils.Optional
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import com.automattic.eventhorizon.EventHorizon
 import com.automattic.eventhorizon.LoginIdentityType
@@ -79,7 +78,6 @@ import com.pocketcasts.service.api.WinbackResponse
 import com.squareup.moshi.Moshi
 import dagger.hilt.android.qualifiers.ApplicationContext
 import io.reactivex.Completable
-import io.reactivex.Flowable
 import io.reactivex.Maybe
 import io.reactivex.Single
 import java.io.File
@@ -157,8 +155,6 @@ class SyncManagerImpl @Inject constructor(
     override fun getEmail(): String? = syncAccountManager.getEmail()
 
     override fun emailFlow() = syncAccountManager.emailFlow().distinctUntilChanged()
-
-    override fun emailFlowable(): Flowable<Optional<String>> = syncAccountManager.emailFlowable().distinctUntilChanged()
 
     override suspend fun getAccessToken(account: Account): AccessToken = syncAccountManager.peekAccessToken(account)
         ?: fetchAccessToken(account)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
@@ -135,7 +135,7 @@ class UserManagerImpl @Inject constructor(
                                 rxSingle { Optional.of(fetchSubscriptionForSignIn()) }
                             }
                         }
-                        .combineLatest(syncManager.emailFlowable())
+                        .combineLatest(syncManager.emailFlow().map { Optional.of(it) }.asFlowable())
                         .map { (maybeSubscription, maybeEmail) ->
                             analyticsController.refreshMetadata()
                             SignInState.SignedIn(email = maybeEmail.get() ?: "", subscription = maybeSubscription.get())

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
@@ -135,10 +135,10 @@ class UserManagerImpl @Inject constructor(
                                 rxSingle { Optional.of(fetchSubscriptionForSignIn()) }
                             }
                         }
-                        .combineLatest(syncManager.emailFlow().map { Optional.of(it) }.asFlowable())
-                        .map { (maybeSubscription, maybeEmail) ->
+                        .combineLatest(syncManager.emailFlow().map { it.orEmpty() }.asFlowable())
+                        .map { (maybeSubscription, email) ->
                             analyticsController.refreshMetadata()
-                            SignInState.SignedIn(email = maybeEmail.get() ?: "", subscription = maybeSubscription.get())
+                            SignInState.SignedIn(email = email, subscription = maybeSubscription.get())
                         }
                         .onErrorReturn {
                             Timber.e(it, "Error getting subscription state")

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncAccountManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncAccountManagerImplTest.kt
@@ -1,0 +1,86 @@
+package au.com.shiftyjelly.pocketcasts.repositories.sync
+
+import android.accounts.Account
+import android.accounts.AccountManager
+import android.accounts.OnAccountsUpdateListener
+import au.com.shiftyjelly.pocketcasts.preferences.AccountConstants
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@Config(manifest = Config.NONE)
+@RunWith(RobolectricTestRunner::class)
+class SyncAccountManagerImplTest {
+    private val accountManager = mock<AccountManager>()
+    private val syncAccountManager = SyncAccountManagerImpl(mock(), accountManager)
+
+    @Test
+    fun `emailFlow emits the current email`() = runTest {
+        stubAccounts("test@example.com")
+
+        assertEquals("test@example.com", syncAccountManager.emailFlow().first())
+    }
+
+    @Test
+    fun `emailFlow emits every account update`() = runTest {
+        stubAccounts("first@example.com")
+        whenever(accountManager.addOnAccountsUpdatedListener(any(), anyOrNull(), any())).thenAnswer { invocation ->
+            val listener = invocation.arguments[0] as OnAccountsUpdateListener
+            listener.onAccountsUpdated(arrayOf(Account("second@example.com", AccountConstants.ACCOUNT_TYPE)))
+            null
+        }
+
+        val emails = syncAccountManager.emailFlow().take(2).toList()
+
+        assertEquals(listOf("first@example.com", "second@example.com"), emails)
+    }
+
+    @Test
+    fun `emailFlow deregisters the listener when it is cancelled`() = runTest {
+        stubAccounts()
+
+        syncAccountManager.emailFlow().first()
+
+        verify(accountManager).removeOnAccountsUpdatedListener(any())
+    }
+
+    @Test
+    fun `emailFlow deregisters the listener when registering it throws`() = runTest {
+        stubAccounts()
+        whenever(accountManager.addOnAccountsUpdatedListener(any(), anyOrNull(), any()))
+            .thenThrow(IllegalStateException("registration failed"))
+
+        val error = runCatching { syncAccountManager.emailFlow().toList() }.exceptionOrNull()
+
+        assertTrue(error is IllegalStateException)
+        verify(accountManager).removeOnAccountsUpdatedListener(any())
+    }
+
+    @Test
+    fun `emailFlow does not deregister a listener it never registered`() = runTest {
+        whenever(accountManager.getAccountsByType(AccountConstants.ACCOUNT_TYPE)).thenThrow(SecurityException("no access"))
+
+        val error = runCatching { syncAccountManager.emailFlow().toList() }.exceptionOrNull()
+
+        assertTrue(error is SecurityException)
+        verify(accountManager, never()).removeOnAccountsUpdatedListener(any())
+    }
+
+    private fun stubAccounts(vararg emails: String) {
+        val accounts = emails.map { Account(it, AccountConstants.ACCOUNT_TYPE) }.toTypedArray()
+        whenever(accountManager.getAccountsByType(AccountConstants.ACCOUNT_TYPE)).thenReturn(accounts)
+    }
+}


### PR DESCRIPTION
## Description

Internal refactor with no visible change: the app now watches the signed-in account's email address with coroutines instead of RxJava. Also fixes a listener leak in the coroutine version that this change makes load-bearing.

`SyncAccountManager` had two hand-written producers wrapping the same `AccountManager` listener — `emailFlow(): Flow<String?>` and `emailFlowable(): Flowable<Optional<String>>`. The `Flow` one is already the production path on `tv`, and the `Flowable` one had a single caller left. So this deletes `emailFlowable()` (and its `Flowable.create` producer) from `SyncAccountManager`, `SyncAccountManagerImpl`, `SyncManager` and `SyncManagerImpl`, and points that caller — `UserManagerImpl.getSignInState()` — at the twin. `getSignInState()` keeps its own `Flowable<SignInState>` signature, so none of its ~30 consumers were touched.

Part of the RxJava removal effort. Both `SyncAccountManager` files are now Rx-free, and this clears one of the two blockers on `getSignInState()`'s own migration (it now waits only on `SyncManager.isLoggedInObservable`).

### Listener leak fix (last commit)

`emailFlow()` had a pre-existing leak, worth fixing here because this PR makes it the only producer. `AccountManager.addOnAccountsUpdatedListener` puts the listener in its map *before* the three calls that can throw — `registerReceiver`, the `registerAccountListener` binder call, and the `getAccounts` binder call behind `updateImmediately = true`. If any throws, the listener stays registered, `awaitClose` is never reached, and the process-wide `AccountManager` retains the listener, the `callbackFlow` `ProducerScope`, and whatever the collecting coroutine captured.

`emailFlow()` is cold and collected per subscription of `getSignInState()`, so each failure leaks another one. The fix removes the listener on the way out; `removeOnAccountsUpdatedListener` logs and returns when it was never added, so it is safe even if the failure happened before registration.

Comes with a new `SyncAccountManagerImplTest` (5 cases). I confirmed the leak test fails without the fix and passes with it, and that the other four pass either way.

**One behavioural delta worth knowing:** the old `distinctUntilChanged()` compared `Optional` instances, and `Optional` has no `equals` override, so it deduped by identity and never actually dropped anything. The new one compares `String?` and genuinely dedupes. Net effect: `getSignInState()` now emits one `SignedIn` per sign-in instead of two, and `analyticsController.refreshMetadata()` fires once instead of twice. I read all ~30 consumers and they are emission-count agnostic — including `AutomotiveSettingsFragment`, whose `windowed(2)` keys off the SignedOut→SignedIn transition, which still happens exactly once.

## Testing Instructions

A pure refactor, so there is nothing to look at — the risk is all in the sign-in state stream.

1. Sign in with email and password, and again with Google. The Profile screen shows the right email, Gravatar and subscription tier.
2. Sign out, then sign in with a **different** account. The profile email updates.
3. With the app running, remove the Pocket Casts account in Android Settings → Accounts. The app signs itself out.
4. Without restarting the app, sign in and out and confirm Files/Cloud, Referrals, Search, Discover, Settings → Appearance and the Plus/Patron gating all flip state.
5. Automotive: signing in from the settings screen still closes it. Wear: sign-in state still reflects the phone account.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

