### PR TITLE
Migrate the downloaded episodes stream from RxJava to Flow

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModel.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModel.kt
@@ -39,7 +39,6 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.reactive.asFlow
-import kotlinx.coroutines.reactive.collect
 import timber.log.Timber
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -92,7 +91,7 @@ class MainActivityViewModel
         }
 
         viewModelScope.launch {
-            episodeManager.findDownloadedEpisodesRxFlowable()
+            episodeManager.findDownloadedEpisodesFlow()
                 .collect { result ->
                     _downloadedEpisodeState.update { state -> state.copy(downloadedEpisodes = result.sumOf { it.sizeInBytes }) }
                 }

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModel.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModel.kt
@@ -59,9 +59,6 @@ class MainActivityViewModel
     private val _state = MutableStateFlow(State())
     val state = _state.asStateFlow()
 
-    private val _downloadedEpisodeState = MutableStateFlow(DownloadedEpisodesState())
-    val downloadedEpisodeState = _downloadedEpisodeState.asStateFlow()
-
     private val _snackbarMessage = MutableSharedFlow<Int>()
     val snackbarMessage = _snackbarMessage.asSharedFlow()
 
@@ -88,13 +85,6 @@ class MainActivityViewModel
             if (!state.value.shouldShowWhatsNew) {
                 updateStoriesModalShowState(settings.getEndOfYearShowModal())
             }
-        }
-
-        viewModelScope.launch {
-            episodeManager.findDownloadedEpisodesFlow()
-                .collect { result ->
-                    _downloadedEpisodeState.update { state -> state.copy(downloadedEpisodes = result.sumOf { it.sizeInBytes }) }
-                }
         }
     }
 

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModel.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModel.kt
@@ -208,10 +208,6 @@ class MainActivityViewModel
         val shouldShowWhatsNew: Boolean = false,
     )
 
-    data class DownloadedEpisodesState(
-        val downloadedEpisodes: Long = 0L,
-    )
-
     sealed class NavigationState {
         object BookmarksForCurrentlyPlaying : NavigationState()
         data class BookmarksForPodcastEpisode(val episode: PodcastEpisode) : NavigationState()

--- a/app/src/test/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModelTest.kt
+++ b/app/src/test/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModelTest.kt
@@ -25,6 +25,7 @@ import io.reactivex.Flowable
 import java.util.Date
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -229,7 +230,7 @@ class MainActivityViewModelTest {
             ),
         )
 
-        whenever(episodeManager.findDownloadedEpisodesRxFlowable()).thenReturn(Flowable.just(downloadedEpisodes))
+        whenever(episodeManager.findDownloadedEpisodesFlow()).thenReturn(flowOf(downloadedEpisodes))
 
         viewModel = MainActivityViewModel(
             episodeManager = episodeManager,

--- a/app/src/test/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModelTest.kt
+++ b/app/src/test/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModelTest.kt
@@ -25,9 +25,7 @@ import io.reactivex.Flowable
 import java.util.Date
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.emptyFlow
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
-import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -81,12 +79,6 @@ class MainActivityViewModelTest {
 
     private val episode = UserEpisode(uuid = TEST_EPISODE_UUID, publishedDate = Date())
 
-    private val downloadedEpisodes = listOf(
-        PodcastEpisode(sizeInBytes = 1024L, uuid = "episode-uuid", title = "Episode Title", publishedDate = Date()),
-        PodcastEpisode(sizeInBytes = 2048L, uuid = "episode-uuid", title = "Episode Title", publishedDate = Date()),
-        PodcastEpisode(sizeInBytes = 512L, uuid = "episode-uuid", title = "Episode Title", publishedDate = Date()),
-    )
-
     @Before
     fun setup() = runTest {
         whenever(playbackManager.playbackStateRelay).thenReturn(BehaviorRelay.create<PlaybackState>().toSerialized())
@@ -119,15 +111,6 @@ class MainActivityViewModelTest {
 
         viewModel.state.test {
             assertFalse(awaitItem().shouldShowWhatsNew)
-        }
-    }
-
-    @Test
-    fun `when episodeManager emits episodes, downloadedEpisodeState should update with total size`() = runTest {
-        initViewModel()
-
-        viewModel.downloadedEpisodeState.test {
-            assertEquals(downloadedEpisodes.sumOf { it.sizeInBytes }, awaitItem().downloadedEpisodes)
         }
     }
 
@@ -229,8 +212,6 @@ class MainActivityViewModelTest {
                 SignInState.SignedIn(email = "", subscription = null),
             ),
         )
-
-        whenever(episodeManager.findDownloadedEpisodesFlow()).thenReturn(flowOf(downloadedEpisodes))
 
         viewModel = MainActivityViewModel(
             episodeManager = episodeManager,

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/ManualCleanupViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/ManualCleanupViewModel.kt
@@ -15,18 +15,15 @@ import com.automattic.eventhorizon.DownloadsCleanUpButtonTappedEvent
 import com.automattic.eventhorizon.DownloadsCleanUpCompletedEvent
 import com.automattic.eventhorizon.DownloadsCleanUpShownEvent
 import com.automattic.eventhorizon.EventHorizon
-import com.jakewharton.rxrelay2.BehaviorRelay
 import dagger.hilt.android.lifecycle.HiltViewModel
-import io.reactivex.BackpressureStrategy
-import io.reactivex.rxkotlin.combineLatest
 import javax.inject.Inject
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.reactive.collect
 import kotlinx.coroutines.withContext
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -76,17 +73,18 @@ class ManualCleanupViewModel
         get() = State.DeleteButton(isEnabled = episodesToDelete.isNotEmpty())
 
     private val episodesToDelete: MutableList<PodcastEpisode> = mutableListOf()
-    private val switchState: BehaviorRelay<Boolean> = BehaviorRelay.createDefault(false)
+    private val switchState = MutableStateFlow(false)
     private var deleteButtonAction: (() -> Unit)? = null
 
     init {
         viewModelScope.launch {
-            episodeManager.findDownloadedEpisodesRxFlowable()
-                .combineLatest(switchState.toFlowable(BackpressureStrategy.LATEST))
-                .collect { result ->
-                    val (downloadedEpisodes, isStarredSwitchChecked) = result
-                    val downloadedAdjustedForStarred =
-                        downloadedEpisodes.filter { !it.isStarred || isStarredSwitchChecked }
+            combine(
+                episodeManager.findDownloadedEpisodesFlow(),
+                switchState,
+            ) { downloadedEpisodes, isStarredSwitchChecked ->
+                downloadedEpisodes.filter { !it.isStarred || isStarredSwitchChecked }
+            }
+                .collect { downloadedAdjustedForStarred ->
                     episodesToDelete.clear()
                     val updatedDiskSpaceViews = EpisodePlayingStatus.values()
                         .mapToDiskSpaceViewsForEpisodes(downloadedAdjustedForStarred)
@@ -118,7 +116,7 @@ class ManualCleanupViewModel
     }
 
     fun onStarredSwitchClicked(isChecked: Boolean) {
-        switchState.accept(isChecked)
+        switchState.value = isChecked
     }
 
     fun onDeleteButtonClicked() {
@@ -196,7 +194,7 @@ class ManualCleanupViewModel
                 unplayed = state.value.unplayed?.isChecked == true,
                 inProgress = state.value.inProgress?.isChecked == true,
                 played = state.value.played?.isChecked == true,
-                includeStarred = switchState.value == true,
+                includeStarred = switchState.value,
             ),
         )
     }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/StorageSettingsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/StorageSettingsViewModel.kt
@@ -33,7 +33,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.reactive.collect
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @HiltViewModel
@@ -96,7 +95,7 @@ class StorageSettingsViewModel @Inject constructor(
         this.permissionGranted = permissionGranted
         this.sdkVersion = sdkVersion
         viewModelScope.launch {
-            episodeManager.findDownloadedEpisodesRxFlowable()
+            episodeManager.findDownloadedEpisodesFlow()
                 .collect { downloadedEpisodes ->
                     val downloadSize = downloadedEpisodes.sumOf { it.sizeInBytes }
                     mutableState.value = mutableState.value.copy(

--- a/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/ManualCleanupViewModelTest.kt
+++ b/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/ManualCleanupViewModelTest.kt
@@ -5,11 +5,11 @@ import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import com.automattic.eventhorizon.EventHorizon
-import io.reactivex.Flowable
 import java.util.Date
 import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.emptyFlow
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -33,8 +33,7 @@ class ManualCleanupViewModelTest {
     @Before
     fun setUp() {
         episodeManager = mock()
-        whenever(episodeManager.findDownloadedEpisodesRxFlowable())
-            .thenReturn(Flowable.generate { listOf(episodes) })
+        whenever(episodeManager.findDownloadedEpisodesFlow()).thenReturn(emptyFlow())
         viewModel = ManualCleanupViewModel(episodeManager, mock(), EventHorizon(TestEventSink()))
     }
 
@@ -64,8 +63,7 @@ class ManualCleanupViewModelTest {
 
     @Test
     fun `given episodes selected, when delete button clicked, then delete action invoked`() {
-        whenever(episodeManager.findDownloadedEpisodesRxFlowable())
-            .thenReturn(Flowable.generate { listOf(episode) })
+        whenever(episodeManager.findDownloadedEpisodesFlow()).thenReturn(emptyFlow())
         val deleteButtonClickAction = mock<() -> Unit>()
         viewModel.setup(deleteButtonClickAction)
         viewModel.onDiskSpaceCheckedChanged(isChecked = true, diskSpaceView = diskSpaceView)

--- a/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/ManualCleanupViewModelTest.kt
+++ b/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/ManualCleanupViewModelTest.kt
@@ -6,10 +6,12 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import com.automattic.eventhorizon.EventHorizon
 import java.util.Date
+import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -63,7 +65,6 @@ class ManualCleanupViewModelTest {
 
     @Test
     fun `given episodes selected, when delete button clicked, then delete action invoked`() {
-        whenever(episodeManager.findDownloadedEpisodesFlow()).thenReturn(emptyFlow())
         val deleteButtonClickAction = mock<() -> Unit>()
         viewModel.setup(deleteButtonClickAction)
         viewModel.onDiskSpaceCheckedChanged(isChecked = true, diskSpaceView = diskSpaceView)
@@ -71,5 +72,18 @@ class ManualCleanupViewModelTest {
         viewModel.onDeleteButtonClicked()
 
         verify(deleteButtonClickAction).invoke()
+    }
+
+    @Test
+    fun `given downloaded episodes, when starred switch toggled, then starred episodes are included`() {
+        val starredEpisode = PodcastEpisode(uuid = "2", publishedDate = Date(), isStarred = true)
+        whenever(episodeManager.findDownloadedEpisodesFlow()).thenReturn(flowOf(listOf(episode, starredEpisode)))
+        viewModel = ManualCleanupViewModel(episodeManager, mock(), EventHorizon(TestEventSink()))
+
+        assertEquals(listOf(episode), viewModel.state.value.unplayed?.episodes)
+
+        viewModel.onStarredSwitchClicked(true)
+
+        assertEquals(listOf(episode, starredEpisode), viewModel.state.value.unplayed?.episodes)
     }
 }

--- a/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/StorageSettingsViewModelTest.kt
+++ b/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/StorageSettingsViewModelTest.kt
@@ -11,12 +11,12 @@ import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import au.com.shiftyjelly.pocketcasts.utils.FileUtilWrapper
 import com.automattic.eventhorizon.EventHorizon
 import dagger.hilt.android.qualifiers.ApplicationContext
-import io.reactivex.Flowable
 import java.io.File
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -71,7 +71,7 @@ class StorageSettingsViewModelTest {
         whenever(settings.getStorageChoiceName()).thenReturn("")
         whenever(settings.backgroundRefreshPodcasts).thenReturn(UserSetting.Mock(true, mock()))
         whenever(settings.warnOnMeteredNetwork).thenReturn(UserSetting.Mock(true, mock()))
-        whenever(episodeManager.findDownloadedEpisodesRxFlowable()).thenReturn(Flowable.empty())
+        whenever(episodeManager.findDownloadedEpisodesFlow()).thenReturn(emptyFlow())
         viewModel = StorageSettingsViewModel(
             episodeManager = episodeManager,
             fileStorage = fileStorage,

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -266,7 +266,7 @@ abstract class EpisodeDao {
 
     @Transaction
     @Query("SELECT * FROM podcast_episodes WHERE episode_status == :downloadEpisodeDownloadStatus ORDER BY last_download_attempt_date DESC")
-    abstract fun findDownloadedEpisodesRxFlowable(downloadEpisodeDownloadStatus: EpisodeDownloadStatus = EpisodeDownloadStatus.Downloaded): Flowable<List<PodcastEpisode>>
+    abstract fun findDownloadedEpisodesFlow(downloadEpisodeDownloadStatus: EpisodeDownloadStatus = EpisodeDownloadStatus.Downloaded): Flow<List<PodcastEpisode>>
 
     @Query("SELECT COUNT(*) FROM podcast_episodes WHERE episode_status == :downloadEpisodeDownloadStatus AND playing_status == :playingStatus")
     abstract suspend fun downloadedEpisodesThatHaveNotBeenPlayedCount(

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/file/FileStorage.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/file/FileStorage.kt
@@ -18,7 +18,6 @@ import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.mapNotNull
-import kotlinx.coroutines.reactive.asFlow
 import timber.log.Timber
 
 open class FileStorage @Inject constructor(
@@ -179,7 +178,7 @@ open class FileStorage @Inject constructor(
                     .updateEpisodesWithNewFilePaths(episodesManager)
 
                 // Move episodes
-                episodesManager.findDownloadedEpisodesRxFlowable().asFlow().first()
+                episodesManager.findDownloadedEpisodesFlow().first()
                     .onEach { episode -> LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Found downloaded episode ${episode.title}") }
                     .matchWithDownloadedFilePaths()
                     .filterNotExistingFiles()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/AutoPlaySelector.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/AutoPlaySelector.kt
@@ -19,7 +19,6 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.reactive.awaitFirst
 import kotlinx.coroutines.withContext
 
 class AutoPlaySelector @Inject constructor(
@@ -115,7 +114,7 @@ class AutoPlaySelector @Inject constructor(
     }
 
     private suspend fun findDownloadedEpisodes(): List<PodcastEpisode> {
-        return episodeManager.findDownloadedEpisodesRxFlowable().awaitFirst()
+        return episodeManager.findDownloadedEpisodesFlow().first()
     }
 
     private suspend fun findUserEpisodes(): List<UserEpisode> {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/BrowseTreeProvider.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/BrowseTreeProvider.kt
@@ -275,7 +275,7 @@ class BrowseTreeProvider @Inject constructor(
 
         val episodesWithSource = if (DOWNLOADS_ROOT == parentId) {
             autoPlaySource = AutoPlaySource.Predefined.Downloads
-            episodeManager.findDownloadedEpisodesRxFlowable().blockingFirst() to ""
+            episodeManager.findDownloadedEpisodesFlow().first() to ""
         } else {
             autoPlaySource = AutoPlaySource.fromId(parentId)
             val episodes = getPlaylistEpisodes(

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -46,7 +46,7 @@ interface EpisodeManager {
     fun findEpisodesForHistorySyncBlocking(): List<PodcastEpisode>
 
     fun findDownloadEpisodesFlow(): Flow<List<PodcastEpisode>>
-    fun findDownloadedEpisodesRxFlowable(): Flowable<List<PodcastEpisode>>
+    fun findDownloadedEpisodesFlow(): Flow<List<PodcastEpisode>>
     fun findStarredEpisodesFlow(limit: Int = Int.MAX_VALUE): Flow<List<PodcastEpisode>>
     suspend fun findStarredEpisodes(): List<PodcastEpisode>
     suspend fun downloadedEpisodesThatHaveNotBeenPlayedCount(): Int

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -673,8 +673,8 @@ class EpisodeManagerImpl @Inject constructor(
         return episodeDao.findDownloadingEpisodesIncludingFailedFlow(failedDownloadCutoff)
     }
 
-    override fun findDownloadedEpisodesRxFlowable(): Flowable<List<PodcastEpisode>> {
-        return episodeDao.findDownloadedEpisodesRxFlowable()
+    override fun findDownloadedEpisodesFlow(): Flow<List<PodcastEpisode>> {
+        return episodeDao.findDownloadedEpisodesFlow()
     }
 
     override suspend fun downloadedEpisodesThatHaveNotBeenPlayedCount(): Int {


### PR DESCRIPTION
## Description

The list of downloaded episodes is now delivered to the app as a Kotlin Flow rather than an RxJava stream. Nothing about the app's behaviour changes: the Downloads screen in Android Auto, the storage and clean-up settings screens, the storage-move routine and the auto-play picker all read the same data as before.

Part of the RxJava removal effort. The backlog entry is `EpisodeManager` / `EpisodeDao` `findDownloadedEpisodesRxFlowable`, which is one of the remaining Rx signatures on the `EpisodeManager` interface.

`EpisodeDao.findDownloadedEpisodesRxFlowable` becomes `findDownloadedEpisodesFlow` and returns `Flow` instead of `Flowable`. Room supports both natively, so the query itself is untouched. That propagates through `EpisodeManager` and `EpisodeManagerImpl` (the only implementor) and out to all seven call sites. `AutoPlaySelector`, `StorageSettingsViewModel` and `ManualCleanupViewModel` end up with no RxJava references left at all.

The most substantial call site is `ManualCleanupViewModel`, where the rxkotlin `Flowable.combineLatest` becomes `combine`. That forced its "include starred" `BehaviorRelay` to change too, and it became a `MutableStateFlow` rather than gaining a new `asFlow()` bridge.

## Testing Instructions

The risk is that one of these screens silently stops updating, so each step is worth watching rather than just loading once.

1. Download a few episodes, including at least one starred episode and a mix of unplayed, in-progress and played ones.
2. Go to Profile → Settings → Storage. Confirm the "Downloaded files" size is populated and is not zero.
3. While that screen is open, delete a download from elsewhere (or download another episode). Confirm the size updates live without leaving the screen.
4. Go to Profile → Settings → Storage → Manage Downloads. Confirm the Unplayed / In progress / Played rows show the right episode counts and sizes.
5. Toggle "Include starred". Confirm the starred episode appears in the rows when it is on and disappears when it is off, and that the total size and the enabled state of the clean-up button follow.
6. Tick one or more categories and run the clean-up. Confirm the right episodes are removed and the rows refresh.
7. Rotate the Manage Downloads and Storage screens and confirm the numbers survive.
8. Connect to Android Auto (or the Desktop Head Unit) and open Pocket Casts → Downloads. Confirm the downloaded episodes are listed and playable. This is the call that stopped blocking a thread, so also back out of the node quickly while it loads and confirm nothing hangs or crashes.
9. With auto-play enabled and its source set to Downloads, let an episode finish and confirm the next downloaded episode plays.
10. In Profile → Settings → Storage, change the storage location to move files to another volume. Confirm downloaded episodes are moved and still play afterwards.
11. Check the home screen / profile downloaded-size figure still reflects reality after downloading and deleting.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

