### PR TITLE
Migrate the two Settings observables from RxJava to StateFlow

### DIFF
--- a/app/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/FolderEditViewModelTest.kt
+++ b/app/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/FolderEditViewModelTest.kt
@@ -14,7 +14,6 @@ import com.automattic.eventhorizon.EventHorizon
 import com.automattic.eventhorizon.FolderCreateColorShownEvent
 import com.automattic.eventhorizon.FolderSavedEvent
 import io.reactivex.Flowable
-import io.reactivex.Observable
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
@@ -61,7 +60,7 @@ class FolderEditViewModelTest {
         val folderManager = mock<FolderManager>()
         whenever(folderManager.observeFolders()).thenReturn(flowOf(emptyList()))
 
-        whenever(settings.selectPodcastSortTypeObservable).thenReturn(Observable.just(PodcastsSortType.EPISODE_DATE_NEWEST_TO_OLDEST))
+        whenever(settings.selectPodcastSortTypeFlow).thenReturn(MutableStateFlow(PodcastsSortType.EPISODE_DATE_NEWEST_TO_OLDEST))
 
         notificationManager = mock()
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/FolderEditViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/FolderEditViewModel.kt
@@ -39,7 +39,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.reactive.asFlow
-import kotlinx.coroutines.rx2.asFlow
 import kotlinx.coroutines.rx2.asObservable
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -111,7 +110,7 @@ class FolderEditViewModel
                     .asFlow<List<Podcast>>(),
                 searchText,
                 selectedUuids,
-                settings.selectPodcastSortTypeObservable.asFlow(),
+                settings.selectPodcastSortTypeFlow,
                 folderManager.observeFolders().combine(folderUuid) { folders, uuidOptional ->
                     val foldersSorted = folders.sortedBy { it.name.lowercase(Locale.getDefault()) }
                     // find the current open folder

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -31,7 +31,6 @@ import au.com.shiftyjelly.pocketcasts.preferences.model.ShelfItem
 import au.com.shiftyjelly.pocketcasts.preferences.model.ThemeSetting
 import com.automattic.eventhorizon.UpNextSwipeActionType
 import com.automattic.eventhorizon.UploadedFilesSortType
-import io.reactivex.Observable
 import java.time.Instant
 import java.util.Date
 import kotlinx.coroutines.flow.Flow
@@ -296,8 +295,8 @@ interface Settings {
     val currentSessionId: String
     val sessionIds: List<String>
 
-    val selectPodcastSortTypeObservable: Observable<PodcastsSortType>
-    val multiSelectItemsObservable: Observable<List<String>>
+    val selectPodcastSortTypeFlow: StateFlow<PodcastsSortType>
+    val multiSelectItemsFlow: StateFlow<List<String>>
     val refreshStateFlow: StateFlow<RefreshState>
 
     val shelfItems: UserSetting<List<ShelfItem>>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -47,7 +47,6 @@ import au.com.shiftyjelly.pocketcasts.utils.config.FirebaseConfig
 import au.com.shiftyjelly.pocketcasts.utils.extensions.getString
 import au.com.shiftyjelly.pocketcasts.utils.extensions.splitIgnoreEmpty
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
-import com.jakewharton.rxrelay2.BehaviorRelay
 import com.squareup.moshi.Moshi
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.nio.charset.Charset
@@ -115,8 +114,8 @@ class SettingsImpl @Inject constructor(
 
     override val sessionIds get() = sessionIdsSetting.value
 
-    override val selectPodcastSortTypeObservable = BehaviorRelay.create<PodcastsSortType>().apply { accept(getSelectPodcastsSortType()) }
-    override val multiSelectItemsObservable = BehaviorRelay.create<List<String>>().apply { accept(getMultiSelectItems()) }
+    override val selectPodcastSortTypeFlow = MutableStateFlow(getSelectPodcastsSortType())
+    override val multiSelectItemsFlow = MutableStateFlow(getMultiSelectItems())
 
     override val shelfItems = UserSetting.PrefFromString(
         sharedPrefKey = "shelfItems",
@@ -261,7 +260,7 @@ class SettingsImpl @Inject constructor(
             putString(Settings.PREFERENCE_SELECT_PODCAST_LIBRARY_SORT, sortType.clientId.toString())
             apply()
         }
-        selectPodcastSortTypeObservable.accept(sortType)
+        selectPodcastSortTypeFlow.value = sortType
     }
 
     override fun getSelectPodcastsSortType(): PodcastsSortType {
@@ -1341,7 +1340,7 @@ class SettingsImpl @Inject constructor(
 
     override fun setMultiSelectItems(items: List<String>) {
         setStringList("multi_select_items", items)
-        multiSelectItemsObservable.accept(items)
+        multiSelectItemsFlow.value = items
     }
 
     override val autoAddUpNextLimit = UserSetting.IntPref(

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodesHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodesHelper.kt
@@ -5,8 +5,8 @@ import android.widget.Toast
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.LiveData
+import androidx.lifecycle.asLiveData
 import androidx.lifecycle.map
-import androidx.lifecycle.toLiveData
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.coroutines.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.localization.extensions.getStringPlural
@@ -40,12 +40,12 @@ import com.automattic.eventhorizon.EpisodeBulkUnstarredEvent
 import com.automattic.eventhorizon.EpisodeRemovedListeningHistoryEvent
 import com.automattic.eventhorizon.EventHorizon
 import com.google.android.material.snackbar.Snackbar
-import io.reactivex.BackpressureStrategy
 import javax.inject.Inject
 import kotlin.math.min
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import au.com.shiftyjelly.pocketcasts.images.R as IR
@@ -68,10 +68,9 @@ class MultiSelectEpisodesHelper @Inject constructor(
 ) : MultiSelectHelper<BaseEpisode>() {
     override val maxToolbarIcons = 4
 
-    override val toolbarActions: LiveData<List<MultiSelectAction>> = settings.multiSelectItemsObservable
-        .toFlowable(BackpressureStrategy.LATEST)
+    override val toolbarActions: LiveData<List<MultiSelectAction>> = settings.multiSelectItemsFlow
         .map { MultiSelectEpisodeAction.listFromIds(it) }
-        .toLiveData()
+        .asLiveData()
         .combineLatest(_selectedListLive)
         .map { (actions, selectedEpisodes) ->
             crashLogging.recordEvent("MultiSelectEpisodesHelper toolbarActions updated (${actions.size}): ${actions.map { it::class.java.simpleName }}, ${selectedEpisodes.size} selectedEpisodes from $source")

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectFragment.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectFragment.kt
@@ -5,7 +5,7 @@ import android.os.Parcelable
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.lifecycle.toLiveData
+import androidx.lifecycle.asLiveData
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.SimpleItemAnimator
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
@@ -22,7 +22,6 @@ import com.automattic.eventhorizon.MultiSelectViewOverflowMenuRearrangeActionMov
 import com.automattic.eventhorizon.MultiSelectViewOverflowMenuRearrangeFinishedEvent
 import com.automattic.eventhorizon.ShelfActionSourceType
 import dagger.hilt.android.AndroidEntryPoint
-import io.reactivex.BackpressureStrategy
 import java.util.Collections
 import javax.inject.Inject
 import kotlinx.parcelize.Parcelize
@@ -85,7 +84,7 @@ class MultiSelectFragment :
         itemTouchHelper = ItemTouchHelper(callback)
         itemTouchHelper.attachToRecyclerView(recyclerView)
 
-        settings.multiSelectItemsObservable.toFlowable(BackpressureStrategy.LATEST).toLiveData()
+        settings.multiSelectItemsFlow.asLiveData()
             .observe(viewLifecycleOwner) {
                 val multiSelectActions: MutableList<Any> = MultiSelectEpisodeAction.listFromIds(it).toMutableList()
 


### PR DESCRIPTION
## Description

Internal refactor with no user-visible change: the two app preferences that broadcast their updates to the UI (the multi-select action order, and the podcast sort order used when adding podcasts to a folder) now use Kotlin coroutines instead of RxJava.

These were the last two RxJava members of the `Settings` interface, and every consumer immediately bridged back out of Rx, so the round trip was pure overhead:

| Before | After |
| --- | --- |
| `selectPodcastSortTypeObservable: Observable<PodcastsSortType>` | `selectPodcastSortTypeFlow: StateFlow<PodcastsSortType>` |
| `multiSelectItemsObservable: Observable<List<String>>` | `multiSelectItemsFlow: StateFlow<List<String>>` |

`BehaviorRelay` becomes `MutableStateFlow` in `SettingsImpl`, and the three consumers drop their `toLiveData()` / `asFlow()` bridges. **`modules/services/preferences` and `modules/services/views` are now Rx-free modules.** Both still declare Rx in their build files, because those `api(...)` entries leak `io.reactivex` transitively to feature modules — removing them is separate work.

One deliberate difference: `StateFlow` deduplicates by equality where `BehaviorRelay` did not, so persisting an unchanged value no longer re-emits. Both consumers are idempotent, and `MultiSelectFragment` already updates its adapter locally before persisting, so nothing depended on that re-emission.

## Testing Instructions

A pure refactor, so there is nothing new to look at. What could plausibly have broken is the multi-select toolbar and the folder sort order still reacting when their preference changes.

1. Long-press an episode to enter multi-select. The toolbar shows the expected actions, and they enable/disable as you change the selection.
2. From the multi-select overflow, choose "Rearrange actions" and drag actions between the two sections. The new order applies to the toolbar immediately and survives an app restart. Dropping an action back where it started changes nothing.
3. Podcasts tab → edit a folder → "Add podcasts". Changing the sort order re-sorts the list immediately, keeps your current selection, and survives rotation.
4. If you can, upgrade over an older install rather than installing fresh, and check the multi-select toolbar still shows the right actions on first launch (a background migration rewrites the stored action ids).

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
