### PR TITLE
Migrate SyncManager.isLoggedInObservable to a StateFlow

### DIFF
--- a/modules/features/account/build.gradle.kts
+++ b/modules/features/account/build.gradle.kts
@@ -74,7 +74,6 @@ dependencies {
     implementation(libs.rx2.android)
     implementation(libs.rx2.java)
     implementation(libs.rx2.kotlin)
-    implementation(libs.rx2.relay)
     implementation(libs.timber)
     implementation(libs.credentials)
     implementation(libs.credentials.google.play)

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/PromoCodeViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/PromoCodeViewModel.kt
@@ -11,13 +11,13 @@ import au.com.shiftyjelly.pocketcasts.servers.sync.PromoCodeResponse
 import au.com.shiftyjelly.pocketcasts.servers.sync.parseErrorResponse
 import com.squareup.moshi.Moshi
 import dagger.hilt.android.lifecycle.HiltViewModel
-import io.reactivex.BackpressureStrategy
 import io.reactivex.Single
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
 import io.reactivex.functions.Function
 import io.reactivex.schedulers.Schedulers
 import javax.inject.Inject
+import kotlinx.coroutines.rx2.asFlowable
 import kotlinx.coroutines.rx2.rxCompletable
 import retrofit2.HttpException
 
@@ -54,7 +54,7 @@ class PromoCodeViewModel @Inject constructor(
             .toFlowable()
 
         disposable?.dispose()
-        disposable = syncManager.isLoggedInObservable.toFlowable(BackpressureStrategy.LATEST)
+        disposable = syncManager.isLoggedInFlow.asFlowable()
             .observeOn(Schedulers.io())
             .takeUntil { it } // Once we are signed in we don't want to be notified for other changes to the account like being upgraded to plus
             .switchMap { signedIn ->

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/DiscoverViewModel.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/DiscoverViewModel.kt
@@ -46,6 +46,7 @@ import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.rx2.asObservable
 import kotlinx.coroutines.rx2.rxMaybe
 import kotlinx.coroutines.rx2.rxSingle
 import timber.log.Timber
@@ -90,7 +91,7 @@ class DiscoverViewModel @Inject constructor(
     }
 
     fun loadFeed(resources: Resources) {
-        val loggedInObservable = syncManager.isLoggedInObservable
+        val loggedInObservable = syncManager.isLoggedInFlow.asObservable()
         Observables.combineLatest(loadDiscoverFeedRxSingle(resources).toObservable(), loggedInObservable)
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())

--- a/modules/features/engage/src/main/kotlin/au/com/shiftyjelly/pocketcasts/engage/EngageSdkAccountSync.kt
+++ b/modules/features/engage/src/main/kotlin/au/com/shiftyjelly/pocketcasts/engage/EngageSdkAccountSync.kt
@@ -11,7 +11,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.rx2.asFlow
 import kotlinx.coroutines.tasks.await
 
 class EngageSdkAccountSync(
@@ -29,7 +28,7 @@ class EngageSdkAccountSync(
             return
         }
         syncJob = coroutineScope.launch {
-            syncManager.isLoggedInObservable.asFlow().collectLatest { isSignedIn ->
+            syncManager.isLoggedInFlow.collectLatest { isSignedIn ->
                 try {
                     val request = ServiceAvailabilityRequest.Builder()
                         .addIntendedClusterType(ClusterType.TYPE_ENGAGEMENT)

--- a/modules/features/engage/src/main/kotlin/au/com/shiftyjelly/pocketcasts/engage/EngageSdkWorkers.kt
+++ b/modules/features/engage/src/main/kotlin/au/com/shiftyjelly/pocketcasts/engage/EngageSdkWorkers.kt
@@ -116,7 +116,7 @@ internal class FeaturedWorker @AssistedInject constructor(
 
 private suspend fun getEngageData(dataManager: ExternalDataManager, syncManager: SyncManager): EngageData {
     // Do not use isLoggedIn() method https://github.com/Automattic/pocket-casts-android/issues/2409
-    val isSignedIn = syncManager.isLoggedInObservable.value == true
+    val isSignedIn = syncManager.isLoggedInFlow.value
     return dataManager.getEngageData(isSignedIn)
 }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManager.kt
@@ -27,7 +27,6 @@ import au.com.shiftyjelly.pocketcasts.servers.sync.history.HistoryYearResponse
 import au.com.shiftyjelly.pocketcasts.servers.sync.login.DeviceAuthorizeResponse
 import au.com.shiftyjelly.pocketcasts.servers.sync.login.ExchangeSonosResponse
 import au.com.shiftyjelly.pocketcasts.utils.Optional
-import com.jakewharton.rxrelay2.BehaviorRelay
 import com.pocketcasts.service.api.BookmarksResponse
 import com.pocketcasts.service.api.EpisodesResponse
 import com.pocketcasts.service.api.PodcastRatingResponse
@@ -50,13 +49,14 @@ import io.reactivex.Maybe
 import io.reactivex.Single
 import java.io.File
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
 import retrofit2.Response
 import com.pocketcasts.service.api.UpNextSyncRequest as UpNextSyncRequestProtobuf
 
 interface SyncManager : NamedSettingsCaller {
 
     // Account
-    val isLoggedInObservable: BehaviorRelay<Boolean>
+    val isLoggedInFlow: StateFlow<Boolean>
     fun isGoogleLogin(): Boolean
     fun isLoggedIn(): Boolean
     fun getLoginIdentity(): LoginIdentity?

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
@@ -59,7 +59,6 @@ import com.automattic.eventhorizon.UserSignedInEvent
 import com.automattic.eventhorizon.UserSignedInWatchFromPhoneEvent
 import com.automattic.eventhorizon.UserSigninFailedEvent
 import com.automattic.eventhorizon.UserSigninWatchFromPhoneFailedEvent
-import com.jakewharton.rxrelay2.BehaviorRelay
 import com.pocketcasts.service.api.BookmarksResponse
 import com.pocketcasts.service.api.EpisodesResponse
 import com.pocketcasts.service.api.PodcastRatingResponse
@@ -88,6 +87,9 @@ import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.rx2.rxSingle
 import retrofit2.HttpException
@@ -113,9 +115,8 @@ class SyncManagerImpl @Inject constructor(
         const val NO_REDIRECT_PATH = "none"
     }
 
-    override val isLoggedInObservable = BehaviorRelay.create<Boolean>().apply {
-        accept(isLoggedIn())
-    }
+    private val _isLoggedInFlow = MutableStateFlow(isLoggedIn())
+    override val isLoggedInFlow: StateFlow<Boolean> = _isLoggedInFlow.asStateFlow()
 
 // Account
 
@@ -195,7 +196,7 @@ class SyncManagerImpl @Inject constructor(
         syncServiceManager.signOut()
         action()
         syncAccountManager.signOut()
-        isLoggedInObservable.accept(false)
+        _isLoggedInFlow.value = false
     }
 
     override suspend fun loginWithGoogle(
@@ -245,7 +246,7 @@ class SyncManagerImpl @Inject constructor(
                 accessToken = response.accessToken,
                 loginIdentity = LoginIdentity.QrCode,
             )
-            isLoggedInObservable.accept(true)
+            _isLoggedInFlow.value = true
             settings.setFullySignedOut(false)
             settings.setLastModified(null)
             val result = AuthResultModel(
@@ -748,7 +749,7 @@ class SyncManagerImpl @Inject constructor(
             accessToken = response.accessToken,
             loginIdentity = loginIdentity,
         )
-        isLoggedInObservable.accept(true)
+        _isLoggedInFlow.value = true
 
         settings.setFullySignedOut(false)
         settings.setLastModified(null)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
@@ -32,7 +32,6 @@ import com.automattic.android.tracks.crashlogging.CrashLogging
 import com.automattic.eventhorizon.EventHorizon
 import com.automattic.eventhorizon.UserSignedOutEvent
 import dagger.hilt.android.qualifiers.ApplicationContext
-import io.reactivex.BackpressureStrategy
 import io.reactivex.Flowable
 import io.reactivex.Single
 import io.reactivex.rxkotlin.combineLatest
@@ -118,7 +117,7 @@ class UserManagerImpl @Inject constructor(
     }
 
     override fun getSignInState(): Flowable<SignInState> {
-        return syncManager.isLoggedInObservable.toFlowable(BackpressureStrategy.LATEST)
+        return syncManager.isLoggedInFlow.asFlowable()
             .switchMap { isLoggedIn ->
                 if (isLoggedIn) {
                     launch(coroutineContext) {

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImplTest.kt
@@ -25,6 +25,7 @@ import java.util.Date
 import kotlinx.coroutines.test.runTest
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -68,15 +69,7 @@ class SyncManagerImplTest {
     fun setUp() {
         MockitoAnnotations.openMocks(this)
 
-        syncManager = SyncManagerImpl(
-            eventHorizon = EventHorizon(eventSink),
-            context = context,
-            settings = settings,
-            syncAccountManager = syncAccountManager,
-            syncServiceManager = syncServiceManager,
-            moshi = moshi,
-            notificationManager = notificationManager,
-        )
+        syncManager = createSyncManager()
     }
 
     @Test
@@ -176,6 +169,51 @@ class SyncManagerImplTest {
         assertEquals("https://files.example.com/signed", syncManager.getSignedPlaybackUrl(episode))
         verify(syncAccountManager).invalidateAccessToken()
     }
+
+    @Test
+    fun `isLoggedInFlow is seeded from the account manager`() {
+        whenever(syncAccountManager.isLoggedIn()).thenReturn(true)
+
+        assertTrue(createSyncManager().isLoggedInFlow.value)
+    }
+
+    @Test
+    fun `isLoggedInFlow turns true after a device auth login`() = runTest {
+        whenever(syncServiceManager.deviceToken(any(), any())).thenReturn(createDeviceTokenResponse())
+
+        syncManager.loginWithDeviceAuth("device-code", SignInSource.UserInitiated.Onboarding, isNewAccount = false)
+
+        assertTrue(syncManager.isLoggedInFlow.value)
+    }
+
+    @Test
+    fun `isLoggedInFlow turns true after creating an account`() = runTest {
+        whenever(syncServiceManager.register(any(), any())).thenReturn(createMockLoginResponse(isNew = true))
+
+        syncManager.createUserWithEmailAndPassword("test@example.com", "password123", SignInSource.UserInitiated.Onboarding)
+
+        assertTrue(syncManager.isLoggedInFlow.value)
+    }
+
+    @Test
+    fun `isLoggedInFlow turns false after signing out`() = runTest {
+        whenever(syncAccountManager.isLoggedIn()).thenReturn(true)
+        val syncManager = createSyncManager()
+
+        syncManager.signOut()
+
+        assertFalse(syncManager.isLoggedInFlow.value)
+    }
+
+    private fun createSyncManager() = SyncManagerImpl(
+        eventHorizon = EventHorizon(eventSink),
+        context = context,
+        settings = settings,
+        syncAccountManager = syncAccountManager,
+        syncServiceManager = syncServiceManager,
+        moshi = moshi,
+        notificationManager = notificationManager,
+    )
 
     private fun stubResources() {
         val resources = mock<Resources>()

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvApplication.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/TvApplication.kt
@@ -29,7 +29,6 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.rx2.asFlow
 import timber.log.Timber
 
 @HiltAndroidApp
@@ -98,7 +97,7 @@ class TvApplication :
         analyticsController.refreshMetadata()
         applicationScope.launch {
             combine(
-                syncManager.isLoggedInObservable.asFlow(),
+                syncManager.isLoggedInFlow,
                 settings.cachedSubscription.flow,
             ) { isLoggedIn, subscription -> isLoggedIn to subscription }
                 .distinctUntilChanged()

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModel.kt
@@ -89,9 +89,7 @@ class TvHomeViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            syncManager.isLoggedInObservable.asFlow()
-                .distinctUntilChanged()
-                .collect { load() }
+            syncManager.isLoggedInFlow.collect { load() }
         }
         observeLocalRowSignals()
     }

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffoldViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/home/TvScaffoldViewModel.kt
@@ -43,7 +43,7 @@ class TvScaffoldViewModel @Inject constructor(
     val uiState: StateFlow<TvScaffoldUiState> = combine(
         selectedTab,
         hasCurrentEpisode,
-        syncManager.isLoggedInObservable.asFlow(),
+        syncManager.isLoggedInFlow,
         syncManager.emailFlow(),
         settings.artworkConfiguration.flow,
     ) { tab, hasEpisode, isLoggedIn, email, artworkConfiguration ->

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsViewModel.kt
@@ -51,7 +51,6 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.rx2.asFlow
 import kotlinx.coroutines.rx2.await
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -92,9 +91,8 @@ class TvPodcastDetailsViewModel @AssistedInject constructor(
             val episodesFlow = podcastFlow
                 .distinctUntilChangedBy { it.episodesSortType }
                 .flatMapLatest { episodeManager.findEpisodesByPodcastOrderedFlow(it) }
-            val isLoggedInFlow = syncManager.isLoggedInObservable.asFlow()
             emitAll(
-                combine(podcastFlow, episodesFlow, isShowingArchivedFlow, isLoggedInFlow) { loadedPodcast, episodes, isShowingArchived, isLoggedIn ->
+                combine(podcastFlow, episodesFlow, isShowingArchivedFlow, syncManager.isLoggedInFlow) { loadedPodcast, episodes, isShowingArchived, isLoggedIn ->
                     TvPodcastDetailsUiState.Loaded(
                         podcast = loadedPodcast,
                         episodes = if (isShowingArchived) episodes else episodes.filterNot(PodcastEpisode::isArchived),

--- a/tv/src/main/java/au/com/shiftyjelly/pocketcasts/settings/TvSettingsViewModel.kt
+++ b/tv/src/main/java/au/com/shiftyjelly/pocketcasts/settings/TvSettingsViewModel.kt
@@ -17,7 +17,6 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.rx2.asFlow
 
 @HiltViewModel
 class TvSettingsViewModel @Inject constructor(
@@ -27,7 +26,7 @@ class TvSettingsViewModel @Inject constructor(
 ) : ViewModel() {
 
     val uiState: StateFlow<TvSettingsUiState> = combine(
-        syncManager.isLoggedInObservable.asFlow(),
+        syncManager.isLoggedInFlow,
         settings.artworkConfiguration.flow,
         settings.cachedSubscription.flow,
     ) { isSignedIn, artworkConfiguration, subscription ->

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/TvScaffoldViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/TvScaffoldViewModelTest.kt
@@ -238,8 +238,9 @@ class TvScaffoldViewModelTest {
 
     @Test
     fun `profile is seeded from the sync manager before the streams emit`() = runTest {
-        whenever(syncManager.isLoggedInFlow).doReturn(MutableStateFlow(true))
-        // emailFlow never emits, so the combine stays silent and the assertion lands on the stateIn seed
+        // emailFlow never emits so the combine stays silent, and the signed-out login stub means any
+        // leaked combine emission would assert as SignedOut rather than matching the stateIn seed
+        whenever(syncManager.isLoggedInFlow).doReturn(MutableStateFlow(false))
         whenever(syncManager.emailFlow()).doReturn(MutableSharedFlow())
         whenever(syncManager.isLoggedIn()).doReturn(true)
         whenever(syncManager.getEmail()).doReturn("user@example.com")

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/TvScaffoldViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/TvScaffoldViewModelTest.kt
@@ -14,7 +14,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import com.automattic.eventhorizon.EventHorizon
 import com.automattic.eventhorizon.ProfileShownEvent
-import com.jakewharton.rxrelay2.BehaviorRelay
 import io.reactivex.subjects.BehaviorSubject
 import java.util.Date
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -35,12 +34,12 @@ class TvScaffoldViewModelTest {
     @get:Rule
     val coroutineRule = MainCoroutineRule()
 
-    private val isLoggedIn = BehaviorRelay.createDefault(false)
+    private val isLoggedIn = MutableStateFlow(false)
     private val email = MutableStateFlow<String?>(null)
 
     private val syncManager = mock<SyncManager> {
         on { isLoggedIn() } doReturn false
-        on { isLoggedInObservable } doReturn isLoggedIn
+        on { isLoggedInFlow } doReturn isLoggedIn
         on { emailFlow() } doReturn email
     }
     private val signOutManager = mock<TvSignOutManager>()
@@ -217,7 +216,7 @@ class TvScaffoldViewModelTest {
     fun `profile has the account email when signed in`() = runTest {
         whenever(syncManager.isLoggedIn()).doReturn(true)
         whenever(syncManager.getEmail()).doReturn("user@example.com")
-        isLoggedIn.accept(true)
+        isLoggedIn.value = true
         email.value = "user@example.com"
 
         viewModel.uiState.test {
@@ -229,7 +228,7 @@ class TvScaffoldViewModelTest {
     fun `profile email is null when signed in with a blank email`() = runTest {
         whenever(syncManager.isLoggedIn()).doReturn(true)
         whenever(syncManager.getEmail()).doReturn("")
-        isLoggedIn.accept(true)
+        isLoggedIn.value = true
         email.value = ""
 
         viewModel.uiState.test {
@@ -239,7 +238,8 @@ class TvScaffoldViewModelTest {
 
     @Test
     fun `profile is seeded from the sync manager before the streams emit`() = runTest {
-        whenever(syncManager.isLoggedInObservable).doReturn(BehaviorRelay.create())
+        whenever(syncManager.isLoggedInFlow).doReturn(MutableStateFlow(true))
+        // emailFlow never emits, so the combine stays silent and the assertion lands on the stateIn seed
         whenever(syncManager.emailFlow()).doReturn(MutableSharedFlow())
         whenever(syncManager.isLoggedIn()).doReturn(true)
         whenever(syncManager.getEmail()).doReturn("user@example.com")
@@ -255,10 +255,10 @@ class TvScaffoldViewModelTest {
             assertEquals(TvProfileState.SignedOut, awaitItem().profile)
 
             email.value = "user@example.com"
-            isLoggedIn.accept(true)
+            isLoggedIn.value = true
             assertEquals(TvProfileState.SignedIn(email = "user@example.com"), awaitItem().profile)
 
-            isLoggedIn.accept(false)
+            isLoggedIn.value = false
             assertEquals(TvProfileState.SignedOut, awaitItem().profile)
         }
     }

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/home/TvHomeViewModelTest.kt
@@ -50,7 +50,6 @@ import com.automattic.eventhorizon.DiscoverListImpressionEvent
 import com.automattic.eventhorizon.DiscoverListPodcastTappedEvent
 import com.automattic.eventhorizon.EventHorizon
 import com.automattic.eventhorizon.HomeShownEvent
-import com.jakewharton.rxrelay2.BehaviorRelay
 import com.jakewharton.rxrelay2.PublishRelay
 import io.reactivex.Observable
 import io.reactivex.Single
@@ -58,6 +57,7 @@ import java.util.Date
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
@@ -94,7 +94,7 @@ class TvHomeViewModelTest {
         }
     }
     private val syncManager = mock<SyncManager> {
-        on { isLoggedInObservable } doReturn BehaviorRelay.createDefault(false)
+        on { isLoggedInFlow } doReturn MutableStateFlow(false)
     }
     private val podcastDao = mock<PodcastDao> {
         on { findAllIn(any()) }.thenReturn(emptyList())

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/TvPodcastDetailsViewModelTest.kt
@@ -27,7 +27,6 @@ import com.automattic.eventhorizon.PodcastScreenUnsubscribeTappedEvent
 import com.automattic.eventhorizon.PodcastSubscribedEvent
 import com.automattic.eventhorizon.PodcastUnsubscribedEvent
 import com.automattic.eventhorizon.PodcastsScreenSortOrderChangedEvent
-import com.jakewharton.rxrelay2.BehaviorRelay
 import io.reactivex.Single
 import java.util.Date
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -68,9 +67,9 @@ class TvPodcastDetailsViewModelTest {
         on { findEpisodesByPodcastOrderedFlow(any()) } doReturn episodes
     }
     private val preferences = mock<TvPreferences>()
-    private val loggedIn = BehaviorRelay.createDefault(false)
+    private val loggedIn = MutableStateFlow(false)
     private val syncManager = mock<SyncManager> {
-        on { isLoggedInObservable } doReturn loggedIn
+        on { isLoggedInFlow } doReturn loggedIn
     }
     private val eventHorizon = mock<EventHorizon>()
     private val discoverPodcastAttribution = TvDiscoverPodcastAttribution()
@@ -239,7 +238,7 @@ class TvPodcastDetailsViewModelTest {
 
     @Test
     fun `the logged in state is reflected in the loaded state`() = runTest {
-        loggedIn.accept(true)
+        loggedIn.value = true
         val viewModel = createViewModel()
 
         viewModel.uiState.test {

--- a/tv/src/test/java/au/com/shiftyjelly/pocketcasts/settings/TvSettingsViewModelTest.kt
+++ b/tv/src/test/java/au/com/shiftyjelly/pocketcasts/settings/TvSettingsViewModelTest.kt
@@ -17,7 +17,6 @@ import com.automattic.eventhorizon.AccountDetailsSubscriptionEvent
 import com.automattic.eventhorizon.EventHorizon
 import com.automattic.eventhorizon.SettingsAppearanceUseEpisodeArtworkToggledEvent
 import com.automattic.eventhorizon.SettingsGeneralShownEvent
-import com.jakewharton.rxrelay2.BehaviorRelay
 import java.time.Instant
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -38,7 +37,7 @@ class TvSettingsViewModelTest {
     @get:Rule
     val coroutineRule = MainCoroutineRule()
 
-    private val isLoggedIn = BehaviorRelay.createDefault(false)
+    private val isLoggedIn = MutableStateFlow(false)
     private val subscriptionFlow = MutableStateFlow<Subscription?>(null)
     private val artworkConfigurationFlow = MutableStateFlow(ArtworkConfiguration(useEpisodeArtwork = false))
 
@@ -60,7 +59,7 @@ class TvSettingsViewModelTest {
     }
     private val syncManager = mock<SyncManager> {
         on { isLoggedIn() } doReturn false
-        on { isLoggedInObservable } doReturn isLoggedIn
+        on { isLoggedInFlow } doReturn isLoggedIn
     }
     private val eventHorizon = mock<EventHorizon>()
 
@@ -82,7 +81,7 @@ class TvSettingsViewModelTest {
         viewModel.uiState.test {
             skipItems(1)
 
-            isLoggedIn.accept(true)
+            isLoggedIn.value = true
             assertEquals(true, awaitItem().isSignedIn)
 
             viewModel.setUseEpisodeArtwork(true)


### PR DESCRIPTION
## Description

Internal refactor with no user-facing change: the signal that tells the app whether you are signed in is now a Kotlin `StateFlow` instead of an RxJava relay.

`SyncManager.isLoggedInObservable: BehaviorRelay<Boolean>` becomes `isLoggedInFlow: StateFlow<Boolean>`, backed by a private `MutableStateFlow` seeded from `isLoggedIn()` exactly as the relay was. `SyncManagerImpl` was the only writer, so the public type no longer exposes `accept()`. The seven call sites that already bridged with `.asFlow()` (engage, tv) now collect directly.

This is a slice of the larger `SyncManager` backlog entry. It is the blocker on the highest-ripple chokepoint in the RxJava removal, `UserManager.getSignInState(): Flowable<SignInState>`, which can now migrate on its own.

Fixes # <!-- no issue: part of the RxJava removal effort (backlog entry: SyncManager.isLoggedInObservable) -->

**Rx semantics preserved by hand**
- `toFlowable(BackpressureStrategy.LATEST)` → `asFlowable()` on a conflating `StateFlow`: same latest-value semantics.
- The bridges collect on `Dispatchers.Unconfined`, so the current value still arrives synchronously at subscribe time, as the relay's replay did.
- Initial value still seeded from `isLoggedIn()` in the constructor.
- `distinctUntilChanged()` dropped in `TvHomeViewModel` only because `StateFlow` already dedupes.
- `BehaviorRelay.value` was `Boolean?`, so `EngageSdkWorkers`' `== true` check is gone rather than lost.

**Bridges deliberately left in place**
- `UserManagerImpl.getSignInState()` — `asFlowable()`, until `getSignInState()` itself becomes a `Flow` (its own backlog entry).
- `DiscoverViewModel` — `asObservable()`, until that ViewModel's Rx pipeline migrates.
- `PromoCodeViewModel` — `asFlowable()`, same.

<details>
<summary>Note on conflation</summary>

`BehaviorRelay` does not conflate; `StateFlow` does, and also swallows equal consecutive values. The three writers are `signOut → false`, `loginWithDeviceAuth → true` and `handleTokenResponse → true`, and every login path is guarded to run only while signed out, so there is no `accept(true)`-while-already-true case. No consumer accumulates state across emissions; all of them either `combine`, `switchMap`/`collectLatest`, or read `.value`.
</details>

## Testing Instructions

1. Sign in with an email and password. Discover should drop the signed-out-only lists and show authenticated lists; the profile should show your email.
2. Sign out. Discover should filter the authenticated lists back out and the profile should return to signed out.
3. Sign in again with Google, then again with "Sign in on another device" (QR / device code). Each should land you signed in with the correct subscription state on the profile screen.
4. Open a promo code deep link while signed out, and again while signed in. Signed out should offer account creation; signed in should redeem and refresh the subscription.
5. On Android TV: sign in and out, and check the home rows reload, the profile in the side nav updates, and Settings shows the right subscription.
6. Kill and relaunch the app while signed in and confirm you are still signed in everywhere.

## Screenshots or Screencast

Not applicable, no UI changed.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack

🤖 Generated with [Claude Code](https://claude.com/claude-code)
