### PR TITLE
Move the manual cleanup starred switch to ViewModel state

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/ManualCleanupPage.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/ManualCleanupPage.kt
@@ -15,9 +15,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -46,7 +43,6 @@ fun ManualCleanupPage(
     modifier: Modifier = Modifier,
 ) {
     val state: ManualCleanupViewModel.State by viewModel.state.collectAsState()
-    var includeStarredSwitchState: Boolean by remember { mutableStateOf(false) }
     val context = LocalContext.current
     Column(
         modifier = modifier,
@@ -58,14 +54,10 @@ fun ManualCleanupPage(
         )
         ManageDownloadsView(
             state = state,
-            includeStarredSwitchState = includeStarredSwitchState,
             onDiskSpaceCheckedChange = { isChecked, diskSpaceView ->
                 viewModel.onDiskSpaceCheckedChanged(isChecked, diskSpaceView)
             },
-            onStarredSwitchClick = {
-                viewModel.onStarredSwitchClicked(it)
-                includeStarredSwitchState = it
-            },
+            onStarredSwitchClick = { viewModel.onStarredSwitchClicked(it) },
             onDeleteButtonClick = { viewModel.onDeleteButtonClicked() },
         )
         LaunchedEffect(Unit) {
@@ -80,7 +72,6 @@ fun ManualCleanupPage(
 @Composable
 private fun ManageDownloadsView(
     state: ManualCleanupViewModel.State,
-    includeStarredSwitchState: Boolean,
     onDiskSpaceCheckedChange: (Boolean, diskSpaceView: ManualCleanupViewModel.State.DiskSpaceView) -> Unit,
     onStarredSwitchClick: (Boolean) -> Unit,
     onDeleteButtonClick: () -> Unit,
@@ -94,7 +85,7 @@ private fun ManageDownloadsView(
             .verticalScroll(rememberScrollState()),
     ) {
         state.diskSpaceViews.forEach { DiskSpaceSizeRow(it, onDiskSpaceCheckedChange) }
-        IncludeStarredRow(includeStarredSwitchState, onStarredSwitchClick)
+        IncludeStarredRow(state.includeStarred, onStarredSwitchClick)
         TotalSelectedDownloadSizeRow(state.totalSelectedDownloadSize)
         RowButton(
             text = stringResource(LR.string.settings_downloads_clean_up),
@@ -188,7 +179,6 @@ private fun ManualCleanupPagePreview(
     AppThemeWithBackground(themeType) {
         ManageDownloadsView(
             state = ManualCleanupViewModel.State(),
-            includeStarredSwitchState = false,
             onDiskSpaceCheckedChange = { _, _ -> },
             onStarredSwitchClick = {},
             onDeleteButtonClick = {},

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/ManualCleanupViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/ManualCleanupViewModel.kt
@@ -42,6 +42,7 @@ class ManualCleanupViewModel
         ),
         val totalSelectedDownloadSize: Long = 0L,
         val deleteButton: DeleteButton = DeleteButton(),
+        val includeStarred: Boolean = false,
     ) {
         val unplayed get() = diskSpaceViews.find { it.title == LR.string.unplayed }
         val inProgress get() = diskSpaceViews.find { it.title == LR.string.in_progress }
@@ -94,6 +95,7 @@ class ManualCleanupViewModel
                         diskSpaceViews = updatedDiskSpaceViews,
                         totalSelectedDownloadSize = downloadSize,
                         deleteButton = deleteButton,
+                        includeStarred = switchState.value,
                     )
                 }
         }
@@ -117,6 +119,7 @@ class ManualCleanupViewModel
 
     fun onStarredSwitchClicked(isChecked: Boolean) {
         switchState.value = isChecked
+        _state.value = _state.value.copy(includeStarred = isChecked)
     }
 
     fun onDeleteButtonClicked() {

--- a/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/ManualCleanupViewModelTest.kt
+++ b/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/ManualCleanupViewModelTest.kt
@@ -81,9 +81,22 @@ class ManualCleanupViewModelTest {
         viewModel = ManualCleanupViewModel(episodeManager, mock(), EventHorizon(TestEventSink()))
 
         assertEquals(listOf(episode), viewModel.state.value.unplayed?.episodes)
+        assertFalse(viewModel.state.value.includeStarred)
 
         viewModel.onStarredSwitchClicked(true)
 
         assertEquals(listOf(episode, starredEpisode), viewModel.state.value.unplayed?.episodes)
+        assertTrue(viewModel.state.value.includeStarred)
+    }
+
+    @Test
+    fun `when starred switch toggled, then include starred state follows the switch`() {
+        assertFalse(viewModel.state.value.includeStarred)
+
+        viewModel.onStarredSwitchClicked(true)
+        assertTrue(viewModel.state.value.includeStarred)
+
+        viewModel.onStarredSwitchClicked(false)
+        assertFalse(viewModel.state.value.includeStarred)
     }
 }


### PR DESCRIPTION
## Description
The "Include starred" switch on the Manual Cleanup screen now keeps its position when the screen is recreated (for example after rotating the device), instead of flipping back to off while starred episodes are still included.

The switch position was held only in the composable with `remember`, while the actual filtering lives in `ManualCleanupViewModel`, which survives configuration changes. After a rotation the switch showed off, but the ViewModel was still including starred episodes in the list and the selected size. The two could drift apart.

This moves the switch value into `ManualCleanupViewModel.State` as `includeStarred`, so the ViewModel is the single source of truth and `ManualCleanupPage` just renders it. `onStarredSwitchClicked` updates the state immediately, and the pipeline that rebuilds the state from the downloaded episodes carries the current value through.

## Testing Instructions
1. Download a few episodes, and star at least one of them.
2. Go to Profile > Downloads > the overflow menu > Clean Up.
3. Turn on "Include starred" and confirm the starred episode is now counted in its section.
4. Rotate the device.
5. Confirm the "Include starred" switch is still on and the counts and selected size still include the starred episode.
6. Turn the switch off and confirm the starred episode is removed from the counts.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
