### PR TITLE
Add a podcastSubscriptionsFlow() twin and migrate the incoming share list off RxJava

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/share/ShareListIncomingViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/share/ShareListIncomingViewModel.kt
@@ -2,7 +2,7 @@ package au.com.shiftyjelly.pocketcasts.podcasts.view.share
 
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.toLiveData
+import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
@@ -15,7 +15,6 @@ import com.automattic.eventhorizon.IncomingShareListSubscribedAllEvent
 import com.automattic.eventhorizon.PodcastSubscribedEvent
 import com.automattic.eventhorizon.PodcastUnsubscribedEvent
 import dagger.hilt.android.lifecycle.HiltViewModel
-import io.reactivex.schedulers.Schedulers
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
@@ -33,12 +32,7 @@ class ShareListIncomingViewModel
     CoroutineScope {
     var isFragmentChangingConfigurations: Boolean = false
     val share = MutableLiveData<ShareState>()
-    val subscribedUuids =
-        podcastManager.getSubscribedPodcastUuidsRxSingle()
-            .subscribeOn(Schedulers.io())
-            .toFlowable()
-            .mergeWith(podcastManager.podcastSubscriptionsRxFlowable())
-            .toLiveData()
+    val subscribedUuids = podcastManager.podcastSubscriptionsFlow().asLiveData()
 
     override val coroutineContext: CoroutineContext
         get() = Dispatchers.Default

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
@@ -32,6 +32,9 @@ interface PodcastManager {
     fun podcastByEpisodeUuidFlow(uuid: String): Flow<Podcast>
     fun podcastSubscriptionsRxFlowable(): Flowable<List<String>>
 
+    // Emits the subscribed uuids, including subscribes still in flight, then again on every subscription change.
+    fun podcastSubscriptionsFlow(): Flow<List<String>>
+
     fun findSubscribedBlocking(): List<Podcast>
     fun findSubscribedRxSingle(): Single<List<Podcast>>
     fun findSubscribedFlow(searchTerm: String? = null): Flow<List<Podcast>>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
@@ -32,7 +32,7 @@ interface PodcastManager {
     fun podcastByEpisodeUuidFlow(uuid: String): Flow<Podcast>
     fun podcastSubscriptionsRxFlowable(): Flowable<List<String>>
 
-    // Emits the subscribed uuids, including subscribes still in flight, then again on every subscription change.
+    // The subscribed uuids, including in-flight subscribes, re-emitted when one subscribes or unsubscribes.
     fun podcastSubscriptionsFlow(): Flow<List<String>>
 
     fun findSubscribedBlocking(): List<Podcast>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -19,6 +19,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.EpisodesSortType
 import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
 import au.com.shiftyjelly.pocketcasts.models.type.TrimMode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.di.IoDispatcher
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadQueue
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.getUrlForArtwork
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
@@ -41,14 +42,20 @@ import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.rx2.asFlow
 import kotlinx.coroutines.rx2.asFlowable
 import kotlinx.coroutines.rx2.await
 import kotlinx.coroutines.rx2.rxMaybe
@@ -64,6 +71,7 @@ class PodcastManagerImpl @Inject constructor(
     private val podcastRefresher: PodcastRefresher,
     private val downloadQueue: DownloadQueue,
     @ApplicationScope private val applicationScope: CoroutineScope,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
     appDatabase: AppDatabase,
 ) : PodcastManager,
     CoroutineScope {
@@ -192,6 +200,19 @@ class PodcastManagerImpl @Inject constructor(
             .flatMap { getSubscribedPodcastUuidsRxSingle().toObservable() } // Every time the subscriptions change, reload the subscribed list and pass it on
             .subscribeOn(Schedulers.io())
             .toFlowable(BackpressureStrategy.LATEST)
+    }
+
+    override fun podcastSubscriptionsFlow(): Flow<List<String>> {
+        val subscriptionChanges = merge(subscribeManager.subscriptionChangedRelay.asFlow(), unsubscribeRelay.asFlow())
+        // The first load is merged in rather than an onStart so the relays are already attached while it runs.
+        return merge(flowOf(Unit), subscriptionChanges.map {})
+            .map { subscribedPodcastUuids() } // Every time the subscriptions change, reload the subscribed list and pass it on
+            .flowOn(ioDispatcher)
+    }
+
+    // The subscribed uuids as an unordered set: the ones in the database plus any subscribe not yet written to it.
+    private suspend fun subscribedPodcastUuids(): List<String> {
+        return (podcastDao.findSubscribedUuids() + subscribeManager.getSubscribingPodcastUuids()).distinct()
     }
 
     override suspend fun findPodcastsToSync(): List<Podcast> {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -47,6 +47,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
@@ -204,9 +205,10 @@ class PodcastManagerImpl @Inject constructor(
 
     override fun podcastSubscriptionsFlow(): Flow<List<String>> {
         val subscriptionChanges = merge(subscribeManager.subscriptionChangedRelay.asFlow(), unsubscribeRelay.asFlow())
-        // The first load is merged in rather than an onStart so the relays are already attached while it runs.
+        // The first load is merged in rather than added with onStart so the relays are attached concurrently with it.
         return merge(flowOf(Unit), subscriptionChanges.map {})
-            .map { subscribedPodcastUuids() } // Every time the subscriptions change, reload the subscribed list and pass it on
+            .conflate() // A burst of changes collapses into one reload, like BackpressureStrategy.LATEST did
+            .map { subscribedPodcastUuids() }
             .flowOn(ioDispatcher)
     }
 

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImplTest.kt
@@ -1,0 +1,96 @@
+package au.com.shiftyjelly.pocketcasts.repositories.podcast
+
+import app.cash.turbine.test
+import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
+import au.com.shiftyjelly.pocketcasts.models.db.dao.PodcastDao
+import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import com.jakewharton.rxrelay2.PublishRelay
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@RunWith(MockitoJUnitRunner::class)
+class PodcastManagerImplTest {
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
+
+    @Mock
+    lateinit var appDatabase: AppDatabase
+
+    @Mock
+    lateinit var podcastDao: PodcastDao
+
+    @Mock
+    lateinit var subscribeManager: SubscribeManager
+
+    private val subscriptionChangedRelay = PublishRelay.create<String>()
+
+    private lateinit var podcastManager: PodcastManagerImpl
+
+    @Before
+    fun setUp() {
+        whenever(appDatabase.podcastDao()).thenReturn(podcastDao)
+        whenever(appDatabase.episodeDao()).thenReturn(mock())
+        whenever(appDatabase.playlistDao()).thenReturn(mock())
+        whenever(subscribeManager.subscriptionChangedRelay).thenReturn(subscriptionChangedRelay)
+        podcastManager = PodcastManagerImpl(
+            episodeManager = mock(),
+            settings = mock(),
+            context = mock(),
+            subscribeManager = subscribeManager,
+            refreshServiceManager = mock(),
+            syncManager = mock(),
+            podcastRefresher = mock(),
+            downloadQueue = mock(),
+            applicationScope = CoroutineScope(coroutineRule.testDispatcher),
+            ioDispatcher = coroutineRule.testDispatcher,
+            appDatabase = appDatabase,
+        )
+    }
+
+    @Test
+    fun `podcast subscriptions emit the current uuids before any change`() = runTest {
+        whenever(podcastDao.findSubscribedUuids()).thenReturn(listOf("uuid-1", "uuid-2"))
+        whenever(subscribeManager.getSubscribingPodcastUuids()).thenReturn(emptySet())
+
+        podcastManager.podcastSubscriptionsFlow().test {
+            assertEquals(listOf("uuid-1", "uuid-2"), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `podcast subscriptions include podcasts that are still subscribing`() = runTest {
+        whenever(podcastDao.findSubscribedUuids()).thenReturn(listOf("uuid-1"))
+        whenever(subscribeManager.getSubscribingPodcastUuids()).thenReturn(setOf("uuid-1", "uuid-2"))
+
+        podcastManager.podcastSubscriptionsFlow().test {
+            assertEquals(listOf("uuid-1", "uuid-2"), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `podcast subscriptions reload when a subscription changes`() = runTest {
+        whenever(podcastDao.findSubscribedUuids()).thenReturn(listOf("uuid-1"))
+        whenever(subscribeManager.getSubscribingPodcastUuids()).thenReturn(emptySet())
+
+        podcastManager.podcastSubscriptionsFlow().test {
+            assertEquals(listOf("uuid-1"), awaitItem())
+
+            whenever(podcastDao.findSubscribedUuids()).thenReturn(listOf("uuid-1", "uuid-2"))
+            subscriptionChangedRelay.accept("uuid-2")
+
+            assertEquals(listOf("uuid-1", "uuid-2"), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+}

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImplTest.kt
@@ -1,8 +1,12 @@
 package au.com.shiftyjelly.pocketcasts.repositories.podcast
 
+import android.content.Context
+import android.content.pm.PackageManager
 import app.cash.turbine.test
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
 import au.com.shiftyjelly.pocketcasts.models.db.dao.PodcastDao
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import com.jakewharton.rxrelay2.PublishRelay
 import kotlinx.coroutines.CoroutineScope
@@ -14,6 +18,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
@@ -31,6 +36,12 @@ class PodcastManagerImplTest {
     @Mock
     lateinit var subscribeManager: SubscribeManager
 
+    @Mock
+    lateinit var context: Context
+
+    @Mock
+    lateinit var packageManager: PackageManager
+
     private val subscriptionChangedRelay = PublishRelay.create<String>()
 
     private lateinit var podcastManager: PodcastManagerImpl
@@ -44,7 +55,7 @@ class PodcastManagerImplTest {
         podcastManager = PodcastManagerImpl(
             episodeManager = mock(),
             settings = mock(),
-            context = mock(),
+            context = context,
             subscribeManager = subscribeManager,
             refreshServiceManager = mock(),
             syncManager = mock(),
@@ -57,13 +68,13 @@ class PodcastManagerImplTest {
     }
 
     @Test
-    fun `podcast subscriptions emit the current uuids before any change`() = runTest {
+    fun `podcast subscriptions emit the current uuids once before any change`() = runTest {
         whenever(podcastDao.findSubscribedUuids()).thenReturn(listOf("uuid-1", "uuid-2"))
         whenever(subscribeManager.getSubscribingPodcastUuids()).thenReturn(emptySet())
 
         podcastManager.podcastSubscriptionsFlow().test {
             assertEquals(listOf("uuid-1", "uuid-2"), awaitItem())
-            cancelAndIgnoreRemainingEvents()
+            expectNoEvents()
         }
     }
 
@@ -90,7 +101,27 @@ class PodcastManagerImplTest {
             subscriptionChangedRelay.accept("uuid-2")
 
             assertEquals(listOf("uuid-1", "uuid-2"), awaitItem())
-            cancelAndIgnoreRemainingEvents()
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `podcast subscriptions reload when a podcast is unsubscribed`() = runTest {
+        whenever(podcastDao.findSubscribedUuids()).thenReturn(listOf("uuid-1", "uuid-2"))
+        whenever(subscribeManager.getSubscribingPodcastUuids()).thenReturn(emptySet())
+        whenever(podcastDao.findPodcastByUuid("uuid-2")).thenReturn(Podcast(uuid = "uuid-2"))
+        whenever(context.packageName).thenReturn("au.com.shiftyjelly.pocketcasts")
+        whenever(context.packageManager).thenReturn(packageManager)
+        whenever(packageManager.getApplicationInfo(any(), any<Int>())).thenReturn(mock())
+
+        podcastManager.podcastSubscriptionsFlow().test {
+            assertEquals(listOf("uuid-1", "uuid-2"), awaitItem())
+
+            whenever(podcastDao.findSubscribedUuids()).thenReturn(listOf("uuid-1"))
+            podcastManager.unsubscribe("uuid-2", SourceView.UNKNOWN)
+
+            assertEquals(listOf("uuid-1"), awaitItem())
+            expectNoEvents()
         }
     }
 }


### PR DESCRIPTION
## Description

The screen you land on when you open a shared podcast list now tracks which of those podcasts you are subscribed to using Kotlin Flow instead of RxJava, with no change to what you see.

`PodcastManager` gains `podcastSubscriptionsFlow()`, a Flow twin of `podcastSubscriptionsRxFlowable()` that emits the current subscribed uuids and then a fresh list on every subscription change, and `ShareListIncomingViewModel` is now fully off Rx. The Rx variants stay because discover's two view models and the recommendations handler still use them.

Semantics preserved by hand:

- **Initial emission, then updates.** The first load is merged into the trigger flow rather than added with `onStart`, so the subscription relays are already attached while it runs, as they were under `mergeWith`.
- **Subscribes still in flight.** The list is the database rows plus `SubscribeManager.getSubscribingPodcastUuids()`, matching the Rx `Single`. The existing `findSubscribedUuids()` twin alone would have dropped them, which is what makes a row look unsubscribed right after you tap subscribe.
- **IO threading.** `subscribeOn(Schedulers.io())` becomes `flowOn(ioDispatcher)`, now injected via `@IoDispatcher` (as `EpisodeManagerImpl` already does) so it is testable.
- **No replay, as before.** The flow is cold, so `asLiveData()` re-collects per active observer, like the old `toLiveData()`.
- **Emission order was never meaningful.** The Rx body already deduped through a `HashSet` and the adapter builds a `HashSet` from the result, so reading the cheaper uuid-only query is equivalent.
- **`BackpressureStrategy.LATEST`.** `conflate()` collapses a burst of changes into one reload, so superseded snapshots are dropped as before, and the relay thread cannot block on a full buffer. Rx's unbounded `flatMap` could emit a stale snapshot last; the sequential `map` cannot.

## Testing Instructions

1. Open a Pocket Casts shared podcast list link (a `pca.st/...` list URL) so the incoming share list screen appears.
2. Check each row shows the correct subscribed state: podcasts you already follow show as subscribed, the rest do not.
3. Tap subscribe on one row. It must flip to subscribed immediately, without leaving the screen.
4. Unsubscribe the same row again and confirm it flips back.
5. Tap "Subscribe to all" and confirm every row ends up subscribed.
6. Rotate the device on that screen and confirm the subscribed states are still correct.
7. Sanity check the untouched Rx consumers of the same data: Discover, a Discover podcast list page, and the "you might like" recommendations on a podcast page still show and update subscribed state.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
