### PR TITLE
Remove ServiceManager.searchForPodcastsRx

### DIFF
--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchHandler.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchHandler.kt
@@ -249,8 +249,8 @@ class SearchHandler @Inject constructor(
             }
         }
         .map { it.term }
-        .switchMap {
-            if (it.length <= 1) {
+        .switchMap { searchTerm ->
+            if (searchTerm.length <= 1) {
                 Observable.just(GlobalServerSearch())
             } else {
                 eventHorizon.track(
@@ -260,17 +260,17 @@ class SearchHandler @Inject constructor(
                 )
                 loadingObservable.accept(true)
 
-                var globalSearch = GlobalServerSearch(searchTerm = it)
-                val podcastServerSearch = rxSingle { serviceManager.searchForPodcasts(searchTerm = it).getOrThrow() }
+                var globalSearch = GlobalServerSearch(searchTerm = searchTerm)
+                val podcastServerSearch = rxSingle { serviceManager.searchForPodcasts(searchTerm).getOrThrow() }
                     .map { podcastSearch ->
                         globalSearch = globalSearch.copy(podcastSearch = podcastSearch)
                         globalSearch
                     }
                     .toObservable()
 
-                if (!it.startsWith("http")) {
+                if (!searchTerm.startsWith("http")) {
                     val episodesServerSearch = cacheServiceManager
-                        .searchEpisodes(it)
+                        .searchEpisodes(searchTerm)
                         .map { episodeSearch ->
                             globalSearch = globalSearch.copy(episodeSearch = episodeSearch)
                             globalSearch

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchHandler.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchHandler.kt
@@ -26,6 +26,7 @@ import io.reactivex.rxkotlin.Observables
 import io.reactivex.schedulers.Schedulers
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
@@ -38,7 +39,8 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.rx2.asFlow
-import kotlinx.coroutines.rx2.await
+import kotlinx.coroutines.rx2.rxSingle
+import kotlinx.coroutines.withContext
 import timber.log.Timber
 
 class SearchHandler @Inject constructor(
@@ -259,8 +261,7 @@ class SearchHandler @Inject constructor(
                 loadingObservable.accept(true)
 
                 var globalSearch = GlobalServerSearch(searchTerm = it)
-                val podcastServerSearch = serviceManager
-                    .searchForPodcastsRx(it)
+                val podcastServerSearch = rxSingle { serviceManager.searchForPodcasts(searchTerm = it).getOrThrow() }
                     .map { podcastSearch ->
                         globalSearch = globalSearch.copy(podcastSearch = podcastSearch)
                         globalSearch
@@ -365,10 +366,12 @@ class SearchHandler @Inject constructor(
                     emit(SearchUiState.SearchOperation.Loading(searchTerm = query))
                     val subscribedUuids = podcastManager.findSubscribedUuids()
                     if (query.startsWith("http")) {
-                        val podcastSearch = serviceManager
-                            .searchForPodcastsRx(query)
-                            .map { list -> list.searchResults.map { ImprovedSearchResultItem.PodcastItem(uuid = it.uuid, title = it.title, author = it.author, isFollowed = subscribedUuids.contains(it.uuid)) } }
-                            .await()
+                        // collected on the main thread, so the blocking body read, the parse and the mapping all have to happen off it
+                        val podcastSearch = withContext(Dispatchers.IO) {
+                            serviceManager.searchForPodcasts(query).getOrThrow()
+                                .searchResults
+                                .map { ImprovedSearchResultItem.PodcastItem(uuid = it.uuid, title = it.title, author = it.author, isFollowed = subscribedUuids.contains(it.uuid)) }
+                        }
                         eventHorizon.track(
                             SearchPerformedEvent(
                                 source = source.analyticsValue,

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/ServiceManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/ServiceManager.kt
@@ -13,7 +13,6 @@ import au.com.shiftyjelly.pocketcasts.servers.refresh.RefreshPodcastBatcher
 import au.com.shiftyjelly.pocketcasts.utils.extensions.await
 import dagger.Lazy
 import dagger.hilt.android.qualifiers.ApplicationContext
-import io.reactivex.Single
 import java.io.IOException
 import java.util.Locale
 import javax.inject.Inject
@@ -22,7 +21,6 @@ import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.rx2.rxSingle
 import kotlinx.coroutines.withContext
 import okhttp3.FormBody
 import okhttp3.OkHttpClient
@@ -47,10 +45,6 @@ open class ServiceManager @Inject constructor(
                 DataParser.parsePodcastSearch(response.data, searchTerm)
             }
         }
-    }
-
-    fun searchForPodcastsRx(searchTerm: String): Single<PodcastSearch> {
-        return rxSingle { searchForPodcasts(searchTerm).getOrThrow() }
     }
 
     suspend fun exportFeedUrls(uuids: List<String>): Result<Map<String, String>?> {


### PR DESCRIPTION
## Description

Podcast search now goes through the plain suspend search call instead of an RxJava wrapper around it. No user-visible change.

`ServiceManager.searchForPodcastsRx` was a thin `rxSingle` bridge over the existing suspend `searchForPodcasts`, and it was the only RxJava in that file. Deleting it and repointing the two call sites in `SearchHandler` makes `ServiceManager` Rx-free.

Rx semantics preserved by hand:
- The improved-search path is collected on the main thread, so the call is wrapped in `withContext(Dispatchers.IO)` — the old `rxSingle` ran the blocking body read, the JSON parse and the result mapping on a background thread, and `Call.await()` is enqueue-based so the body read happens on the caller's dispatcher.
- Error path is unchanged: `getOrThrow()` still throws into the surrounding `catch`/`onErrorReturn`, and `postToMainServer` still rethrows `CancellationException` rather than folding it into a `Result.failure`.
- Cold/lazy subscription, per-subscription cancellation and analytics ordering in the legacy chain are unchanged.

## Testing Instructions

1. Open Search and type a podcast name (3+ characters). Results appear for both podcasts and episodes.
2. Keep typing and then delete characters quickly. Results track the latest query and the loading spinner clears.
3. Turn off networking and search again. The error state appears rather than a hang or crash.
4. Turn networking back on and paste an RSS feed URL (starting with `http`) into the search field. The podcast for that feed is returned.
5. Paste a feed URL for a podcast you already follow. It still shows as followed.
6. From Search, follow a result, go back, and search the same term again. The followed tick is shown.
7. In the Automotive/Android Auto browse UI, use voice or text search. Results still appear (shares the same suspend search call).

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.