### PR TITLE
Migrate the cloud files sorted query from RxJava to Flow

### DIFF
--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/UserEpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/UserEpisodeDao.kt
@@ -46,25 +46,25 @@ abstract class UserEpisodeDao {
     abstract suspend fun findAllUuids(): List<String>
 
     @Query("SELECT * FROM user_episodes ORDER BY added_date DESC")
-    abstract fun findUserEpisodesDescRxFlowable(): Flowable<List<UserEpisode>>
+    abstract fun findUserEpisodesDescFlow(): Flow<List<UserEpisode>>
 
     @Query("SELECT * FROM user_episodes ORDER BY added_date DESC")
     abstract suspend fun findUserEpisodesDesc(): List<UserEpisode>
 
     @Query("SELECT * FROM user_episodes ORDER BY added_date ASC")
-    abstract fun findUserEpisodesAscRxFlowable(): Flowable<List<UserEpisode>>
+    abstract fun findUserEpisodesAscFlow(): Flow<List<UserEpisode>>
 
     @Query("SELECT * FROM user_episodes ORDER BY title ASC")
-    abstract fun findUserEpisodesTitleAscRxFlowable(): Flowable<List<UserEpisode>>
+    abstract fun findUserEpisodesTitleAscFlow(): Flow<List<UserEpisode>>
 
     @Query("SELECT * FROM user_episodes ORDER BY title DESC")
-    abstract fun findUserEpisodesTitleDescRxFlowable(): Flowable<List<UserEpisode>>
+    abstract fun findUserEpisodesTitleDescFlow(): Flow<List<UserEpisode>>
 
     @Query("SELECT * FROM user_episodes ORDER BY duration ASC")
-    abstract fun findUserEpisodesDurationAscRxFlowable(): Flowable<List<UserEpisode>>
+    abstract fun findUserEpisodesDurationAscFlow(): Flow<List<UserEpisode>>
 
     @Query("SELECT * FROM user_episodes ORDER BY duration DESC")
-    abstract fun findUserEpisodesDurationDescRxFlowable(): Flowable<List<UserEpisode>>
+    abstract fun findUserEpisodesDurationDescFlow(): Flow<List<UserEpisode>>
 
     @Query("SELECT * FROM user_episodes WHERE download_task_id IS NOT NULL")
     abstract fun findDownloadingUserEpisodesRxFlowable(): Flowable<List<UserEpisode>>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/file/CloudFilesManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/file/CloudFilesManager.kt
@@ -5,12 +5,11 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
 import javax.inject.Inject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.reactive.asFlow
 
 class CloudFilesManager @Inject constructor(
     settings: Settings,
     private val userEpisodeManager: UserEpisodeManager,
 ) {
     @OptIn(ExperimentalCoroutinesApi::class)
-    val sortedCloudFiles = settings.cloudSortOrder.flow.flatMapLatest { userEpisodeManager.userEpisodesSortedRxFlowable(it).asFlow() }
+    val sortedCloudFiles = settings.cloudSortOrder.flow.flatMapLatest { userEpisodeManager.userEpisodesSortedFlow(it) }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/UserEpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/UserEpisodeManager.kt
@@ -51,11 +51,11 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.rx2.await
-import kotlinx.coroutines.rx2.awaitSingleOrNull
 import kotlinx.coroutines.rx2.rxCompletable
 import kotlinx.coroutines.withContext
 import retrofit2.HttpException
@@ -88,7 +88,7 @@ interface UserEpisodeManager {
     suspend fun updateDownloadErrorDetails(episode: UserEpisode, errorDetails: String?)
     suspend fun updateDownloadTaskId(episode: UserEpisode, taskId: String?)
     fun accountUsageRxFlowable(): Flowable<Optional<FileAccount>>
-    fun userEpisodesSortedRxFlowable(sortOrder: Settings.CloudSortOrder): Flowable<List<UserEpisode>>
+    fun userEpisodesSortedFlow(sortOrder: Settings.CloudSortOrder): Flow<List<UserEpisode>>
     suspend fun deletePlayedEpisodeIfReq(episode: UserEpisode, playbackManager: PlaybackManager)
     fun autoUploadToCloudIfReq(episode: UserEpisode)
     fun downloadMissingUserEpisodeRxMaybe(uuid: String, placeholderTitle: String?, placeholderPublished: Date?): Maybe<UserEpisode>
@@ -207,14 +207,14 @@ class UserEpisodeManagerImpl @Inject constructor(
         return userEpisodeDao.findUserEpisodesDesc()
     }
 
-    override fun userEpisodesSortedRxFlowable(sortOrder: Settings.CloudSortOrder): Flowable<List<UserEpisode>> {
+    override fun userEpisodesSortedFlow(sortOrder: Settings.CloudSortOrder): Flow<List<UserEpisode>> {
         return when (sortOrder) {
-            Settings.CloudSortOrder.NEWEST_OLDEST -> userEpisodeDao.findUserEpisodesDescRxFlowable()
-            Settings.CloudSortOrder.OLDEST_NEWEST -> userEpisodeDao.findUserEpisodesAscRxFlowable()
-            Settings.CloudSortOrder.A_TO_Z -> userEpisodeDao.findUserEpisodesTitleAscRxFlowable()
-            Settings.CloudSortOrder.Z_TO_A -> userEpisodeDao.findUserEpisodesTitleDescRxFlowable()
-            Settings.CloudSortOrder.SHORT_LONG -> userEpisodeDao.findUserEpisodesDurationAscRxFlowable()
-            Settings.CloudSortOrder.LONG_SHORT -> userEpisodeDao.findUserEpisodesDurationDescRxFlowable()
+            Settings.CloudSortOrder.NEWEST_OLDEST -> userEpisodeDao.findUserEpisodesDescFlow()
+            Settings.CloudSortOrder.OLDEST_NEWEST -> userEpisodeDao.findUserEpisodesAscFlow()
+            Settings.CloudSortOrder.A_TO_Z -> userEpisodeDao.findUserEpisodesTitleAscFlow()
+            Settings.CloudSortOrder.Z_TO_A -> userEpisodeDao.findUserEpisodesTitleDescFlow()
+            Settings.CloudSortOrder.SHORT_LONG -> userEpisodeDao.findUserEpisodesDurationAscFlow()
+            Settings.CloudSortOrder.LONG_SHORT -> userEpisodeDao.findUserEpisodesDurationDescFlow()
         }.map { it.filterNot { episode -> episode.serverStatus == UserEpisodeServerStatus.MISSING } }
     }
 
@@ -579,7 +579,7 @@ class UserEpisodeManagerImpl @Inject constructor(
     }
 
     override suspend fun removeCloudStatusFromFiles(playbackManager: PlaybackManager) = withContext(Dispatchers.IO) {
-        userEpisodeDao.findUserEpisodesDescRxFlowable().firstElement().awaitSingleOrNull()?.forEach {
+        userEpisodeDao.findUserEpisodesDesc().forEach {
             if (!it.isDownloaded) { // Cloud only
                 delete(it, playbackManager)
             } else if (it.isDownloaded && it.serverStatus == UserEpisodeServerStatus.UPLOADED) {

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/FilesViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/FilesViewModel.kt
@@ -5,7 +5,6 @@ import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
-import kotlinx.coroutines.reactive.asFlow
 
 @HiltViewModel
 class FilesViewModel @Inject constructor(
@@ -14,8 +13,7 @@ class FilesViewModel @Inject constructor(
 ) : ViewModel() {
 
     val userEpisodes = userEpisodeManager
-        .userEpisodesSortedRxFlowable(settings.cloudSortOrder.value)
-        .asFlow()
+        .userEpisodesSortedFlow(settings.cloudSortOrder.value)
 
     val artworkConfiguration = settings.artworkConfiguration.flow
 }


### PR DESCRIPTION
## Description
Internal refactor with no user-visible change: the Files list keeps working exactly as it does today, it just gets its data through Kotlin Flow instead of RxJava.

Part of the RxJava removal effort — the `UserEpisodeDao` / cloud files sorted query entry from the backlog.

The six sorted cloud-files queries in `UserEpisodeDao` returned `Flowable`, and both of the things that consumed them immediately converted the result with `.asFlow()`. Returning a native Room `Flow` deletes those two bridges rather than adding any. `UserEpisodeManager.userEpisodesSortedRxFlowable` becomes `userEpisodesSortedFlow`; its only two callers are `CloudFilesManager` and wear's `FilesViewModel`, both already Flow consumers, so `sortedCloudFiles` keeps its existing type and nothing downstream changes.

`removeCloudStatusFromFiles` also moves to the pre-existing suspend twin `findUserEpisodesDesc()`. It was the last caller keeping the Rx `Desc` Flowable alive, and it was only ever taking a one-shot snapshot (`.firstElement().awaitSingleOrNull()`) anyway.

Semantics checked by hand:
- Identical SQL on all six queries, so the sort-order mapping is unchanged.
- Room `Flow` and Room's Rx `Flowable` adapter are both backed by the same invalidation flow, so initial emission and re-query on table change are preserved.
- The `filterNot(MISSING)` filter is unchanged; `.map` is now `kotlinx.coroutines.flow.map`.
- `.firstElement().awaitSingleOrNull()?` → non-null `List`: Room never emits null for a list query, and the call stays inside `withContext(Dispatchers.IO)`.
- **One deliberate difference worth a reviewer's eye:** that `filterNot` used to run on Room's query executor and now runs in the collector's context (main thread for both consumers). The list is the user's own uploaded files, so this is a trivially small amount of work; I left it rather than add a `flowOn` buffer hop the Rx version never had. Happy to add `.flowOn(Dispatchers.Default)` if you'd rather.

Rx bridges deliberately left in place: `findDownloadingUserEpisodesRxFlowable`, `findEpisodeRxFlowable`, `findEpisodeByUuidRxMaybe`, `insertRxCompletable`, `updateServerStatusRxCompletable` and `updateUploadErrorRxCompetable` all stay. They are blocked on public `UserEpisodeManager` signatures consumed from `PlaybackManager`, `UpNextSync` and `UploadEpisodeTask`, which are out of scope here.

## Testing Instructions
1. Sign in to an account with Pocket Casts Plus and open **Profile → Files**.
2. Confirm the uploaded files list appears and is correct.
3. Change the sort order (Newest to oldest, Oldest to newest, A–Z, Z–A, Shortest to longest, Longest to shortest) and confirm the list reorders correctly for every option.
4. Upload a new file and confirm it appears in the list without needing to leave and re-enter the screen.
5. Delete a file and confirm it disappears from the list immediately.
6. Confirm files with a "missing" server status are still hidden from the list.
7. On a Wear OS device or emulator, open the **Files** screen and confirm the list loads and is sorted per the phone's sort setting.
8. Go to **Profile → Settings → Files** (or cancel your subscription flow) and trigger "remove cloud status from files"; confirm cloud-only files are deleted and downloaded files revert to local.
9. With Up Next empty and auto-play configured to continue from Files, confirm playback continues into a cloud file.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

