### PR TITLE
Migrate LegacyPlaybackService notification pipeline from RxJava to Flow

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/LegacyPlaybackService.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/LegacyPlaybackService.kt
@@ -27,12 +27,12 @@ import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
@@ -195,17 +195,19 @@ open class LegacyPlaybackService :
     }
 
     private inner class MediaControllerCallback(currentMetadataCompat: MediaMetadataCompat?) : MediaControllerCompat.Callback() {
-        private val playbackStatusFlow = MutableStateFlow<PlaybackStateCompat?>(null)
-        private val mediaMetadataFlow = MutableStateFlow(currentMetadataCompat)
+        // not StateFlow: isForeground accumulates across transitions, so conflating them would skip foreground handling
+        private val playbackStatusFlow = bufferedReplayFlow<PlaybackStateCompat>()
+        private val mediaMetadataFlow = bufferedReplayFlow<MediaMetadataCompat>().apply {
+            if (currentMetadataCompat != null) {
+                tryEmit(currentMetadataCompat)
+            }
+        }
 
         init {
             // the consumer calls startForeground/notify, so it has to stay on the main thread
             launch(Dispatchers.Main) {
-                combine(playbackStatusFlow, mediaMetadataFlow, settings.artworkConfiguration.flow) { playbackState, metadata, artworkConfiguration ->
-                    // nothing is emitted until a playback state and metadata have both arrived
-                    if (playbackState != null && metadata != null) Triple(playbackState, metadata, artworkConfiguration) else null
-                }
-                    .filterNotNull()
+                // neither flow replays a value until its first emission, so this waits for both, as combineLatest did
+                combine(playbackStatusFlow, mediaMetadataFlow, settings.artworkConfiguration.flow, ::Triple)
                     .distinctUntilChanged { (state1, metadata1, artworkConfiguration1), (state2, metadata2, artworkConfiguration2) ->
                         val isForegroundService = isForegroundService()
                         (state1.state == state2.state && metadata1.getString(METADATA_KEY_MEDIA_ID) == metadata2.getString(METADATA_KEY_MEDIA_ID) && artworkConfiguration1 == artworkConfiguration2) &&
@@ -224,7 +226,7 @@ open class LegacyPlaybackService :
 
         override fun onMetadataChanged(metadata: MediaMetadataCompat?) {
             metadata ?: return
-            mediaMetadataFlow.value = metadata
+            mediaMetadataFlow.tryEmit(metadata)
         }
 
         override fun onQueueChanged(queue: MutableList<MediaSessionCompat.QueueItem>) {
@@ -233,11 +235,11 @@ open class LegacyPlaybackService :
 
         override fun onPlaybackStateChanged(state: PlaybackStateCompat?) {
             state ?: return
-            // logged here rather than off the notification pipeline, which conflates and can skip a superseded error
+            // logged here, not in the handler, where the transient-loss early return could skip it
             if (state.state == PlaybackStateCompat.STATE_ERROR) {
                 LogBuffer.e(LogBuffer.TAG_PLAYBACK, "Playback state error: ${state.errorCode} ${state.errorMessage ?: "Unknown error"}")
             }
-            playbackStatusFlow.value = state
+            playbackStatusFlow.tryEmit(state)
         }
 
         private fun onPlaybackStateChangedWithNotification(playbackState: PlaybackStateCompat, notification: Notification?) {
@@ -321,3 +323,10 @@ open class LegacyPlaybackService :
         }
     }
 }
+
+// stands in for a BehaviorRelay: replays the latest value and queues the rest, so tryEmit never fails or conflates
+private fun <T> bufferedReplayFlow() = MutableSharedFlow<T>(
+    replay = 1,
+    extraBufferCapacity = 64,
+    onBufferOverflow = BufferOverflow.DROP_OLDEST,
+)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/LegacyPlaybackService.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/LegacyPlaybackService.kt
@@ -19,22 +19,24 @@ import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationDraw
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationHelper
 import au.com.shiftyjelly.pocketcasts.repositories.playback.auto.MediaItemCompatConverter
 import au.com.shiftyjelly.pocketcasts.repositories.playback.auto.PackageValidator
-import au.com.shiftyjelly.pocketcasts.utils.SchedulerProvider
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
-import com.jakewharton.rxrelay2.BehaviorRelay
 import dagger.hilt.android.AndroidEntryPoint
-import io.reactivex.disposables.CompositeDisposable
-import io.reactivex.rxkotlin.Observables
-import io.reactivex.rxkotlin.addTo
-import io.reactivex.rxkotlin.subscribeBy
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.rx2.asObservable
 import timber.log.Timber
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -69,8 +71,6 @@ open class LegacyPlaybackService :
 
     private var mediaControllerCallback: MediaControllerCallback? = null
     lateinit var notificationManager: PlayerNotificationManager
-
-    private val disposables = CompositeDisposable()
 
     @Volatile
     private var isForeground: Boolean = false
@@ -125,7 +125,6 @@ open class LegacyPlaybackService :
         super.onDestroy()
         isForeground = false
 
-        disposables.clear()
         sleepTimerHandler?.dispose()
         job.cancel()
 
@@ -196,39 +195,36 @@ open class LegacyPlaybackService :
     }
 
     private inner class MediaControllerCallback(currentMetadataCompat: MediaMetadataCompat?) : MediaControllerCompat.Callback() {
-        private val playbackStatusRelay = BehaviorRelay.create<PlaybackStateCompat>()
-        private val mediaMetadataRelay = BehaviorRelay.create<MediaMetadataCompat>().apply {
-            if (currentMetadataCompat != null) {
-                accept(currentMetadataCompat)
-            }
-        }
-        private val artworkConfiguration = settings.artworkConfiguration.flow.asObservable()
+        private val playbackStatusFlow = MutableStateFlow<PlaybackStateCompat?>(null)
+        private val mediaMetadataFlow = MutableStateFlow(currentMetadataCompat)
 
         init {
-            Observables.combineLatest(playbackStatusRelay, mediaMetadataRelay, artworkConfiguration)
-                .observeOn(SchedulerProvider.io)
-                .distinctUntilChanged { (state1, metadata1, artworkConfiguration1), (state2, metadata2, artworkConfiguration2) ->
-                    val isForegroundService = isForegroundService()
-                    (state1.state == state2.state && metadata1.getString(METADATA_KEY_MEDIA_ID) == metadata2.getString(METADATA_KEY_MEDIA_ID) && artworkConfiguration1 == artworkConfiguration2) &&
-                        (isForegroundService && (state2.state == PlaybackStateCompat.STATE_PLAYING || state2.state == PlaybackStateCompat.STATE_BUFFERING))
+            // the consumer calls startForeground/notify, so it has to stay on the main thread
+            launch(Dispatchers.Main) {
+                combine(playbackStatusFlow, mediaMetadataFlow, settings.artworkConfiguration.flow) { playbackState, metadata, artworkConfiguration ->
+                    // nothing is emitted until a playback state and metadata have both arrived
+                    if (playbackState != null && metadata != null) Triple(playbackState, metadata, artworkConfiguration) else null
                 }
-                .map { (playbackState, metadata, artworkConfiguration) -> playbackState to buildNotification(playbackState.state, metadata, artworkConfiguration.useEpisodeArtwork) }
-                .observeOn(SchedulerProvider.mainThread)
-                .subscribeBy(
-                    onNext = { (state: PlaybackStateCompat, notification: Notification?) ->
-                        onPlaybackStateChangedWithNotification(state, notification)
-                    },
-                    onError = { throwable ->
+                    .filterNotNull()
+                    .distinctUntilChanged { (state1, metadata1, artworkConfiguration1), (state2, metadata2, artworkConfiguration2) ->
+                        val isForegroundService = isForegroundService()
+                        (state1.state == state2.state && metadata1.getString(METADATA_KEY_MEDIA_ID) == metadata2.getString(METADATA_KEY_MEDIA_ID) && artworkConfiguration1 == artworkConfiguration2) &&
+                            (isForegroundService && (state2.state == PlaybackStateCompat.STATE_PLAYING || state2.state == PlaybackStateCompat.STATE_BUFFERING))
+                    }
+                    .map { (playbackState, metadata, artworkConfiguration) -> playbackState to buildNotification(playbackState.state, metadata, artworkConfiguration.useEpisodeArtwork) }
+                    .flowOn(Dispatchers.IO)
+                    .onEach { (state, notification) -> onPlaybackStateChangedWithNotification(state, notification) }
+                    .catch { throwable ->
                         Timber.e(throwable)
                         LogBuffer.e(LogBuffer.TAG_PLAYBACK, throwable, "Legacy playback service error")
-                    },
-                )
-                .addTo(disposables)
+                    }
+                    .collect()
+            }
         }
 
         override fun onMetadataChanged(metadata: MediaMetadataCompat?) {
             metadata ?: return
-            mediaMetadataRelay.accept(metadata)
+            mediaMetadataFlow.value = metadata
         }
 
         override fun onQueueChanged(queue: MutableList<MediaSessionCompat.QueueItem>) {
@@ -237,7 +233,11 @@ open class LegacyPlaybackService :
 
         override fun onPlaybackStateChanged(state: PlaybackStateCompat?) {
             state ?: return
-            playbackStatusRelay.accept(state)
+            // logged here rather than off the notification pipeline, which conflates and can skip a superseded error
+            if (state.state == PlaybackStateCompat.STATE_ERROR) {
+                LogBuffer.e(LogBuffer.TAG_PLAYBACK, "Playback state error: ${state.errorCode} ${state.errorMessage ?: "Unknown error"}")
+            }
+            playbackStatusFlow.value = state
         }
 
         private fun onPlaybackStateChangedWithNotification(playbackState: PlaybackStateCompat, notification: Notification?) {
@@ -299,13 +299,6 @@ open class LegacyPlaybackService :
                         if (removeNotification) {
                             notificationManager.cancel(Settings.NotificationId.PLAYING.value)
                         }
-                    }
-
-                    if (state == PlaybackStateCompat.STATE_ERROR) {
-                        LogBuffer.e(
-                            LogBuffer.TAG_PLAYBACK,
-                            "Playback state error: ${playbackStatusRelay.value?.errorCode ?: -1} ${playbackStatusRelay.value?.errorMessage ?: "Unknown error"}",
-                        )
                     }
                 }
             }


### PR DESCRIPTION
## Description

Internal refactor with no intended change in behaviour: the notification, lock-screen and car controls for playback are now driven by Kotlin coroutines instead of RxJava.

Part of the RxJava removal effort, backlog entry `LegacyPlaybackService.kt`. The legacy media-session service kept its playback state and metadata in two `BehaviorRelay`s, combined them with the artwork setting via `Observables.combineLatest`, and drove the playing notification off that subscription. All of it was private to the class, so this swaps the relays for buffered `MutableSharedFlow`s, `combineLatest` for `combine`, and the `CompositeDisposable` for the service's existing `CoroutineScope`. No public signature changes.

**Rx semantics preserved by hand**

- **`distinctUntilChanged` comparator** copied verbatim: it folds in `isForegroundService()` so identical playing/buffering states are only dropped while the service is in the foreground, and deliberately *forces* an emission otherwise.
- **Thread affinity**: `combine`/`distinctUntilChanged`/`map` (which builds the notification) run on `Dispatchers.IO`, matching `observeOn(SchedulerProvider.io)`; the consumer runs on `Dispatchers.Main`, matching `observeOn(SchedulerProvider.mainThread)`, because `startForeground`/`notify` are main-thread sensitive.
- **`BehaviorRelay` is not conflating**, so the two flows are `MutableSharedFlow(replay = 1, extraBufferCapacity = 64, onBufferOverflow = DROP_OLDEST)` rather than `MutableStateFlow`. This matters: `isForeground` accumulates across transitions, so a conflated-away `PLAYING` would leave it false and the following `PAUSED` would skip the block that posts the notification. `DROP_OLDEST` over the default `SUSPEND` so `tryEmit` cannot fail and lose the newest state.
- **`combineLatest` gating**: it emitted nothing until every source had a value. Neither flow replays a value before its first emission, so `combine` waits the same way. The metadata flow keeps its seeded initial value from `MediaControllerCompat.metadata`.
- **Error path**: `subscribeBy(onError)` logged and terminated the subscription; `onEach { }.catch { }.collect()` does the same for exceptions from both the notification build and the consumer.
- **Cancellation**: the subscription lived in a `CompositeDisposable` cleared in `onDestroy`, which already calls `job.cancel()` on the next line, so collecting in that scope dies at exactly the same point.

**One intentional change**

The `STATE_ERROR` diagnostic now logs from `onPlaybackStateChanged` instead of the notification handler, with the error code of the state in hand. In the handler it sat after the `isTransientLoss` early return, so an error during a transient audio-focus loss was never logged, and it re-read the latest relay value rather than the state being handled.

**Bridge left in place**

`playbackManager.playbackStateRelay.blockingFirst().transientLoss` is unchanged. `playbackStateRelay` is a cross-cutting chokepoint with ~40 `blockingFirst()` readers and its own backlog entry; `PlaybackManager.playbackStateFlow` is a plain `Flow`, so there is no non-suspending `.value` to swap in yet.

Fixes # <!-- no issue: part of the RxJava removal effort -->

## Testing Instructions

No unit tests cover this service, and it drives the lock screen, notification, Android Auto and Bluetooth media session, so it needs a device pass on the legacy playback path (Media3 flag off). Note that `SchedulerProvider` used to hand this pipeline a never-advanced `TestScheduler` under instrumentation, so it was inert there and now runs for real.

1. Play an episode. Confirm the playing notification appears with the right title, podcast and artwork.
2. Lock the device. Confirm the lock-screen controls show the same title and artwork.
3. Pause and resume from the notification and from the lock screen. Confirm the notification updates each time and is neither duplicated nor dropped.
4. Play and then pause again quickly, a few times in a row. Confirm the notification always ends up in the right state (this is the conflation path above).
5. Scrub, then skip forward/back. Confirm the notification and lock screen stay in sync.
6. While paused, change Settings > Appearance > episode artwork options. Confirm the notification artwork changes.
7. Repeat step 6 *during* playback. Confirm the artwork changes without playback stuttering or the notification disappearing.
8. Background the app while playing. Confirm playback continues and the notification survives; reopen the app and confirm the player matches.
9. Stop playback / clear the episode. Confirm the notification is removed. With Settings > "Hide notification on pause" off, confirm pausing leaves the notification in place.
10. Swipe the app away from recents while paused. Confirm the notification goes away and playback does not restart.
11. If available: connect Android Auto or a Bluetooth head unit and confirm browsing, metadata and play/pause/skip from the car controls.
12. Trigger a transient audio-focus loss (incoming call or alarm) while playing. Confirm the notification is not torn down and playback resumes afterwards.

## Screenshots or Screencast

Not applicable, no UI changes.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
