### PR TITLE
Remove the dead findDownloadingEpisodesRxFlowable chain

### DIFF
--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -68,10 +68,6 @@ abstract class EpisodeDao {
     @Query("SELECT * FROM podcast_episodes WHERE uuid = :uuid")
     abstract fun findByUuidFlow(uuid: String): Flow<PodcastEpisode?>
 
-    @Transaction
-    @Query("SELECT * FROM podcast_episodes WHERE download_task_id IS NOT NULL")
-    abstract fun findDownloadingEpisodesRxFlowable(): Flowable<List<PodcastEpisode>>
-
     @Query("SELECT * FROM podcast_episodes WHERE UPPER(title) = UPPER(:query) LIMIT 1")
     abstract suspend fun findFirstBySearchQuery(query: String): PodcastEpisode?
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -117,7 +117,6 @@ interface EpisodeManager {
     fun markAsUnplayed(episodes: List<BaseEpisode>)
     suspend fun findEpisodeByUuid(uuid: String): BaseEpisode?
     suspend fun findEpisodesByUuids(uuids: List<String>): List<BaseEpisode>
-    fun findDownloadingEpisodesRxFlowable(): Flowable<List<BaseEpisode>>
     suspend fun updatePlaybackInteractionDate(episode: BaseEpisode?)
     suspend fun updatePlaybackInteraction(episodeUuid: String, interactionDate: Long, syncStatus: Long)
     suspend fun findStaleDownloads(): List<PodcastEpisode>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -191,11 +191,6 @@ class EpisodeManagerImpl @Inject constructor(
         return episodeDao.findPlaybackHistoryEpisodes()
     }
 
-    @Suppress("USELESS_CAST")
-    override fun findDownloadingEpisodesRxFlowable(): Flowable<List<BaseEpisode>> {
-        return episodeDao.findDownloadingEpisodesRxFlowable().map { it as List<BaseEpisode> }.mergeWith(userEpisodeManager.downloadUserEpisodesRxFlowable())
-    }
-
     override fun updatePlayedUpToBlocking(episode: BaseEpisode?, playedUpTo: Double, forceUpdate: Boolean) {
         if (playedUpTo < 0 || episode == null) {
             return

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/UserEpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/UserEpisodeManager.kt
@@ -79,7 +79,6 @@ interface UserEpisodeManager {
     suspend fun syncFiles(playbackManager: PlaybackManager)
     fun getPlaybackUrl(userEpisode: UserEpisode): String
     suspend fun getSignedPlaybackUrl(userEpisode: UserEpisode): String
-    fun downloadUserEpisodesRxFlowable(): Flowable<List<UserEpisode>>
     suspend fun updateDownloadedFilePath(episode: UserEpisode, filePath: String)
     suspend fun updateFileType(episode: UserEpisode, fileType: String)
     suspend fun updateSizeInBytes(episode: UserEpisode, sizeInBytes: Long)
@@ -216,10 +215,6 @@ class UserEpisodeManagerImpl @Inject constructor(
             Settings.CloudSortOrder.SHORT_LONG -> userEpisodeDao.findUserEpisodesDurationAscRxFlowable()
             Settings.CloudSortOrder.LONG_SHORT -> userEpisodeDao.findUserEpisodesDurationDescRxFlowable()
         }.map { it.filterNot { episode -> episode.serverStatus == UserEpisodeServerStatus.MISSING } }
-    }
-
-    override fun downloadUserEpisodesRxFlowable(): Flowable<List<UserEpisode>> {
-        return userEpisodeDao.findDownloadingUserEpisodesRxFlowable()
     }
 
     override fun episodeRxFlowable(uuid: String): Flowable<UserEpisode> {


### PR DESCRIPTION
This removes three unused RxJava methods that nothing in the app called. There is no behaviour change.

Part of the RxJava removal effort (backlog entries `EpisodeDao.kt`, `EpisodeManager.kt` and `UserEpisodeManager.kt`). `EpisodeManager.findDownloadingEpisodesRxFlowable` had zero consumers, which made `EpisodeDao.findDownloadingEpisodesRxFlowable` and `UserEpisodeManager.downloadUserEpisodesRxFlowable` dead as well, so all three go in one pure-deletion diff: 15 lines removed, nothing added.

- No Rx semantics needed preserving: nothing subscribed to these streams, so the `mergeWith` in the deleted override had no observer and no Room invalidation was registered.
- No bridges added or removed, and no imports orphaned: `io.reactivex.Flowable` is still used by other signatures in all four files.
- The in-app downloads list already uses the Flow path (`findDownloadingEpisodesIncludingFailedFlow`), which is untouched.

Two follow-ups found during review and deliberately left out to keep this diff purely the dead-code removal:
- `UserEpisodeDao.findDownloadingUserEpisodesRxFlowable` (`UserEpisodeDao.kt:70`) becomes dead with this change and can be deleted next.
- `UserEpisodeManager.kt:38` imports `io.reactivex.Single` without using it, unchanged from `main`.

Note for whoever merges second: draft PR #5919 touches `EpisodeDao.kt`, `EpisodeManager.kt` and `EpisodeManagerImpl.kt` in different hunks, so a trivial conflict is possible.

## Testing Instructions

Nothing should change, so this is a regression check that downloads still work.

1. Open the app, go to a podcast and download two or three episodes.
2. Open Profile > Downloads and confirm the episodes appear and their progress bars advance while downloading.
3. Go to Profile > Files, upload a file, and download it. Confirm it also shows progress and completes.
4. Pause and resume a download, and cancel one, confirming the list updates each time.
5. Background the app during a download and return to it: the list should still be accurate.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
