### PR TITLE
Migrate EpisodeRowDataProvider off RxJava

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/BaseEpisodeViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/BaseEpisodeViewHolder.kt
@@ -25,9 +25,11 @@ import au.com.shiftyjelly.pocketcasts.views.buttons.PlayButton
 import au.com.shiftyjelly.pocketcasts.views.swipe.SwipeAction
 import au.com.shiftyjelly.pocketcasts.views.swipe.SwipeRowActions
 import au.com.shiftyjelly.pocketcasts.views.swipe.SwipeRowLayout
-import io.reactivex.disposables.CompositeDisposable
-import io.reactivex.rxkotlin.plusAssign
-import io.reactivex.rxkotlin.subscribeBy
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
@@ -60,7 +62,8 @@ abstract class BaseEpisodeViewHolder<T : Any>(
 
     private val dateFormatter = RelativeDateFormatter(context)
 
-    private val disposable = CompositeDisposable()
+    private val holderScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private var rowDataJob: Job? = null
 
     private var isMultiSelectEnabled = false
 
@@ -158,17 +161,18 @@ abstract class BaseEpisodeViewHolder<T : Any>(
     }
 
     fun unbind() {
-        disposable.clear()
+        rowDataJob?.cancel()
+        rowDataJob = null
+        isObservingRowData = false
         binding.episodeRow.handler?.removeCallbacksAndMessages(null)
     }
 
     private fun observeRowData() {
-        disposable.clear()
+        rowDataJob?.cancel()
         hasHlsAlternateEnclosure = false
-        disposable += rowDataProvider.episodeRowDataObservable(episode.uuid)
-            .doOnSubscribe { isObservingRowData = true }
-            .doOnDispose { isObservingRowData = false }
-            .subscribeBy(onNext = { data ->
+        isObservingRowData = true
+        rowDataJob = holderScope.launch {
+            rowDataProvider.episodeRowDataFlow(episode.uuid).collect { data ->
                 hasHlsAlternateEnclosure = data.hasHlsAlternateEnclosure
                 isPlaying = data.playbackState.isPlaying && data.playbackState.episodeUuid == episode.uuid
                 bindPlaybackButton()
@@ -184,7 +188,8 @@ abstract class BaseEpisodeViewHolder<T : Any>(
                 }
                 bindSwipeActions()
                 bindContentDescription(isInUpNext = data.isInUpNext)
-            })
+            }
+        }
     }
 
     private fun bindArtwork(useEpisodeArtwork: Boolean) {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/UserEpisodeViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/UserEpisodeViewHolder.kt
@@ -23,9 +23,11 @@ import au.com.shiftyjelly.pocketcasts.views.buttons.PlayButton
 import au.com.shiftyjelly.pocketcasts.views.swipe.SwipeAction
 import au.com.shiftyjelly.pocketcasts.views.swipe.SwipeRowActions
 import au.com.shiftyjelly.pocketcasts.views.swipe.SwipeRowLayout
-import io.reactivex.disposables.CompositeDisposable
-import io.reactivex.rxkotlin.plusAssign
-import io.reactivex.rxkotlin.subscribeBy
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
 class UserEpisodeViewHolder(
@@ -53,7 +55,8 @@ class UserEpisodeViewHolder(
 
     private val dateFormatter = RelativeDateFormatter(context)
 
-    private val disposable: CompositeDisposable = CompositeDisposable()
+    private val holderScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private var rowDataJob: Job? = null
 
     private var boundEpisode: UserEpisode? = null
     private val episode get() = requireNotNull(boundEpisode)
@@ -133,22 +136,24 @@ class UserEpisodeViewHolder(
     }
 
     fun unbind() {
-        disposable.clear()
+        rowDataJob?.cancel()
+        rowDataJob = null
+        isObservingRowData = false
         binding.episodeRow.handler?.removeCallbacksAndMessages(null)
     }
 
     private fun observeRowData() {
-        disposable.clear()
-        disposable += rowDataProvider.userEpisodeRowDataObservable(episode.uuid)
-            .doOnSubscribe { isObservingRowData = true }
-            .doOnDispose { isObservingRowData = false }
-            .subscribeBy(onNext = { data ->
+        rowDataJob?.cancel()
+        isObservingRowData = true
+        rowDataJob = holderScope.launch {
+            rowDataProvider.userEpisodeRowDataFlow(episode.uuid).collect { data ->
                 bindPlaybackButton()
                 bindDate()
                 bindSwipeActions()
                 bindContentDescription()
                 bindFileStatusUpdate(data)
-            })
+            }
+        }
     }
 
     private fun bindFileStatus() {

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFileBottomSheetFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFileBottomSheetFragment.kt
@@ -14,6 +14,7 @@ import androidx.core.view.doOnLayout
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
+import androidx.lifecycle.lifecycleScope
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeViewSource
@@ -46,10 +47,9 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
-import io.reactivex.disposables.CompositeDisposable
-import io.reactivex.rxkotlin.plusAssign
-import io.reactivex.rxkotlin.subscribeBy
 import javax.inject.Inject
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -95,7 +95,7 @@ class CloudFileBottomSheetFragment : BottomSheetDialogFragment() {
     private var pocketCastsImageRequestFactory: PocketCastsImageRequestFactory? = null
     private val viewModel: CloudBottomSheetViewModel by viewModels()
     private var binding: BottomSheetCloudFileBinding? = null
-    private val disposables = CompositeDisposable()
+    private var rowDataJob: Job? = null
 
     private val args get() = requireArguments().requireParcelable<Args>(NEW_INSTANCE_ARG)
 
@@ -130,7 +130,8 @@ class CloudFileBottomSheetFragment : BottomSheetDialogFragment() {
 
     override fun onDestroyView() {
         super.onDestroyView()
-        disposables.clear()
+        rowDataJob?.cancel()
+        rowDataJob = null
         binding = null
     }
 
@@ -264,11 +265,12 @@ class CloudFileBottomSheetFragment : BottomSheetDialogFragment() {
                     hideErrorDetails = true,
                 )
 
-                disposables.clear()
-                disposables += rowDataProvider.userEpisodeRowDataObservable(episode.uuid)
-                    .subscribeBy(onNext = { data ->
+                rowDataJob?.cancel()
+                rowDataJob = viewLifecycleOwner.lifecycleScope.launch {
+                    rowDataProvider.userEpisodeRowDataFlow(episode.uuid).collect { data ->
                         binding.fileStatusIconsView.update(data)
-                    })
+                    }
+                }
 
                 binding.lblCloud.text = when (episode.serverStatus) {
                     UserEpisodeServerStatus.LOCAL -> getString(LR.string.profile_cloud_upload)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueue.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueue.kt
@@ -178,3 +178,9 @@ fun Observable<UpNextQueue.State>.containsUuid(uuid: String): Observable<Boolean
         }
     }
 }
+
+fun Flow<UpNextQueue.State>.containsUuid(uuid: String): Flow<Boolean> {
+    return map { state ->
+        state is UpNextQueue.State.Loaded && (state.queue.any { it.uuid == uuid } || state.episode.uuid == uuid)
+    }
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeRowData.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeRowData.kt
@@ -9,19 +9,23 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.repositories.playback.containsUuid
-import io.reactivex.Observable
-import io.reactivex.android.schedulers.AndroidSchedulers
-import io.reactivex.rxkotlin.Observables
-import io.reactivex.schedulers.Schedulers
-import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import kotlin.math.roundToInt
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.rx2.asObservable
-import kotlinx.coroutines.rx2.rxMaybe
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.rx2.asFlow
 
 data class EpisodeRowData(
     val downloadProgress: Int,
@@ -51,94 +55,105 @@ class EpisodeRowDataProvider @Inject constructor(
     private val settings: Settings,
 ) {
 
-    fun userEpisodeRowDataObservable(episodeUuid: String): Observable<UserEpisodeRowData> {
-        return Observables.combineLatest(
-            userEpisodeManager.episodeFlow(episodeUuid).filterNotNull().asObservable(),
-            downloadProgressObservable(episodeUuid),
-            uploadProgressObservable(episodeUuid),
-            playbackStatusObservable(episodeUuid),
-            isInUpNextObservable(episodeUuid),
-            hasBookmarksObservable(episodeUuid),
-            ::UserEpisodeRowData,
-        )
-            .subscribeOn(Schedulers.io())
-            .observeOn(AndroidSchedulers.mainThread())
+    fun userEpisodeRowDataFlow(episodeUuid: String): Flow<UserEpisodeRowData> {
+        // combine has no typed overload for six sources, hence the nested combine for the two flags
+        return combine(
+            userEpisodeManager.episodeFlow(episodeUuid).filterNotNull(),
+            downloadProgressFlow(episodeUuid),
+            uploadProgressFlow(episodeUuid),
+            playbackStatusFlow(episodeUuid),
+            combine(isInUpNextFlow(episodeUuid), hasBookmarksFlow(episodeUuid), ::Pair),
+        ) { episode, downloadProgress, uploadProgress, playbackState, (isInUpNext, hasBookmarks) ->
+            UserEpisodeRowData(
+                episode = episode,
+                downloadProgress = downloadProgress,
+                uploadProgress = uploadProgress,
+                playbackState = playbackState,
+                isInUpNext = isInUpNext,
+                hasBookmarks = hasBookmarks,
+            )
+        }.flowOn(Dispatchers.IO)
     }
 
-    fun episodeRowDataObservable(episodeUuid: String): Observable<EpisodeRowData> {
-        return rxMaybe { episodeManager.findEpisodeByUuid(episodeUuid) }.toObservable()
-            .switchMap { episode ->
-                Observables.combineLatest(
-                    downloadProgressObservable(episodeUuid),
-                    playbackStatusObservable(episodeUuid),
-                    isInUpNextObservable(episodeUuid),
-                    hasBookmarksObservable(episodeUuid),
-                    hasHlsAlternateEnclosureObservable(episodeUuid),
-                    ::EpisodeRowData,
-                )
+    fun episodeRowDataFlow(episodeUuid: String): Flow<EpisodeRowData> {
+        return flow {
+            // an episode that is not in the database has no row data, so emit nothing
+            if (episodeManager.findEpisodeByUuid(episodeUuid) == null) {
+                return@flow
             }
-            .subscribeOn(Schedulers.io())
-            .observeOn(AndroidSchedulers.mainThread())
+            emitAll(
+                combine(
+                    downloadProgressFlow(episodeUuid),
+                    playbackStatusFlow(episodeUuid),
+                    isInUpNextFlow(episodeUuid),
+                    hasBookmarksFlow(episodeUuid),
+                    hasHlsAlternateEnclosureFlow(episodeUuid),
+                    ::EpisodeRowData,
+                ),
+            )
+        }.flowOn(Dispatchers.IO)
     }
 
-    private fun downloadProgressObservable(episodeUuid: String): Observable<Int> {
+    private fun downloadProgressFlow(episodeUuid: String): Flow<Int> {
         return downloadProgressCache.progressFlow(episodeUuid)
             .map { progress -> progress?.percentage ?: 0 }
             .distinctUntilChanged()
-            .asObservable()
     }
 
-    private fun uploadProgressObservable(episodeUuid: String): Observable<Int> {
+    private fun uploadProgressFlow(episodeUuid: String): Flow<Int> {
         return UploadProgressManager.progressFlow(episodeUuid)
-            .asObservable()
             .map { (it * 100).roundToInt() }
-            .throttleLatest(1, TimeUnit.SECONDS)
-            .startWith(0)
+            .throttleLatest(1.seconds)
+            .onStart { emit(0) }
             .distinctUntilChanged()
     }
 
-    private fun playbackStatusObservable(episodeUuid: String): Observable<PlaybackState> {
+    private fun playbackStatusFlow(episodeUuid: String): Flow<PlaybackState> {
         val emptyState = PlaybackState(episodeUuid = episodeUuid)
-        return playbackManager.playbackStateRelay
-            .startWith(emptyState)
+        return playbackManager.playbackStateFlow
+            .onStart { emit(emptyState) }
             .map { if (it.episodeUuid == episodeUuid) it else emptyState }
-            .distinctUntilChanged { prev, curr ->
-                prev.state == curr.state &&
-                    prev.episodeUuid == curr.episodeUuid &&
-                    prev.positionMs == curr.positionMs &&
-                    prev.isBuffering == curr.isBuffering
+            .distinctUntilChanged { previous, current ->
+                previous.state == current.state &&
+                    previous.episodeUuid == current.episodeUuid &&
+                    previous.positionMs == current.positionMs &&
+                    previous.isBuffering == current.isBuffering
             }
     }
 
-    private fun hasHlsAlternateEnclosureObservable(episodeUuid: String): Observable<Boolean> {
+    private fun hasHlsAlternateEnclosureFlow(episodeUuid: String): Flow<Boolean> {
         return alternateEnclosureManager.hasHlsAlternateEnclosure(episodeUuid)
-            .asObservable()
-            .startWith(false)
+            .onStart { emit(false) }
             .distinctUntilChanged()
     }
 
-    private fun isInUpNextObservable(episodeUuid: String): Observable<Boolean> {
-        return upNextQueue
-            .changesObservable
+    private fun isInUpNextFlow(episodeUuid: String): Flow<Boolean> {
+        return upNextQueue.changesObservable
+            .asFlow()
             .containsUuid(episodeUuid)
-            .startWith(false)
+            .onStart { emit(false) }
             .distinctUntilChanged()
     }
 
-    private fun hasBookmarksObservable(episodeUuid: String): Observable<Boolean> {
+    private fun hasBookmarksFlow(episodeUuid: String): Flow<Boolean> {
         fun hasActiveBookmarks(subscription: Subscription?, hasBookmarks: Boolean): Boolean {
             return hasBookmarks && subscription != null
         }
 
-        val combinedDataFlow = combine(
+        return combine(
             settings.cachedSubscription.flow,
             bookmarkManager.hasBookmarksFlow(episodeUuid),
             ::hasActiveBookmarks,
         )
-
-        return combinedDataFlow
-            .asObservable()
-            .startWith(false)
+            .onStart { emit(false) }
             .distinctUntilChanged()
+    }
+}
+
+// emits the first value straight away, then at most one value per window, always the latest one
+private fun <T> Flow<T>.throttleLatest(window: Duration): Flow<T> = flow {
+    conflate().collect { value ->
+        emit(value)
+        delay(window)
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeRowData.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeRowData.kt
@@ -4,6 +4,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
+import au.com.shiftyjelly.pocketcasts.repositories.di.IoDispatcher
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadProgressCache
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
@@ -13,7 +14,7 @@ import javax.inject.Inject
 import kotlin.math.roundToInt
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
@@ -53,6 +54,7 @@ class EpisodeRowDataProvider @Inject constructor(
     private val userEpisodeManager: UserEpisodeManager,
     private val alternateEnclosureManager: AlternateEnclosureManager,
     private val settings: Settings,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) {
 
     /** Collect on the main dispatcher, the row data is bound straight into views. */
@@ -73,7 +75,7 @@ class EpisodeRowDataProvider @Inject constructor(
                 isInUpNext = isInUpNext,
                 hasBookmarks = hasBookmarks,
             )
-        }.flowOn(Dispatchers.IO)
+        }.flowOn(ioDispatcher)
     }
 
     /** Collect on the main dispatcher, the row data is bound straight into views. */
@@ -93,7 +95,7 @@ class EpisodeRowDataProvider @Inject constructor(
                     ::EpisodeRowData,
                 ),
             )
-        }.flowOn(Dispatchers.IO)
+        }.flowOn(ioDispatcher)
     }
 
     private fun downloadProgressFlow(episodeUuid: String): Flow<Int> {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeRowData.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeRowData.kt
@@ -55,6 +55,7 @@ class EpisodeRowDataProvider @Inject constructor(
     private val settings: Settings,
 ) {
 
+    /** Collect on the main dispatcher, the row data is bound straight into views. */
     fun userEpisodeRowDataFlow(episodeUuid: String): Flow<UserEpisodeRowData> {
         // combine has no typed overload for six sources, hence the nested combine for the two flags
         return combine(
@@ -75,6 +76,7 @@ class EpisodeRowDataProvider @Inject constructor(
         }.flowOn(Dispatchers.IO)
     }
 
+    /** Collect on the main dispatcher, the row data is bound straight into views. */
     fun episodeRowDataFlow(episodeUuid: String): Flow<EpisodeRowData> {
         return flow {
             // an episode that is not in the database has no row data, so emit nothing

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeRowDataProviderTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeRowDataProviderTest.kt
@@ -13,6 +13,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import io.reactivex.Observable
 import java.util.Date
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
@@ -132,19 +133,25 @@ class EpisodeRowDataProviderTest {
     }
 
     @Test
-    fun `user episode row data follows upload progress`() = runTest {
+    fun `user episode row data emits the first upload progress immediately and then the latest per window`() = runTest {
         val episode = UserEpisode(uuid = EPISODE_UUID, publishedDate = Date())
         userEpisodeManager.stub {
             on { episodeFlow(EPISODE_UUID) } doReturn flowOf(episode)
         }
 
         try {
-            provider.userEpisodeRowDataFlow(EPISODE_UUID).test {
+            provider.userEpisodeRowDataFlow(EPISODE_UUID).test(timeout = 10.seconds) {
                 assertEquals(0, awaitItem().uploadProgress)
 
-                UploadProgressManager.pushProgress(EPISODE_UUID, 0.42f)
+                UploadProgressManager.pushProgress(EPISODE_UUID, 0.1f)
 
-                assertEquals(42, awaitItem().uploadProgress)
+                assertEquals(10, awaitItem().uploadProgress)
+
+                UploadProgressManager.pushProgress(EPISODE_UUID, 0.2f)
+                UploadProgressManager.pushProgress(EPISODE_UUID, 0.3f)
+
+                // 20 is dropped, the window only lets the latest value through
+                assertEquals(30, awaitItem().uploadProgress)
                 cancelAndIgnoreRemainingEvents()
             }
         } finally {

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeRowDataProviderTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeRowDataProviderTest.kt
@@ -1,0 +1,174 @@
+package au.com.shiftyjelly.pocketcasts.repositories.podcast
+
+import app.cash.turbine.test
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription
+import au.com.shiftyjelly.pocketcasts.preferences.ReadSetting
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
+import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadProgressCache
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
+import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
+import io.reactivex.Observable
+import java.util.Date
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.stub
+
+private const val EPISODE_UUID = "episode-uuid"
+
+class EpisodeRowDataProviderTest {
+    private val episodeManager = mock<EpisodeManager>()
+    private val userEpisodeManager = mock<UserEpisodeManager>()
+    private val downloadProgressCache = DownloadProgressCache()
+
+    private val playbackManager = mock<PlaybackManager> {
+        on { playbackStateFlow } doReturn emptyFlow()
+    }
+
+    private val upNextQueue = mock<UpNextQueue> {
+        on { changesObservable } doReturn Observable.empty()
+    }
+
+    private val bookmarkManager = mock<BookmarkManager> {
+        on { hasBookmarksFlow(any()) } doReturn emptyFlow()
+    }
+
+    private val alternateEnclosureManager = mock<AlternateEnclosureManager> {
+        on { hasHlsAlternateEnclosure(any()) } doReturn emptyFlow()
+    }
+
+    private val settings = mock<Settings> {
+        val cachedSubscription = mock<ReadSetting<Subscription?>> {
+            on { flow } doReturn MutableStateFlow(null)
+        }
+        on { this.cachedSubscription } doReturn cachedSubscription
+    }
+
+    private val provider = EpisodeRowDataProvider(
+        episodeManager = episodeManager,
+        downloadProgressCache = downloadProgressCache,
+        playbackManager = playbackManager,
+        upNextQueue = upNextQueue,
+        bookmarkManager = bookmarkManager,
+        userEpisodeManager = userEpisodeManager,
+        alternateEnclosureManager = alternateEnclosureManager,
+        settings = settings,
+    )
+
+    @Test
+    fun `episode row data emits nothing for an unknown episode`() = runTest {
+        episodeManager.stub {
+            on { findEpisodeByUuid(EPISODE_UUID) } doReturn null
+        }
+
+        val rowData = provider.episodeRowDataFlow(EPISODE_UUID).toList()
+
+        assertTrue(rowData.isEmpty())
+    }
+
+    @Test
+    fun `episode row data emits once every source has a value`() = runTest {
+        episodeManager.stub {
+            on { findEpisodeByUuid(EPISODE_UUID) } doReturn PodcastEpisode(uuid = EPISODE_UUID, publishedDate = Date())
+        }
+
+        provider.episodeRowDataFlow(EPISODE_UUID).test {
+            val rowData = awaitItem()
+
+            assertEquals(0, rowData.downloadProgress)
+            assertEquals(PlaybackState(episodeUuid = EPISODE_UUID), rowData.playbackState)
+            assertEquals(false, rowData.isInUpNext)
+            assertEquals(false, rowData.hasBookmarks)
+            assertEquals(false, rowData.hasHlsAlternateEnclosure)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `episode row data follows download progress`() = runTest {
+        episodeManager.stub {
+            on { findEpisodeByUuid(EPISODE_UUID) } doReturn PodcastEpisode(uuid = EPISODE_UUID, publishedDate = Date())
+        }
+
+        provider.episodeRowDataFlow(EPISODE_UUID).test {
+            assertEquals(0, awaitItem().downloadProgress)
+
+            downloadProgressCache.updateProgress(EPISODE_UUID, downloadedByteCount = 25, contentLength = 100)
+
+            assertEquals(25, awaitItem().downloadProgress)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `user episode row data emits nothing while the episode is missing`() = runTest {
+        userEpisodeManager.stub {
+            on { episodeFlow(EPISODE_UUID) } doReturn flowOf(null)
+        }
+
+        // real time, because the provider emits on Dispatchers.IO and would outrun the test scheduler
+        val rowData = withContext(Dispatchers.Default) {
+            withTimeoutOrNull(300) { provider.userEpisodeRowDataFlow(EPISODE_UUID).first() }
+        }
+
+        assertNull(rowData)
+    }
+
+    @Test
+    fun `user episode row data follows upload progress`() = runTest {
+        val episode = UserEpisode(uuid = EPISODE_UUID, publishedDate = Date())
+        userEpisodeManager.stub {
+            on { episodeFlow(EPISODE_UUID) } doReturn flowOf(episode)
+        }
+
+        try {
+            provider.userEpisodeRowDataFlow(EPISODE_UUID).test {
+                assertEquals(0, awaitItem().uploadProgress)
+
+                UploadProgressManager.pushProgress(EPISODE_UUID, 0.42f)
+
+                assertEquals(42, awaitItem().uploadProgress)
+                cancelAndIgnoreRemainingEvents()
+            }
+        } finally {
+            UploadProgressManager.clearProgress(EPISODE_UUID)
+        }
+    }
+
+    @Test
+    fun `user episode row data emits once every source has a value`() = runTest {
+        val episode = UserEpisode(uuid = EPISODE_UUID, publishedDate = Date())
+        userEpisodeManager.stub {
+            on { episodeFlow(EPISODE_UUID) } doReturn flowOf(episode)
+        }
+
+        provider.userEpisodeRowDataFlow(EPISODE_UUID).test {
+            val rowData = awaitItem()
+
+            assertEquals(episode, rowData.episode)
+            assertEquals(0, rowData.downloadProgress)
+            assertEquals(0, rowData.uploadProgress)
+            assertEquals(PlaybackState(episodeUuid = EPISODE_UUID), rowData.playbackState)
+            assertEquals(false, rowData.isInUpNext)
+            assertEquals(false, rowData.hasBookmarks)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+}

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeRowDataProviderTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeRowDataProviderTest.kt
@@ -14,14 +14,17 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import io.reactivex.Observable
 import java.util.Date
 import kotlin.time.Duration.Companion.seconds
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -34,6 +37,7 @@ import org.mockito.kotlin.stub
 
 private const val EPISODE_UUID = "episode-uuid"
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class EpisodeRowDataProviderTest {
     private val episodeManager = mock<EpisodeManager>()
     private val userEpisodeManager = mock<UserEpisodeManager>()
@@ -62,7 +66,7 @@ class EpisodeRowDataProviderTest {
         on { this.cachedSubscription } doReturn cachedSubscription
     }
 
-    private val provider = EpisodeRowDataProvider(
+    private fun TestScope.createProvider(dispatcher: CoroutineDispatcher = StandardTestDispatcher(testScheduler)) = EpisodeRowDataProvider(
         episodeManager = episodeManager,
         downloadProgressCache = downloadProgressCache,
         playbackManager = playbackManager,
@@ -71,6 +75,7 @@ class EpisodeRowDataProviderTest {
         userEpisodeManager = userEpisodeManager,
         alternateEnclosureManager = alternateEnclosureManager,
         settings = settings,
+        ioDispatcher = dispatcher,
     )
 
     @Test
@@ -79,7 +84,7 @@ class EpisodeRowDataProviderTest {
             on { findEpisodeByUuid(EPISODE_UUID) } doReturn null
         }
 
-        val rowData = provider.episodeRowDataFlow(EPISODE_UUID).toList()
+        val rowData = createProvider().episodeRowDataFlow(EPISODE_UUID).toList()
 
         assertTrue(rowData.isEmpty())
     }
@@ -90,7 +95,7 @@ class EpisodeRowDataProviderTest {
             on { findEpisodeByUuid(EPISODE_UUID) } doReturn PodcastEpisode(uuid = EPISODE_UUID, publishedDate = Date())
         }
 
-        provider.episodeRowDataFlow(EPISODE_UUID).test {
+        createProvider().episodeRowDataFlow(EPISODE_UUID).test {
             val rowData = awaitItem()
 
             assertEquals(0, rowData.downloadProgress)
@@ -108,7 +113,7 @@ class EpisodeRowDataProviderTest {
             on { findEpisodeByUuid(EPISODE_UUID) } doReturn PodcastEpisode(uuid = EPISODE_UUID, publishedDate = Date())
         }
 
-        provider.episodeRowDataFlow(EPISODE_UUID).test {
+        createProvider().episodeRowDataFlow(EPISODE_UUID).test {
             assertEquals(0, awaitItem().downloadProgress)
 
             downloadProgressCache.updateProgress(EPISODE_UUID, downloadedByteCount = 25, contentLength = 100)
@@ -124,10 +129,7 @@ class EpisodeRowDataProviderTest {
             on { episodeFlow(EPISODE_UUID) } doReturn flowOf(null)
         }
 
-        // real time, because the provider emits on Dispatchers.IO and would outrun the test scheduler
-        val rowData = withContext(Dispatchers.Default) {
-            withTimeoutOrNull(300) { provider.userEpisodeRowDataFlow(EPISODE_UUID).first() }
-        }
+        val rowData = withTimeoutOrNull(300) { createProvider().userEpisodeRowDataFlow(EPISODE_UUID).first() }
 
         assertNull(rowData)
     }
@@ -140,7 +142,7 @@ class EpisodeRowDataProviderTest {
         }
 
         try {
-            provider.userEpisodeRowDataFlow(EPISODE_UUID).test(timeout = 10.seconds) {
+            createProvider().userEpisodeRowDataFlow(EPISODE_UUID).test(timeout = 10.seconds) {
                 assertEquals(0, awaitItem().uploadProgress)
 
                 UploadProgressManager.pushProgress(EPISODE_UUID, 0.1f)
@@ -149,6 +151,7 @@ class EpisodeRowDataProviderTest {
 
                 UploadProgressManager.pushProgress(EPISODE_UUID, 0.2f)
                 UploadProgressManager.pushProgress(EPISODE_UUID, 0.3f)
+                advanceTimeBy(1.seconds)
 
                 // 20 is dropped, the window only lets the latest value through
                 assertEquals(30, awaitItem().uploadProgress)
@@ -166,7 +169,7 @@ class EpisodeRowDataProviderTest {
             on { episodeFlow(EPISODE_UUID) } doReturn flowOf(episode)
         }
 
-        provider.userEpisodeRowDataFlow(EPISODE_UUID).test {
+        createProvider().userEpisodeRowDataFlow(EPISODE_UUID).test {
             val rowData = awaitItem()
 
             assertEquals(episode, rowData.episode)


### PR DESCRIPTION
## Description

The status indicators on episode rows (download progress, playing/buffering, Up Next, bookmarks, file upload progress) are now driven by Kotlin coroutines instead of RxJava. Behaviour should be identical; this is a refactor.

The provider that feeds those indicators exposed two `Observable`s even though nearly all of its inputs were already `Flow`s bridged to Rx, so the migration mostly deletes `asObservable()` calls. Its three consumers (the podcast episode row, the cloud file row and the cloud file bottom sheet) now collect in a scope cancelled at exactly the point their `CompositeDisposable` was cleared.

Rx semantics preserved by hand:

- `throttleLatest(1, SECONDS)` on upload progress is **not** Flow `sample`, which drops the first emission and only emits on window boundaries. Replaced with a small `conflate()` + `delay` throttle that keeps Rx's behaviour: first value immediately, then at most one per second, latest wins. `EpisodeRowDataProviderTest` asserts both halves: the first value arrives without waiting out the window, and a burst inside one window yields only the latest value.
- `startWith(x)` → `onStart { emit(x) }`, kept on the same side of `distinctUntilChanged()` as before.
- The custom playback-state `distinctUntilChanged` comparator is unchanged and still sits after the `map` (Rx `BiPredicate` and Kotlin `areEquivalent` have the same polarity: `true` means drop).
- `subscribeOn(io)` + `observeOn(mainThread())` → `flowOn` on the injected IO dispatcher, with collection on the main dispatcher at each call site, so row updates still land on the main thread.
- A missing episode used to mean an empty `Maybe` and therefore no emissions at all. The flow returns early instead of emitting a null-shaped row.
- Every combined source still has an initial value, so the first combined emission cannot be blocked (the one deliberate exception is the user episode itself, which gates emission exactly as it did before).

The only signature change is the provider's constructor, which gains `@IoDispatcher CoroutineDispatcher` following the convention `EpisodeManagerImpl` already uses, so its tests run on the test scheduler.

Bridges deliberately left in place: `upNextQueue.changesObservable.asFlow()` and `playbackManager.playbackStateFlow` (itself `playbackStateRelay.asFlow()`). Both wait on their own backlog entries: `UpNextQueue.changesObservable` and `PlaybackManager.playbackStateRelay`. `UpNextQueue.kt` gains an additive `Flow<State>.containsUuid()` overload; the `Observable` one is untouched.

## Testing Instructions

The risk here is a row that silently stops updating, so please watch the indicators change live rather than just checking they render.

1. Open a podcast with undownloaded episodes. Download one and watch the row: the circular progress advances, the label counts up, and the row flips to the downloaded tick when it finishes.
2. Start playing an episode from that list. The row's play button becomes a pause button, and shows "Buffering" while it buffers. Pause it and check the button flips back.
3. Long-press or swipe a row to add its episode to Up Next. The Up Next icon appears on that row immediately, without leaving the screen. Remove it again and check the icon disappears.
4. Add a bookmark to an episode (Plus/Patron account required), then return to the episode list and confirm the bookmark icon shows on that row.
5. Start a few downloads, then scroll the list fast so the downloading rows go off screen and come back. Progress should still be correct on return, and no other row should show a stray progress bar.
6. Profile → Files: upload a file and watch the upload progress on its row, then check the row settles on the uploaded state.
7. Tap that file to open its bottom sheet and confirm the status icons there match the row, including while a download or upload is running.
8. Repeat step 1 on a filter/playlist episode list and on Profile → Listening history, which use the same row.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
