### PR TITLE
Fix back navigation out of the Auto Add podcast selector

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -854,6 +854,11 @@ class MainActivity :
     private fun setupBackPressedCallbacks() {
         val bottomNavigatorCallback = object : OnBackPressedCallback(false) {
             override fun handleOnBackPressed() {
+                // Give the current fragment a chance to unwind its own back stack before popping it.
+                val currentFragment = navigator.currentFragment()
+                if (currentFragment is HasBackstack && currentFragment.onBackPressed()) {
+                    return
+                }
                 navigator.pop()
             }
         }

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -854,12 +854,7 @@ class MainActivity :
     private fun setupBackPressedCallbacks() {
         val bottomNavigatorCallback = object : OnBackPressedCallback(false) {
             override fun handleOnBackPressed() {
-                // Give the current fragment a chance to unwind its own back stack before popping it.
-                val currentFragment = navigator.currentFragment()
-                if (currentFragment is HasBackstack && currentFragment.onBackPressed()) {
-                    return
-                }
-                navigator.pop()
+                popOrDelegateBack()
             }
         }
         onBackPressedDispatcher.addCallback(this, bottomNavigatorCallback)
@@ -904,15 +899,7 @@ class MainActivity :
 
         val modalFragmentCallback = object : OnBackPressedCallback(false) {
             override fun handleOnBackPressed() {
-                val currentFragment = navigator.currentFragment()
-                if (currentFragment is HasBackstack) {
-                    val handled = currentFragment.onBackPressed()
-                    if (!handled) {
-                        navigator.pop()
-                    }
-                } else {
-                    navigator.pop()
-                }
+                popOrDelegateBack()
             }
         }
         onBackPressedDispatcher.addCallback(this, modalFragmentCallback)
@@ -953,6 +940,15 @@ class MainActivity :
         this.playerContainerBackCallback = playerContainerBackstackCallback
         this.modalFragmentBackCallback = modalFragmentCallback
         this.frameBottomSheetBackCallback = frameBottomSheetCallback
+    }
+
+    // Give the current fragment a chance to unwind its own back stack before popping it off the navigator.
+    private fun popOrDelegateBack() {
+        val currentFragment = navigator.currentFragment()
+        if (currentFragment is HasBackstack && currentFragment.onBackPressed()) {
+            return
+        }
+        navigator.pop()
     }
 
     private var playerBottomSheetBackCallback: OnBackPressedCallback? = null

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoAddSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoAddSettingsFragment.kt
@@ -53,6 +53,8 @@ class AutoAddSettingsFragment :
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         viewModel.onShown()
+        // The back callback is seeded at attach, before the podcast selector is on the child back stack.
+        childFragmentManager.addOnBackStackChangedListener { notifyBackstackChanged() }
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoAddSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoAddSettingsFragment.kt
@@ -53,8 +53,6 @@ class AutoAddSettingsFragment :
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         viewModel.onShown()
-        // The back callback is seeded at attach, before the podcast selector is on the child back stack.
-        childFragmentManager.addOnBackStackChangedListener { notifyBackstackChanged() }
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {


### PR DESCRIPTION
## Description

Backing out of the "Choose podcasts" screen in Auto Add to Up Next now returns to the Auto Add screen, instead of jumping all the way back to Settings.

The Auto Add screen shows its podcast selector inside a child fragment container, and it knows how to unwind that itself. Every other back-press path in the app asks the visible screen to handle back first and only pops the whole screen if it says it did not, but the bottom navigation path skipped that step and popped the screen straight off the tab stack. Any screen with its own internal back stack lost a level of navigation as a result.

The bottom navigation back callback now delegates to the current fragment the same way the modal path already does: if the fragment implements `HasBackstack` and handles the press, nothing else happens; otherwise the navigator pops as before. Because the check reads the fragment's live state at press time rather than a flag cached when the fragment was attached, it also stays correct across rotation.

## Testing Instructions

1. Go to Profile > Settings > General > Auto Add to Up Next.
2. Tap "Choose podcasts".
3. Press the toolbar back arrow. You should return to the Auto Add to Up Next screen, not Settings.
4. Repeat steps 2 and 3 using the system back button (and the predictive back gesture, if enabled).
5. Repeat step 2, rotate the device to landscape, then press back. You should still return to the Auto Add to Up Next screen.
6. Sanity check normal back navigation elsewhere in the tabs, for example Podcasts tab > a podcast > back, and Discover > a list > a podcast > back, to confirm popping still works as before.

## Video

https://github.com/user-attachments/assets/762a7f02-d52d-422b-aa8a-3b9b557aab1c

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
